### PR TITLE
Minor edits to jobs 

### DIFF
--- a/generated/test_pull_requests_origin_check_future.xml
+++ b/generated/test_pull_requests_origin_check_future.xml
@@ -1,20 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <com.tikal.jenkins.plugins.multijob.MultiJobProject plugin="jenkins-multijob-plugin@1.21">
   <actions/>
-  <description>&lt;div style=&quot;white-space: pre-wrap;&quot;&gt;Run some commands in an EC2 VM.&#xd;
-  &#xd;
-&lt;div style=&quot;font-size: 32px; line-height: 1.5em; background-color: yellow; padding: 5px;&quot;&gt;WARNING: THIS IS AN AUTO-GENERATED JOB DEFINITION. CHANGES MADE USING THE ONLINE EDITOR WILL NOT BE HONORED. MAKE CHANGES TO THE JOB DEFINITIONS IN THE openshift/aos-cd-jobs REPOSITORY INSTEAD.&#xd;
-&lt;/div&gt;&#xd;
-THIS JOB WAS GENERATED WITH CONFIGURATION OPTIONS:
-command=&quot;# run commitchecker outside release container as it needs
-# access to git; also explicitly force godeps verification
-symbolic_ref=&#34;\$( git symbolic-ref HEAD )&#34;
-branch=&#34;\${symbolic_ref##refs/heads/}&#34;
-if [[ &#34;\${branch}&#34; == &#34;master&#34; ]]; then
-	RESTORE_AND_VERIFY_GODEPS=1 make verify-commits -j
-fi
-
-OS_BUILD_ENV_PRESERVE=_output/local hack/env TEST_KUBE=&#39;true&#39; JUNIT_REPORT=&#39;true&#39; make check -j -k&quot;&lt;/div&gt;</description>
+  <description>
+    &lt;div style=&quot;font-size: 32px; line-height: 1.5em; background-color: yellow; padding: 5px;&quot;&gt;WARNING: THIS IS AN AUTO-GENERATED JOB DEFINITION. CHANGES MADE USING THE ONLINE EDITOR WILL NOT BE HONORED. MAKE CHANGES TO THE JOB DEFINITIONS IN THE openshift/aos-cd-jobs REPOSITORY INSTEAD.&#xd;&lt;/div&gt;
+  </description>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.plugins.buildblocker.BuildBlockerProperty plugin="build-blocker-plugin@1.7.3">
@@ -121,16 +110,16 @@ oct sync remote origin --refspec=&quot;pull/${PULL_ID}/head&quot; \
 # run the test
 {
 cat &lt;&lt;EOF
+# run tests as the right user
+sudo su origin
+
 set -o errexit
 set -o nounset
 set -o pipefail
 set -o xtrace
 
-# run tests as the right user
-sudo su origin
-
 # use a ramdisk for etcd storage
-sudo mkdir /tmp || true
+sudo mkdir -p /tmp
 sudo mount -t tmpfs -o size=2048m tmpfs /tmp
 
 # Print useful version information
@@ -230,6 +219,11 @@ popd</command>
       <userMetadata/>
     </hudson.plugins.s3.S3BucketPublisher>
   </publishers>
-  <buildWrappers/>
+  <buildWrappers>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.8.8"/>
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.4.2">
+      <colorMapName>xterm</colorMapName>
+    </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
+  </buildWrappers>
   <pollSubjobs>false</pollSubjobs>
 </com.tikal.jenkins.plugins.multijob.MultiJobProject>

--- a/generated/test_pull_requests_origin_conformance_future.xml
+++ b/generated/test_pull_requests_origin_conformance_future.xml
@@ -1,17 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <com.tikal.jenkins.plugins.multijob.MultiJobProject plugin="jenkins-multijob-plugin@1.21">
   <actions/>
-  <description>&lt;div style=&quot;white-space: pre-wrap;&quot;&gt;Run some commands in an EC2 VM.&#xd;
-  &#xd;
-&lt;div style=&quot;font-size: 32px; line-height: 1.5em; background-color: yellow; padding: 5px;&quot;&gt;WARNING: THIS IS AN AUTO-GENERATED JOB DEFINITION. CHANGES MADE USING THE ONLINE EDITOR WILL NOT BE HONORED. MAKE CHANGES TO THE JOB DEFINITIONS IN THE openshift/aos-cd-jobs REPOSITORY INSTEAD.&#xd;
-&lt;/div&gt;&#xd;
-THIS JOB WAS GENERATED WITH CONFIGURATION OPTIONS:
-command=&quot;go get github.com/openshift/imagebuilder/cmd/imagebuilder
-
-export OS_BUILD_IMAGE_ARGS=&#39;&#39;
-hack/build-base-images.sh
-make release
-JUNIT_REPORT=&#39;true&#39; make test-extended SUITE=conformance&quot;&lt;/div&gt;</description>
+  <description>
+    &lt;div style=&quot;font-size: 32px; line-height: 1.5em; background-color: yellow; padding: 5px;&quot;&gt;WARNING: THIS IS AN AUTO-GENERATED JOB DEFINITION. CHANGES MADE USING THE ONLINE EDITOR WILL NOT BE HONORED. MAKE CHANGES TO THE JOB DEFINITIONS IN THE openshift/aos-cd-jobs REPOSITORY INSTEAD.&#xd;&lt;/div&gt;
+  </description>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.plugins.buildblocker.BuildBlockerProperty plugin="build-blocker-plugin@1.7.3">
@@ -118,16 +110,16 @@ oct sync remote origin --refspec=&quot;pull/${PULL_ID}/head&quot; \
 # run the test
 {
 cat &lt;&lt;EOF
+# run tests as the right user
+sudo su origin
+
 set -o errexit
 set -o nounset
 set -o pipefail
 set -o xtrace
 
-# run tests as the right user
-sudo su origin
-
 # use a ramdisk for etcd storage
-sudo mkdir /tmp || true
+sudo mkdir -p /tmp
 sudo mount -t tmpfs -o size=2048m tmpfs /tmp
 
 # Print useful version information
@@ -224,6 +216,11 @@ popd</command>
       <userMetadata/>
     </hudson.plugins.s3.S3BucketPublisher>
   </publishers>
-  <buildWrappers/>
+  <buildWrappers>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.8.8"/>
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.4.2">
+      <colorMapName>xterm</colorMapName>
+    </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
+  </buildWrappers>
   <pollSubjobs>false</pollSubjobs>
 </com.tikal.jenkins.plugins.multijob.MultiJobProject>

--- a/generated/test_pull_requests_origin_future.xml
+++ b/generated/test_pull_requests_origin_future.xml
@@ -1,12 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <com.tikal.jenkins.plugins.multijob.MultiJobProject plugin="jenkins-multijob-plugin@1.21">
   <actions/>
-  <description>&lt;div style=&quot;white-space: pre-wrap;&quot;&gt;Run Origin test suites against the result of merging a PR&apos;s HEAD with an upstream branch.&#xd;
-  &#xd;
-&lt;div style=&quot;font-size: 32px; line-height: 1.5em; background-color: yellow; padding: 5px;&quot;&gt;WARNING: THIS IS AN AUTO-GENERATED JOB DEFINITION. CHANGES MADE USING THE ONLINE EDITOR WILL NOT BE HONORED. MAKE CHANGES TO THE JOB DEFINITIONS IN THE openshift/aos-cd-jobs REPOSITORY INSTEAD.&#xd;
-&lt;/div&gt;&#xd;
-THIS JOB WAS GENERATED WITH CONFIGURATION OPTIONS:
-child_jobs=['test_pull_requests_origin_check_future', 'test_pull_requests_origin_conformance_future', 'test_pull_requests_origin_integration_future', 'test_pull_requests_origin_networking_future', 'test_pull_requests_origin_gce']&lt;/div&gt;</description>
+  <description>
+    &lt;div style=&quot;font-size: 32px; line-height: 1.5em; background-color: yellow; padding: 5px;&quot;&gt;WARNING: THIS IS AN AUTO-GENERATED JOB DEFINITION. CHANGES MADE USING THE ONLINE EDITOR WILL NOT BE HONORED. MAKE CHANGES TO THE JOB DEFINITIONS IN THE openshift/aos-cd-jobs REPOSITORY INSTEAD.&#xd;&lt;/div&gt;
+  </description>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.plugins.buildblocker.BuildBlockerProperty plugin="build-blocker-plugin@1.7.3">
@@ -246,6 +243,11 @@ fi</command>
       <markBuildUnstable>false</markBuildUnstable>
     </org.jenkinsci.plugins.postbuildscript.PostBuildScript>
   </publishers>
-  <buildWrappers/>
+  <buildWrappers>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.8.8"/>
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.4.2">
+      <colorMapName>xterm</colorMapName>
+    </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
+  </buildWrappers>
   <pollSubjobs>false</pollSubjobs>
 </com.tikal.jenkins.plugins.multijob.MultiJobProject>

--- a/generated/test_pull_requests_origin_integration_future.xml
+++ b/generated/test_pull_requests_origin_integration_future.xml
@@ -1,17 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <com.tikal.jenkins.plugins.multijob.MultiJobProject plugin="jenkins-multijob-plugin@1.21">
   <actions/>
-  <description>&lt;div style=&quot;white-space: pre-wrap;&quot;&gt;Run some commands in an EC2 VM.&#xd;
-  &#xd;
-&lt;div style=&quot;font-size: 32px; line-height: 1.5em; background-color: yellow; padding: 5px;&quot;&gt;WARNING: THIS IS AN AUTO-GENERATED JOB DEFINITION. CHANGES MADE USING THE ONLINE EDITOR WILL NOT BE HONORED. MAKE CHANGES TO THE JOB DEFINITIONS IN THE openshift/aos-cd-jobs REPOSITORY INSTEAD.&#xd;
-&lt;/div&gt;&#xd;
-THIS JOB WAS GENERATED WITH CONFIGURATION OPTIONS:
-command=&quot;go get github.com/openshift/imagebuilder/cmd/imagebuilder
-
-export OS_BUILD_IMAGE_ARGS=&#39;&#39;
-hack/build-base-images.sh
-make release
-JUNIT_REPORT=&#39;true&#39; make test -o check -k&quot;&lt;/div&gt;</description>
+  <description>
+    &lt;div style=&quot;font-size: 32px; line-height: 1.5em; background-color: yellow; padding: 5px;&quot;&gt;WARNING: THIS IS AN AUTO-GENERATED JOB DEFINITION. CHANGES MADE USING THE ONLINE EDITOR WILL NOT BE HONORED. MAKE CHANGES TO THE JOB DEFINITIONS IN THE openshift/aos-cd-jobs REPOSITORY INSTEAD.&#xd;&lt;/div&gt;
+  </description>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.plugins.buildblocker.BuildBlockerProperty plugin="build-blocker-plugin@1.7.3">
@@ -118,16 +110,16 @@ oct sync remote origin --refspec=&quot;pull/${PULL_ID}/head&quot; \
 # run the test
 {
 cat &lt;&lt;EOF
+# run tests as the right user
+sudo su origin
+
 set -o errexit
 set -o nounset
 set -o pipefail
 set -o xtrace
 
-# run tests as the right user
-sudo su origin
-
 # use a ramdisk for etcd storage
-sudo mkdir /tmp || true
+sudo mkdir -p /tmp
 sudo mount -t tmpfs -o size=2048m tmpfs /tmp
 
 # Print useful version information
@@ -224,6 +216,11 @@ popd</command>
       <userMetadata/>
     </hudson.plugins.s3.S3BucketPublisher>
   </publishers>
-  <buildWrappers/>
+  <buildWrappers>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.8.8"/>
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.4.2">
+      <colorMapName>xterm</colorMapName>
+    </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
+  </buildWrappers>
   <pollSubjobs>false</pollSubjobs>
 </com.tikal.jenkins.plugins.multijob.MultiJobProject>

--- a/generated/test_pull_requests_origin_networking_future.xml
+++ b/generated/test_pull_requests_origin_networking_future.xml
@@ -1,17 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <com.tikal.jenkins.plugins.multijob.MultiJobProject plugin="jenkins-multijob-plugin@1.21">
   <actions/>
-  <description>&lt;div style=&quot;white-space: pre-wrap;&quot;&gt;Run some commands in an EC2 VM.&#xd;
-  &#xd;
-&lt;div style=&quot;font-size: 32px; line-height: 1.5em; background-color: yellow; padding: 5px;&quot;&gt;WARNING: THIS IS AN AUTO-GENERATED JOB DEFINITION. CHANGES MADE USING THE ONLINE EDITOR WILL NOT BE HONORED. MAKE CHANGES TO THE JOB DEFINITIONS IN THE openshift/aos-cd-jobs REPOSITORY INSTEAD.&#xd;
-&lt;/div&gt;&#xd;
-THIS JOB WAS GENERATED WITH CONFIGURATION OPTIONS:
-command=&quot;go get github.com/openshift/imagebuilder/cmd/imagebuilder
-
-export OS_BUILD_IMAGE_ARGS=&#39;&#39;
-hack/build-base-images.sh
-make release
-JUNIT_REPORT=&#39;true&#39; make test-extended SUITE=networking-minimal&quot;&lt;/div&gt;</description>
+  <description>
+    &lt;div style=&quot;font-size: 32px; line-height: 1.5em; background-color: yellow; padding: 5px;&quot;&gt;WARNING: THIS IS AN AUTO-GENERATED JOB DEFINITION. CHANGES MADE USING THE ONLINE EDITOR WILL NOT BE HONORED. MAKE CHANGES TO THE JOB DEFINITIONS IN THE openshift/aos-cd-jobs REPOSITORY INSTEAD.&#xd;&lt;/div&gt;
+  </description>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.plugins.buildblocker.BuildBlockerProperty plugin="build-blocker-plugin@1.7.3">
@@ -118,16 +110,16 @@ oct sync remote origin --refspec=&quot;pull/${PULL_ID}/head&quot; \
 # run the test
 {
 cat &lt;&lt;EOF
+# run tests as the right user
+sudo su origin
+
 set -o errexit
 set -o nounset
 set -o pipefail
 set -o xtrace
 
-# run tests as the right user
-sudo su origin
-
 # use a ramdisk for etcd storage
-sudo mkdir /tmp || true
+sudo mkdir -p /tmp
 sudo mount -t tmpfs -o size=2048m tmpfs /tmp
 
 # Print useful version information
@@ -224,6 +216,11 @@ popd</command>
       <userMetadata/>
     </hudson.plugins.s3.S3BucketPublisher>
   </publishers>
-  <buildWrappers/>
+  <buildWrappers>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.8.8"/>
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.4.2">
+      <colorMapName>xterm</colorMapName>
+    </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
+  </buildWrappers>
   <pollSubjobs>false</pollSubjobs>
 </com.tikal.jenkins.plugins.multijob.MultiJobProject>

--- a/templates/test_case.xml.j2
+++ b/templates/test_case.xml.j2
@@ -113,13 +113,13 @@ oct sync remote origin --refspec=&quot;pull/${PULL_ID}/head&quot; \
 # run the test
 {
 cat &lt;&lt;EOF
+# run tests as the right user
+sudo su origin
+
 set -o errexit
 set -o nounset
 set -o pipefail
 set -o xtrace
-
-# run tests as the right user
-sudo su origin
 
 # use a ramdisk for etcd storage
 sudo mkdir /tmp || true

--- a/templates/test_case.xml.j2
+++ b/templates/test_case.xml.j2
@@ -122,7 +122,7 @@ set -o pipefail
 set -o xtrace
 
 # use a ramdisk for etcd storage
-sudo mkdir /tmp || true
+sudo mkdir -p /tmp
 sudo mount -t tmpfs -o size=2048m tmpfs /tmp
 
 # Print useful version information

--- a/templates/test_case.xml.j2
+++ b/templates/test_case.xml.j2
@@ -1,12 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <com.tikal.jenkins.plugins.multijob.MultiJobProject plugin="jenkins-multijob-plugin@1.21">
   <actions/>
-  <description>&lt;div style=&quot;white-space: pre-wrap;&quot;&gt;Run some commands in an EC2 VM.&#xd;
-  &#xd;
-&lt;div style=&quot;font-size: 32px; line-height: 1.5em; background-color: yellow; padding: 5px;&quot;&gt;WARNING: THIS IS AN AUTO-GENERATED JOB DEFINITION. CHANGES MADE USING THE ONLINE EDITOR WILL NOT BE HONORED. MAKE CHANGES TO THE JOB DEFINITIONS IN THE openshift/aos-cd-jobs REPOSITORY INSTEAD.&#xd;
-&lt;/div&gt;&#xd;
-THIS JOB WAS GENERATED WITH CONFIGURATION OPTIONS:
-command=&quot;{{ command | escape }}&quot;&lt;/div&gt;</description>
+  <description>
+    &lt;div style=&quot;font-size: 32px; line-height: 1.5em; background-color: yellow; padding: 5px;&quot;&gt;WARNING: THIS IS AN AUTO-GENERATED JOB DEFINITION. CHANGES MADE USING THE ONLINE EDITOR WILL NOT BE HONORED. MAKE CHANGES TO THE JOB DEFINITIONS IN THE openshift/aos-cd-jobs REPOSITORY INSTEAD.&#xd;&lt;/div&gt;
+  </description>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.plugins.buildblocker.BuildBlockerProperty plugin="build-blocker-plugin@1.7.3">

--- a/templates/test_case.xml.j2
+++ b/templates/test_case.xml.j2
@@ -214,6 +214,11 @@ popd</command>
       <userMetadata/>
     </hudson.plugins.s3.S3BucketPublisher>
   </publishers>
-  <buildWrappers/>
+  <buildWrappers>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.8.8"/>
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.4.2">
+      <colorMapName>xterm</colorMapName>
+    </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
+  </buildWrappers>
   <pollSubjobs>false</pollSubjobs>
 </com.tikal.jenkins.plugins.multijob.MultiJobProject>

--- a/templates/test_suite.xml.j2
+++ b/templates/test_suite.xml.j2
@@ -141,6 +141,11 @@ fi</command>
       <markBuildUnstable>false</markBuildUnstable>
     </org.jenkinsci.plugins.postbuildscript.PostBuildScript>
   </publishers>
-  <buildWrappers/>
+  <buildWrappers>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.8.8"/>
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.4.2">
+      <colorMapName>xterm</colorMapName>
+    </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
+  </buildWrappers>
   <pollSubjobs>false</pollSubjobs>
 </com.tikal.jenkins.plugins.multijob.MultiJobProject>

--- a/templates/test_suite.xml.j2
+++ b/templates/test_suite.xml.j2
@@ -1,13 +1,10 @@
+{%- set child_jobs = child_jobs.split('\n') -%}
 <?xml version='1.0' encoding='UTF-8'?>
 <com.tikal.jenkins.plugins.multijob.MultiJobProject plugin="jenkins-multijob-plugin@1.21">
   <actions/>
-  <description>&lt;div style=&quot;white-space: pre-wrap;&quot;&gt;Run Origin test suites against the result of merging a PR&apos;s HEAD with an upstream branch.&#xd;
-  &#xd;
-&lt;div style=&quot;font-size: 32px; line-height: 1.5em; background-color: yellow; padding: 5px;&quot;&gt;WARNING: THIS IS AN AUTO-GENERATED JOB DEFINITION. CHANGES MADE USING THE ONLINE EDITOR WILL NOT BE HONORED. MAKE CHANGES TO THE JOB DEFINITIONS IN THE openshift/aos-cd-jobs REPOSITORY INSTEAD.&#xd;
-&lt;/div&gt;&#xd;
-THIS JOB WAS GENERATED WITH CONFIGURATION OPTIONS:
-{%- set child_jobs = child_jobs.split('\n') %}
-child_jobs={{ child_jobs }}&lt;/div&gt;</description>
+  <description>
+    &lt;div style=&quot;font-size: 32px; line-height: 1.5em; background-color: yellow; padding: 5px;&quot;&gt;WARNING: THIS IS AN AUTO-GENERATED JOB DEFINITION. CHANGES MADE USING THE ONLINE EDITOR WILL NOT BE HONORED. MAKE CHANGES TO THE JOB DEFINITIONS IN THE openshift/aos-cd-jobs REPOSITORY INSTEAD.&#xd;&lt;/div&gt;
+  </description>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.plugins.buildblocker.BuildBlockerProperty plugin="build-blocker-plugin@1.7.3">


### PR DESCRIPTION
Regenerate job definitions

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Clean up job descriptions

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Add timestamp and ANSI color build wrappers

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Use `mkdir -p` instead of `mkdir || true`

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Change users before `set -o xtrace`

Changing the login user after setting options for the shell renders the
options useless by resetting them to the defaults on login.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---