### PR TITLE
Prepare the CI user again for good measure in build stage

### DIFF
--- a/sjb/config/test_cases/ami_build_origin_int_rhel_build.yml
+++ b/sjb/config/test_cases/ami_build_origin_int_rhel_build.yml
@@ -43,20 +43,13 @@ actions:
     script: |-
       hack/build-images.sh
   - type: "host_script"
+    title: "set up CI user again"
+    script: |-
+      oct prepare user
+  - type: "host_script"
     title: "package the AMI"
     script: |-
       oct package ami --stage=next
-  - type: "script"
-    title: "use a ramdisk for etcd"
-    script: |-
-      sudo su root <<SUDO
-      mkdir -p /tmp
-      mount -t tmpfs -o size=4096m tmpfs /tmp
-      mkdir -p /tmp/etcd
-      chmod a+rwx /tmp/etcd
-      restorecon -R /tmp
-      echo "ETCD_DATA_DIR=/tmp/etcd" >> /etc/environment
-      SUDO
   - type: "host_script"
     title: "release the AMI"
     script: |-

--- a/sjb/generated/ami_build_origin_int_rhel_build.xml
+++ b/sjb/generated/ami_build_origin_int_rhel_build.xml
@@ -124,29 +124,13 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-echo &#34;########## STARTING STAGE: PACKAGE THE AMI ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: PACKAGE THE AMI ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-oct package ami --stage=next</command>
+echo &#34;########## STARTING STAGE: SET UP CI USER AGAIN ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: SET UP CI USER AGAIN ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+oct prepare user</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-echo &#34;########## STARTING STAGE: USE A RAMDISK FOR ETCD ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: USE A RAMDISK FOR ETCD ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-script=&#34;$( mktemp )&#34;
-cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
-#!/bin/bash
-set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${HOME}&#34;
-sudo su root &lt;&lt;SUDO
-mkdir -p /tmp
-mount -t tmpfs -o size=4096m tmpfs /tmp
-mkdir -p /tmp/etcd
-chmod a+rwx /tmp/etcd
-restorecon -R /tmp
-echo &#34;ETCD_DATA_DIR=/tmp/etcd&#34; &gt;&gt; /etc/environment
-SUDO
-SCRIPT
-chmod +x &#34;${script}&#34;
-scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;${script}\&#34;&#34; </command>
+echo &#34;########## STARTING STAGE: PACKAGE THE AMI ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: PACKAGE THE AMI ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+oct package ami --stage=next</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash


### PR DESCRIPTION
We are seeing build stage AMIs that are missing authorized keys for the
CI user, so let's re-initialize that user right before we package the
build stage AMI and see if we can keep this stable until we figure out
why the issue exists in the first place.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @kargakis 