### PR TITLE
Python yum wrapper to get all available pkgs

### DIFF
--- a/hack/get_available_pkgs.py
+++ b/hack/get_available_pkgs.py
@@ -1,0 +1,8 @@
+import yum
+import sys
+
+yb = yum.YumBase()
+pkgs = yb.doPackageLists('available', patterns=[sys.argv[1]], showdups=True).available
+pkgs.sort(key=lambda x: x.version)
+for p in pkgs:
+    print p.vra


### PR DESCRIPTION
Takes package name as a single argument.
Output is list of all the pkgs versions. eg(arg: 'origin'):

>Loaded plugins: amazon-id, rhui-lb
1.1.6-1.git.9999.9c5694f.el7.x86_64
1.2.0-2.el7.x86_64
1.2.0-1.git.10183.7386b49.el7.x86_64
1.2.0-4.el7.x86_64
1.2.1-1.el7.x86_64
1.3.0-3.el7.x86_64
1.3.1-1.el7.x86_64
1.3.3-1.el7.x86_64

Didnt come up with a clean way (something like `--quite`) how to drop the first line:
`Loaded plugins: amazon-id, rhui-lb`
We can either nuke it in this script or outside it(so far  im doing it outside ot the script since Im doing other operations over the list as well - sort, uniq ...)

@stevekuznetsov PTAL