### PR TITLE
configure template service broker in gce test environments

### DIFF
--- a/sjb/inventory/group_vars/OSEv3/general.yml
+++ b/sjb/inventory/group_vars/OSEv3/general.yml
@@ -11,5 +11,7 @@ openshift_master_identity_providers:
     login: "true"
     challenge: "true"
     kind: "AllowAllPasswordIdentityProvider"
+openshift_template_service_broker_namespaces:
+  - "openshift"
 ansible_ssh_user: "ec2-user"
 enable_excluders: "false"


### PR DESCRIPTION
this is needed to add the template service broker tests to conformance (https://github.com/openshift/origin/pull/14320).