### PR TITLE
Build out the pull request approval process

### DIFF
--- a/approvers/approve.sh
+++ b/approvers/approve.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# This script will determine if a pull request of the
+# given severity should be merging into a a specific
+# target branch of a specific repository at this time.
+
+if [[ $# -ne 3 ]]; then
+	echo "[ERROR] Usage: $0 REPO BRANCH SEVERITY"
+	exit 127
+else
+	repo="$1"
+	branch="$2"
+	severity="$3"
+	if [[ ! -f "/var/lib/jenkins/approvers/openshift/${repo}/${branch}/approver" ]]; then
+		echo "[ERROR] No approval criteria are configured for '${branch}' branch of '${repo}' repo."
+		exit 127
+	else
+		"/var/lib/jenkins/approvers/openshift/${repo}/${branch}/approver" "${severity}"
+	fi
+fi

--- a/approvers/closed_approver.sh
+++ b/approvers/closed_approver.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# This approver is to be used during the closed period in the
+# post-release state, where no pull requests are allowed to
+# merge.
+
+if [[ $# -ne 1 ]]; then
+	echo "[ERROR] Usage: $0 SEVERITY"
+	exit 127
+else
+	severity="$1"
+	case "${severity}" in
+		"none")
+			echo "[ERROR] This branch is closed for pull requests at this time."
+			exit 1
+			;;
+		"bug")
+			echo "[ERROR] This branch is closed for pull requests at this time."
+			exit 1
+			;;
+		"blocker")
+			echo "[ERROR] This branch is closed for pull requests at this time."
+			exit 1
+			;;
+		*)
+			echo "[ERROR] Unknown severity '${severity}': only one of 'none', 'bug', or 'blocker' allowed."
+			exit 127
+	esac
+fi

--- a/approvers/configure_approver.sh
+++ b/approvers/configure_approver.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This script will ensure the correct approver is
+# symbolically linked in the appropriate location
+# for the branch of the specified repository.
+
+if [[ $# -ne 3 ]]; then
+	echo "[ERROR] Usage: $0 REPOSITORY BRANCH STAGE"
+	exit 127
+else
+	repo="$1"
+	branch="$2"
+	stage="$3"
+
+	approver_dir="/var/lib/jenkins/approvers/openshift/${repo}/${branch}/"
+	approver="${approver_dir}/approver"
+	rm -f "${approver}"
+	mkdir -p "${approver_dir}"
+
+	ln -s "/usr/bin/${stage}_approver.sh" "${approver}"
+fi

--- a/approvers/devcut_approver.sh
+++ b/approvers/devcut_approver.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# This approver is to be used during the frozen period in the
+# second half of every sprint, where only pull requests that
+# fix bugs are allowed to merge.
+
+if [[ $# -ne 1 ]]; then
+	echo "[ERROR] Usage: $0 SEVERITY"
+	exit 127
+else
+	severity="$1"
+	case "${severity}" in
+		"none")
+			echo "[ERROR] Only bugs and blocker bugs are allowed to merge during dev-cut."
+			exit 1
+			;;
+		"bug")
+			exit 0
+			;;
+		"blocker")
+			exit 0
+			;;
+		*)
+			echo "[ERROR] Unknown severity '${severity}': only one of 'none', 'bug', or 'blocker' allowed."
+			exit 127
+	esac
+fi

--- a/approvers/list_approvers.sh
+++ b/approvers/list_approvers.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This script will list the current state of all
+# configured approvers on the system.
+
+if [[ $# -ne 0 ]]; then
+	echo "[ERROR] Usage: $0"
+	exit 127
+else
+	echo -e "Current approver state:\n"
+	for repo in /var/lib/jenkins/approvers/openshift/*; do
+		echo "openshift/$( basename "${repo}" ):"
+		for branch in "${repo}"/*; do
+			echo -e "\t$( basename "${branch}" ): $( basename "$( readlink "${branch}/approver" )" "_approver.sh" )"
+		done
+		echo
+	done
+fi

--- a/approvers/open_approver.sh
+++ b/approvers/open_approver.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# This approver is to be used during the open period in the
+# first half of every sprint, where all pull requests regard-
+# less of severity are allowed to merge.
+
+if [[ $# -ne 1 ]]; then
+	echo "[ERROR] Usage: $0 SEVERITY"
+	exit 127
+else
+	severity="$1"
+	case "${severity}" in
+		"none")
+			exit 0
+			;;
+		"bug")
+			exit 0
+			;;
+		"blocker")
+			exit 0
+			;;
+		*)
+			echo "[ERROR] Unknown severity '${severity}': only one of 'none', 'bug', or 'blocker' allowed."
+			exit 127
+	esac
+fi

--- a/approvers/push.sh
+++ b/approvers/push.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This script will deploy the approver scripts to
+# the internal and external Jenkins masters. You
+# must have your ~/.ssh/config set up to connect
+# to them before running this script.
+
+pushd approvers/ >/dev/null
+
+for master in 'ci.openshift' 'ci.dev.openshift'; do
+	echo "[INFO] Updating Jenkins master at ${master}..."
+	for stage in 'open' 'devcut' 'stagecut' 'closed'; do
+		scp "${stage}_approver.sh" "${master}:/usr/bin"
+	done
+
+	scp approve.sh "${master}:/usr/bin"
+	scp configure_approver.sh "${master}:/usr/bin"
+	scp list_approvers.sh "${master}:/usr/bin"
+done
+
+popd >/dev/null

--- a/approvers/stagecut_approver.sh
+++ b/approvers/stagecut_approver.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# This approver is to be used during the staging period after
+# the staging branch has been cut, where only pull requests
+# that fix blocker bugs are allowed to merge.
+
+if [[ $# -ne 1 ]]; then
+	echo "[ERROR] Usage: $0 SEVERITY"
+	exit 127
+else
+	severity="$1"
+	case "${severity}" in
+		"none")
+			echo "[ERROR] Only blocker bugs are allowed to merge during stage-cut."
+			exit 1
+			;;
+		"bug")
+			echo "[ERROR] Only blocker bugs are allowed to merge during stage-cut."
+			exit 1
+			;;
+		"blocker")
+			exit 0
+			;;
+		*)
+			echo "[ERROR] Unknown severity '${severity}': only one of 'none', 'bug', or 'blocker' allowed."
+			exit 127
+	esac
+fi

--- a/sjb/generated/merge_pull_request_openshift_ansible.xml
+++ b/sjb/generated/merge_pull_request_openshift_ansible.xml
@@ -38,6 +38,11 @@
           <description>The branch in the &lt;a href=&#34;https://github.com/openshift/origin&#34;&gt;origin&lt;/a&gt; repository to test against.</description>
           <defaultValue>master</defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>MERGE_SEVERITY</name>
+          <description>How important this pull request is.</description>
+          <defaultValue>none</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@1.9.0">
@@ -59,6 +64,12 @@
   <triggers/>
   <concurrentBuild>true</concurrentBuild>
   <builders>
+        <hudson.tasks.Shell>
+          <command>#!/bin/bash
+set -o errexit -o nounset -o pipefail -o xtrace
+approve.sh openshift-ansible &quot;${OPENSHIFT_ANSIBLE_TARGET_BRANCH}&quot; &quot;${MERGE_SEVERITY}&quot;
+          </command>
+        </hudson.tasks.Shell>
     <com.tikal.jenkins.plugins.multijob.MultiJobBuilder>
       <phaseName>Test Phase</phaseName>
       <phaseJobs>

--- a/sjb/generated/merge_pull_request_origin.xml
+++ b/sjb/generated/merge_pull_request_origin.xml
@@ -81,6 +81,11 @@ See also:
           <description>The branch in the &lt;a href=&#34;https://github.com/openshift/release&#34;&gt;release&lt;/a&gt; repository to test against.</description>
           <defaultValue>master</defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>MERGE_SEVERITY</name>
+          <description>How important this pull request is.</description>
+          <defaultValue>none</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@1.9.0">
@@ -102,6 +107,12 @@ See also:
   <triggers/>
   <concurrentBuild>true</concurrentBuild>
   <builders>
+        <hudson.tasks.Shell>
+          <command>#!/bin/bash
+set -o errexit -o nounset -o pipefail -o xtrace
+approve.sh origin &quot;${ORIGIN_TARGET_BRANCH}&quot; &quot;${MERGE_SEVERITY}&quot;
+          </command>
+        </hudson.tasks.Shell>
     <com.tikal.jenkins.plugins.multijob.MultiJobBuilder>
       <phaseName>Test Phase</phaseName>
       <phaseJobs>

--- a/sjb/templates/test_case.xml
+++ b/sjb/templates/test_case.xml
@@ -22,6 +22,13 @@
 {%- for parameter in parameters %}
 {{ parameter }}
 {%- endfor %}
+{%- if action == "merge" %}
+        <hudson.model.StringParameterDefinition>
+          <name>MERGE_SEVERITY</name>
+          <description>How important this pull request is.</description>
+          <defaultValue>none</defaultValue>
+        </hudson.model.StringParameterDefinition>
+{%- endif %}
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
 {%- endif %}
@@ -52,6 +59,14 @@
 {%- endif %}
   <concurrentBuild>true</concurrentBuild>
   <builders>
+{%- if action == "merge" %}
+        <hudson.tasks.Shell>
+          <command>#!/bin/bash
+set -o errexit -o nounset -o pipefail -o xtrace
+approve.sh {{ target_repo }} &quot;${{ '{' }}{{ target_repo | replace('-', '_') | upper }}_TARGET_BRANCH}&quot; &quot;${MERGE_SEVERITY}&quot;
+          </command>
+        </hudson.tasks.Shell>
+{%- endif %}
 {%- for build_step in build_steps %}
 {{ build_step }}
 {%- endfor %}


### PR DESCRIPTION
Configure the merge jobs to use the new approver script

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Add shell scripts that underpin the PR approval process

In the next sprint, we will need to programmatically approve or deny
pull requests for each branch of each repository depending on the phase
of the development cycle that we are in as an organization in order to
ensure that breaking changes do not make it into the code that is
deployed to OpenShift Online at the end of every sprint.

In order to do this, each job that handles `[merge]` tags for all of the
separate repositories will call the `approve.sh` script on the Jenkins
master that it is running on. This will call into an approver script via
a symlink that will have been set up by a team lead using the
appropriate Jenkins job previously.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/cc @jupierce 