### PR TITLE
Preserve 2 old PR build RPM repos to prevent flakes

### DIFF
--- a/config/test_cases/test_branch_origin_extended_conformance_gce.yml
+++ b/config/test_cases/test_branch_origin_extended_conformance_gce.yml
@@ -65,7 +65,7 @@ extensions:
         gsutil -m cp -r artifacts/rpms "gs://${location}"
         if [[ -n "${ORIGIN_PULL_ID:-}" ]]; then
           # if we've built this PR before, remove older rpm artifact directories
-          out="$( gsutil ls -d "gs://origin-ci-test/pr-logs/${ORIGIN_PULL_ID}/${JOB_NAME}/*/artifacts/rpms" | sort -n -t / -k 7 | head -n -1 )"
+          out="$( gsutil ls -d "gs://origin-ci-test/pr-logs/${ORIGIN_PULL_ID}/${JOB_NAME}/*/artifacts/rpms" | sort -n -t / -k 7 | head -n -2 )"
           if [[ -n "${out}" ]]; then
             echo "${out}" | xargs -L 1 gsutil rm -rf
           fi

--- a/generated/test_branch_origin_extended_conformance_gce.xml
+++ b/generated/test_branch_origin_extended_conformance_gce.xml
@@ -169,7 +169,7 @@ rsync --archive --omit-dir-times --rsh &#34;ssh -F ./.config/origin-ci-tool/inve
 gsutil -m cp -r artifacts/rpms &#34;gs://${location}&#34;
 if [[ -n &#34;${ORIGIN_PULL_ID:-}&#34; ]]; then
   # if we&#39;ve built this PR before, remove older rpm artifact directories
-  out=&#34;$( gsutil ls -d &#34;gs://origin-ci-test/pr-logs/${ORIGIN_PULL_ID}/${JOB_NAME}/*/artifacts/rpms&#34; | sort -n -t / -k 7 | head -n -1 )&#34;
+  out=&#34;$( gsutil ls -d &#34;gs://origin-ci-test/pr-logs/${ORIGIN_PULL_ID}/${JOB_NAME}/*/artifacts/rpms&#34; | sort -n -t / -k 7 | head -n -2 )&#34;
   if [[ -n &#34;${out}&#34; ]]; then
     echo &#34;${out}&#34; | xargs -L 1 gsutil rm -rf
   fi

--- a/generated/test_pull_request_origin_extended_conformance_gce.xml
+++ b/generated/test_pull_request_origin_extended_conformance_gce.xml
@@ -179,7 +179,7 @@ rsync --archive --omit-dir-times --rsh &#34;ssh -F ./.config/origin-ci-tool/inve
 gsutil -m cp -r artifacts/rpms &#34;gs://${location}&#34;
 if [[ -n &#34;${ORIGIN_PULL_ID:-}&#34; ]]; then
   # if we&#39;ve built this PR before, remove older rpm artifact directories
-  out=&#34;$( gsutil ls -d &#34;gs://origin-ci-test/pr-logs/${ORIGIN_PULL_ID}/${JOB_NAME}/*/artifacts/rpms&#34; | sort -n -t / -k 7 | head -n -1 )&#34;
+  out=&#34;$( gsutil ls -d &#34;gs://origin-ci-test/pr-logs/${ORIGIN_PULL_ID}/${JOB_NAME}/*/artifacts/rpms&#34; | sort -n -t / -k 7 | head -n -2 )&#34;
   if [[ -n &#34;${out}&#34; ]]; then
     echo &#34;${out}&#34; | xargs -L 1 gsutil rm -rf
   fi


### PR DESCRIPTION
By preserving two, closely sequenced PR jobs executed against the same
run don't fail.