### PR TITLE
Increase /tmp in base AMI

### DIFF
--- a/sjb/config/common/test_cases/origin.yml
+++ b/sjb/config/common/test_cases/origin.yml
@@ -12,7 +12,7 @@ actions:
     script: |-
       sudo su root <<SUDO
       mkdir -p /tmp
-      mount -t tmpfs -o size=2048m tmpfs /tmp
+      mount -t tmpfs -o size=4096m tmpfs /tmp
       mkdir -p /tmp/etcd
       chmod a+rwx /tmp/etcd
       restorecon -R /tmp

--- a/sjb/config/test_cases/ami_build_origin_int_rhel_base.yml
+++ b/sjb/config/test_cases/ami_build_origin_int_rhel_base.yml
@@ -47,7 +47,7 @@ actions:
     script: |-
       sudo su root <<SUDO
       mkdir -p /tmp
-      mount -t tmpfs -o size=2048m tmpfs /tmp
+      mount -t tmpfs -o size=4096m tmpfs /tmp
       mkdir -p /tmp/etcd
       chmod a+rwx /tmp/etcd
       restorecon -R /tmp

--- a/sjb/config/test_cases/ami_build_origin_int_rhel_build.yml
+++ b/sjb/config/test_cases/ami_build_origin_int_rhel_build.yml
@@ -51,7 +51,7 @@ actions:
     script: |-
       sudo su root <<SUDO
       mkdir -p /tmp
-      mount -t tmpfs -o size=2048m tmpfs /tmp
+      mount -t tmpfs -o size=4096m tmpfs /tmp
       mkdir -p /tmp/etcd
       chmod a+rwx /tmp/etcd
       restorecon -R /tmp

--- a/sjb/generated/ami_build_origin_int_rhel_base.xml
+++ b/sjb/generated/ami_build_origin_int_rhel_base.xml
@@ -123,7 +123,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/ami_build_origin_int_rhel_build.xml
+++ b/sjb/generated/ami_build_origin_int_rhel_build.xml
@@ -137,7 +137,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/push_origin_release.xml
+++ b/sjb/generated/push_origin_release.xml
@@ -87,7 +87,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_branch_origin_aggregated_logging.xml
+++ b/sjb/generated/test_branch_origin_aggregated_logging.xml
@@ -87,7 +87,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_branch_origin_check.xml
+++ b/sjb/generated/test_branch_origin_check.xml
@@ -87,7 +87,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_branch_origin_extended.xml
+++ b/sjb/generated/test_branch_origin_extended.xml
@@ -97,7 +97,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_branch_origin_extended_builds.xml
+++ b/sjb/generated/test_branch_origin_extended_builds.xml
@@ -71,7 +71,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_branch_origin_extended_conformance.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance.xml
@@ -87,7 +87,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_branch_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce.xml
@@ -136,7 +136,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_branch_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install.xml
@@ -109,7 +109,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_branch_origin_extended_conformance_install_containerized.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_containerized.xml
@@ -109,7 +109,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
@@ -109,7 +109,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_branch_origin_extended_gssapi.xml
+++ b/sjb/generated/test_branch_origin_extended_gssapi.xml
@@ -71,7 +71,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_branch_origin_extended_image_ecosystem.xml
+++ b/sjb/generated/test_branch_origin_extended_image_ecosystem.xml
@@ -71,7 +71,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_branch_origin_extended_ldap_groups.xml
+++ b/sjb/generated/test_branch_origin_extended_ldap_groups.xml
@@ -71,7 +71,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_branch_origin_extended_networking.xml
+++ b/sjb/generated/test_branch_origin_extended_networking.xml
@@ -91,7 +91,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_branch_origin_extended_networking_minimal.xml
+++ b/sjb/generated/test_branch_origin_extended_networking_minimal.xml
@@ -87,7 +87,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_branch_origin_integration.xml
+++ b/sjb/generated/test_branch_origin_integration.xml
@@ -87,7 +87,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
@@ -119,7 +119,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized.xml
@@ -119,7 +119,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
@@ -119,7 +119,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
@@ -119,7 +119,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_pull_request_origin_aggregated_logging.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging.xml
@@ -97,7 +97,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_pull_request_origin_check.xml
+++ b/sjb/generated/test_pull_request_origin_check.xml
@@ -97,7 +97,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_pull_request_origin_extended.xml
+++ b/sjb/generated/test_pull_request_origin_extended.xml
@@ -107,7 +107,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_pull_request_origin_extended_conformance.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance.xml
@@ -97,7 +97,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
@@ -146,7 +146,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
@@ -119,7 +119,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
@@ -119,7 +119,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_pull_request_origin_extended_networking_minimal.xml
+++ b/sjb/generated/test_pull_request_origin_extended_networking_minimal.xml
@@ -97,7 +97,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp

--- a/sjb/generated/test_pull_request_origin_integration.xml
+++ b/sjb/generated/test_pull_request_origin_integration.xml
@@ -97,7 +97,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo su root &lt;&lt;SUDO
 mkdir -p /tmp
-mount -t tmpfs -o size=2048m tmpfs /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
 mkdir -p /tmp/etcd
 chmod a+rwx /tmp/etcd
 restorecon -R /tmp


### PR DESCRIPTION
@stevekuznetsov the base AMI now fails with:
```
++ Building go targets for linux/amd64: images/pod cmd/dockerregistry cmd/gitserver pkg/sdn/plugin/sdn-cni-plugin vendor/github.com/containernetworking/cni/plugins/ipam/host-local vendor/github.com/containernetworking/cni/plugins/main/loopback examples/hello-openshift
++ Building go targets for linux/amd64: cmd/openshift cmd/oc
# github.com/openshift/origin/cmd/oc
/usr/lib/golang/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
collect2: error: ld returned 1 exit status

# github.com/openshift/origin/cmd/openshift
/usr/lib/golang/pkg/tool/linux_amd64/link: flushing /tmp/go-link-266822244/go.o: write /tmp/go-link-266822244/go.o: no space left on device
```
Increased /tmp in https://ci.openshift.redhat.com/jenkins/view/All/job/ami_build_origin_int_rhel_base/102 and it seems to work fine.

Signed-off-by: Michail Kargakis <mkargaki@redhat.com>