### PR TITLE
Change all approver behavior to log instead of deny

### DIFF
--- a/approvers/approve.sh
+++ b/approvers/approve.sh
@@ -15,6 +15,10 @@ else
 		echo "[ERROR] No approval criteria are configured for '${branch}' branch of '${repo}' repo." | tee -a "/var/lib/jenkins/approvers/denials.log"
 		exit 0
 	else
-		"/var/lib/jenkins/approvers/openshift/${repo}/${branch}/approver" "${severity}"
+		if ! "/var/lib/jenkins/approvers/openshift/${repo}/${branch}/approver" "${severity}"; then
+			result='approved'
+		fi
+		echo "[INF0] Pull request of '${severity}' severity would be ${result:-rejected} for merge into '${branch}' branch of '${repo}' repo." | tee -a "/var/lib/jenkins/approvers/denials.log"
+		exit 0
 	fi
 fi


### PR DESCRIPTION
Until we are ready to cut over for the dev-cut and stage-cut in the next
sprint, the approvers should be run but should always return success
while logging their actions.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>