### PR TITLE
Make approvers permissive for unknown branches but log the events

### DIFF
--- a/approvers/approve.sh
+++ b/approvers/approve.sh
@@ -12,8 +12,8 @@ else
 	branch="$2"
 	severity="$3"
 	if [[ ! -f "/var/lib/jenkins/approvers/openshift/${repo}/${branch}/approver" ]]; then
-		echo "[ERROR] No approval criteria are configured for '${branch}' branch of '${repo}' repo."
-		exit 127
+		echo "[ERROR] No approval criteria are configured for '${branch}' branch of '${repo}' repo." | tee -a "/var/lib/jenkins/approvers/denials.log"
+		exit 0
 	else
 		"/var/lib/jenkins/approvers/openshift/${repo}/${branch}/approver" "${severity}"
 	fi

--- a/approvers/push.sh
+++ b/approvers/push.sh
@@ -9,13 +9,15 @@ pushd approvers/ >/dev/null
 
 for master in 'ci.openshift' 'ci.dev.openshift'; do
 	echo "[INFO] Updating Jenkins master at ${master}..."
+	scripts=()
 	for stage in 'open' 'devcut' 'stagecut' 'closed'; do
-		scp "${stage}_approver.sh" "${master}:/usr/bin"
+		scripts+=( "${stage}_approver.sh" )
 	done
 
-	scp approve.sh "${master}:/usr/bin"
-	scp configure_approver.sh "${master}:/usr/bin"
-	scp list_approvers.sh "${master}:/usr/bin"
+	scripts+=( approve.sh )
+	scripts+=( configure_approver.sh )
+	scripts+=( list_approvers.sh )
+	scp "${scripts[@]}" "${master}:/usr/bin"
 done
 
 popd >/dev/null


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

@jupierce I had set the most common branches to "open" but we can just make non-registered branches open by default with an audit log so we know what to change when we switch over