### PR TITLE
Add the Aggregated Logging images to build AMI

### DIFF
--- a/sjb/config/test_cases/ami_build_origin_int_rhel_build.yml
+++ b/sjb/config/test_cases/ami_build_origin_int_rhel_build.yml
@@ -8,7 +8,7 @@ actions:
   - type: "host_script"
     title: "bring source code up to date"
     script: |-
-      for repo in origin origin-web-console openshift-ansible; do
+      for repo in origin origin-web-console openshift-ansible origin-aggregated-logging; do
         oct sync remote "${repo}"
       done
   - type: "script"
@@ -37,6 +37,11 @@ actions:
       name = OpenShift Ansible Release from Local Source
       EOR
       sudo cp ./openshift-ansible-local-release.repo /etc/yum.repos.d
+  - type: "script"
+    title: "build an origin-aggregated-logging release"
+    repository: "origin-aggregated-logging"
+    script: |-
+      hack/build-images.sh
   - type: "host_script"
     title: "package the AMI"
     script: |-


### PR DESCRIPTION
The Origin Aggregated Logging team will soon be using the build stage
AMI for their CI. Having a set of images already built on their local
daemon will speed up their job times significantly and not require that
they pre-pull images to warm up their caches, either.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @richm -- please confirm that we are running the correct script