### PR TITLE
Archive binary journal

### DIFF
--- a/actions/systemd_journal.py
+++ b/actions/systemd_journal.py
@@ -12,6 +12,8 @@ mkdir "${ARTIFACT_DIR}"
 {%- for unit in units %}
 ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo journalctl --unit {{ unit }} --no-pager --all --lines=all >> "${ARTIFACT_DIR}/{{ unit }}"
 {%- endfor %}
+# May exit 1 if files were modified while archiving
+tar czf "${ARTIFACT_DIR}/journal.tar.gz" -C /var/log/journal .
 tree "${ARTIFACT_DIR}" """)
 
 


### PR DESCRIPTION
We need to create the persistent journal directory first, so as one of the last steps when building your AMI do `mkdir -p /var/log/journal`. I didn't see where you were building the AMI.

Then, to read the contents of this archive extract it and `journalctl -D .`