### PR TITLE
Touch latest installation when it's used

### DIFF
--- a/actions/oct_install.py
+++ b/actions/oct_install.py
@@ -4,7 +4,9 @@ from actions.named_shell_task import render_task
 from .interface import Action
 
 _OCT_INSTALL_TITLE = "INSTALL THE ORIGIN-CI-TOOL"
-_OCT_INSTALL_ACTION = """cp "${HOME}/origin-ci-tool/latest/bin/activate" "${WORKSPACE}/activate"
+_OCT_INSTALL_ACTION = """latest="$( readlink "${HOME}/origin-ci-tool/latest" )"
+touch "${latest}"
+cp "${latest}/bin/activate" "${WORKSPACE}/activate"
 cat >> "${WORKSPACE}/activate" <<EOF
 export OCT_CONFIG_HOME="${WORKSPACE}/.config"
 EOF

--- a/generated/ami_build_origin_int_rhel_base.xml
+++ b/generated/ami_build_origin_int_rhel_base.xml
@@ -34,7 +34,9 @@
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 echo &#34;########## STARTING STAGE: INSTALL THE ORIGIN-CI-TOOL ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE ORIGIN-CI-TOOL ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-cp &#34;${HOME}/origin-ci-tool/latest/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
+latest=&#34;$( readlink &#34;${HOME}/origin-ci-tool/latest&#34; )&#34;
+touch &#34;${latest}&#34;
+cp &#34;${latest}/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
 cat &gt;&gt; &#34;${WORKSPACE}/activate&#34; &lt;&lt;EOF
 export OCT_CONFIG_HOME=&#34;${WORKSPACE}/.config&#34;
 EOF

--- a/generated/test_branch_origin_check.xml
+++ b/generated/test_branch_origin_check.xml
@@ -39,7 +39,9 @@
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 echo &#34;########## STARTING STAGE: INSTALL THE ORIGIN-CI-TOOL ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE ORIGIN-CI-TOOL ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-cp &#34;${HOME}/origin-ci-tool/latest/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
+latest=&#34;$( readlink &#34;${HOME}/origin-ci-tool/latest&#34; )&#34;
+touch &#34;${latest}&#34;
+cp &#34;${latest}/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
 cat &gt;&gt; &#34;${WORKSPACE}/activate&#34; &lt;&lt;EOF
 export OCT_CONFIG_HOME=&#34;${WORKSPACE}/.config&#34;
 EOF

--- a/generated/test_branch_origin_extended.xml
+++ b/generated/test_branch_origin_extended.xml
@@ -49,7 +49,9 @@
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 echo &#34;########## STARTING STAGE: INSTALL THE ORIGIN-CI-TOOL ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE ORIGIN-CI-TOOL ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-cp &#34;${HOME}/origin-ci-tool/latest/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
+latest=&#34;$( readlink &#34;${HOME}/origin-ci-tool/latest&#34; )&#34;
+touch &#34;${latest}&#34;
+cp &#34;${latest}/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
 cat &gt;&gt; &#34;${WORKSPACE}/activate&#34; &lt;&lt;EOF
 export OCT_CONFIG_HOME=&#34;${WORKSPACE}/.config&#34;
 EOF

--- a/generated/test_branch_origin_extended_builds.xml
+++ b/generated/test_branch_origin_extended_builds.xml
@@ -39,7 +39,9 @@
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 echo &#34;########## STARTING STAGE: INSTALL THE ORIGIN-CI-TOOL ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE ORIGIN-CI-TOOL ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-cp &#34;${HOME}/origin-ci-tool/latest/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
+latest=&#34;$( readlink &#34;${HOME}/origin-ci-tool/latest&#34; )&#34;
+touch &#34;${latest}&#34;
+cp &#34;${latest}/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
 cat &gt;&gt; &#34;${WORKSPACE}/activate&#34; &lt;&lt;EOF
 export OCT_CONFIG_HOME=&#34;${WORKSPACE}/.config&#34;
 EOF

--- a/generated/test_branch_origin_extended_conformance.xml
+++ b/generated/test_branch_origin_extended_conformance.xml
@@ -39,7 +39,9 @@
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 echo &#34;########## STARTING STAGE: INSTALL THE ORIGIN-CI-TOOL ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE ORIGIN-CI-TOOL ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-cp &#34;${HOME}/origin-ci-tool/latest/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
+latest=&#34;$( readlink &#34;${HOME}/origin-ci-tool/latest&#34; )&#34;
+touch &#34;${latest}&#34;
+cp &#34;${latest}/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
 cat &gt;&gt; &#34;${WORKSPACE}/activate&#34; &lt;&lt;EOF
 export OCT_CONFIG_HOME=&#34;${WORKSPACE}/.config&#34;
 EOF

--- a/generated/test_branch_origin_extended_conformance_gce.xml
+++ b/generated/test_branch_origin_extended_conformance_gce.xml
@@ -72,7 +72,9 @@ See also:
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 echo &#34;########## STARTING STAGE: INSTALL THE ORIGIN-CI-TOOL ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE ORIGIN-CI-TOOL ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-cp &#34;${HOME}/origin-ci-tool/latest/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
+latest=&#34;$( readlink &#34;${HOME}/origin-ci-tool/latest&#34; )&#34;
+touch &#34;${latest}&#34;
+cp &#34;${latest}/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
 cat &gt;&gt; &#34;${WORKSPACE}/activate&#34; &lt;&lt;EOF
 export OCT_CONFIG_HOME=&#34;${WORKSPACE}/.config&#34;
 EOF

--- a/generated/test_branch_origin_extended_conformance_install.xml
+++ b/generated/test_branch_origin_extended_conformance_install.xml
@@ -49,7 +49,9 @@
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 echo &#34;########## STARTING STAGE: INSTALL THE ORIGIN-CI-TOOL ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE ORIGIN-CI-TOOL ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-cp &#34;${HOME}/origin-ci-tool/latest/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
+latest=&#34;$( readlink &#34;${HOME}/origin-ci-tool/latest&#34; )&#34;
+touch &#34;${latest}&#34;
+cp &#34;${latest}/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
 cat &gt;&gt; &#34;${WORKSPACE}/activate&#34; &lt;&lt;EOF
 export OCT_CONFIG_HOME=&#34;${WORKSPACE}/.config&#34;
 EOF

--- a/generated/test_branch_origin_extended_conformance_install_update.xml
+++ b/generated/test_branch_origin_extended_conformance_install_update.xml
@@ -49,7 +49,9 @@
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 echo &#34;########## STARTING STAGE: INSTALL THE ORIGIN-CI-TOOL ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE ORIGIN-CI-TOOL ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-cp &#34;${HOME}/origin-ci-tool/latest/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
+latest=&#34;$( readlink &#34;${HOME}/origin-ci-tool/latest&#34; )&#34;
+touch &#34;${latest}&#34;
+cp &#34;${latest}/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
 cat &gt;&gt; &#34;${WORKSPACE}/activate&#34; &lt;&lt;EOF
 export OCT_CONFIG_HOME=&#34;${WORKSPACE}/.config&#34;
 EOF

--- a/generated/test_branch_origin_extended_image_ecosystem.xml
+++ b/generated/test_branch_origin_extended_image_ecosystem.xml
@@ -39,7 +39,9 @@
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 echo &#34;########## STARTING STAGE: INSTALL THE ORIGIN-CI-TOOL ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE ORIGIN-CI-TOOL ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-cp &#34;${HOME}/origin-ci-tool/latest/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
+latest=&#34;$( readlink &#34;${HOME}/origin-ci-tool/latest&#34; )&#34;
+touch &#34;${latest}&#34;
+cp &#34;${latest}/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
 cat &gt;&gt; &#34;${WORKSPACE}/activate&#34; &lt;&lt;EOF
 export OCT_CONFIG_HOME=&#34;${WORKSPACE}/.config&#34;
 EOF

--- a/generated/test_branch_origin_extended_networking.xml
+++ b/generated/test_branch_origin_extended_networking.xml
@@ -39,7 +39,9 @@
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 echo &#34;########## STARTING STAGE: INSTALL THE ORIGIN-CI-TOOL ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE ORIGIN-CI-TOOL ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-cp &#34;${HOME}/origin-ci-tool/latest/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
+latest=&#34;$( readlink &#34;${HOME}/origin-ci-tool/latest&#34; )&#34;
+touch &#34;${latest}&#34;
+cp &#34;${latest}/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
 cat &gt;&gt; &#34;${WORKSPACE}/activate&#34; &lt;&lt;EOF
 export OCT_CONFIG_HOME=&#34;${WORKSPACE}/.config&#34;
 EOF

--- a/generated/test_branch_origin_extended_networking_minimal.xml
+++ b/generated/test_branch_origin_extended_networking_minimal.xml
@@ -39,7 +39,9 @@
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 echo &#34;########## STARTING STAGE: INSTALL THE ORIGIN-CI-TOOL ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE ORIGIN-CI-TOOL ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-cp &#34;${HOME}/origin-ci-tool/latest/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
+latest=&#34;$( readlink &#34;${HOME}/origin-ci-tool/latest&#34; )&#34;
+touch &#34;${latest}&#34;
+cp &#34;${latest}/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
 cat &gt;&gt; &#34;${WORKSPACE}/activate&#34; &lt;&lt;EOF
 export OCT_CONFIG_HOME=&#34;${WORKSPACE}/.config&#34;
 EOF

--- a/generated/test_branch_origin_integration.xml
+++ b/generated/test_branch_origin_integration.xml
@@ -39,7 +39,9 @@
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 echo &#34;########## STARTING STAGE: INSTALL THE ORIGIN-CI-TOOL ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE ORIGIN-CI-TOOL ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-cp &#34;${HOME}/origin-ci-tool/latest/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
+latest=&#34;$( readlink &#34;${HOME}/origin-ci-tool/latest&#34; )&#34;
+touch &#34;${latest}&#34;
+cp &#34;${latest}/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
 cat &gt;&gt; &#34;${WORKSPACE}/activate&#34; &lt;&lt;EOF
 export OCT_CONFIG_HOME=&#34;${WORKSPACE}/.config&#34;
 EOF

--- a/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
+++ b/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
@@ -54,7 +54,9 @@
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 echo &#34;########## STARTING STAGE: INSTALL THE ORIGIN-CI-TOOL ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE ORIGIN-CI-TOOL ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-cp &#34;${HOME}/origin-ci-tool/latest/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
+latest=&#34;$( readlink &#34;${HOME}/origin-ci-tool/latest&#34; )&#34;
+touch &#34;${latest}&#34;
+cp &#34;${latest}/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
 cat &gt;&gt; &#34;${WORKSPACE}/activate&#34; &lt;&lt;EOF
 export OCT_CONFIG_HOME=&#34;${WORKSPACE}/.config&#34;
 EOF

--- a/generated/test_pull_request_origin_check.xml
+++ b/generated/test_pull_request_origin_check.xml
@@ -44,7 +44,9 @@
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 echo &#34;########## STARTING STAGE: INSTALL THE ORIGIN-CI-TOOL ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE ORIGIN-CI-TOOL ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-cp &#34;${HOME}/origin-ci-tool/latest/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
+latest=&#34;$( readlink &#34;${HOME}/origin-ci-tool/latest&#34; )&#34;
+touch &#34;${latest}&#34;
+cp &#34;${latest}/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
 cat &gt;&gt; &#34;${WORKSPACE}/activate&#34; &lt;&lt;EOF
 export OCT_CONFIG_HOME=&#34;${WORKSPACE}/.config&#34;
 EOF

--- a/generated/test_pull_request_origin_extended.xml
+++ b/generated/test_pull_request_origin_extended.xml
@@ -54,7 +54,9 @@
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 echo &#34;########## STARTING STAGE: INSTALL THE ORIGIN-CI-TOOL ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE ORIGIN-CI-TOOL ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-cp &#34;${HOME}/origin-ci-tool/latest/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
+latest=&#34;$( readlink &#34;${HOME}/origin-ci-tool/latest&#34; )&#34;
+touch &#34;${latest}&#34;
+cp &#34;${latest}/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
 cat &gt;&gt; &#34;${WORKSPACE}/activate&#34; &lt;&lt;EOF
 export OCT_CONFIG_HOME=&#34;${WORKSPACE}/.config&#34;
 EOF

--- a/generated/test_pull_request_origin_extended_conformance.xml
+++ b/generated/test_pull_request_origin_extended_conformance.xml
@@ -44,7 +44,9 @@
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 echo &#34;########## STARTING STAGE: INSTALL THE ORIGIN-CI-TOOL ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE ORIGIN-CI-TOOL ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-cp &#34;${HOME}/origin-ci-tool/latest/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
+latest=&#34;$( readlink &#34;${HOME}/origin-ci-tool/latest&#34; )&#34;
+touch &#34;${latest}&#34;
+cp &#34;${latest}/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
 cat &gt;&gt; &#34;${WORKSPACE}/activate&#34; &lt;&lt;EOF
 export OCT_CONFIG_HOME=&#34;${WORKSPACE}/.config&#34;
 EOF

--- a/generated/test_pull_request_origin_extended_conformance_gce.xml
+++ b/generated/test_pull_request_origin_extended_conformance_gce.xml
@@ -77,7 +77,9 @@ See also:
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 echo &#34;########## STARTING STAGE: INSTALL THE ORIGIN-CI-TOOL ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE ORIGIN-CI-TOOL ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-cp &#34;${HOME}/origin-ci-tool/latest/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
+latest=&#34;$( readlink &#34;${HOME}/origin-ci-tool/latest&#34; )&#34;
+touch &#34;${latest}&#34;
+cp &#34;${latest}/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
 cat &gt;&gt; &#34;${WORKSPACE}/activate&#34; &lt;&lt;EOF
 export OCT_CONFIG_HOME=&#34;${WORKSPACE}/.config&#34;
 EOF

--- a/generated/test_pull_request_origin_extended_conformance_install.xml
+++ b/generated/test_pull_request_origin_extended_conformance_install.xml
@@ -54,7 +54,9 @@
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 echo &#34;########## STARTING STAGE: INSTALL THE ORIGIN-CI-TOOL ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE ORIGIN-CI-TOOL ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-cp &#34;${HOME}/origin-ci-tool/latest/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
+latest=&#34;$( readlink &#34;${HOME}/origin-ci-tool/latest&#34; )&#34;
+touch &#34;${latest}&#34;
+cp &#34;${latest}/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
 cat &gt;&gt; &#34;${WORKSPACE}/activate&#34; &lt;&lt;EOF
 export OCT_CONFIG_HOME=&#34;${WORKSPACE}/.config&#34;
 EOF

--- a/generated/test_pull_request_origin_extended_conformance_install_update.xml
+++ b/generated/test_pull_request_origin_extended_conformance_install_update.xml
@@ -54,7 +54,9 @@
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 echo &#34;########## STARTING STAGE: INSTALL THE ORIGIN-CI-TOOL ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE ORIGIN-CI-TOOL ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-cp &#34;${HOME}/origin-ci-tool/latest/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
+latest=&#34;$( readlink &#34;${HOME}/origin-ci-tool/latest&#34; )&#34;
+touch &#34;${latest}&#34;
+cp &#34;${latest}/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
 cat &gt;&gt; &#34;${WORKSPACE}/activate&#34; &lt;&lt;EOF
 export OCT_CONFIG_HOME=&#34;${WORKSPACE}/.config&#34;
 EOF

--- a/generated/test_pull_request_origin_extended_networking_minimal.xml
+++ b/generated/test_pull_request_origin_extended_networking_minimal.xml
@@ -44,7 +44,9 @@
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 echo &#34;########## STARTING STAGE: INSTALL THE ORIGIN-CI-TOOL ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE ORIGIN-CI-TOOL ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-cp &#34;${HOME}/origin-ci-tool/latest/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
+latest=&#34;$( readlink &#34;${HOME}/origin-ci-tool/latest&#34; )&#34;
+touch &#34;${latest}&#34;
+cp &#34;${latest}/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
 cat &gt;&gt; &#34;${WORKSPACE}/activate&#34; &lt;&lt;EOF
 export OCT_CONFIG_HOME=&#34;${WORKSPACE}/.config&#34;
 EOF

--- a/generated/test_pull_request_origin_integration.xml
+++ b/generated/test_pull_request_origin_integration.xml
@@ -44,7 +44,9 @@
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 echo &#34;########## STARTING STAGE: INSTALL THE ORIGIN-CI-TOOL ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE ORIGIN-CI-TOOL ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-cp &#34;${HOME}/origin-ci-tool/latest/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
+latest=&#34;$( readlink &#34;${HOME}/origin-ci-tool/latest&#34; )&#34;
+touch &#34;${latest}&#34;
+cp &#34;${latest}/bin/activate&#34; &#34;${WORKSPACE}/activate&#34;
 cat &gt;&gt; &#34;${WORKSPACE}/activate&#34; &lt;&lt;EOF
 export OCT_CONFIG_HOME=&#34;${WORKSPACE}/.config&#34;
 EOF


### PR DESCRIPTION
The logic to prune installation directories on the Jenkins master looks
at the last modified date; when the installation is more than a day old
and is not the installation pointed to with the `/latest` symlink, the
job removes it. This algorithm can crash jobs, however, if the latest
installation is very old and a new one is made, then the prune job runs.
In this case, a job could have been started before the upgrade and would
be using the old version, but the prune job would not know this. If we
touch the installation directory we are using in the job when we use it,
we keep it "new" and the prune job will only remove installations that
have not been used for a day, which is reasonable as no job should run
that long.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>