### PR TITLE
Check the right set of statuses based on the branch

### DIFF
--- a/check-pull-request-status.py
+++ b/check-pull-request-status.py
@@ -6,12 +6,14 @@ import sys
 from yaml import load
 from github3 import login
 
-if len(sys.argv) != 3:
-    print("USAGE: {} PULL_REQUEST_ID CREDENTIAL_STORE".format(sys.argv[0]))
+if len(sys.argv) != 5:
+    print("USAGE: {} PULL_REQUEST_ID OPENSHIFT_ANSIBLE_TARGET_BRANCH CREDENTIAL_STORE STATUS_CONFIG".format(sys.argv[0]))
     exit(1)
 
 pull_request_id = int(sys.argv[1])
-credential_file = sys.argv[2]
+target_branch = sys.argv[2]
+credential_file = sys.argv[3]
+status_config_file = sys.argv[4]
 
 with open(credential_file) as credential_store:
     credentials = load(credential_store)
@@ -23,13 +25,14 @@ client = login(token=oauth_token)
 pull_request = client.pull_request(owner='openshift', repository='openshift-ansible', number=pull_request_id)
 pull_request_statuses = client._json(client._get(pull_request.statuses_url.replace('statuses', 'status')), 200)['statuses']
 
-blocking_statuses = [
-    'aos-ci-jenkins/OS_3.5_NOT_containerized',
-    'aos-ci-jenkins/OS_3.5_NOT_containerized_e2e_tests',
-    'aos-ci-jenkins/OS_3.5_containerized',
-    'aos-ci-jenkins/OS_3.5_containerized_e2e_tests',
-    'continuous-integration/travis-ci/pr'
-]
+blocking_statuses = []
+
+with open(status_config_file) as status_config:
+    config = load(status_config)
+    if target_branch not in config:
+        print("[ERROR] No GitHub PR statuses have been configured for branch '{}'.".format(target_branch))
+    blocking_statuses.extend(config[target_branch])
+    blocking_statuses.extend(config["common_status"])
 
 found_statuses = {}
 

--- a/config/test_cases/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.yml
+++ b/config/test_cases/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.yml
@@ -7,8 +7,12 @@ overrides:
       type: "pull_request"
     - name: "origin"
 extensions:
+  sync_repos:
+    - name: "aos-cd-jobs"
   actions:
     - type: "host_script"
       title: "check other job statuses"
+      repository: "aos-cd-jobs"
       script: |-
-        /usr/bin/check-pull-request-status.py "${OPENSHIFT_ANSIBLE_PULL_ID}" /var/lib/jenkins/.config/hub
+        git checkout sjb
+        python check-pull-request-status.py "${OPENSHIFT_ANSIBLE_PULL_ID}" "${OPENSHIFT_ANSIBLE_TARGET_BRANCH}" /var/lib/jenkins/.config/hub test_status_config.yml

--- a/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
+++ b/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
@@ -38,6 +38,11 @@
           <description>The branch in the &lt;a href=&quot;https://github.com/openshift/origin&quot;&gt;origin&lt;/a&gt; repository to test against.</description>
           <defaultValue>master</defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>AOS_CD_JOBS_TARGET_BRANCH</name>
+          <description>The branch in the &lt;a href=&quot;https://github.com/openshift/aos-cd-jobs&quot;&gt;aos-cd-jobs&lt;/a&gt; repository to test against.</description>
+          <defaultValue>master</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@1.9.0">
@@ -86,7 +91,8 @@ oct provision remote all-in-one --os &#34;rhel&#34; --stage &#34;base&#34; --pro
       <description>&lt;div&gt;
 Using the &lt;a href=&#34;https://github.com/openshift/aos-cd-jobs/tree/${AOS_CD_JOBS_TARGET_BRANCH}&#34;&gt;aos-cd-jobs ${AOS_CD_JOBS_TARGET_BRANCH}&lt;/a&gt; branch.&lt;br/&gt;
 Using PR &lt;a href=&#34;https://github.com/openshift/openshift-ansible/pull/${OPENSHIFT_ANSIBLE_PULL_ID}&#34;&gt;${OPENSHIFT_ANSIBLE_PULL_ID}&lt;/a&gt; merged into the &lt;a href=&#34;https://github.com/openshift/openshift-ansible/tree/${OPENSHIFT_ANSIBLE_TARGET_BRANCH}&#34;&gt;openshift-ansible ${OPENSHIFT_ANSIBLE_TARGET_BRANCH}&lt;/a&gt; branch.&lt;br/&gt;
-Using the &lt;a href=&#34;https://github.com/openshift/origin/tree/${ORIGIN_TARGET_BRANCH}&#34;&gt;origin ${ORIGIN_TARGET_BRANCH}&lt;/a&gt; branch.
+Using the &lt;a href=&#34;https://github.com/openshift/origin/tree/${ORIGIN_TARGET_BRANCH}&#34;&gt;origin ${ORIGIN_TARGET_BRANCH}&lt;/a&gt; branch.&lt;br/&gt;
+Using the &lt;a href=&#34;https://github.com/openshift/aos-cd-jobs/tree/${AOS_CD_JOBS_TARGET_BRANCH}&#34;&gt;aos-cd-jobs ${AOS_CD_JOBS_TARGET_BRANCH}&lt;/a&gt; branch.
 &lt;/div&gt;</description>
     </hudson.plugins.descriptionsetter.DescriptionSetterBuilder>
         <hudson.tasks.Shell>
@@ -108,6 +114,11 @@ oct sync remote openshift-ansible --refspec &#34;pull/${OPENSHIFT_ANSIBLE_PULL_I
           <command>#!/bin/bash
 echo &#34;########## STARTING STAGE: SYNC ORIGIN REPOSITORY ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: SYNC ORIGIN REPOSITORY ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 oct sync remote origin --branch &#34;${ORIGIN_TARGET_BRANCH}&#34; </command>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
+          <command>#!/bin/bash
+echo &#34;########## STARTING STAGE: SYNC AOS-CD-JOBS REPOSITORY ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: SYNC AOS-CD-JOBS REPOSITORY ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+oct sync remote aos-cd-jobs --branch &#34;${AOS_CD_JOBS_TARGET_BRANCH}&#34; </command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -275,7 +286,8 @@ EOF
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 echo &#34;########## STARTING STAGE: CHECK OTHER JOB STATUSES ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: CHECK OTHER JOB STATUSES ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-/usr/bin/check-pull-request-status.py &#34;${OPENSHIFT_ANSIBLE_PULL_ID}&#34; /var/lib/jenkins/.config/hub</command>
+git checkout sjb
+python check-pull-request-status.py &#34;${OPENSHIFT_ANSIBLE_PULL_ID}&#34; &#34;${OPENSHIFT_ANSIBLE_TARGET_BRANCH}&#34; /var/lib/jenkins/.config/hub test_status_config.yml</command>
         </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/test_status_config.yml
+++ b/test_status_config.yml
@@ -1,0 +1,42 @@
+---
+master:
+  - "aos-ci-jenkins/OS_3.6_NOT_containerized"
+  - "aos-ci-jenkins/OS_3.6_NOT_containerized_e2e_tests"
+  - "aos-ci-jenkins/OS_3.6_containerized"
+  - "aos-ci-jenkins/OS_3.6_containerized_e2e_tests"
+  - "aos-ci-jenkins/OS_3.5_NOT_containerized"
+  - "aos-ci-jenkins/OS_3.5_NOT_containerized_e2e_tests"
+  - "aos-ci-jenkins/OS_3.5_containerized"
+  - "aos-ci-jenkins/OS_3.5_containerized_e2e_tests"
+release-1.6:
+  - "aos-ci-jenkins/OS_3.6_NOT_containerized"
+  - "aos-ci-jenkins/OS_3.6_NOT_containerized_e2e_tests"
+  - "aos-ci-jenkins/OS_3.6_containerized"
+  - "aos-ci-jenkins/OS_3.6_containerized_e2e_tests"
+release-1.5:
+  - "aos-ci-jenkins/OS_3.5_NOT_containerized"
+  - "aos-ci-jenkins/OS_3.5_NOT_containerized_e2e_tests"
+  - "aos-ci-jenkins/OS_3.5_containerized"
+  - "aos-ci-jenkins/OS_3.5_containerized_e2e_tests"
+release-1.4:
+  - "aos-ci-jenkins/OS_3.4_NOT_containerized"
+  - "aos-ci-jenkins/OS_3.4_NOT_containerized_e2e_tests"
+  - "aos-ci-jenkins/OS_3.4_containerized"
+  - "aos-ci-jenkins/OS_3.4_containerized_e2e_tests"
+release-1.3:
+  - "aos-ci-jenkins/OS_3.3_NOT_containerized"
+  - "aos-ci-jenkins/OS_3.3_NOT_containerized_e2e_tests"
+  - "aos-ci-jenkins/OS_3.3_containerized"
+  - "aos-ci-jenkins/OS_3.3_containerized_e2e_tests"
+release-1.2:
+  - "aos-ci-jenkins/OS_3.2_NOT_containerized"
+  - "aos-ci-jenkins/OS_3.2_NOT_containerized_e2e_tests"
+  - "aos-ci-jenkins/OS_3.2_containerized"
+  - "aos-ci-jenkins/OS_3.2_containerized_e2e_tests"
+release-1.1:
+  - "aos-ci-jenkins/OS_3.1_NOT_containerized"
+  - "aos-ci-jenkins/OS_3.1_NOT_containerized_e2e_tests"
+  - "aos-ci-jenkins/OS_3.1_containerized"
+  - "aos-ci-jenkins/OS_3.1_containerized_e2e_tests"
+common_status:
+  - "continuous-integration/travis-ci/pr"


### PR DESCRIPTION
So now the set of the blocking statuses will be determined based on the branch against which the PR is sent.
Based on the sonversation with @sdodson, master tests current devel (3.6) and last release (3.5). Other branches only test their respective versions. So when testing against master 3.6 and 3.5 blocking statuses shall be checked.

@stevekuznetsov PTAL