### PR TITLE
Determine install/upgrade version script

### DIFF
--- a/config/test_cases/test_branch_origin_extended_conformance_install_update.yml
+++ b/config/test_cases/test_branch_origin_extended_conformance_install_update.yml
@@ -6,45 +6,123 @@ extensions:
     - name: "aos-cd-jobs"
   actions:
     - type: "script"
-      title: "install origin GA and update"
+      title: "determine the release commit for origin images"
+      repository: "origin"
+      script: |-
+        jobs_repo="/data/src/github.com/openshift/aos-cd-jobs/"
+        git log -1 --pretty=%h > "${jobs_repo}/ORIGIN_COMMIT"
+        source hack/lib/init.sh
+        os::build::rpm::format_nvra > "${jobs_repo}/ORIGIN_BUILT_VERSION"
+    - type: "script"
+      title: "build an openshift-ansible release"
+      repository: "openshift-ansible"
+      script: |-
+        tito_tmp_dir="tito"
+        mkdir -p "${tito_tmp_dir}"
+        tito tag --offline --accept-auto-changelog
+        tito build --output="${tito_tmp_dir}" --rpm --test --offline --quiet
+        createrepo "${tito_tmp_dir}/noarch"
+        cat << EOR > ./openshift-ansible-local-release.repo
+        [openshift-ansible-local-release]
+        baseurl = file://$( pwd )/${tito_tmp_dir}/noarch
+        gpgcheck = 0
+        name = OpenShift Ansible Release from Local Source
+        EOR
+        sudo cp ./openshift-ansible-local-release.repo /etc/yum.repos.d
+        basename "${tito_tmp_dir}"/noarch/atomic-openshift-utils*.rpm .rpm > /data/src/github.com/openshift/aos-cd-jobs/OPENSHIFT_ANSIBLE_BUILT_VERSION
+    - type: "script"
+      title: "install ansible atomic-openshift-utils"
       repository: "aos-cd-jobs"
       script: |-
         pkg_name="origin"
-        sudo yum install -y ansible-2.2.0.0
         git checkout sjb
-        general_yml_file=inventory/group_vars/OSEv3/general.yml
-        if [ $pkg_name = "atomic-openshift" ]
+        echo $pkg_name > PKG_NAME
+        echo "openshift-ansible openshift-ansible-callback-plugins openshift-ansible-docs openshift-ansible-filter-plugins openshift-ansible-lookup-plugins openshift-ansible-playbooks openshift-ansible-roles" > OPENSHIFT_ANSIBLE_PKGS
+        sudo python hack/determine_install_upgrade_version.py $( cat OPENSHIFT_ANSIBLE_BUILT_VERSION ) > OPENSHIFT_ANSIBLE_VARS
+        source OPENSHIFT_ANSIBLE_VARS
+        versioned_packages_to_install=""
+        if [[ ${ATOMIC_OPENSHIFT_UTILS_INSTALL_MINOR_VERSION} -le 4 ]]
         then
-          sed -i "s/deployment_type:.*/deployment_type: \"openshift-enterprise\" /g" $general_yml_file
+          sudo yum erase -y ansible
+          versioned_packages_to_install="ansible-2.2.0.0"
         fi
-        openshift_pkgs=( $pkg_name openshift-ansible-playbooks )
-        for pkg in "${openshift_pkgs[@]}"
+        packages_to_install=( $( cat ./OPENSHIFT_ANSIBLE_PKGS ) )
+        for pkg in "${packages_to_install[@]}"
         do
-          sudo python hack/get_available_pkgs.py $pkg > "all_${pkg}_versions"
-          sed -i '/^[a-zA-Z]/d' all_${pkg}_versions
-          sort -u -o all_${pkg}_versions all_${pkg}_versions
-          cat all_${pkg}_versions
+          versioned_packages_to_install+=" ${pkg}-${ATOMIC_OPENSHIFT_UTILS_INSTALL_VERSION}"
         done
-        current_openshift_version=$(tail -n1 all_${pkg_name}_versions | awk -F'-' '{print $1}')
-        echo "current version -> $current_openshift_version"
-        current_openshift_major_version=$(echo $current_openshift_version | awk -F'.' '{print $1}')
-        current_openshift_minor_version=$(echo $current_openshift_version | awk -F'.' '{print $2}')
-        latest_version=$current_openshift_major_version.$(($current_openshift_minor_version + 1))
-        all_current_openshift_versions_array=($(cat "all_${pkg_name}_versions" | grep "$current_openshift_major_version.$current_openshift_minor_version"))
-        all_current_openshift_ansible_versions_array=($(cat "all_openshift-ansible-playbooks_versions" | grep "^3.$current_openshift_minor_version"))
-        set_openshift_version=$(echo ${all_current_openshift_versions_array[0]})
-        echo "=== Installing openshift-ansible-${all_current_openshift_ansible_versions_array[0]} ==="
-        sudo yum install -y openshift-ansible-playbooks-${all_current_openshift_ansible_versions_array[0]}
-        echo "=== Installing ${pkg_name}-${set_openshift_version} ==="
-        ansible-playbook --become --become-user root --connection local -i inventory/ /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
-        ansible-playbook --become --become-user root --connection local -i inventory/ /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml -e set_openshift_version="${set_openshift_version}"
-        if [ ${#all_current_openshift_versions_array[@]} -gt 1 ]
+        echo "=== Installing atomic-openshift-utils-${ATOMIC_OPENSHIFT_UTILS_INSTALL_VERSION} packages ==="
+        sudo yum install -y ${versioned_packages_to_install}
+    - type: "script"
+      title: "install Ansible plugins"
+      repository: "origin"
+      script: |-
+        sudo yum install -y python-pip
+        sudo pip install junit_xml
+        sudo chmod o+rw /etc/environment
+        echo "ANSIBLE_JUNIT_DIR=$( pwd )/_output/tests/ansible_junit" >> /etc/environment
+        sudo mkdir -p /usr/share/ansible/plugins/callback
+        for plugin in 'default_with_output_lists' 'generate_junit'; do
+           wget "https://raw.githubusercontent.com/openshift/origin-ci-tool/master/oct/ansible/oct/callback_plugins/${plugin}.py"
+           sudo mv "${plugin}.py" /usr/share/ansible/plugins/callback
+        done
+        sudo sed -r -i -e 's/^#?stdout_callback.*/stdout_callback = default_with_output_lists/' -e 's/^#?callback_whitelist.*/callback_whitelist = generate_junit/' /etc/ansible/ansible.cfg
+    - type: "script"
+      title: "install origin GA and update"
+      repository: "aos-cd-jobs"
+      script: |-
+        pkg_name=$( cat ./PKG_NAME )
+        if [[ "${pkg_name}" == "origin" ]]; then
+            deployment_type="origin"
+        elif [[ "${pkg_name}" == "atomic-openshift" ]]; then
+            deployment_type="openshift-enterprise"
+        else
+            echo "Can't determine deployment type"
+            exit 1
+        fi
+        echo "${deployment_type}" > DEPLOYMENT_TYPE
+        sudo python hack/determine_install_upgrade_version.py $( cat ORIGIN_BUILT_VERSION ) > ORIGIN_VARS
+        source ORIGIN_VARS
+        source OPENSHIFT_ANSIBLE_VARS
+        echo "=== Installing ${pkg_name}-${ORIGIN_INSTALL_VERSION} ==="
+        ansible-playbook  -vv                \
+                          --become           \
+                          --become-user root \
+                          --connection local \
+                          -i inventory/      \
+                          /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml \
+                          -e deployment_type=$( cat ./DEPLOYMENT_TYPE)
+        # Remove "enable_excluders" variable after openshift-ansbile pkgs are rebuilded with https://github.com/openshift/openshift-ansible/pull/3788
+        ansible-playbook  -vv                \
+                          --become           \
+                          --become-user root \
+                          --connection local \
+                          -i inventory/      \
+                          /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml \
+                          -e openshift_pkg_version="-${ORIGIN_INSTALL_VERSION}"         \
+                          -e deployment_type=$( cat ./DEPLOYMENT_TYPE)                  \
+                          -e enable_excluders=false
+        if [[ -v ORIGIN_UPGRADE_VERSION  && -v ATOMIC_OPENSHIFT_UTILS_UPGRADE_VERSION ]]
         then
-          echo "=== Updating openshift-ansible to openshift-ansible-${all_current_openshift_ansible_versions_array[${#all_current_openshift_ansible_versions_array[@]}-1]} ==="
-          sudo yum erase -y openshift-ansible
-          sudo yum install -y openshift-ansible-playbooks-${all_current_openshift_ansible_versions_array[${#all_current_openshift_ansible_versions_array[@]}-1]}
-          echo "=== Updating ${pkg_name} to ${pkg_name}-${all_current_openshift_versions_array[${#all_current_openshift_versions_array[@]}-1]} ==="
-          ansible-playbook --become --become-user root --connection local --inventory inventory/ /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_${current_openshift_minor_version}/upgrade.yml -e openshift_upgrade_target="${all_current_openshift_versions_array[${#all_current_openshift_versions_array[@]}-1]}"
+          echo "=== Updating atomic-openshift-utils-${ATOMIC_OPENSHIFT_UTILS_UPGRADE_VERSION} ==="
+          versioned_packages_to_install=""
+          packages_to_install=( $( cat ./OPENSHIFT_ANSIBLE_PKGS ) )
+          for pkg in "${packages_to_install[@]}"
+          do
+            versioned_packages_to_install+=" ${pkg}-${ATOMIC_OPENSHIFT_UTILS_UPGRADE_VERSION}"
+          done
+          sudo yum upgrade -y ${versioned_packages_to_install}
+          echo "=== Updating ${pkg_name} to ${ORIGIN_UPGRADE_VERSION} ==="
+          upgrade_playbook="/usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_${ORIGIN_UPGRADE_MINOR_VERSION}/upgrade.yml"
+          ansible-playbook  -vv                    \
+                            --become               \
+                            --become-user root     \
+                            --connection local     \
+                            --inventory inventory/ \
+                            "${upgrade_playbook}"  \
+                            -e openshift_pkg_version="-${ORIGIN_UPGRADE_VERSION}" \
+                            -e deployment_type=$( cat ./DEPLOYMENT_TYPE)          \
+                            -e oreg_url='openshift/origin-${component}:'"${ORIGIN_UPGRADE_VERSION_PKG_VERSION}"
         fi
     - type: "script"
       title: "build an origin release"
@@ -57,45 +135,34 @@ extensions:
         sed -i 's|go/src|data/src|' _output/local/releases/rpms/origin-local-release.repo
         sudo cp _output/local/releases/rpms/origin-local-release.repo /etc/yum.repos.d/
     - type: "script"
-      title: "build an openshift-ansible release"
-      repository: "openshift-ansible"
-      script: |-
-        tito_tmp_dir="tito"
-        mkdir -p "${tito_tmp_dir}"
-        tito tag --offline --use-version 3.6.0 --accept-auto-changelog
-        tito build --output="${tito_tmp_dir}" --rpm --test --offline --quiet
-        createrepo "${tito_tmp_dir}/noarch"
-        cat << EOR > ./openshift-ansible-local-release.repo
-        [openshift-ansible-local-release]
-        baseurl = file://$( pwd )/${tito_tmp_dir}/noarch
-        gpgcheck = 0
-        name = OpenShift Ansible Release from Local Source
-        EOR
-        sudo cp ./openshift-ansible-local-release.repo /etc/yum.repos.d
-    - type: "script"
-      title: "install the openshift-ansible release"
-      script: |-
-        sudo yum install -y atomic-openshift-utils
-    - type: "script"
-      title: "check out the correct branch of aos-cd-jobs"
+      title: "upgrade openshift-ansible to release"
       repository: "aos-cd-jobs"
       script: |-
-        git checkout sjb
+        source ORIGIN_VARS
+        source OPENSHIFT_ANSIBLE_VARS
+        versioned_packages_to_upgrade=""
+        packages_to_upgrade="$( cat ./OPENSHIFT_ANSIBLE_PKGS )"
+        for pkg in "${packages_to_upgrade[@]}"
+        do
+          versioned_packages_to_upgrade+=" ${pkg}-${ATOMIC_OPENSHIFT_UTILS_UPGRADE_RELEASE_VERSION}"
+        done
+        sudo yum upgrade -y ${versioned_packages_to_upgrade}
     - type: "script"
-      title: "determine the release commit for origin images"
-      repository: "origin"
-      script: |-
-        git log -1 --pretty=%h >> /data/src/github.com/openshift/aos-cd-jobs/ORIGIN_COMMIT
-    - type: "script"
-      title: "update origin"
+      title: "update origin to release"
       repository: "aos-cd-jobs"
       script: |-
-        sudo python hack/get_available_pkgs.py origin > "all_origin_versions"
-        sed -i '/^[a-zA-Z]/d' all_origin_versions
-        sort -u -o all_origin_versions all_origin_versions
-        upgrade_version=$(tail -1 all_origin_versions)
-        upgrade_minor_version=$(echo "${upgrade_version}" | awk -F'.' '{print $2}')
-        ansible-playbook --become --become-user root --connection local --inventory inventory/ /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_${upgrade_minor_version}/upgrade.yml -e openshift_image_tag="$( cat ./ORIGIN_COMMIT )" -e openshift_upgrade_target="${upgrade_version}"
+        pkg_name=$( cat ./PKG_NAME )
+        source ORIGIN_VARS
+        upgrade_playbook="/usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_${ORIGIN_UPGRADE_RELEASE_MINOR_VERSION}/upgrade.yml"
+        ansible-playbook  -vv                    \
+                          --become               \
+                          --become-user root     \
+                          --connection local     \
+                          --inventory inventory/ \
+                           "${upgrade_playbook}" \
+                          -e openshift_pkg_version="-${ORIGIN_UPGRADE_RELEASE_VERSION}" \
+                          -e deployment_type=$( cat ./DEPLOYMENT_TYPE) \
+                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )"
     - type: "script"
       title: "expose the kubeconfig"
       script: |-
@@ -106,6 +173,9 @@ extensions:
       repository: "origin"
       script: |-
         KUBECONFIG=/etc/origin/master/admin.kubeconfig TEST_ONLY='true' JUNIT_REPORT='true' make test-extended SUITE=conformance
+  generated_artifacts:
+    origin_package_history.log: "sudo yum history info origin"
+    openshift_ansible_package_history.log: "sudo yum history info openshift-ansible"
   system_journals:
     - origin-master.service
     - origin-node.service

--- a/generated/test_branch_origin_extended_conformance_install_update.xml
+++ b/generated/test_branch_origin_extended_conformance_install_update.xml
@@ -115,48 +115,154 @@ EOF
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-echo &#34;########## STARTING STAGE: INSTALL ORIGIN GA AND UPDATE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL ORIGIN GA AND UPDATE ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+echo &#34;########## STARTING STAGE: DETERMINE THE RELEASE COMMIT FOR ORIGIN IMAGES ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: DETERMINE THE RELEASE COMMIT FOR ORIGIN IMAGES ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+{
+cat &lt;&lt;EOF
+sudo su origin
+set -o errexit -o nounset -o pipefail -o xtrace
+cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
+jobs_repo=&#34;/data/src/github.com/openshift/aos-cd-jobs/&#34;
+git log -1 --pretty=%h &gt; &#34;\${jobs_repo}/ORIGIN_COMMIT&#34;
+source hack/lib/init.sh
+os::build::rpm::format_nvra &gt; &#34;\${jobs_repo}/ORIGIN_BUILT_VERSION&#34;
+EOF
+} | ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel</command>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
+          <command>#!/bin/bash
+echo &#34;########## STARTING STAGE: BUILD AN OPENSHIFT-ANSIBLE RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: BUILD AN OPENSHIFT-ANSIBLE RELEASE ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+{
+cat &lt;&lt;EOF
+sudo su origin
+set -o errexit -o nounset -o pipefail -o xtrace
+cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
+tito_tmp_dir=&#34;tito&#34;
+mkdir -p &#34;\${tito_tmp_dir}&#34;
+tito tag --offline --accept-auto-changelog
+tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
+createrepo &#34;\${tito_tmp_dir}/noarch&#34;
+cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo
+[openshift-ansible-local-release]
+baseurl = file://\$( pwd )/\${tito_tmp_dir}/noarch
+gpgcheck = 0
+name = OpenShift Ansible Release from Local Source
+EOR
+sudo cp ./openshift-ansible-local-release.repo /etc/yum.repos.d
+basename &#34;\${tito_tmp_dir}&#34;/noarch/atomic-openshift-utils*.rpm .rpm &gt; /data/src/github.com/openshift/aos-cd-jobs/OPENSHIFT_ANSIBLE_BUILT_VERSION
+EOF
+} | ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel</command>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
+          <command>#!/bin/bash
+echo &#34;########## STARTING STAGE: INSTALL ANSIBLE ATOMIC-OPENSHIFT-UTILS ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL ANSIBLE ATOMIC-OPENSHIFT-UTILS ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 {
 cat &lt;&lt;EOF
 sudo su origin
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
 pkg_name=&#34;origin&#34;
-sudo yum install -y ansible-2.2.0.0
 git checkout sjb
-general_yml_file=inventory/group_vars/OSEv3/general.yml
-if [ \$pkg_name = &#34;atomic-openshift&#34; ]
+echo \$pkg_name &gt; PKG_NAME
+echo &#34;openshift-ansible openshift-ansible-callback-plugins openshift-ansible-docs openshift-ansible-filter-plugins openshift-ansible-lookup-plugins openshift-ansible-playbooks openshift-ansible-roles&#34; &gt; OPENSHIFT_ANSIBLE_PKGS
+sudo python hack/determine_install_upgrade_version.py \$( cat OPENSHIFT_ANSIBLE_BUILT_VERSION ) &gt; OPENSHIFT_ANSIBLE_VARS
+source OPENSHIFT_ANSIBLE_VARS
+versioned_packages_to_install=&#34;&#34;
+if [[ \${ATOMIC_OPENSHIFT_UTILS_INSTALL_MINOR_VERSION} -le 4 ]]
 then
-  sed -i &#34;s/deployment_type:.*/deployment_type: \&#34;openshift-enterprise\&#34; /g&#34; \$general_yml_file
+  sudo yum erase -y ansible
+  versioned_packages_to_install=&#34;ansible-2.2.0.0&#34;
 fi
-openshift_pkgs=( \$pkg_name openshift-ansible-playbooks )
-for pkg in &#34;\${openshift_pkgs[@]}&#34;
+packages_to_install=( \$( cat ./OPENSHIFT_ANSIBLE_PKGS ) )
+for pkg in &#34;\${packages_to_install[@]}&#34;
 do
-  sudo python hack/get_available_pkgs.py \$pkg &gt; &#34;all_\${pkg}_versions&#34;
-  sed -i &#39;/^[a-zA-Z]/d&#39; all_\${pkg}_versions
-  sort -u -o all_\${pkg}_versions all_\${pkg}_versions
-  cat all_\${pkg}_versions
+  versioned_packages_to_install+=&#34; \${pkg}-\${ATOMIC_OPENSHIFT_UTILS_INSTALL_VERSION}&#34;
 done
-current_openshift_version=\$(tail -n1 all_\${pkg_name}_versions | awk -F&#39;-&#39; &#39;{print \$1}&#39;)
-echo &#34;current version -&gt; \$current_openshift_version&#34;
-current_openshift_major_version=\$(echo \$current_openshift_version | awk -F&#39;.&#39; &#39;{print \$1}&#39;)
-current_openshift_minor_version=\$(echo \$current_openshift_version | awk -F&#39;.&#39; &#39;{print \$2}&#39;)
-latest_version=\$current_openshift_major_version.\$((\$current_openshift_minor_version + 1))
-all_current_openshift_versions_array=(\$(cat &#34;all_\${pkg_name}_versions&#34; | grep &#34;\$current_openshift_major_version.\$current_openshift_minor_version&#34;))
-all_current_openshift_ansible_versions_array=(\$(cat &#34;all_openshift-ansible-playbooks_versions&#34; | grep &#34;^3.\$current_openshift_minor_version&#34;))
-set_openshift_version=\$(echo \${all_current_openshift_versions_array[0]})
-echo &#34;=== Installing openshift-ansible-\${all_current_openshift_ansible_versions_array[0]} ===&#34;
-sudo yum install -y openshift-ansible-playbooks-\${all_current_openshift_ansible_versions_array[0]}
-echo &#34;=== Installing \${pkg_name}-\${set_openshift_version} ===&#34;
-ansible-playbook --become --become-user root --connection local -i inventory/ /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
-ansible-playbook --become --become-user root --connection local -i inventory/ /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml -e set_openshift_version=&#34;\${set_openshift_version}&#34;
-if [ \${#all_current_openshift_versions_array[@]} -gt 1 ]
+echo &#34;=== Installing atomic-openshift-utils-\${ATOMIC_OPENSHIFT_UTILS_INSTALL_VERSION} packages ===&#34;
+sudo yum install -y \${versioned_packages_to_install}
+EOF
+} | ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel</command>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
+          <command>#!/bin/bash
+echo &#34;########## STARTING STAGE: INSTALL ANSIBLE PLUGINS ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL ANSIBLE PLUGINS ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+{
+cat &lt;&lt;EOF
+sudo su origin
+set -o errexit -o nounset -o pipefail -o xtrace
+cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
+sudo yum install -y python-pip
+sudo pip install junit_xml
+sudo chmod o+rw /etc/environment
+echo &#34;ANSIBLE_JUNIT_DIR=\$( pwd )/_output/tests/ansible_junit&#34; &gt;&gt; /etc/environment
+sudo mkdir -p /usr/share/ansible/plugins/callback
+for plugin in &#39;default_with_output_lists&#39; &#39;generate_junit&#39;; do
+   wget &#34;https://raw.githubusercontent.com/openshift/origin-ci-tool/master/oct/ansible/oct/callback_plugins/\${plugin}.py&#34;
+   sudo mv &#34;\${plugin}.py&#34; /usr/share/ansible/plugins/callback
+done
+sudo sed -r -i -e &#39;s/^#?stdout_callback.*/stdout_callback = default_with_output_lists/&#39; -e &#39;s/^#?callback_whitelist.*/callback_whitelist = generate_junit/&#39; /etc/ansible/ansible.cfg
+EOF
+} | ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel</command>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
+          <command>#!/bin/bash
+echo &#34;########## STARTING STAGE: INSTALL ORIGIN GA AND UPDATE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL ORIGIN GA AND UPDATE ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+{
+cat &lt;&lt;EOF
+sudo su origin
+set -o errexit -o nounset -o pipefail -o xtrace
+cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
+pkg_name=\$( cat ./PKG_NAME )
+if [[ &#34;\${pkg_name}&#34; == &#34;origin&#34; ]]; then
+    deployment_type=&#34;origin&#34;
+elif [[ &#34;\${pkg_name}&#34; == &#34;atomic-openshift&#34; ]]; then
+    deployment_type=&#34;openshift-enterprise&#34;
+else
+    echo &#34;Can&#39;t determine deployment type&#34;
+    exit 1
+fi
+echo &#34;\${deployment_type}&#34; &gt; DEPLOYMENT_TYPE
+sudo python hack/determine_install_upgrade_version.py \$( cat ORIGIN_BUILT_VERSION ) &gt; ORIGIN_VARS
+source ORIGIN_VARS
+source OPENSHIFT_ANSIBLE_VARS
+echo &#34;=== Installing \${pkg_name}-\${ORIGIN_INSTALL_VERSION} ===&#34;
+ansible-playbook  -vv                \
+                  --become           \
+                  --become-user root \
+                  --connection local \
+                  -i inventory/      \
+                  /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml \
+                  -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)
+# Remove &#34;enable_excluders&#34; variable after openshift-ansbile pkgs are rebuilded with https://github.com/openshift/openshift-ansible/pull/3788
+ansible-playbook  -vv                \
+                  --become           \
+                  --become-user root \
+                  --connection local \
+                  -i inventory/      \
+                  /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml \
+                  -e openshift_pkg_version=&#34;-\${ORIGIN_INSTALL_VERSION}&#34;         \
+                  -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)                  \
+                  -e enable_excluders=false
+if [[ -v ORIGIN_UPGRADE_VERSION  &amp;&amp; -v ATOMIC_OPENSHIFT_UTILS_UPGRADE_VERSION ]]
 then
-  echo &#34;=== Updating openshift-ansible to openshift-ansible-\${all_current_openshift_ansible_versions_array[\${#all_current_openshift_ansible_versions_array[@]}-1]} ===&#34;
-  sudo yum erase -y openshift-ansible
-  sudo yum install -y openshift-ansible-playbooks-\${all_current_openshift_ansible_versions_array[\${#all_current_openshift_ansible_versions_array[@]}-1]}
-  echo &#34;=== Updating \${pkg_name} to \${pkg_name}-\${all_current_openshift_versions_array[\${#all_current_openshift_versions_array[@]}-1]} ===&#34;
-  ansible-playbook --become --become-user root --connection local --inventory inventory/ /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_\${current_openshift_minor_version}/upgrade.yml -e openshift_upgrade_target=&#34;\${all_current_openshift_versions_array[\${#all_current_openshift_versions_array[@]}-1]}&#34;
+  echo &#34;=== Updating atomic-openshift-utils-\${ATOMIC_OPENSHIFT_UTILS_UPGRADE_VERSION} ===&#34;
+  versioned_packages_to_install=&#34;&#34;
+  packages_to_install=( \$( cat ./OPENSHIFT_ANSIBLE_PKGS ) )
+  for pkg in &#34;\${packages_to_install[@]}&#34;
+  do
+    versioned_packages_to_install+=&#34; \${pkg}-\${ATOMIC_OPENSHIFT_UTILS_UPGRADE_VERSION}&#34;
+  done
+  sudo yum upgrade -y \${versioned_packages_to_install}
+  echo &#34;=== Updating \${pkg_name} to \${ORIGIN_UPGRADE_VERSION} ===&#34;
+  upgrade_playbook=&#34;/usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_\${ORIGIN_UPGRADE_MINOR_VERSION}/upgrade.yml&#34;
+  ansible-playbook  -vv                    \
+                    --become               \
+                    --become-user root     \
+                    --connection local     \
+                    --inventory inventory/ \
+                    &#34;\${upgrade_playbook}&#34;  \
+                    -e openshift_pkg_version=&#34;-\${ORIGIN_UPGRADE_VERSION}&#34; \
+                    -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)          \
+                    -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\${ORIGIN_UPGRADE_VERSION_PKG_VERSION}&#34;
 fi
 EOF
 } | ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel</command>
@@ -180,77 +286,44 @@ EOF
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-echo &#34;########## STARTING STAGE: BUILD AN OPENSHIFT-ANSIBLE RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: BUILD AN OPENSHIFT-ANSIBLE RELEASE ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-{
-cat &lt;&lt;EOF
-sudo su origin
-set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
-tito_tmp_dir=&#34;tito&#34;
-mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --use-version 3.6.0 --accept-auto-changelog
-tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
-createrepo &#34;\${tito_tmp_dir}/noarch&#34;
-cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo
-[openshift-ansible-local-release]
-baseurl = file://\$( pwd )/\${tito_tmp_dir}/noarch
-gpgcheck = 0
-name = OpenShift Ansible Release from Local Source
-EOR
-sudo cp ./openshift-ansible-local-release.repo /etc/yum.repos.d
-EOF
-} | ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel</command>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-          <command>#!/bin/bash
-echo &#34;########## STARTING STAGE: INSTALL THE OPENSHIFT-ANSIBLE RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE OPENSHIFT-ANSIBLE RELEASE ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-{
-cat &lt;&lt;EOF
-sudo su origin
-set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${HOME}&#34;
-sudo yum install -y atomic-openshift-utils
-EOF
-} | ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel</command>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-          <command>#!/bin/bash
-echo &#34;########## STARTING STAGE: CHECK OUT THE CORRECT BRANCH OF AOS-CD-JOBS ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: CHECK OUT THE CORRECT BRANCH OF AOS-CD-JOBS ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+echo &#34;########## STARTING STAGE: UPGRADE OPENSHIFT-ANSIBLE TO RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: UPGRADE OPENSHIFT-ANSIBLE TO RELEASE ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 {
 cat &lt;&lt;EOF
 sudo su origin
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-git checkout sjb
+source ORIGIN_VARS
+source OPENSHIFT_ANSIBLE_VARS
+versioned_packages_to_upgrade=&#34;&#34;
+packages_to_upgrade=&#34;\$( cat ./OPENSHIFT_ANSIBLE_PKGS )&#34;
+for pkg in &#34;\${packages_to_upgrade[@]}&#34;
+do
+  versioned_packages_to_upgrade+=&#34; \${pkg}-\${ATOMIC_OPENSHIFT_UTILS_UPGRADE_RELEASE_VERSION}&#34;
+done
+sudo yum upgrade -y \${versioned_packages_to_upgrade}
 EOF
 } | ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-echo &#34;########## STARTING STAGE: DETERMINE THE RELEASE COMMIT FOR ORIGIN IMAGES ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: DETERMINE THE RELEASE COMMIT FOR ORIGIN IMAGES ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-{
-cat &lt;&lt;EOF
-sudo su origin
-set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-git log -1 --pretty=%h &gt;&gt; /data/src/github.com/openshift/aos-cd-jobs/ORIGIN_COMMIT
-EOF
-} | ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel</command>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-          <command>#!/bin/bash
-echo &#34;########## STARTING STAGE: UPDATE ORIGIN ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: UPDATE ORIGIN ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+echo &#34;########## STARTING STAGE: UPDATE ORIGIN TO RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: UPDATE ORIGIN TO RELEASE ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 {
 cat &lt;&lt;EOF
 sudo su origin
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-sudo python hack/get_available_pkgs.py origin &gt; &#34;all_origin_versions&#34;
-sed -i &#39;/^[a-zA-Z]/d&#39; all_origin_versions
-sort -u -o all_origin_versions all_origin_versions
-upgrade_version=\$(tail -1 all_origin_versions)
-upgrade_minor_version=\$(echo &#34;\${upgrade_version}&#34; | awk -F&#39;.&#39; &#39;{print \$2}&#39;)
-ansible-playbook --become --become-user root --connection local --inventory inventory/ /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_\${upgrade_minor_version}/upgrade.yml -e openshift_image_tag=&#34;\$( cat ./ORIGIN_COMMIT )&#34; -e openshift_upgrade_target=&#34;\${upgrade_version}&#34;
+pkg_name=\$( cat ./PKG_NAME )
+source ORIGIN_VARS
+upgrade_playbook=&#34;/usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_\${ORIGIN_UPGRADE_RELEASE_MINOR_VERSION}/upgrade.yml&#34;
+ansible-playbook  -vv                    \
+                  --become               \
+                  --become-user root     \
+                  --connection local     \
+                  --inventory inventory/ \
+                   &#34;\${upgrade_playbook}&#34; \
+                  -e openshift_pkg_version=&#34;-\${ORIGIN_UPGRADE_RELEASE_VERSION}&#34; \
+                  -e deployment_type=\$( cat ./DEPLOYMENT_TYPE) \
+                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34;
 EOF
 } | ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel</command>
         </hudson.tasks.Shell>
@@ -306,6 +379,8 @@ ARTIFACT_DIR=&#34;$( pwd )/artifacts/generated&#34;
 rm -rf &#34;${ARTIFACT_DIR}&#34;
 mkdir &#34;${ARTIFACT_DIR}&#34;
 ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo docker version &amp;&amp; sudo docker info &amp;&amp; sudo docker images &amp;&amp; sudo docker ps -a 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/docker.info&#34; || true
+ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo yum history info openshift-ansible 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/openshift_ansible_package_history.log&#34; || true
+ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo yum history info origin 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/origin_package_history.log&#34; || true
 ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo yum list installed 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/installed_packages.log&#34; || true
 ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo ausearch -m avc 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/avc_denials.log&#34; || true
 ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo journalctl _PID=1 --no-pager --all --lines=all 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/pid1.journal&#34; || true

--- a/generated/test_pull_request_origin_extended_conformance_install_update.xml
+++ b/generated/test_pull_request_origin_extended_conformance_install_update.xml
@@ -125,48 +125,154 @@ EOF
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-echo &#34;########## STARTING STAGE: INSTALL ORIGIN GA AND UPDATE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL ORIGIN GA AND UPDATE ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+echo &#34;########## STARTING STAGE: DETERMINE THE RELEASE COMMIT FOR ORIGIN IMAGES ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: DETERMINE THE RELEASE COMMIT FOR ORIGIN IMAGES ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+{
+cat &lt;&lt;EOF
+sudo su origin
+set -o errexit -o nounset -o pipefail -o xtrace
+cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
+jobs_repo=&#34;/data/src/github.com/openshift/aos-cd-jobs/&#34;
+git log -1 --pretty=%h &gt; &#34;\${jobs_repo}/ORIGIN_COMMIT&#34;
+source hack/lib/init.sh
+os::build::rpm::format_nvra &gt; &#34;\${jobs_repo}/ORIGIN_BUILT_VERSION&#34;
+EOF
+} | ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel</command>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
+          <command>#!/bin/bash
+echo &#34;########## STARTING STAGE: BUILD AN OPENSHIFT-ANSIBLE RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: BUILD AN OPENSHIFT-ANSIBLE RELEASE ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+{
+cat &lt;&lt;EOF
+sudo su origin
+set -o errexit -o nounset -o pipefail -o xtrace
+cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
+tito_tmp_dir=&#34;tito&#34;
+mkdir -p &#34;\${tito_tmp_dir}&#34;
+tito tag --offline --accept-auto-changelog
+tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
+createrepo &#34;\${tito_tmp_dir}/noarch&#34;
+cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo
+[openshift-ansible-local-release]
+baseurl = file://\$( pwd )/\${tito_tmp_dir}/noarch
+gpgcheck = 0
+name = OpenShift Ansible Release from Local Source
+EOR
+sudo cp ./openshift-ansible-local-release.repo /etc/yum.repos.d
+basename &#34;\${tito_tmp_dir}&#34;/noarch/atomic-openshift-utils*.rpm .rpm &gt; /data/src/github.com/openshift/aos-cd-jobs/OPENSHIFT_ANSIBLE_BUILT_VERSION
+EOF
+} | ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel</command>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
+          <command>#!/bin/bash
+echo &#34;########## STARTING STAGE: INSTALL ANSIBLE ATOMIC-OPENSHIFT-UTILS ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL ANSIBLE ATOMIC-OPENSHIFT-UTILS ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 {
 cat &lt;&lt;EOF
 sudo su origin
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
 pkg_name=&#34;origin&#34;
-sudo yum install -y ansible-2.2.0.0
 git checkout sjb
-general_yml_file=inventory/group_vars/OSEv3/general.yml
-if [ \$pkg_name = &#34;atomic-openshift&#34; ]
+echo \$pkg_name &gt; PKG_NAME
+echo &#34;openshift-ansible openshift-ansible-callback-plugins openshift-ansible-docs openshift-ansible-filter-plugins openshift-ansible-lookup-plugins openshift-ansible-playbooks openshift-ansible-roles&#34; &gt; OPENSHIFT_ANSIBLE_PKGS
+sudo python hack/determine_install_upgrade_version.py \$( cat OPENSHIFT_ANSIBLE_BUILT_VERSION ) &gt; OPENSHIFT_ANSIBLE_VARS
+source OPENSHIFT_ANSIBLE_VARS
+versioned_packages_to_install=&#34;&#34;
+if [[ \${ATOMIC_OPENSHIFT_UTILS_INSTALL_MINOR_VERSION} -le 4 ]]
 then
-  sed -i &#34;s/deployment_type:.*/deployment_type: \&#34;openshift-enterprise\&#34; /g&#34; \$general_yml_file
+  sudo yum erase -y ansible
+  versioned_packages_to_install=&#34;ansible-2.2.0.0&#34;
 fi
-openshift_pkgs=( \$pkg_name openshift-ansible-playbooks )
-for pkg in &#34;\${openshift_pkgs[@]}&#34;
+packages_to_install=( \$( cat ./OPENSHIFT_ANSIBLE_PKGS ) )
+for pkg in &#34;\${packages_to_install[@]}&#34;
 do
-  sudo python hack/get_available_pkgs.py \$pkg &gt; &#34;all_\${pkg}_versions&#34;
-  sed -i &#39;/^[a-zA-Z]/d&#39; all_\${pkg}_versions
-  sort -u -o all_\${pkg}_versions all_\${pkg}_versions
-  cat all_\${pkg}_versions
+  versioned_packages_to_install+=&#34; \${pkg}-\${ATOMIC_OPENSHIFT_UTILS_INSTALL_VERSION}&#34;
 done
-current_openshift_version=\$(tail -n1 all_\${pkg_name}_versions | awk -F&#39;-&#39; &#39;{print \$1}&#39;)
-echo &#34;current version -&gt; \$current_openshift_version&#34;
-current_openshift_major_version=\$(echo \$current_openshift_version | awk -F&#39;.&#39; &#39;{print \$1}&#39;)
-current_openshift_minor_version=\$(echo \$current_openshift_version | awk -F&#39;.&#39; &#39;{print \$2}&#39;)
-latest_version=\$current_openshift_major_version.\$((\$current_openshift_minor_version + 1))
-all_current_openshift_versions_array=(\$(cat &#34;all_\${pkg_name}_versions&#34; | grep &#34;\$current_openshift_major_version.\$current_openshift_minor_version&#34;))
-all_current_openshift_ansible_versions_array=(\$(cat &#34;all_openshift-ansible-playbooks_versions&#34; | grep &#34;^3.\$current_openshift_minor_version&#34;))
-set_openshift_version=\$(echo \${all_current_openshift_versions_array[0]})
-echo &#34;=== Installing openshift-ansible-\${all_current_openshift_ansible_versions_array[0]} ===&#34;
-sudo yum install -y openshift-ansible-playbooks-\${all_current_openshift_ansible_versions_array[0]}
-echo &#34;=== Installing \${pkg_name}-\${set_openshift_version} ===&#34;
-ansible-playbook --become --become-user root --connection local -i inventory/ /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
-ansible-playbook --become --become-user root --connection local -i inventory/ /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml -e set_openshift_version=&#34;\${set_openshift_version}&#34;
-if [ \${#all_current_openshift_versions_array[@]} -gt 1 ]
+echo &#34;=== Installing atomic-openshift-utils-\${ATOMIC_OPENSHIFT_UTILS_INSTALL_VERSION} packages ===&#34;
+sudo yum install -y \${versioned_packages_to_install}
+EOF
+} | ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel</command>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
+          <command>#!/bin/bash
+echo &#34;########## STARTING STAGE: INSTALL ANSIBLE PLUGINS ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL ANSIBLE PLUGINS ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+{
+cat &lt;&lt;EOF
+sudo su origin
+set -o errexit -o nounset -o pipefail -o xtrace
+cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
+sudo yum install -y python-pip
+sudo pip install junit_xml
+sudo chmod o+rw /etc/environment
+echo &#34;ANSIBLE_JUNIT_DIR=\$( pwd )/_output/tests/ansible_junit&#34; &gt;&gt; /etc/environment
+sudo mkdir -p /usr/share/ansible/plugins/callback
+for plugin in &#39;default_with_output_lists&#39; &#39;generate_junit&#39;; do
+   wget &#34;https://raw.githubusercontent.com/openshift/origin-ci-tool/master/oct/ansible/oct/callback_plugins/\${plugin}.py&#34;
+   sudo mv &#34;\${plugin}.py&#34; /usr/share/ansible/plugins/callback
+done
+sudo sed -r -i -e &#39;s/^#?stdout_callback.*/stdout_callback = default_with_output_lists/&#39; -e &#39;s/^#?callback_whitelist.*/callback_whitelist = generate_junit/&#39; /etc/ansible/ansible.cfg
+EOF
+} | ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel</command>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
+          <command>#!/bin/bash
+echo &#34;########## STARTING STAGE: INSTALL ORIGIN GA AND UPDATE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL ORIGIN GA AND UPDATE ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+{
+cat &lt;&lt;EOF
+sudo su origin
+set -o errexit -o nounset -o pipefail -o xtrace
+cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
+pkg_name=\$( cat ./PKG_NAME )
+if [[ &#34;\${pkg_name}&#34; == &#34;origin&#34; ]]; then
+    deployment_type=&#34;origin&#34;
+elif [[ &#34;\${pkg_name}&#34; == &#34;atomic-openshift&#34; ]]; then
+    deployment_type=&#34;openshift-enterprise&#34;
+else
+    echo &#34;Can&#39;t determine deployment type&#34;
+    exit 1
+fi
+echo &#34;\${deployment_type}&#34; &gt; DEPLOYMENT_TYPE
+sudo python hack/determine_install_upgrade_version.py \$( cat ORIGIN_BUILT_VERSION ) &gt; ORIGIN_VARS
+source ORIGIN_VARS
+source OPENSHIFT_ANSIBLE_VARS
+echo &#34;=== Installing \${pkg_name}-\${ORIGIN_INSTALL_VERSION} ===&#34;
+ansible-playbook  -vv                \
+                  --become           \
+                  --become-user root \
+                  --connection local \
+                  -i inventory/      \
+                  /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml \
+                  -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)
+# Remove &#34;enable_excluders&#34; variable after openshift-ansbile pkgs are rebuilded with https://github.com/openshift/openshift-ansible/pull/3788
+ansible-playbook  -vv                \
+                  --become           \
+                  --become-user root \
+                  --connection local \
+                  -i inventory/      \
+                  /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml \
+                  -e openshift_pkg_version=&#34;-\${ORIGIN_INSTALL_VERSION}&#34;         \
+                  -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)                  \
+                  -e enable_excluders=false
+if [[ -v ORIGIN_UPGRADE_VERSION  &amp;&amp; -v ATOMIC_OPENSHIFT_UTILS_UPGRADE_VERSION ]]
 then
-  echo &#34;=== Updating openshift-ansible to openshift-ansible-\${all_current_openshift_ansible_versions_array[\${#all_current_openshift_ansible_versions_array[@]}-1]} ===&#34;
-  sudo yum erase -y openshift-ansible
-  sudo yum install -y openshift-ansible-playbooks-\${all_current_openshift_ansible_versions_array[\${#all_current_openshift_ansible_versions_array[@]}-1]}
-  echo &#34;=== Updating \${pkg_name} to \${pkg_name}-\${all_current_openshift_versions_array[\${#all_current_openshift_versions_array[@]}-1]} ===&#34;
-  ansible-playbook --become --become-user root --connection local --inventory inventory/ /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_\${current_openshift_minor_version}/upgrade.yml -e openshift_upgrade_target=&#34;\${all_current_openshift_versions_array[\${#all_current_openshift_versions_array[@]}-1]}&#34;
+  echo &#34;=== Updating atomic-openshift-utils-\${ATOMIC_OPENSHIFT_UTILS_UPGRADE_VERSION} ===&#34;
+  versioned_packages_to_install=&#34;&#34;
+  packages_to_install=( \$( cat ./OPENSHIFT_ANSIBLE_PKGS ) )
+  for pkg in &#34;\${packages_to_install[@]}&#34;
+  do
+    versioned_packages_to_install+=&#34; \${pkg}-\${ATOMIC_OPENSHIFT_UTILS_UPGRADE_VERSION}&#34;
+  done
+  sudo yum upgrade -y \${versioned_packages_to_install}
+  echo &#34;=== Updating \${pkg_name} to \${ORIGIN_UPGRADE_VERSION} ===&#34;
+  upgrade_playbook=&#34;/usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_\${ORIGIN_UPGRADE_MINOR_VERSION}/upgrade.yml&#34;
+  ansible-playbook  -vv                    \
+                    --become               \
+                    --become-user root     \
+                    --connection local     \
+                    --inventory inventory/ \
+                    &#34;\${upgrade_playbook}&#34;  \
+                    -e openshift_pkg_version=&#34;-\${ORIGIN_UPGRADE_VERSION}&#34; \
+                    -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)          \
+                    -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\${ORIGIN_UPGRADE_VERSION_PKG_VERSION}&#34;
 fi
 EOF
 } | ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel</command>
@@ -190,77 +296,44 @@ EOF
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-echo &#34;########## STARTING STAGE: BUILD AN OPENSHIFT-ANSIBLE RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: BUILD AN OPENSHIFT-ANSIBLE RELEASE ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-{
-cat &lt;&lt;EOF
-sudo su origin
-set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
-tito_tmp_dir=&#34;tito&#34;
-mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --use-version 3.6.0 --accept-auto-changelog
-tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
-createrepo &#34;\${tito_tmp_dir}/noarch&#34;
-cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo
-[openshift-ansible-local-release]
-baseurl = file://\$( pwd )/\${tito_tmp_dir}/noarch
-gpgcheck = 0
-name = OpenShift Ansible Release from Local Source
-EOR
-sudo cp ./openshift-ansible-local-release.repo /etc/yum.repos.d
-EOF
-} | ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel</command>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-          <command>#!/bin/bash
-echo &#34;########## STARTING STAGE: INSTALL THE OPENSHIFT-ANSIBLE RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE OPENSHIFT-ANSIBLE RELEASE ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-{
-cat &lt;&lt;EOF
-sudo su origin
-set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${HOME}&#34;
-sudo yum install -y atomic-openshift-utils
-EOF
-} | ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel</command>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-          <command>#!/bin/bash
-echo &#34;########## STARTING STAGE: CHECK OUT THE CORRECT BRANCH OF AOS-CD-JOBS ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: CHECK OUT THE CORRECT BRANCH OF AOS-CD-JOBS ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+echo &#34;########## STARTING STAGE: UPGRADE OPENSHIFT-ANSIBLE TO RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: UPGRADE OPENSHIFT-ANSIBLE TO RELEASE ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 {
 cat &lt;&lt;EOF
 sudo su origin
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-git checkout sjb
+source ORIGIN_VARS
+source OPENSHIFT_ANSIBLE_VARS
+versioned_packages_to_upgrade=&#34;&#34;
+packages_to_upgrade=&#34;\$( cat ./OPENSHIFT_ANSIBLE_PKGS )&#34;
+for pkg in &#34;\${packages_to_upgrade[@]}&#34;
+do
+  versioned_packages_to_upgrade+=&#34; \${pkg}-\${ATOMIC_OPENSHIFT_UTILS_UPGRADE_RELEASE_VERSION}&#34;
+done
+sudo yum upgrade -y \${versioned_packages_to_upgrade}
 EOF
 } | ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-echo &#34;########## STARTING STAGE: DETERMINE THE RELEASE COMMIT FOR ORIGIN IMAGES ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: DETERMINE THE RELEASE COMMIT FOR ORIGIN IMAGES ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-{
-cat &lt;&lt;EOF
-sudo su origin
-set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-git log -1 --pretty=%h &gt;&gt; /data/src/github.com/openshift/aos-cd-jobs/ORIGIN_COMMIT
-EOF
-} | ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel</command>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-          <command>#!/bin/bash
-echo &#34;########## STARTING STAGE: UPDATE ORIGIN ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: UPDATE ORIGIN ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+echo &#34;########## STARTING STAGE: UPDATE ORIGIN TO RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: UPDATE ORIGIN TO RELEASE ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 {
 cat &lt;&lt;EOF
 sudo su origin
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-sudo python hack/get_available_pkgs.py origin &gt; &#34;all_origin_versions&#34;
-sed -i &#39;/^[a-zA-Z]/d&#39; all_origin_versions
-sort -u -o all_origin_versions all_origin_versions
-upgrade_version=\$(tail -1 all_origin_versions)
-upgrade_minor_version=\$(echo &#34;\${upgrade_version}&#34; | awk -F&#39;.&#39; &#39;{print \$2}&#39;)
-ansible-playbook --become --become-user root --connection local --inventory inventory/ /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_\${upgrade_minor_version}/upgrade.yml -e openshift_image_tag=&#34;\$( cat ./ORIGIN_COMMIT )&#34; -e openshift_upgrade_target=&#34;\${upgrade_version}&#34;
+pkg_name=\$( cat ./PKG_NAME )
+source ORIGIN_VARS
+upgrade_playbook=&#34;/usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_\${ORIGIN_UPGRADE_RELEASE_MINOR_VERSION}/upgrade.yml&#34;
+ansible-playbook  -vv                    \
+                  --become               \
+                  --become-user root     \
+                  --connection local     \
+                  --inventory inventory/ \
+                   &#34;\${upgrade_playbook}&#34; \
+                  -e openshift_pkg_version=&#34;-\${ORIGIN_UPGRADE_RELEASE_VERSION}&#34; \
+                  -e deployment_type=\$( cat ./DEPLOYMENT_TYPE) \
+                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34;
 EOF
 } | ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel</command>
         </hudson.tasks.Shell>
@@ -316,6 +389,8 @@ ARTIFACT_DIR=&#34;$( pwd )/artifacts/generated&#34;
 rm -rf &#34;${ARTIFACT_DIR}&#34;
 mkdir &#34;${ARTIFACT_DIR}&#34;
 ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo docker version &amp;&amp; sudo docker info &amp;&amp; sudo docker images &amp;&amp; sudo docker ps -a 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/docker.info&#34; || true
+ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo yum history info openshift-ansible 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/openshift_ansible_package_history.log&#34; || true
+ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo yum history info origin 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/origin_package_history.log&#34; || true
 ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo yum list installed 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/installed_packages.log&#34; || true
 ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo ausearch -m avc 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/avc_denials.log&#34; || true
 ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo journalctl _PID=1 --no-pager --all --lines=all 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/pid1.journal&#34; || true

--- a/hack/determine_install_upgrade_version.py
+++ b/hack/determine_install_upgrade_version.py
@@ -1,0 +1,87 @@
+import yum
+import sys
+import os.path
+import rpmUtils.miscutils as rpmutils
+
+# Get all the matching `MAJOR.MINOR` versions of provided input package nerva
+# Returned list of package versions is in `'pkg_version'-'pkg_release'` format ,eg: `1.3.0-3.el7`
+def get_matching_versions(input_pkg_name, available_pkgs, search_version):
+	release_pkgs = []
+	pre_release_pkgs = []
+	for pkg in available_pkgs:
+		if pkg.version.startswith(search_version):
+			if pkg.release.startswith("0"):
+				pre_release_pkgs.append("-".join([pkg.version, pkg.release]))
+			else:
+				release_pkgs.append("-".join([pkg.version, pkg.release]))
+	# If there are any release versions use those, otherwise use pre-release versions
+	if release_pkgs:
+		return release_pkgs
+	elif pre_release_pkgs:
+		return pre_release_pkgs
+	else:
+		print("[ERROR] Can not determine install and upgrade version for the `" + input_pkg_name + "` package", sys.stderr)
+		sys.exit(1)
+
+# Get only install(first) and upgrade(last) versions from version list
+def get_install_upgrade_version(version_list):
+	if len(version_list) > 1: 
+		return [version_list[0],version_list[len(version_list)-1]]
+	return [version_list[0]]
+
+# Return minor version of provided package version-release pair
+def get_minor_version(pkg_version_release):
+	return pkg_version_release.split('.', 2)[1]
+
+# Return version of provided package version-release pair
+def get_version(pkg_version_release):
+	return pkg_version_release.split('-', 2)[0]
+
+# Print install, upgrade and upgrade_release versions of desired package to STDOUT.
+# The upgrade version will be printed only in case there is more then one version of packages previous minor release. 
+def print_version_vars(version_list):
+	used_pkg_name = pkg_name.upper().replace("-", "_")
+	print (used_pkg_name + "_INSTALL_VERSION=" + version_list[0])
+	print (used_pkg_name + "_INSTALL_MINOR_VERSION=" + get_minor_version(version_list[0]))
+	if len(version_list) > 1:
+		print (used_pkg_name + "_UPGRADE_VERSION=" + version_list[1])
+		print (used_pkg_name + "_UPGRADE_MINOR_VERSION=" + get_minor_version(version_list[1]))
+		print (used_pkg_name + "_UPGRADE_VERSION_PKG_VERSION=" + get_version(version_list[1]))
+	print (used_pkg_name + "_UPGRADE_RELEASE_VERSION=" + pkg_version + "-" + pkg_release)
+	print (used_pkg_name + "_UPGRADE_RELEASE_MINOR_VERSION=" + get_minor_version(pkg_version + "-" + pkg_release))
+
+def determine_search_version(pkg_name, pkg_version):
+	major, minor, rest = pkg_version.split('.', 2)
+	# Cause of the origin version schema change we had to manually change the version just for this 
+	# case where we should look for 1.5.x versions if the built version is origin-3.6.x 
+	if pkg_name == "origin" and major == "3" and minor == "6":
+		major = "1"
+	search_version = '.'.join([major, str(int(minor) - 1)])
+	return search_version
+
+if __name__ == "__main__":
+	if len(sys.argv) != 2:
+	    print ("[ERROR] No NEVRA provided!", sys.stderr)
+	    sys.exit(3)
+	input_pkg = sys.argv[1]
+	pkg_name, pkg_version, pkg_release, pkg_epoch, pkg_arch = rpmutils.splitFilename(input_pkg)
+
+	if any(char.isalpha() for char in pkg_version):
+		print ("[ERROR] Incorrect package nevra format: " + input_pkg, sys.stderr)
+		sys.exit(2)
+
+	yb = yum.YumBase()
+	# Have to redirect redirect the yum configuration to /dev/null cause we dont want to have any additional output
+	# that configuration prints. eg: `Loaded plugins: amazon-id, rhui-lb`  
+	old_stdout = sys.stdout
+	sys.stdout = open(os.devnull, 'w')
+	# Need make sure that all the packages are listed, cause if excluders are enabled for some reason,
+	# listing of origin or docker pkgs will be disabled, based on the enabled excluder.
+	yb.conf.disable_excludes = ["all"]
+	sys.stdout = old_stdout
+	available_pkgs = rpmutils.unique(yb.doPackageLists('available', patterns=[pkg_name], showdups=True).available)
+	available_pkgs.sort(lambda x, y: rpmutils.compareEVR((x.epoch, x.version, x.release), (y.epoch, y.version, y.release)))
+	search_version = determine_search_version(pkg_name, pkg_version)
+	matching_pkgs = get_matching_versions(pkg_name, available_pkgs, search_version)
+	install_upgrade_version_list = get_install_upgrade_version(matching_pkgs)
+	print_version_vars(install_upgrade_version_list)

--- a/hack/determine_install_upgrade_version_test.py
+++ b/hack/determine_install_upgrade_version_test.py
@@ -1,0 +1,125 @@
+import unittest
+import rpmUtils.miscutils as rpmutils
+from determine_install_upgrade_version import *
+
+class TestPackage(object):
+	def __init__(self, version, release, vra):
+		self.version = version
+		self.release = release
+		self.vra = vra
+
+class GetMatchingVersionTestCase(unittest.TestCase):
+	"Test for `determine_install_upgrade_version.py`"
+
+	def create_test_packages(self, test_pkgs):
+		test_pkgs_objs = []
+		for pkg in test_pkgs:
+			pkg_name, pkg_version, pkg_release, pkg_epoch, pkg_arch =  rpmutils.splitFilename(pkg)
+			pkg_vra = pkg_version + "-" + pkg_release + "." + pkg_arch
+			test_pkgs_objs.append(TestPackage(pkg_version, pkg_release, pkg_vra))
+		return test_pkgs_objs
+
+	def test_get_matching_versions(self):
+		""" when only one matching version exist and its pre-release, it is returned """
+		test_pkgs = ["origin-1.4.1-1.el7.x86_64", "origin-1.5.0-0.4.el7.x86_64"]
+		test_pkgs_objs = self.create_test_packages(test_pkgs)
+		self.assertEqual(get_matching_versions('origin', test_pkgs_objs, '1.5'), ['1.5.0-0.4.el7'])
+
+	def test_with_single_pre_release(self):
+		""" when only one pre-release version exist, it is returned """
+		test_pkgs = ["origin-1.5.0-0.4.el7.x86_64"]
+		test_pkgs_objs = self.create_test_packages(test_pkgs)
+		self.assertEqual(get_matching_versions('origin', test_pkgs_objs, '1.5'), ['1.5.0-0.4.el7'])
+
+	def test_with_multiple_pre_release(self):
+		""" when only one pre-release version exist, it is returned """
+		test_pkgs = ["origin-1.5.0-0.4.el7.x86_64", "origin-1.5.2-0.1.el7.x86_64"]
+		test_pkgs_objs = self.create_test_packages(test_pkgs)
+		self.assertEqual(get_matching_versions('origin', test_pkgs_objs, '1.5'), ['1.5.0-0.4.el7', '1.5.2-0.1.el7'])
+
+	def test_with_single_release(self):
+		""" when both release and pre-release versions exist, only release versions are returned """
+		test_pkgs = ["origin-1.5.0-0.4.el7.x86_64", "origin-1.5.0-1.1.el7.x86_64"]
+		test_pkgs_objs = self.create_test_packages(test_pkgs)
+		self.assertEqual(get_matching_versions('origin', test_pkgs_objs, '1.5'), ["1.5.0-1.1.el7"])
+
+	def test_with_muptiple_release(self):
+		""" when both release and pre-release versions exist, only release version is returned """
+		test_pkgs = ["origin-1.5.0-0.4.el7.x86_64", "origin-1.5.0-1.1.el7.x86_64", "origin-1.5.2-1.1.el7.x86_64"]
+		test_pkgs_objs = self.create_test_packages(test_pkgs)
+		self.assertEqual(get_matching_versions('origin', test_pkgs_objs, '1.5'), ["1.5.0-1.1.el7", "1.5.2-1.1.el7"])
+
+	def test_with_no_matches(self):
+		test_pkgs = ["origin-1.2.0-0.4.el7.x86_64", "origin-1.3.0-1.1.el7.x86_64", "origin-1.4.2-1.1.el7.x86_64"]
+		test_pkgs_objs = self.create_test_packages(test_pkgs)
+		self.assertRaises(SystemExit, get_matching_versions, 'origin', test_pkgs_objs, '1.5')
+
+class DetermineSearchVersionTestCase(unittest.TestCase):
+	"Test for `determine_install_upgrade_version.py`"
+
+	def test_origin_with_standard_versioning_schema(self):
+		""" when the origin version is higher then the first version of the new origin versioning schema - origin-3.6 """
+		self.assertEqual(determine_search_version("origin", "3.7.0"), "3.6")
+
+	def test_origin_with_standard_to_legacy_versioning_schema(self):
+		""" when the origin version is the first from the new origin versioning schema - origin-3.6 """
+		self.assertEqual(determine_search_version("origin", "3.6.0"), "1.5")
+
+	def test_origin_with_legacy_schema(self):
+		""" when the origin version is in the old versioning schema """
+		self.assertEqual(determine_search_version("origin", "1.5.0"), "1.4")
+
+	def test_openshift_ansible_with_standard_versioning_schema(self):
+		""" when openshift-ansible, which doesnt have different versioning schema, is in 3.7 version  """
+		self.assertEqual(determine_search_version("openshift-ansible", "3.7.0"), "3.6")
+
+	def test_openshift_ansible_with_standard_to_legacy_versioning_schema(self):
+		""" when openshift-ansible, which doesnt have different versioning schema is in 3.6 version """
+		self.assertEqual(determine_search_version("openshift-ansible", "3.6.0"), "3.5")
+
+	def test_openshift_ansible_with_legacy_versioning_schema(self):
+		""" when openshift-ansible, which doesnt have different versioning schema is in 3.4 version """
+		self.assertEqual(determine_search_version("openshift-ansible", "3.5.0"), "3.4")
+
+class GetInstallUpgradeVersionTestCase(unittest.TestCase):
+	"Test for `determine_install_upgrade_version.py`"
+
+	def test_with_multiple_matching_release_versions(self):
+		""" when multiple matching version are present in released versions """
+		matching_versions = ["1.2.0-1.el7", "1.2.2-1.el7", "1.2.5-1.el7"]
+		install_upgrade_versions = ["1.2.0-1.el7", "1.2.5-1.el7"]
+		self.assertEqual(get_install_upgrade_version(matching_versions), install_upgrade_versions)
+
+	def test_with_single_matching_release_version(self):
+		""" when only a single matching version is present in released versions """
+		matching_versions = ["1.5.0-1.4.el7"]
+		install_upgrade_versions = ["1.5.0-1.4.el7"]
+		self.assertEqual(get_install_upgrade_version(matching_versions), install_upgrade_versions)
+
+	def test_with_multiple_matching_pre_release_versions(self):
+		""" when multiple matching pre-release version are present in pre-released versions """
+		matching_versions = ["1.2.0-0.el7", "1.2.2-0.el7", "1.2.5-0.el7"]
+		install_upgrade_versions = ["1.2.0-0.el7", "1.2.5-0.el7"]
+		self.assertEqual(get_install_upgrade_version(matching_versions), install_upgrade_versions)
+
+	def test_with_single_matching_pre_release_version(self):
+		""" when only single matching pre-release version is present in pre-released versions """
+		matching_versions = ["1.5.0-0.4.el7"]
+		install_upgrade_versions = ["1.5.0-0.4.el7"]
+		self.assertEqual(get_install_upgrade_version(matching_versions), install_upgrade_versions)
+
+class GetVersionTestCase(unittest.TestCase):
+	"Test for `determine_install_upgrade_version.py`"
+
+	def test_get_version(self):
+		""" when package version is picked its version-release pair """
+		version_release = "1.5.0-0.4.el7"
+		self.assertEqual(get_version(version_release), "1.5.0")
+
+	def test_get_minor_version(self):
+		""" when package minor version is picked its version-release pair """
+		version_release = "1.5.0-0.4.el7"
+		self.assertEqual(get_minor_version(version_release), "5")
+
+if __name__ == '__main__':
+	unittest.main()

--- a/hack/get_available_pkgs.py
+++ b/hack/get_available_pkgs.py
@@ -1,9 +1,0 @@
-import yum
-import sys
-
-yb = yum.YumBase()
-yb.conf.disable_excludes = ["all"]
-pkgs = yb.doPackageLists('available', patterns=[sys.argv[1]], showdups=True).available
-pkgs.sort(key=lambda x: x.version)
-for p in pkgs:
-    print p.vra

--- a/inventory/group_vars/OSEv3/general.yml
+++ b/inventory/group_vars/OSEv3/general.yml
@@ -11,5 +11,4 @@ openshift_master_identity_providers:
     login: "true"
     challenge: "true"
     kind: "AllowAllPasswordIdentityProvider"
-deployment_type: "origin"
 ansible_ssh_user: "ec2-user"


### PR DESCRIPTION
This script will determine the GA and latest packages for previous version of package that will be on input.
EG:
input: ` origin-1.4.1-1.el7`
output:
 - ORIGIN_INSTALL_VERSION file that includes previous GA version-> `1.3.0-3.el7.x86_64`
 - ORIGIN_UPGRADE_VERSION file that includes previous latest version-> `1.3.3-1.el7.x86_64`

The script will return pre-release versions of packages if there are no released ones or fail.