### PR TITLE
Bump golang version in the base ami

### DIFF
--- a/sjb/config/test_cases/ami_build_origin_int_rhel_base.yml
+++ b/sjb/config/test_cases/ami_build_origin_int_rhel_base.yml
@@ -18,7 +18,7 @@ actions:
   - type: "host_script"
     title: "install golang"
     script: |-
-      oct prepare golang --version '1.7.3' --repourl 'https://cbs.centos.org/repos/paas7-openshift-origin15-candidate/x86_64/os/'
+      oct prepare golang --version '1.7.5' --repourl 'https://cbs.centos.org/repos/paas7-openshift-origin15-candidate/x86_64/os/'
   - type: "host_script"
     title: "install docker"
     script: |-

--- a/sjb/generated/ami_build_origin_int_rhel_base.xml
+++ b/sjb/generated/ami_build_origin_int_rhel_base.xml
@@ -75,7 +75,7 @@ oct prepare dependencies</command>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 echo &#34;########## STARTING STAGE: INSTALL GOLANG ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL GOLANG ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-oct prepare golang --version &#39;1.7.3&#39; --repourl &#39;https://cbs.centos.org/repos/paas7-openshift-origin15-candidate/x86_64/os/&#39;</command>
+oct prepare golang --version &#39;1.7.5&#39; --repourl &#39;https://cbs.centos.org/repos/paas7-openshift-origin15-candidate/x86_64/os/&#39;</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash


### PR DESCRIPTION
Seems like the golang package was updated today to go1.7.5 in the centos paas repo. Hit this while testing https://github.com/openshift/aos-cd-jobs/pull/221 and it also seems to be broken for the base ami in https://ci.openshift.redhat.com/jenkins/view/AMIs/job/base_ami/2835/consoleFull. Running a new test with 1.7.5 in https://ci.openshift.redhat.com/jenkins/view/All/job/michalis_test/3/console

Signed-off-by: Michail Kargakis <mkargaki@redhat.com>