### PR TITLE
Install-Upgrade job should do single upgrade

### DIFF
--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update.yml
@@ -100,29 +100,6 @@ extensions:
                           -e openshift_pkg_version="-${ORIGIN_INSTALL_VERSION}"         \
                           -e etcd_data_dir="${ETCD_DATA_DIR}"                           \
                           -e deployment_type=$( cat ./DEPLOYMENT_TYPE)
-        if [[ -v ORIGIN_UPGRADE_VERSION  && -v ATOMIC_OPENSHIFT_UTILS_UPGRADE_VERSION ]]
-        then
-          echo "=== Updating atomic-openshift-utils-${ATOMIC_OPENSHIFT_UTILS_UPGRADE_VERSION} ==="
-          versioned_packages_to_install=""
-          packages_to_install=( $( cat ./OPENSHIFT_ANSIBLE_PKGS ) )
-          for pkg in "${packages_to_install[@]}"
-          do
-            versioned_packages_to_install+=" ${pkg}-${ATOMIC_OPENSHIFT_UTILS_UPGRADE_VERSION}"
-          done
-          sudo yum upgrade -y ${versioned_packages_to_install}
-          echo "=== Updating ${pkg_name} to ${ORIGIN_UPGRADE_VERSION} ==="
-          upgrade_playbook="/usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_${ORIGIN_UPGRADE_MINOR_VERSION}/upgrade.yml"
-          ansible-playbook  -vv                    \
-                            --become               \
-                            --become-user root     \
-                            --connection local     \
-                            --inventory sjb/inventory/ \
-                            "${upgrade_playbook}"      \
-                            -e etcd_data_dir="${ETCD_DATA_DIR}" \
-                            -e openshift_pkg_version="-${ORIGIN_UPGRADE_VERSION}" \
-                            -e deployment_type=$( cat ./DEPLOYMENT_TYPE)          \
-                            -e oreg_url='openshift/origin-${component}:'"${ORIGIN_UPGRADE_VERSION_PKG_VERSION}"
-        fi
     - type: "script"
       title: "build an origin release"
       repository: "origin"

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
@@ -255,29 +255,6 @@ ansible-playbook  -vv                \
                   -e openshift_pkg_version=&#34;-\${ORIGIN_INSTALL_VERSION}&#34;         \
                   -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34;                           \
                   -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)
-if [[ -v ORIGIN_UPGRADE_VERSION  &amp;&amp; -v ATOMIC_OPENSHIFT_UTILS_UPGRADE_VERSION ]]
-then
-  echo &#34;=== Updating atomic-openshift-utils-\${ATOMIC_OPENSHIFT_UTILS_UPGRADE_VERSION} ===&#34;
-  versioned_packages_to_install=&#34;&#34;
-  packages_to_install=( \$( cat ./OPENSHIFT_ANSIBLE_PKGS ) )
-  for pkg in &#34;\${packages_to_install[@]}&#34;
-  do
-    versioned_packages_to_install+=&#34; \${pkg}-\${ATOMIC_OPENSHIFT_UTILS_UPGRADE_VERSION}&#34;
-  done
-  sudo yum upgrade -y \${versioned_packages_to_install}
-  echo &#34;=== Updating \${pkg_name} to \${ORIGIN_UPGRADE_VERSION} ===&#34;
-  upgrade_playbook=&#34;/usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_\${ORIGIN_UPGRADE_MINOR_VERSION}/upgrade.yml&#34;
-  ansible-playbook  -vv                    \
-                    --become               \
-                    --become-user root     \
-                    --connection local     \
-                    --inventory sjb/inventory/ \
-                    &#34;\${upgrade_playbook}&#34;      \
-                    -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
-                    -e openshift_pkg_version=&#34;-\${ORIGIN_UPGRADE_VERSION}&#34; \
-                    -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)          \
-                    -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\${ORIGIN_UPGRADE_VERSION_PKG_VERSION}&#34;
-fi
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
@@ -265,29 +265,6 @@ ansible-playbook  -vv                \
                   -e openshift_pkg_version=&#34;-\${ORIGIN_INSTALL_VERSION}&#34;         \
                   -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34;                           \
                   -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)
-if [[ -v ORIGIN_UPGRADE_VERSION  &amp;&amp; -v ATOMIC_OPENSHIFT_UTILS_UPGRADE_VERSION ]]
-then
-  echo &#34;=== Updating atomic-openshift-utils-\${ATOMIC_OPENSHIFT_UTILS_UPGRADE_VERSION} ===&#34;
-  versioned_packages_to_install=&#34;&#34;
-  packages_to_install=( \$( cat ./OPENSHIFT_ANSIBLE_PKGS ) )
-  for pkg in &#34;\${packages_to_install[@]}&#34;
-  do
-    versioned_packages_to_install+=&#34; \${pkg}-\${ATOMIC_OPENSHIFT_UTILS_UPGRADE_VERSION}&#34;
-  done
-  sudo yum upgrade -y \${versioned_packages_to_install}
-  echo &#34;=== Updating \${pkg_name} to \${ORIGIN_UPGRADE_VERSION} ===&#34;
-  upgrade_playbook=&#34;/usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_\${ORIGIN_UPGRADE_MINOR_VERSION}/upgrade.yml&#34;
-  ansible-playbook  -vv                    \
-                    --become               \
-                    --become-user root     \
-                    --connection local     \
-                    --inventory sjb/inventory/ \
-                    &#34;\${upgrade_playbook}&#34;      \
-                    -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
-                    -e openshift_pkg_version=&#34;-\${ORIGIN_UPGRADE_VERSION}&#34; \
-                    -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)          \
-                    -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\${ORIGIN_UPGRADE_VERSION_PKG_VERSION}&#34;
-fi
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
@@ -265,29 +265,6 @@ ansible-playbook  -vv                \
                   -e openshift_pkg_version=&#34;-\${ORIGIN_INSTALL_VERSION}&#34;         \
                   -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34;                           \
                   -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)
-if [[ -v ORIGIN_UPGRADE_VERSION  &amp;&amp; -v ATOMIC_OPENSHIFT_UTILS_UPGRADE_VERSION ]]
-then
-  echo &#34;=== Updating atomic-openshift-utils-\${ATOMIC_OPENSHIFT_UTILS_UPGRADE_VERSION} ===&#34;
-  versioned_packages_to_install=&#34;&#34;
-  packages_to_install=( \$( cat ./OPENSHIFT_ANSIBLE_PKGS ) )
-  for pkg in &#34;\${packages_to_install[@]}&#34;
-  do
-    versioned_packages_to_install+=&#34; \${pkg}-\${ATOMIC_OPENSHIFT_UTILS_UPGRADE_VERSION}&#34;
-  done
-  sudo yum upgrade -y \${versioned_packages_to_install}
-  echo &#34;=== Updating \${pkg_name} to \${ORIGIN_UPGRADE_VERSION} ===&#34;
-  upgrade_playbook=&#34;/usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_\${ORIGIN_UPGRADE_MINOR_VERSION}/upgrade.yml&#34;
-  ansible-playbook  -vv                    \
-                    --become               \
-                    --become-user root     \
-                    --connection local     \
-                    --inventory sjb/inventory/ \
-                    &#34;\${upgrade_playbook}&#34;      \
-                    -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
-                    -e openshift_pkg_version=&#34;-\${ORIGIN_UPGRADE_VERSION}&#34; \
-                    -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)          \
-                    -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\${ORIGIN_UPGRADE_VERSION_PKG_VERSION}&#34;
-fi
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/hack/determine_install_upgrade_version.py
+++ b/sjb/hack/determine_install_upgrade_version.py
@@ -33,11 +33,9 @@ def get_matching_versions(input_pkg_name, available_pkgs, search_version):
 		print("[ERROR] Can not determine install and upgrade version for the `" + input_pkg_name + "` package", sys.stderr)
 		sys.exit(1)
 
-# Get only install(first) and upgrade(last) versions from version list
-def get_install_upgrade_version(version_list):
-	if len(version_list) > 1: 
-		return [version_list[0],version_list[len(version_list)-1]]
-	return [version_list[0]]
+# Get only install(last) version from version list
+def get_install_version(version_list):
+	return version_list[-1]
 
 # Return minor version of provided package version-release pair
 def get_minor_version(pkg_version_release):
@@ -49,14 +47,10 @@ def get_version(pkg_version_release):
 
 # Print install, upgrade and upgrade_release versions of desired package to STDOUT.
 # The upgrade version will be printed only in case there is more then one version of packages previous minor release. 
-def print_version_vars(version_list):
+def print_version_vars(install_version):
 	used_pkg_name = pkg_name.upper().replace("-", "_")
-	print (used_pkg_name + "_INSTALL_VERSION=" + version_list[0])
-	print (used_pkg_name + "_INSTALL_MINOR_VERSION=" + get_minor_version(version_list[0]))
-	if len(version_list) > 1:
-		print (used_pkg_name + "_UPGRADE_VERSION=" + version_list[1])
-		print (used_pkg_name + "_UPGRADE_MINOR_VERSION=" + get_minor_version(version_list[1]))
-		print (used_pkg_name + "_UPGRADE_VERSION_PKG_VERSION=" + get_version(version_list[1]))
+	print (used_pkg_name + "_INSTALL_VERSION=" + install_version)
+	print (used_pkg_name + "_INSTALL_MINOR_VERSION=" + get_minor_version(install_version))
 	print (used_pkg_name + "_UPGRADE_RELEASE_VERSION=" + pkg_version + "-" + pkg_release)
 	print (used_pkg_name + "_UPGRADE_RELEASE_MINOR_VERSION=" + get_minor_version(pkg_version + "-" + pkg_release))
 
@@ -94,5 +88,5 @@ if __name__ == "__main__":
 	available_pkgs = remove_duplicate_pkgs(available_pkgs)
 	available_pkgs.sort(lambda x, y: rpmutils.compareEVR((x.epoch, x.version, x.release), (y.epoch, y.version, y.release)))
 	matching_pkgs = get_matching_versions(pkg_name, available_pkgs, search_version)
-	install_upgrade_version_list = get_install_upgrade_version(matching_pkgs)
-	print_version_vars(install_upgrade_version_list)
+	install_version = get_install_version(matching_pkgs)
+	print_version_vars(install_version)

--- a/sjb/hack/determine_install_upgrade_version_test.py
+++ b/sjb/hack/determine_install_upgrade_version_test.py
@@ -101,32 +101,32 @@ class DetermineSearchVersionTestCase(unittest.TestCase):
 		""" when openshift-ansible, which doesnt have different versioning schema is in 3.4 version """
 		self.assertEqual(determine_search_version("openshift-ansible", "3.5.0"), "3.4")
 
-class GetInstallUpgradeVersionTestCase(unittest.TestCase):
+class GetInstallVersionTestCase(unittest.TestCase):
 	"Test for `determine_install_upgrade_version.py`"
 
 	def test_with_multiple_matching_release_versions(self):
 		""" when multiple matching version are present in released versions """
 		matching_versions = ["1.2.0-1.el7", "1.2.2-1.el7", "1.2.5-1.el7"]
-		install_upgrade_versions = ["1.2.0-1.el7", "1.2.5-1.el7"]
-		self.assertEqual(get_install_upgrade_version(matching_versions), install_upgrade_versions)
+		install_version = "1.2.5-1.el7"
+		self.assertEqual(get_install_version(matching_versions), install_version)
 
 	def test_with_single_matching_release_version(self):
 		""" when only a single matching version is present in released versions """
 		matching_versions = ["1.5.0-1.4.el7"]
-		install_upgrade_versions = ["1.5.0-1.4.el7"]
-		self.assertEqual(get_install_upgrade_version(matching_versions), install_upgrade_versions)
+		install_version = "1.5.0-1.4.el7"
+		self.assertEqual(get_install_version(matching_versions), install_version)
 
 	def test_with_multiple_matching_pre_release_versions(self):
 		""" when multiple matching pre-release version are present in pre-released versions """
 		matching_versions = ["1.2.0-0.el7", "1.2.2-0.el7", "1.2.5-0.el7"]
-		install_upgrade_versions = ["1.2.0-0.el7", "1.2.5-0.el7"]
-		self.assertEqual(get_install_upgrade_version(matching_versions), install_upgrade_versions)
+		install_version = "1.2.5-0.el7"
+		self.assertEqual(get_install_version(matching_versions), install_version)
 
 	def test_with_single_matching_pre_release_version(self):
 		""" when only single matching pre-release version is present in pre-released versions """
 		matching_versions = ["1.5.0-0.4.el7"]
-		install_upgrade_versions = ["1.5.0-0.4.el7"]
-		self.assertEqual(get_install_upgrade_version(matching_versions), install_upgrade_versions)
+		install_version = "1.5.0-0.4.el7"
+		self.assertEqual(get_install_version(matching_versions), install_version)
 
 class GetVersionTestCase(unittest.TestCase):
 	"Test for `determine_install_upgrade_version.py`"


### PR DESCRIPTION
Got rid of the first upgrade in the install_upgrade job so now we install the latest instead of the GA of the previous version of origin
@stevekuznetsov PTAL

This PR is prior to https://github.com/openshift/aos-cd-jobs/pull/207