### PR TITLE
Job updates

### DIFF
--- a/generated/test_pull_requests_origin_check_future.xml
+++ b/generated/test_pull_requests_origin_check_future.xml
@@ -62,6 +62,10 @@ OS_BUILD_ENV_PRESERVE=_output/local hack/env TEST_KUBE=&#39;true&#39; JUNIT_REPO
   <triggers/>
   <concurrentBuild>true</concurrentBuild>
   <builders>
+    <hudson.plugins.descriptionsetter.DescriptionSetterBuilder plugin="description-setter@1.10">
+      <regexp></regexp>
+      <description>Testing PR https://github.com/openshift/origin/pull/${PULL_ID} merged into ${BRANCH} branch.</description>
+    </hudson.plugins.descriptionsetter.DescriptionSetterBuilder>
     <hudson.tasks.Shell>
       <command>#!/bin/bash
 

--- a/generated/test_pull_requests_origin_conformance_future.xml
+++ b/generated/test_pull_requests_origin_conformance_future.xml
@@ -59,6 +59,10 @@ JUNIT_REPORT=&#39;true&#39; make test-extended SUITE=conformance&quot;&lt;/div&g
   <triggers/>
   <concurrentBuild>true</concurrentBuild>
   <builders>
+    <hudson.plugins.descriptionsetter.DescriptionSetterBuilder plugin="description-setter@1.10">
+      <regexp></regexp>
+      <description>Testing PR https://github.com/openshift/origin/pull/${PULL_ID} merged into ${BRANCH} branch.</description>
+    </hudson.plugins.descriptionsetter.DescriptionSetterBuilder>
     <hudson.tasks.Shell>
       <command>#!/bin/bash
 

--- a/generated/test_pull_requests_origin_future.xml
+++ b/generated/test_pull_requests_origin_future.xml
@@ -60,6 +60,10 @@ child_jobs=['test_pull_requests_origin_check_future', 'test_pull_requests_origin
   <triggers/>
   <concurrentBuild>true</concurrentBuild>
   <builders>
+    <hudson.plugins.descriptionsetter.DescriptionSetterBuilder plugin="description-setter@1.10">
+      <regexp></regexp>
+      <description>Testing PR https://github.com/openshift/origin/pull/${PULL_ID} merged into ${BRANCH} branch.</description>
+    </hudson.plugins.descriptionsetter.DescriptionSetterBuilder>
     <com.tikal.jenkins.plugins.multijob.MultiJobBuilder>
       <phaseName>Test Phase</phaseName>
       <phaseJobs>
@@ -210,8 +214,18 @@ cat /var/lib/jenkins/jobs/test_pull_requests_origin_networking_future/builds/${T
 cat /var/lib/jenkins/jobs/test_pull_requests_origin_gce/builds/${TEST_PULL_REQUESTS_ORIGIN_GCE_BUILD_NUMBER}/log
       </command>
     </hudson.tasks.Shell>
-    <hudson.tasks.Shell>
-      <command>#!/bin/bash
+  </builders>
+  <publishers>
+    <hudson.tasks.junit.JUnitResultArchiver plugin="junit@1.13">
+      <testResults>.config/origin-ci-tool/logs/junit/*.xml,artifacts/**/**/**/*.xml</testResults>
+      <keepLongStdio>true</keepLongStdio>
+      <healthScaleFactor>1.0</healthScaleFactor>
+      <allowEmptyResults>true</allowEmptyResults>
+    </hudson.tasks.junit.JUnitResultArchiver>
+    <org.jenkinsci.plugins.postbuildscript.PostBuildScript plugin="postbuildscript@0.17">
+      <buildSteps>
+        <hudson.tasks.Shell>
+          <command>#!/bin/bash
 
 set -o errexit
 set -o nounset
@@ -225,16 +239,12 @@ if [[ &quot;${MERGE}&quot; == &quot;true&quot; ]]; then
 else
   test_pull_requests --mark_test_success &quot;${PULL_ID}&quot; --repo origin --config ~/.test_pull_requests_origin.json || true
 fi</command>
-    </hudson.tasks.Shell>
-
-  </builders>
-  <publishers>
-    <hudson.tasks.junit.JUnitResultArchiver plugin="junit@1.13">
-      <testResults>.config/origin-ci-tool/logs/junit/*.xml,artifacts/**/**/**/*.xml</testResults>
-      <keepLongStdio>true</keepLongStdio>
-      <healthScaleFactor>1.0</healthScaleFactor>
-      <allowEmptyResults>true</allowEmptyResults>
-    </hudson.tasks.junit.JUnitResultArchiver>
+        </hudson.tasks.Shell>
+      </buildSteps>
+      <scriptOnlyIfSuccess>true</scriptOnlyIfSuccess>
+      <scriptOnlyIfFailure>false</scriptOnlyIfFailure>
+      <markBuildUnstable>false</markBuildUnstable>
+    </org.jenkinsci.plugins.postbuildscript.PostBuildScript>
   </publishers>
   <buildWrappers/>
   <pollSubjobs>false</pollSubjobs>

--- a/generated/test_pull_requests_origin_integration_future.xml
+++ b/generated/test_pull_requests_origin_integration_future.xml
@@ -59,6 +59,10 @@ JUNIT_REPORT=&#39;true&#39; make test -o check -k&quot;&lt;/div&gt;</description
   <triggers/>
   <concurrentBuild>true</concurrentBuild>
   <builders>
+    <hudson.plugins.descriptionsetter.DescriptionSetterBuilder plugin="description-setter@1.10">
+      <regexp></regexp>
+      <description>Testing PR https://github.com/openshift/origin/pull/${PULL_ID} merged into ${BRANCH} branch.</description>
+    </hudson.plugins.descriptionsetter.DescriptionSetterBuilder>
     <hudson.tasks.Shell>
       <command>#!/bin/bash
 

--- a/generated/test_pull_requests_origin_networking_future.xml
+++ b/generated/test_pull_requests_origin_networking_future.xml
@@ -59,6 +59,10 @@ JUNIT_REPORT=&#39;true&#39; make test-extended SUITE=networking-minimal&quot;&lt
   <triggers/>
   <concurrentBuild>true</concurrentBuild>
   <builders>
+    <hudson.plugins.descriptionsetter.DescriptionSetterBuilder plugin="description-setter@1.10">
+      <regexp></regexp>
+      <description>Testing PR https://github.com/openshift/origin/pull/${PULL_ID} merged into ${BRANCH} branch.</description>
+    </hudson.plugins.descriptionsetter.DescriptionSetterBuilder>
     <hudson.tasks.Shell>
       <command>#!/bin/bash
 

--- a/templates/test_case.xml.j2
+++ b/templates/test_case.xml.j2
@@ -54,6 +54,10 @@ command=&quot;{{ command | escape }}&quot;&lt;/div&gt;</description>
   <triggers/>
   <concurrentBuild>true</concurrentBuild>
   <builders>
+    <hudson.plugins.descriptionsetter.DescriptionSetterBuilder plugin="description-setter@1.10">
+      <regexp></regexp>
+      <description>Testing PR https://github.com/openshift/origin/pull/${PULL_ID} merged into ${BRANCH} branch.</description>
+    </hudson.plugins.descriptionsetter.DescriptionSetterBuilder>
     <hudson.tasks.Shell>
       <command>#!/bin/bash
 

--- a/templates/test_suite.xml.j2
+++ b/templates/test_suite.xml.j2
@@ -105,8 +105,18 @@ cat /var/lib/jenkins/jobs/{{ child_job }}/builds/${{ '{' }}{{ child_job | upper 
 {%- endfor %}
       </command>
     </hudson.tasks.Shell>
-    <hudson.tasks.Shell>
-      <command>#!/bin/bash
+  </builders>
+  <publishers>
+    <hudson.tasks.junit.JUnitResultArchiver plugin="junit@1.13">
+      <testResults>.config/origin-ci-tool/logs/junit/*.xml,artifacts/**/**/**/*.xml</testResults>
+      <keepLongStdio>true</keepLongStdio>
+      <healthScaleFactor>1.0</healthScaleFactor>
+      <allowEmptyResults>true</allowEmptyResults>
+    </hudson.tasks.junit.JUnitResultArchiver>
+    <org.jenkinsci.plugins.postbuildscript.PostBuildScript plugin="postbuildscript@0.17">
+      <buildSteps>
+        <hudson.tasks.Shell>
+          <command>#!/bin/bash
 
 set -o errexit
 set -o nounset
@@ -120,16 +130,12 @@ if [[ &quot;${MERGE}&quot; == &quot;true&quot; ]]; then
 else
   test_pull_requests --mark_test_success &quot;${PULL_ID}&quot; --repo origin --config ~/.test_pull_requests_origin.json || true
 fi</command>
-    </hudson.tasks.Shell>
-
-  </builders>
-  <publishers>
-    <hudson.tasks.junit.JUnitResultArchiver plugin="junit@1.13">
-      <testResults>.config/origin-ci-tool/logs/junit/*.xml,artifacts/**/**/**/*.xml</testResults>
-      <keepLongStdio>true</keepLongStdio>
-      <healthScaleFactor>1.0</healthScaleFactor>
-      <allowEmptyResults>true</allowEmptyResults>
-    </hudson.tasks.junit.JUnitResultArchiver>
+        </hudson.tasks.Shell>
+      </buildSteps>
+      <scriptOnlyIfSuccess>true</scriptOnlyIfSuccess>
+      <scriptOnlyIfFailure>false</scriptOnlyIfFailure>
+      <markBuildUnstable>false</markBuildUnstable>
+    </org.jenkinsci.plugins.postbuildscript.PostBuildScript>
   </publishers>
   <buildWrappers/>
   <pollSubjobs>false</pollSubjobs>

--- a/templates/test_suite.xml.j2
+++ b/templates/test_suite.xml.j2
@@ -61,6 +61,10 @@ child_jobs={{ child_jobs }}&lt;/div&gt;</description>
   <triggers/>
   <concurrentBuild>true</concurrentBuild>
   <builders>
+    <hudson.plugins.descriptionsetter.DescriptionSetterBuilder plugin="description-setter@1.10">
+      <regexp></regexp>
+      <description>Testing PR https://github.com/openshift/origin/pull/${PULL_ID} merged into ${BRANCH} branch.</description>
+    </hudson.plugins.descriptionsetter.DescriptionSetterBuilder>
     <com.tikal.jenkins.plugins.multijob.MultiJobBuilder>
       <phaseName>Test Phase</phaseName>
       <phaseJobs>


### PR DESCRIPTION
Updated generated job definitions

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Set build description with pull request number

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Run merge and success mark only on job success

Previously the repository merge and test success marking code ran as a
build step on all jobs, even when tests in the multi-job phase failed.
Running this as a conditional post-build step only when the multi-job
phase was successful is more appropriate.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

