### PR TITLE
Move golang installs to 3.6 candidate repo, remove version lock

### DIFF
--- a/jobs/package-dockertested/Jenkinsfile
+++ b/jobs/package-dockertested/Jenkinsfile
@@ -78,7 +78,7 @@ node('buildvm-devops') {
 				sh 'oct prepare dependencies'
 			}
 			stage ('Install Golang') {
-				sh 'oct prepare golang --version 1.7.3 --repourl https://cbs.centos.org/repos/paas7-openshift-origin15-candidate/x86_64/os/'
+				sh 'oct prepare golang --version 1.7 --repourl https://cbs.centos.org/repos/paas7-openshift-origin36-candidate/x86_64/os/'
 			}
 			stage ('Install Docker') {
 				sh 'oct prepare docker --repo "rhel7next*"'

--- a/sjb/config/test_cases/ami_build_origin_int_rhel_base.yml
+++ b/sjb/config/test_cases/ami_build_origin_int_rhel_base.yml
@@ -18,7 +18,7 @@ actions:
   - type: "host_script"
     title: "install golang"
     script: |-
-      oct prepare golang --version '1.7.3' --repourl 'https://cbs.centos.org/repos/paas7-openshift-origin15-candidate/x86_64/os/'
+      oct prepare golang --version '1.7' --repourl 'https://cbs.centos.org/repos/paas7-openshift-origin36-candidate/x86_64/os/'
   - type: "host_script"
     title: "install docker"
     script: |-

--- a/sjb/generated/ami_build_origin_int_rhel_base.xml
+++ b/sjb/generated/ami_build_origin_int_rhel_base.xml
@@ -75,7 +75,7 @@ oct prepare dependencies</command>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 echo &#34;########## STARTING STAGE: INSTALL GOLANG ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL GOLANG ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-oct prepare golang --version &#39;1.7.3&#39; --repourl &#39;https://cbs.centos.org/repos/paas7-openshift-origin15-candidate/x86_64/os/&#39;</command>
+oct prepare golang --version &#39;1.7&#39; --repourl &#39;https://cbs.centos.org/repos/paas7-openshift-origin36-candidate/x86_64/os/&#39;</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>