### PR TITLE
Don't replace the UUID in the current topology

### DIFF
--- a/jobs/openshift/openshift-defaults.yml
+++ b/jobs/openshift/openshift-defaults.yml
@@ -37,10 +37,10 @@
     name: paas-sig-ci-scm
     scm:
         - git:
-            url: 'git://github.com/herlo/paas-sig-ci.git'
+            url: 'git://github.com/openshift/aos-cd-jobs.git'
             branches:
                 - origin/master
-            basedir: paas-ci
+            basedir: aos-cd-jobs
             skip-tag: true
         - git:
             url: 'git://github.com/CentOS-PaaS-SIG/duffy-ansible-module.git'

--- a/jobs/openshift/openshift-defaults.yml
+++ b/jobs/openshift/openshift-defaults.yml
@@ -29,7 +29,7 @@
     name: openshift-cred-wrappers
     wrappers:
         - credentials-binding:
-          - text:
+          - file:
               credential-id: b83f057b-6dde-402e-8cc6-c995d2b48e69
               variable: OS_OSE_TENANT
 

--- a/jobs/openshift/origin-jobs.yml
+++ b/jobs/openshift/origin-jobs.yml
@@ -5,7 +5,7 @@
 #    parameters:
 #      - label:
 #          name: node
-#          default: paas-sig-ci-slave01
+#          default: aos-ci-cd-slave in the openshift-enterprise tenant
 #          description: "The node on which to run the job"
 
 - job-template:

--- a/jobs/openshift/origin-jobs.yml
+++ b/jobs/openshift/origin-jobs.yml
@@ -19,7 +19,7 @@
           type: user-defined
           name: TOPOLOGY
           values:
-            - os_origin-3node-cluster.yml
+            - os_origin-3node-cluster
       - axis:
          type: slave
          name: nodes

--- a/jobs/openshift/origin-macros.yml
+++ b/jobs/openshift/origin-macros.yml
@@ -137,7 +137,6 @@
       # Setup to provision
       mkdir -p $WORKSPACE/inventory
       cp $OS_OSE_TENANT $WORKSPACE/linch-pin/provision/roles/openstack/vars/os_openshift-tenant.yml
-      sed -i "s|res_name: \"\(.*\)\"|res_name: \1-${{UUID}}|g" $WORKSPACE/aos-cd-jobs/configs/topologies/${{TOPOLOGY}}.yml
 
       # teardown cluster
       ansible-playbook {provision-pb} -u root -vv \


### PR DESCRIPTION
We want to use the same UUID we provisioned with to remove resources