### PR TITLE
Install and upgrade versions should be different

### DIFF
--- a/hack/determine_install_upgrade_version.py
+++ b/hack/determine_install_upgrade_version.py
@@ -25,8 +25,9 @@ def get_matching_versions(input_pkg_name, available_pkgs, search_version):
 
 # Get only install(first) and upgrade(last) versions from version list
 def get_install_upgrade_version(version_list):
-	if len(version_list) > 1: 
-		return [version_list[0],version_list[len(version_list)-1]]
+	last_version_index = len(version_list)-1
+	if (len(version_list) > 1 and version_list[0] != version_list[last_version_index])
+		return [version_list[0],version_list[last_version_index]]
 	return [version_list[0]]
 
 # Return minor version of provided package version-release pair

--- a/hack/determine_install_upgrade_version_test.py
+++ b/hack/determine_install_upgrade_version_test.py
@@ -108,6 +108,12 @@ class GetInstallUpgradeVersionTestCase(unittest.TestCase):
 		install_upgrade_versions = ["1.5.0-0.4.el7"]
 		self.assertEqual(get_install_upgrade_version(matching_versions), install_upgrade_versions)
 
+	def test_with_version_duplicates(self):
+		""" when the install and upgrade verions are the same, which is cause by having the same versions in different repositories """
+		matching_versions = ["1.5.0-0.4.el7", "1.5.0-0.4.el7"]
+		install_upgrade_versions = ["1.5.0-0.4.el7"]
+		self.assertEqual(get_install_upgrade_version(matching_versions), install_upgrade_versions)
+
 class GetVersionTestCase(unittest.TestCase):
 	"Test for `determine_install_upgrade_version.py`"
 


### PR DESCRIPTION
It might happen the `determine_install_upgrade_versions.py` will determine the same versions of the install and upgrade pkg. This happens when there are the same versions of pkgs but in different repositories.
As an example we can use [this install_upgrade test](https://ci.openshift.redhat.com/jenkins/job/test_pull_request_origin_extended_conformance_install_update/193/consoleFull#197040384158b6e51eb7608a5981914356), where when you search for `source OPENSHIFT_ANSIBLE_VARS` you will see that the install and upgrade versions are the same. 
@stevekuznetsov PTAL