### PR TITLE
Add `$ETCD_DATA_DIR` to system environment

### DIFF
--- a/config/common/test_cases/origin.yml
+++ b/config/common/test_cases/origin.yml
@@ -10,9 +10,12 @@ actions:
   - type: "script"
     title: "use a ramdisk for etcd"
     script: |-
-      sudo mkdir -p /tmp
-      sudo mount -t tmpfs -o size=2048m tmpfs /tmp
-      sudo restorecon -R /tmp
+      sudo su root
+      mkdir -p /tmp
+      mount -t tmpfs -o size=2048m tmpfs /tmp
+      restorecon -R /tmp
+      mkdir -p /tmp/etcd
+      echo "ETCD_DATA_DIR=/tmp/etcd" >> /etc/environment
 post_actions: []
 artifacts:
   - "/tmp/openshift"

--- a/inventory/group_vars/OSEv3/general.yml
+++ b/inventory/group_vars/OSEv3/general.yml
@@ -13,3 +13,5 @@ openshift_master_identity_providers:
     kind: "AllowAllPasswordIdentityProvider"
 deployment_type: "origin"
 ansible_ssh_user: "ec2-user"
+etcd_data_dir: "/tmp/etcd"
+etcd_debug: true


### PR DESCRIPTION
We need `etcd` to store it's data in a tmpfs to ensure that the weird
semantics around IO on EC2 EBS don't cause `etcd` to fall over in the
middle of our test suites. We don't control the installation of `etcd`
so we try to influence storage via system-wide environment.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @smarterclayton @liggitt does this seem reasonable?