### PR TITLE
Improving emails and mode names

### DIFF
--- a/jobs/build/openshift-scripts/Jenkinsfile
+++ b/jobs/build/openshift-scripts/Jenkinsfile
@@ -20,9 +20,9 @@ node('buildvm-devops') {
                                      [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'jupierce@redhat.com,tdawson@redhat.com,smunilla@redhat.com,sedgar@redhat.com,vdinh@redhat.com', description: 'Failure Mailing List', name: 'MAIL_LIST_FAILURE'],
                                      [$class: 'hudson.model.BooleanParameterDefinition', defaultValue: false, description: 'Force rebuild even if no changes are detected?', name: 'FORCE_REBUILD'],
                                      [$class: 'hudson.model.ChoiceParameterDefinition',
-                                        choices: "online/master\nonline/stg", 
-                                        description: '''online/master openshift/online/master -> rhel-7-libra-candidate yum repo<br>
-                                                        online/stg openshift/online/stage -> rhel-7-libra-candidate-stage yum repo<br>
+                                        choices: "online:int\nonline:stg",
+                                        description: '''online:int      online/master -> rhel-7-libra-candidate yum repo<br>
+                                                        online:stg      online/stage -> rhel-7-libra-candidate-stage yum repo<br>
                                                         ''',
                                         name: 'BUILD_MODE'],
                              ]

--- a/jobs/build/openshift-scripts/scripts/merge-and-build-openshift-scripts.sh
+++ b/jobs/build/openshift-scripts/scripts/merge-and-build-openshift-scripts.sh
@@ -26,7 +26,7 @@ rm -rf online
 git clone git@github.com:openshift/online.git
 cd online/
 
-if [ "${BUILD_MODE}" == "online/stg" ] ; then
+if [ "${BUILD_MODE}" == "online:stg" ] ; then
     git checkout -q stage
 fi
 
@@ -63,7 +63,7 @@ else
     echo "=========="
     TAG=`git describe --abbrev=0`
     COMMIT=`git log -n 1 --pretty=%h`
-    if [ "${BUILD_MODE}" == "online/stg" ] ; then
+    if [ "${BUILD_MODE}" == "online:stg" ] ; then
       brew tag-pkg libra-rhel-7-stage ${TAG}.git.0.${COMMIT}.el7
     else
       brew tag-pkg libra-rhel-7-candidate ${TAG}.git.0.${COMMIT}.el7
@@ -73,7 +73,7 @@ else
     echo "=========="
     echo "Build and Push libra repos"
     echo "=========="
-    if [ "${BUILD_MODE}" == "online/stg" ] ; then
+    if [ "${BUILD_MODE}" == "online:stg" ] ; then
       ssh ocp-build@rcm-guest.app.eng.bos.redhat.com "/mnt/rcm-guest/puddles/RHAOS/scripts/libra-repo-to-mirrors.sh stage"
     else
       ssh ocp-build@rcm-guest.app.eng.bos.redhat.com "/mnt/rcm-guest/puddles/RHAOS/scripts/libra-repo-to-mirrors.sh candidate"
@@ -86,7 +86,7 @@ else
     ose_images.sh --user ocp-build update_docker --branch libra-rhel-7 --group oso --force --release 1 --version ${VERSION}
 
     # If we are at the stage mode, dont be messing with the dist-git checking
-    if [ "${BUILD_MODE}" != "online/stg" ] ; then
+    if [ "${BUILD_MODE}" != "online:stg" ] ; then
         echo
         echo "=========="
         echo "Sync distgit"

--- a/jobs/build/ose/Jenkinsfile
+++ b/jobs/build/ose/Jenkinsfile
@@ -1,5 +1,8 @@
 #!/usr/bin/env groovy
 
+// Update OSE_MASTER when the version in ose/master changes
+def OSE_MASTER = "3.6"
+
 // https://issues.jenkins-ci.org/browse/JENKINS-33511
 def set_workspace() {
     if(env.WORKSPACE == null) {
@@ -15,15 +18,16 @@ def version(f) {
 def mail_success(version) {
 
     def target = "Enterprise"
-    def mirrorURL = "https://mirror.openshift.com/enterprise/enterprise-${version.substring(0,3)}/"
+    def mirrorURL = "https://mirror.openshift.com/enterprise/enterprise-${version.substring(0,3)}"
 
-    if ( BUILD_MODE == "online/master" ) {
+    if ( BUILD_MODE == "online:int" ) {
         target = "Online-int"
-        mirrorURL = "https://mirror.openshift.com/enterprise/online-int/"
+        mirrorURL = "https://mirror.openshift.com/enterprise/online-int"
     }
-    if ( BUILD_MODE == "online/stg" ) {
+
+    if ( BUILD_MODE == "online:stg" ) {
         target = "Online-stg"
-        mirrorURL = "https://mirror.openshift.com/enterprise/online-stg/"
+        mirrorURL = "https://mirror.openshift.com/enterprise/online-stg"
     }
 
     def oaBrewURL = readFile("results/openshift-ansible-brew.url")
@@ -61,27 +65,36 @@ node('buildvm-devops') {
                               [$class: 'hudson.model.StringParameterDefinition', defaultValue: '', description: 'OSE Minor Version', name: 'OSE_MINOR'],
                               [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'aos-devel@redhat.com, aos-qe@redhat.com', description: 'Success Mailing List', name: 'MAIL_LIST_SUCCESS'],
                               [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'jupierce@redhat.com,tdawson@redhat.com,smunilla@redhat.com', description: 'Failure Mailing List', name: 'MAIL_LIST_FAILURE'],
-                              [$class: 'hudson.model.ChoiceParameterDefinition', choices: "online/master\nonline/stg\nenterprise/master\nenterprise/release", description: '''online/master openshift/origin/master -> online-int yum repo<br>
-online/stg openshift/origin/stg -> online-stg yum repo<br>
-enterprise/master  openshift/origin/master ->  https://mirror.openshift.com/enterprise/enterprise-X.Y/latest/<br>
-enterprise/release  openshift/origin/release-X.Y ->  https://mirror.openshift.com/enterprise/enterprise-X.Y/latest/<br>''', name: 'BUILD_MODE'],
+                              [$class: 'hudson.model.ChoiceParameterDefinition', choices: "enterprise\nenterprise:pre-release\nonline-int\nonline-stg", description:
+'''
+enterprise                {ose,origin-web-console,openshift-ansible}/release-X.Y ->  https://mirror.openshift.com/enterprise/enterprise-X.Y/latest/<br>
+enterprise:pre-release    {origin,origin-web-console,openshift-ansible}/release-X.Y ->  https://mirror.openshift.com/enterprise/enterprise-X.Y/latest/<br>
+online:int                {origin,origin-web-console,openshift-ansible}/master -> online-int yum repo<br>
+online:stg                {origin,origin-web-console,openshift-ansible}/stage -> online-stg yum repo<br>
+''', name: 'BUILD_MODE'],
                       ]
              ]]
     )
     
     // Force Jenkins to fail early if this is the first time this job has been run/and or new parameters have not been discovered.
     echo "${OSE_MAJOR}.${OSE_MINOR}, MAIL_LIST_SUCCESS:[${MAIL_LIST_SUCCESS}], MAIL_LIST_FAILURE:[${MAIL_LIST_FAILURE}], BUILD_MODE:${BUILD_MODE}"
-    
+
     currentBuild.displayName = "#${currentBuild.number} - ${OSE_MAJOR}.${OSE_MINOR}.??"
     
     set_workspace()
     stage('Merge and build') {
         try {
+
+            if ( BUILD_MODE != "enterprise" && "${OSE_MAJOR}.${OSE_MINOR}" != OSE_MASTER ) {
+                error("Unable to build older version ${OSE_MAJOR}.${OSE_MINOR} in online or pre-release mode: ${BUILD_MODE}. Only ${OSE_MASTER} can be built in this mode.")
+            }
+
             checkout scm
 
             env.PATH = "${pwd()}/build-scripts/ose_images:${env.PATH}"
 
             sshagent(['openshift-bot']) { // merge-and-build must run with the permissions of openshift-bot to succeed
+                env.OSE_MASTER = "${OSE_MASTER}"
                 env.BUILD_MODE = "${BUILD_MODE}"
                 sh "./scripts/merge-and-build.sh ${OSE_MAJOR} ${OSE_MINOR}"
             }
@@ -93,14 +106,12 @@ enterprise/release  openshift/origin/release-X.Y ->  https://mirror.openshift.co
             // Replace flow control with: https://jenkins.io/blog/2016/12/19/declarative-pipeline-beta/ when available
             mail_success(thisBuildVersion)
 
-
         } catch ( err ) {
             // Replace flow control with: https://jenkins.io/blog/2016/12/19/declarative-pipeline-beta/ when available
             mail(to: "${MAIL_LIST_FAILURE}",
                     from: "aos-cd@redhat.com",
                     subject: "Error building OSE: ${OSE_MAJOR}.${OSE_MINOR}",
                     body: """Encoutered an error while running merge-and-build.sh: ${err}
-
 
 Jenkins job: ${env.BUILD_URL}
 """);

--- a/jobs/build/ose3.6/Jenkinsfile
+++ b/jobs/build/ose3.6/Jenkinsfile
@@ -9,6 +9,7 @@ properties(
 b = build       job: '../aos-cd-builds/build%2Fose', propagate: false,
                 parameters: [   [$class: 'StringParameterValue', name: 'OSE_MAJOR', value: '3'],
                                 [$class: 'StringParameterValue', name: 'OSE_MINOR', value: '6'],
+                                [$class: 'StringParameterValue', name: 'BUILD_MODE', value: 'online:int'],
                                 ]
 
 currentBuild.displayName = "ose:${b.displayName}"


### PR DESCRIPTION
@tdawson This started by trying to clean up the success email (the wrong puddle URLs were being sent out for older levels). Ended up moving OSE_MASTER to the Jenkinsfile and changing the BUILD_MODE options for clarity. 

I tried to factor out OSE_MASTER_BRANCHED with "enterprise:pre-release" build mode. Please let me know your thoughts. 