### PR TITLE
Configure tmpfs to use a ramdisk in docker testing job

### DIFF
--- a/jobs/package-dockertested/Jenkinsfile
+++ b/jobs/package-dockertested/Jenkinsfile
@@ -85,6 +85,9 @@ node('buildvm-devops') {
 				sh 'oct prepare user'
 				sh "sed -i 's/User ec2-user/User origin/g' ./.config/origin-ci-tool/inventory/.ssh_config"
 			}
+			stage ('Configure TMPFS') {
+				runScript './configure-tmpfs.sh'
+			}
 			stage ('Install distribution dependencies') {
 				sh 'oct prepare dependencies'
 			}

--- a/jobs/package-dockertested/configure-tmpfs.sh
+++ b/jobs/package-dockertested/configure-tmpfs.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -o errexit 
+set -o nounset 
+set -o pipefail 
+set -o xtrace
+
+sudo su root <<SUDO
+mkdir -p /tmp
+mount -t tmpfs -o size=4096m tmpfs /tmp
+mkdir -p /tmp/etcd
+chmod a+rwx /tmp/etcd
+restorecon -R /tmp
+echo "ETCD_DATA_DIR=/tmp/etcd" >> /etc/environment
+SUDO


### PR DESCRIPTION
Having the XFS test actually run on an XFS for the volume directory was
causing it to fail. It is unclear if the test works at all. We can
disable it the same way that the other jobs do -- not using XFS.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>