### PR TITLE
Remove extended_conformance_install from testing origin PR

### DIFF
--- a/sjb/config/common/test_suites/origin_fast.yml
+++ b/sjb/config/common/test_suites/origin_fast.yml
@@ -2,7 +2,7 @@
 children:
   - "test_pull_request_origin_check"
   - "test_pull_request_origin_integration"
-  - "test_pull_request_origin_extended_conformance_install"
-  # - "test_pull_request_origin_extended_conformance_install_update"
+  # - "test_pull_request_origin_extended_conformance_install"
+  - "test_pull_request_origin_extended_conformance_install_update"
   - "test_pull_request_origin_extended_conformance_gce"
   - "test_pull_request_origin_extended_networking_minimal"

--- a/sjb/config/test_suites/test_branch_origin.yml
+++ b/sjb/config/test_suites/test_branch_origin.yml
@@ -2,7 +2,7 @@
 children:
   - "test_branch_origin_check"
   - "test_branch_origin_integration"
-  - "test_branch_origin_extended_conformance_install"
+  # - "test_branch_origin_extended_conformance_install"
   - "test_branch_origin_extended_conformance_install_update"
   - "test_branch_origin_extended_networking_minimal"
   - "test_branch_origin_extended_conformance_gce"

--- a/sjb/generated/merge_pull_request_origin.xml
+++ b/sjb/generated/merge_pull_request_origin.xml
@@ -149,7 +149,7 @@ approve.sh origin &quot;${ORIGIN_TARGET_BRANCH}&quot; &quot;${MERGE_SEVERITY}&qu
           <applyConditionOnlyIfNoSCMChanges>false</applyConditionOnlyIfNoSCMChanges>
         </com.tikal.jenkins.plugins.multijob.PhaseJobsConfig>
         <com.tikal.jenkins.plugins.multijob.PhaseJobsConfig>
-          <jobName>test_pull_request_origin_extended_conformance_install</jobName>
+          <jobName>test_pull_request_origin_extended_conformance_install_update</jobName>
           <currParams>true</currParams>
           <exposedSCM>false</exposedSCM>
           <disableJob>false</disableJob>
@@ -222,12 +222,12 @@ approve.sh origin &quot;${ORIGIN_TARGET_BRANCH}&quot; &quot;${MERGE_SEVERITY}&qu
       <doNotFingerprintArtifacts>true</doNotFingerprintArtifacts>
     </hudson.plugins.copyartifact.CopyArtifact>
     <hudson.plugins.copyartifact.CopyArtifact plugin="copyartifact@1.38">
-      <project>test_pull_request_origin_extended_conformance_install</project>
+      <project>test_pull_request_origin_extended_conformance_install_update</project>
       <filter>**</filter>
-      <target>test_pull_request_origin_extended_conformance_install/</target>
+      <target>test_pull_request_origin_extended_conformance_install_update/</target>
       <excludes></excludes>
       <selector class="hudson.plugins.copyartifact.SpecificBuildSelector">
-        <buildNumber>${TEST_PULL_REQUEST_ORIGIN_EXTENDED_CONFORMANCE_INSTALL_BUILD_NUMBER}</buildNumber>
+        <buildNumber>${TEST_PULL_REQUEST_ORIGIN_EXTENDED_CONFORMANCE_INSTALL_UPDATE_BUILD_NUMBER}</buildNumber>
       </selector>
       <optional>true</optional>
       <doNotFingerprintArtifacts>true</doNotFingerprintArtifacts>
@@ -258,7 +258,7 @@ approve.sh origin &quot;${ORIGIN_TARGET_BRANCH}&quot; &quot;${MERGE_SEVERITY}&qu
       <command># record the log from the downstream job here for FCM parsing
 cat /var/lib/jenkins/jobs/test_pull_request_origin_check/builds/${TEST_PULL_REQUEST_ORIGIN_CHECK_BUILD_NUMBER}/log
 cat /var/lib/jenkins/jobs/test_pull_request_origin_integration/builds/${TEST_PULL_REQUEST_ORIGIN_INTEGRATION_BUILD_NUMBER}/log
-cat /var/lib/jenkins/jobs/test_pull_request_origin_extended_conformance_install/builds/${TEST_PULL_REQUEST_ORIGIN_EXTENDED_CONFORMANCE_INSTALL_BUILD_NUMBER}/log
+cat /var/lib/jenkins/jobs/test_pull_request_origin_extended_conformance_install_update/builds/${TEST_PULL_REQUEST_ORIGIN_EXTENDED_CONFORMANCE_INSTALL_UPDATE_BUILD_NUMBER}/log
 cat /var/lib/jenkins/jobs/test_pull_request_origin_extended_conformance_gce/builds/${TEST_PULL_REQUEST_ORIGIN_EXTENDED_CONFORMANCE_GCE_BUILD_NUMBER}/log
 cat /var/lib/jenkins/jobs/test_pull_request_origin_extended_networking_minimal/builds/${TEST_PULL_REQUEST_ORIGIN_EXTENDED_NETWORKING_MINIMAL_BUILD_NUMBER}/log
       </command>

--- a/sjb/generated/test_branch_origin.xml
+++ b/sjb/generated/test_branch_origin.xml
@@ -133,22 +133,6 @@ See also:
           <applyConditionOnlyIfNoSCMChanges>false</applyConditionOnlyIfNoSCMChanges>
         </com.tikal.jenkins.plugins.multijob.PhaseJobsConfig>
         <com.tikal.jenkins.plugins.multijob.PhaseJobsConfig>
-          <jobName>test_branch_origin_extended_conformance_install</jobName>
-          <currParams>true</currParams>
-          <exposedSCM>false</exposedSCM>
-          <disableJob>false</disableJob>
-          <parsingRulesPath></parsingRulesPath>
-          <maxRetries>0</maxRetries>
-          <enableRetryStrategy>false</enableRetryStrategy>
-          <enableCondition>false</enableCondition>
-          <abortAllJob>false</abortAllJob>
-          <condition></condition>
-          <configs class="empty-list"/>
-          <killPhaseOnJobResultCondition>NEVER</killPhaseOnJobResultCondition>
-          <buildOnlyIfSCMChanges>false</buildOnlyIfSCMChanges>
-          <applyConditionOnlyIfNoSCMChanges>false</applyConditionOnlyIfNoSCMChanges>
-        </com.tikal.jenkins.plugins.multijob.PhaseJobsConfig>
-        <com.tikal.jenkins.plugins.multijob.PhaseJobsConfig>
           <jobName>test_branch_origin_extended_conformance_install_update</jobName>
           <currParams>true</currParams>
           <exposedSCM>false</exposedSCM>
@@ -254,17 +238,6 @@ See also:
       <doNotFingerprintArtifacts>true</doNotFingerprintArtifacts>
     </hudson.plugins.copyartifact.CopyArtifact>
     <hudson.plugins.copyartifact.CopyArtifact plugin="copyartifact@1.38">
-      <project>test_branch_origin_extended_conformance_install</project>
-      <filter>**</filter>
-      <target>test_branch_origin_extended_conformance_install/</target>
-      <excludes></excludes>
-      <selector class="hudson.plugins.copyartifact.SpecificBuildSelector">
-        <buildNumber>${TEST_BRANCH_ORIGIN_EXTENDED_CONFORMANCE_INSTALL_BUILD_NUMBER}</buildNumber>
-      </selector>
-      <optional>true</optional>
-      <doNotFingerprintArtifacts>true</doNotFingerprintArtifacts>
-    </hudson.plugins.copyartifact.CopyArtifact>
-    <hudson.plugins.copyartifact.CopyArtifact plugin="copyartifact@1.38">
       <project>test_branch_origin_extended_conformance_install_update</project>
       <filter>**</filter>
       <target>test_branch_origin_extended_conformance_install_update/</target>
@@ -323,7 +296,6 @@ See also:
       <command># record the log from the downstream job here for FCM parsing
 cat /var/lib/jenkins/jobs/test_branch_origin_check/builds/${TEST_BRANCH_ORIGIN_CHECK_BUILD_NUMBER}/log
 cat /var/lib/jenkins/jobs/test_branch_origin_integration/builds/${TEST_BRANCH_ORIGIN_INTEGRATION_BUILD_NUMBER}/log
-cat /var/lib/jenkins/jobs/test_branch_origin_extended_conformance_install/builds/${TEST_BRANCH_ORIGIN_EXTENDED_CONFORMANCE_INSTALL_BUILD_NUMBER}/log
 cat /var/lib/jenkins/jobs/test_branch_origin_extended_conformance_install_update/builds/${TEST_BRANCH_ORIGIN_EXTENDED_CONFORMANCE_INSTALL_UPDATE_BUILD_NUMBER}/log
 cat /var/lib/jenkins/jobs/test_branch_origin_extended_networking_minimal/builds/${TEST_BRANCH_ORIGIN_EXTENDED_NETWORKING_MINIMAL_BUILD_NUMBER}/log
 cat /var/lib/jenkins/jobs/test_branch_origin_extended_conformance_gce/builds/${TEST_BRANCH_ORIGIN_EXTENDED_CONFORMANCE_GCE_BUILD_NUMBER}/log

--- a/sjb/generated/test_pull_request_origin.xml
+++ b/sjb/generated/test_pull_request_origin.xml
@@ -138,7 +138,7 @@ See also:
           <applyConditionOnlyIfNoSCMChanges>false</applyConditionOnlyIfNoSCMChanges>
         </com.tikal.jenkins.plugins.multijob.PhaseJobsConfig>
         <com.tikal.jenkins.plugins.multijob.PhaseJobsConfig>
-          <jobName>test_pull_request_origin_extended_conformance_install</jobName>
+          <jobName>test_pull_request_origin_extended_conformance_install_update</jobName>
           <currParams>true</currParams>
           <exposedSCM>false</exposedSCM>
           <disableJob>false</disableJob>
@@ -211,12 +211,12 @@ See also:
       <doNotFingerprintArtifacts>true</doNotFingerprintArtifacts>
     </hudson.plugins.copyartifact.CopyArtifact>
     <hudson.plugins.copyartifact.CopyArtifact plugin="copyartifact@1.38">
-      <project>test_pull_request_origin_extended_conformance_install</project>
+      <project>test_pull_request_origin_extended_conformance_install_update</project>
       <filter>**</filter>
-      <target>test_pull_request_origin_extended_conformance_install/</target>
+      <target>test_pull_request_origin_extended_conformance_install_update/</target>
       <excludes></excludes>
       <selector class="hudson.plugins.copyartifact.SpecificBuildSelector">
-        <buildNumber>${TEST_PULL_REQUEST_ORIGIN_EXTENDED_CONFORMANCE_INSTALL_BUILD_NUMBER}</buildNumber>
+        <buildNumber>${TEST_PULL_REQUEST_ORIGIN_EXTENDED_CONFORMANCE_INSTALL_UPDATE_BUILD_NUMBER}</buildNumber>
       </selector>
       <optional>true</optional>
       <doNotFingerprintArtifacts>true</doNotFingerprintArtifacts>
@@ -247,7 +247,7 @@ See also:
       <command># record the log from the downstream job here for FCM parsing
 cat /var/lib/jenkins/jobs/test_pull_request_origin_check/builds/${TEST_PULL_REQUEST_ORIGIN_CHECK_BUILD_NUMBER}/log
 cat /var/lib/jenkins/jobs/test_pull_request_origin_integration/builds/${TEST_PULL_REQUEST_ORIGIN_INTEGRATION_BUILD_NUMBER}/log
-cat /var/lib/jenkins/jobs/test_pull_request_origin_extended_conformance_install/builds/${TEST_PULL_REQUEST_ORIGIN_EXTENDED_CONFORMANCE_INSTALL_BUILD_NUMBER}/log
+cat /var/lib/jenkins/jobs/test_pull_request_origin_extended_conformance_install_update/builds/${TEST_PULL_REQUEST_ORIGIN_EXTENDED_CONFORMANCE_INSTALL_UPDATE_BUILD_NUMBER}/log
 cat /var/lib/jenkins/jobs/test_pull_request_origin_extended_conformance_gce/builds/${TEST_PULL_REQUEST_ORIGIN_EXTENDED_CONFORMANCE_GCE_BUILD_NUMBER}/log
 cat /var/lib/jenkins/jobs/test_pull_request_origin_extended_networking_minimal/builds/${TEST_PULL_REQUEST_ORIGIN_EXTENDED_NETWORKING_MINIMAL_BUILD_NUMBER}/log
       </command>


### PR DESCRIPTION
@stevekuznetsov @smarterclayton PTAL
as you spoke I've removed extended_conformance_install from testing origins PR.
