### PR TITLE
Construct the changelog correctly

### DIFF
--- a/scripts/merge-and-build.sh
+++ b/scripts/merge-and-build.sh
@@ -192,8 +192,11 @@ echo
 echo "=========="
 echo "Tito Tagging"
 echo "=========="
-CHANGELOG=$(git log $PREVIOUS_ORIGIN_HEAD..$CURRENT_ORIGIN_HEAD --pretty="%s (%ae)" --no-merges)
-tito tag --accept-auto-changelog --changelog="$CHANGELOG"
+declare -a changelog
+for commit in $( git log "${PREVIOUS_ORIGIN_HEAD}..${CURRENT_ORIGIN_HEAD}" --pretty=%h --no-merges ); do
+  changelog+=( "--changelog='$( git log -1 "${commit}" --pretty='%s (%ae)' )'" )
+done
+tito tag --accept-auto-changelog "${changelog[@]}"
 git diff HEAD~1..HEAD > tito_new_diff
 cat tito_new_diff
 git log --oneline -10


### PR DESCRIPTION
@stevekuznetsov need your bash expertise

The problem I am trying to fix:
Passing a single --changelog into tito tag will result into a single changelog entry. Passing multiple --changelog entries is what we want to do, each one for a new commit. The later approach works fine (I tested it).

The problem I currently have (related to bash):
I am constructing a string that contains all the --changelog invocations we need but bash for some reason injects single quotes into it thus breaking the whole thing:
```sh
$ tito tag --accept-auto-changelog $CHANGELOG_FLAGS
+ tito tag --accept-auto-changelog '--changelog="provider' recorder to attach detach controller '(hchen@redhat.com)"' '--changelog="Necessary' origin updates '(maszulik@redhat.com)"' '--changelog="UPSTREAM:' 40301: present request header cert CA '(maszulik@redhat.com)"' '--changelog="UPSTREAM:' revert: 15aaac7f8391a1e0514f80e6450f4bf12c0db191: '<drop>:' add ExtraClientCACerts to 'SecureServingInfo"' '(maszulik@redhat.com)"' '--changelog="UPSTREAM:' 39825: Make PDBs represent percentage in StatefulSet '(mfojtik@redhat.com)"' '--changelog="Update' the reconciler sync period in master_config_test '(mfojtik@redhat.com)"' '--changelog="UPSTREAM:' 40903: Set docker opt separator correctly for SELinux options '(maszulik@redhat.com)"' '--changelog="UPSTREAM:' revert: 9f81f6f: '<carry>:' Change docker security opt separator to be compatible with 1.11+ '(maszulik@redhat.com)"' '--changelog="UPSTREAM:' 42097: Enqueue controllers after minreadyseconds when all pods are ready '(maszulik@redhat.com)"' '--changelog="UPSTREAM:' 40625: controller: old pods should block deployment completeness '(mfojtik@redhat.com)"' '--changelog="UPSTREAM:' 37093: Endpoints with TolerateUnready annotation, should list Pods in state terminating '(maszulik@redhat.com)"' '--changelog="UPSTREAM:' 41366: Change default reconciler sync period to 1 minute '(mfojtik@redhat.com)"' '--changelog="UPSTREAM:' 41455: Fix AWS device allocator to only use valid device names '(mfojtik@redhat.com)"' '--changelog="UPSTREAM:' 38818: Add sequential allocator for device names in AWS '(mfojtik@redhat.com)"' '--changelog="UPSTREAM:' 42178: stop spamming logs on restart of server '(decarr@redhat.com)"' '--changelog="backup' and remove keys during migration '(sjenning@redhat.com)"' '--changelog="add' migration script to fix etcd paths '(sjenning@redhat.com)"' '--changelog="UPSTREAM:' 40553: Adjust global log limit to 1ms '(pweil@redhat.com)"' '--changelog="UPSTREAM:' 40497: Make HandleError prevent hot-loops '(pweil@redhat.com)"' '--changelog="UPSTREAM:' 40935: Plumb subresource through subjectaccessreview '(pweil@redhat.com)"' '--changelog="UPSTREAM:' 38855: Fix variable shadowing in exponential backoff when deleting volumes '(pweil@redhat.com)"' '--changelog="UPSTREAM:' 38909: Add path exist check in getPodVolumePathListFromDisk '(pweil@redhat.com)"' '--changelog="UPSTREAM:' 38746: recognize eu-west-2 region '(pweil@redhat.com)"'
```
I also tried other various calls: ${CHANGELOG_FLAGS}, "${CHANGELOG_FLAGS}", none yielded the desired result.