### PR TITLE
Generate a certificate for the router on install

### DIFF
--- a/sjb/inventory/group_vars/OSEv3/general.yml
+++ b/sjb/inventory/group_vars/OSEv3/general.yml
@@ -5,6 +5,7 @@ osm_controller_args:
   enable-hostpath-provisioner:
     - "true"
 openshift_hosted_router_selector: "region=infra"
+openshift_hosted_router_create_certificate: "true"
 openshift_hosted_registry_selector: "region=infra"
 openshift_master_identity_providers:
   - name: "allow_all"


### PR DESCRIPTION
Some of our extended tests require that the router have a cert.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @csrwng @abutcher 