### PR TITLE
Bump Golang on the AMI to 1.7, install from CentOS PaaS SIG

### DIFF
--- a/config/test_cases/ami_build_origin_int_rhel_base.yml
+++ b/config/test_cases/ami_build_origin_int_rhel_base.yml
@@ -13,7 +13,7 @@ actions:
   - type: "host_script"
     title: "install golang"
     script: |-
-      oct prepare golang --version '1.6.3' --repo 'oso-rhui-rhel-server-releases-optional'
+      oct prepare golang --version '1.7.3' --repourl 'https://cbs.centos.org/repos/paas7-openshift-origin15-candidate/x86_64/os/'
   - type: "host_script"
     title: "install docker"
     script: |-

--- a/generated/ami_build_origin_int_rhel_base.xml
+++ b/generated/ami_build_origin_int_rhel_base.xml
@@ -69,7 +69,7 @@ oct prepare dependencies</command>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 echo &#34;########## STARTING STAGE: INSTALL GOLANG ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL GOLANG ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-oct prepare golang --version &#39;1.6.3&#39; --repo &#39;oso-rhui-rhel-server-releases-optional&#39;</command>
+oct prepare golang --version &#39;1.7.3&#39; --repourl &#39;https://cbs.centos.org/repos/paas7-openshift-origin15-candidate/x86_64/os/&#39;</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @bparees we can source it from CentOS so we should switch `base_ami` to do this too