### PR TITLE
Don't rebuild integration and extended test binaries; use the ones al…

### DIFF
--- a/commands/test_pull_requests_origin_integration_future.sh
+++ b/commands/test_pull_requests_origin_integration_future.sh
@@ -3,4 +3,4 @@ go get github.com/openshift/imagebuilder/cmd/imagebuilder
 export OS_BUILD_IMAGE_ARGS=''
 hack/build-base-images.sh
 make release
-JUNIT_REPORT='true' make test -o check -k
+OPENSHIFT_SKIP_BUILD=1 JUNIT_REPORT='true' make test -o check -k

--- a/commands/test_pull_requests_origin_networking_future.sh
+++ b/commands/test_pull_requests_origin_networking_future.sh
@@ -3,4 +3,4 @@ go get github.com/openshift/imagebuilder/cmd/imagebuilder
 export OS_BUILD_IMAGE_ARGS=''
 hack/build-base-images.sh
 make release
-JUNIT_REPORT='true' make test-extended SUITE=networking-minimal
+OPENSHIFT_SKIP_BUILD=1 JUNIT_REPORT='true' make test-extended SUITE=networking-minimal

--- a/generated/test_pull_requests_origin_integration_future.xml
+++ b/generated/test_pull_requests_origin_integration_future.xml
@@ -132,7 +132,7 @@ go get github.com/openshift/imagebuilder/cmd/imagebuilder
 export OS_BUILD_IMAGE_ARGS=&#39;&#39;
 hack/build-base-images.sh
 make release
-JUNIT_REPORT=&#39;true&#39; make test -o check -k
+OPENSHIFT_SKIP_BUILD=1 JUNIT_REPORT=&#39;true&#39; make test -o check -k
 EOF
 } | ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel</command>
     </hudson.tasks.Shell>

--- a/generated/test_pull_requests_origin_networking_future.xml
+++ b/generated/test_pull_requests_origin_networking_future.xml
@@ -132,7 +132,7 @@ go get github.com/openshift/imagebuilder/cmd/imagebuilder
 export OS_BUILD_IMAGE_ARGS=&#39;&#39;
 hack/build-base-images.sh
 make release
-JUNIT_REPORT=&#39;true&#39; make test-extended SUITE=networking-minimal
+OPENSHIFT_SKIP_BUILD=1 JUNIT_REPORT=&#39;true&#39; make test-extended SUITE=networking-minimal
 EOF
 } | ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel</command>
     </hudson.tasks.Shell>


### PR DESCRIPTION
This PR should be applied after https://github.com/openshift/origin/pull/13275 has merged.

This PR should ensure that our tests use integration and extended test binaries that have already been compiled within the release container as part of the `make release` process.