### PR TITLE
Pass openshift_hosted_router_create_certificate as a boolean

### DIFF
--- a/sjb/inventory/group_vars/OSEv3/general.yml
+++ b/sjb/inventory/group_vars/OSEv3/general.yml
@@ -5,7 +5,7 @@ osm_controller_args:
   enable-hostpath-provisioner:
     - "true"
 openshift_hosted_router_selector: "region=infra"
-openshift_hosted_router_create_certificate: "true"
+openshift_hosted_router_create_certificate: true
 openshift_hosted_registry_selector: "region=infra"
 openshift_master_identity_providers:
   - name: "allow_all"


### PR DESCRIPTION
While the other `"true"` values in the inventory do need to be strings
due to the way OpenShift ends up interpreting them, this specific value
should be a real YAML boolean as it gets used by Ansible.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>