### PR TITLE
Enable approvers, disable silent logging

### DIFF
--- a/approvers/approve.sh
+++ b/approvers/approve.sh
@@ -12,13 +12,9 @@ else
 	branch="$2"
 	severity="$3"
 	if [[ ! -f "/var/lib/jenkins/approvers/openshift/${repo}/${branch}/approver" ]]; then
-		echo "[ERROR] No approval criteria are configured for '${branch}' branch of '${repo}' repo." | tee -a "/var/lib/jenkins/approvers/denials.log"
-		exit 0
+		echo "[ERROR] No approval criteria are configured for '${branch}' branch of '${repo}' repo."
+		exit 1
 	else
-		if ! "/var/lib/jenkins/approvers/openshift/${repo}/${branch}/approver" "${severity}"; then
-			result='approved'
-		fi
-		echo "[INF0] Pull request of '${severity}' severity would be ${result:-rejected} for merge into '${branch}' branch of '${repo}' repo." | tee -a "/var/lib/jenkins/approvers/denials.log"
-		exit 0
+		"/var/lib/jenkins/approvers/openshift/${repo}/${branch}/approver" "${severity}"
 	fi
 fi


### PR DESCRIPTION
Now that we are ready to enable the approvers for pull requests, a pull
request for a branch that we do not have an approver for will result in
an error and we will honor the result of the approver that we call.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

@jupierce this is the PR to enable the approvers, we can merge and push when we're ready