### PR TITLE
Change tmpdir mountpath for jobs to harvest artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+venv/
+.idea/

--- a/commands/test_pull_requests_origin_check_future.sh
+++ b/commands/test_pull_requests_origin_check_future.sh
@@ -6,4 +6,4 @@ if [[ "${branch}" == "master" ]]; then
 	RESTORE_AND_VERIFY_GODEPS=1 make verify-commits -j
 fi
 
-OS_BUILD_ENV_PRESERVE=_output/local hack/env TEST_KUBE='true' JUNIT_REPORT='true' make check -j -k
+OS_BUILD_ENV_DOCKER_ARGS="-v /tmp/ci:/tmp " hack/env TEST_KUBE='true' JUNIT_REPORT='true' make check -j -k

--- a/generated/test_pull_requests_origin_check_future.xml
+++ b/generated/test_pull_requests_origin_check_future.xml
@@ -135,7 +135,7 @@ if [[ &#34;\${branch}&#34; == &#34;master&#34; ]]; then
 	RESTORE_AND_VERIFY_GODEPS=1 make verify-commits -j
 fi
 
-OS_BUILD_ENV_PRESERVE=_output/local hack/env TEST_KUBE=&#39;true&#39; JUNIT_REPORT=&#39;true&#39; make check -j -k
+OS_BUILD_ENV_DOCKER_ARGS=&#34;-v /tmp/ci:/tmp &#34; hack/env TEST_KUBE=&#39;true&#39; JUNIT_REPORT=&#39;true&#39; make check -j -k
 EOF
 } | ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel</command>
     </hudson.tasks.Shell>


### PR DESCRIPTION
If we do not change the tmpdir mountpath for the release container, any
artifacts that the test jobs running inside of the release container try
to add to the `${BASETMPDIR}` will be lost.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>