### PR TITLE
Continuous upgrade job

### DIFF
--- a/continuous-upgrade/generate-jobs.sh
+++ b/continuous-upgrade/generate-jobs.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+jobs=( provision upgrade terminate )
+
+for job in ${jobs[@]}; do
+    jenkins-jobs test jobs/${job}-job.yml > generated/continuous-upgrade_${job}-job.xml
+done

--- a/continuous-upgrade/generated/continuous-upgrade_provision-job.xml
+++ b/continuous-upgrade/generated/continuous-upgrade_provision-job.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <actions/>
+  <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+  <keepDependencies>false</keepDependencies>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <concurrentBuild>false</concurrentBuild>
+  <canRoam>true</canRoam>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <triggers class="vector">
+    <jenkins.triggers.ReverseBuildTrigger>
+      <spec/>
+      <upstreamProjects>continuous-upgrade_terminate-job</upstreamProjects>
+      <threshold>
+        <name>SUCCESS</name>
+        <ordinal>0</ordinal>
+        <color>BLUE</color>
+        <completeBuild>true</completeBuild>
+      </threshold>
+    </jenkins.triggers.ReverseBuildTrigger>
+  </triggers>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>#!/bin/bash
+set -o errexit -o nounset -o pipefail -o xtrace
+echo $HOME
+latest=$( readlink $HOME/origin-ci-tool/latest )
+touch $latest
+cp $latest/bin/activate $WORKSPACE/activate
+cat &gt;&gt; $WORKSPACE/activate &lt;&lt;EOF
+export OCT_CONFIG_HOME=$WORKSPACE/.config
+EOF
+
+source $WORKSPACE/activate
+mkdir -p $OCT_CONFIG_HOME
+rm -rf $OCT_CONFIG_HOME/origin-ci-tool
+oct configure ansible-client verbosity 2
+oct configure aws-client 'keypair_name' 'libra'
+oct configure aws-client 'private_key_path' '/var/lib/jenkins/.ssh/devenv.pem'
+oct provision remote all-in-one --os &quot;rhel&quot; --stage &quot;base&quot; --provider &quot;aws&quot; --discrete-ssh-config --name &quot;$JOB_NAME&quot;_&quot;$BUILD_NUMBER&quot;
+rm -rf ~/continuous-upgrade
+mkdir -p ~/continuous-upgrade
+cp -fr ./.config/origin-ci-tool ~/continuous-upgrade/
+tree ~/continuous-upgrade/
+cat ~/continuous-upgrade/origin-ci-tool/inventory/.ssh_config
+
+script=&quot;$( mktemp )&quot;
+cat &lt;&lt;SCRIPT &gt;&quot;${script}&quot;
+#!/bin/bash
+set -o errexit -o nounset -o pipefail -o xtrace
+
+cat &lt;&lt; EOR &gt; ./openshift-int.repo
+[openshift-int]
+baseurl = https://mirror.openshift.com/enterprise/online-int/latest/x86_64/os/
+enabled = 1
+gpgcheck = 0
+gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
+name = OpenShift Enterprise int Builds
+sslclientcert = /var/lib/yum/client-cert.pem
+sslclientkey = /var/lib/yum/client-key.pem
+sslverify = 0
+EOR
+
+sudo cp ./openshift-int.repo /etc/yum.repos.d
+sudo yum --disablerepo=* --enablerepo=openshift-int,oso-rhui-rhel-server-releases install -y atomic-openshift-utils
+cd /data/src/github.com/openshift/aos-cd-jobs/
+ansible-playbook  -vv          \
+          --become           \
+          --become-user root \
+          --connection local \
+          --inventory sjb/inventory/ \
+          /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml \
+          -e etcd_data_dir=&quot;/tmp/etcd&quot;                                  \
+          -e deployment_type=&quot;openshift-enterprise&quot;                     \
+          -e oreg_url='registry.ops.openshift.com/openshift3/ose-\${component}:\${version}' \
+          -e openshift_docker_insecure_registries=&quot;brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888&quot; \
+          -e openshift_docker_additional_registries=&quot;brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888,registry.ops.openshift.com&quot;
+
+SCRIPT
+chmod +x &quot;${script}&quot;
+scp -F ~/continuous-upgrade/origin-ci-tool/inventory/.ssh_config &quot;${script}&quot; openshiftdevel:&quot;${script}&quot;
+ssh -F ~/continuous-upgrade/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &quot;bash -l -c \&quot;${script}\&quot;&quot;</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers>
+    <hudson.tasks.Mailer>
+      <recipients>jhadvig@redhat.com skuznets@redhat.com</recipients>
+      <dontNotifyEveryUnstableBuild>false</dontNotifyEveryUnstableBuild>
+      <sendToIndividuals>false</sendToIndividuals>
+    </hudson.tasks.Mailer>
+  </publishers>
+  <buildWrappers/>
+</project>

--- a/continuous-upgrade/generated/continuous-upgrade_terminate-job.xml
+++ b/continuous-upgrade/generated/continuous-upgrade_terminate-job.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <actions/>
+  <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+  <keepDependencies>false</keepDependencies>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <concurrentBuild>false</concurrentBuild>
+  <canRoam>true</canRoam>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>#!/bin/bash
+set -o errexit -o nounset -o pipefail -o xtrace
+latest=$( readlink $HOME/origin-ci-tool/latest )
+touch $latest
+cp $latest/bin/activate $WORKSPACE/activate
+cat &gt;&gt; $WORKSPACE/activate &lt;&lt;EOF
+export OCT_CONFIG_HOME=~/continuous-upgrade/
+EOF
+
+source $WORKSPACE/activate
+oct deprovision</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/continuous-upgrade/generated/continuous-upgrade_upgrade-job.xml
+++ b/continuous-upgrade/generated/continuous-upgrade_upgrade-job.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <actions/>
+  <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+  <keepDependencies>false</keepDependencies>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <concurrentBuild>false</concurrentBuild>
+  <canRoam>true</canRoam>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <triggers class="vector">
+    <jenkins.triggers.ReverseBuildTrigger>
+      <spec/>
+      <upstreamProjects>continuous-upgrade_provision-job,continuous-upgrade_upgrade-job</upstreamProjects>
+      <threshold>
+        <name>SUCCESS</name>
+        <ordinal>0</ordinal>
+        <color>BLUE</color>
+        <completeBuild>true</completeBuild>
+      </threshold>
+    </jenkins.triggers.ReverseBuildTrigger>
+  </triggers>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>#!/bin/bash
+script=&quot;$( mktemp )&quot;
+cat &lt;&lt;SCRIPT &gt;&quot;${script}&quot;
+#!/bin/bash
+set -o errexit -o nounset -o pipefail -o xtrace
+
+sudo yum --disablerepo=* --enablerepo=openshift-int,oso-rhui-rhel-server-releases update -y atomic-openshift-utils
+cd /data/src/github.com/openshift/aos-cd-jobs/
+rpm -qa atomic-openshift
+sudo python sjb/hack/determine_install_upgrade_version.py &quot;\$( rpm -qa atomic-openshift )&quot; &gt; AOS_VARS
+source AOS_VARS
+ansible-playbook  -vv                    \
+                  --become               \
+                  --become-user root     \
+                  --connection local     \
+                  --inventory sjb/inventory/ \
+                   &quot;/usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_${ATOMIC_OPENSHIFT_UPGRADE_RELEASE_MINOR_VERSION=6}/upgrade.yml&quot;     \
+                  -e etcd_data_dir=&quot;/tmp/etcd&quot; \
+                  -e openshift_pkg_version=&quot;-\${ATOMIC_OPENSHIFT_UPGRADE_RELEASE_VERSION}&quot; \
+                  -e deployment_type=&quot;openshift-enterprise&quot; \
+                  -e oreg_url='registry.ops.openshift.com/openshift3/ose-\${component}:\${version}' \
+                  -e openshift_docker_insecure_registries=&quot;brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888&quot; \
+                  -e openshift_docker_additional_registries=&quot;brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888,registry.ops.openshift.com&quot;
+
+SCRIPT
+chmod +x &quot;${script}&quot;
+scp -F ~/continuous-upgrade/origin-ci-tool/inventory/.ssh_config &quot;${script}&quot; openshiftdevel:&quot;${script}&quot;
+ssh -F ~/continuous-upgrade/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &quot;bash -l -c \&quot;${script}\&quot;&quot;</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers>
+    <hudson.tasks.Mailer>
+      <recipients>jhadvig@redhat.com skuznets@redhat.com</recipients>
+      <dontNotifyEveryUnstableBuild>false</dontNotifyEveryUnstableBuild>
+      <sendToIndividuals>false</sendToIndividuals>
+    </hudson.tasks.Mailer>
+  </publishers>
+  <buildWrappers/>
+</project>

--- a/continuous-upgrade/jobs/global-defaults.yml
+++ b/continuous-upgrade/jobs/global-defaults.yml
@@ -1,0 +1,6 @@
+- defaults:
+    name: global
+    publishers:
+      - email:
+          recipients: jhadvig@redhat.com skuznets@redhat.com
+          notify-every-unstable-build: true

--- a/continuous-upgrade/jobs/install-ocp.sh
+++ b/continuous-upgrade/jobs/install-ocp.sh
@@ -1,0 +1,36 @@
+script="$( mktemp )"
+cat <<SCRIPT >"${script}"
+#!/bin/bash
+set -o errexit -o nounset -o pipefail -o xtrace
+
+cat << EOR > ./openshift-int.repo
+[openshift-int]
+baseurl = https://mirror.openshift.com/enterprise/online-int/latest/x86_64/os/
+enabled = 1
+gpgcheck = 0
+gpgkey = https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
+name = OpenShift Enterprise int Builds
+sslclientcert = /var/lib/yum/client-cert.pem
+sslclientkey = /var/lib/yum/client-key.pem
+sslverify = 0
+EOR
+
+sudo cp ./openshift-int.repo /etc/yum.repos.d
+sudo yum --disablerepo=* --enablerepo=openshift-int,oso-rhui-rhel-server-releases install -y atomic-openshift-utils
+cd /data/src/github.com/openshift/aos-cd-jobs/
+ansible-playbook  -vv          \
+          --become           \
+          --become-user root \
+          --connection local \
+          --inventory sjb/inventory/ \
+          /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml \
+          -e etcd_data_dir="/tmp/etcd"                                  \
+          -e deployment_type="openshift-enterprise"                     \
+          -e oreg_url='registry.ops.openshift.com/openshift3/ose-\${component}:\${version}' \
+          -e openshift_docker_insecure_registries="brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888" \
+          -e openshift_docker_additional_registries="brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888,registry.ops.openshift.com"
+
+SCRIPT
+chmod +x "${script}"
+scp -F ~/continuous-upgrade/origin-ci-tool/inventory/.ssh_config "${script}" openshiftdevel:"${script}"
+ssh -F ~/continuous-upgrade/origin-ci-tool/inventory/.ssh_config -t openshiftdevel "bash -l -c \"${script}\""

--- a/continuous-upgrade/jobs/install-oct.sh
+++ b/continuous-upgrade/jobs/install-oct.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail -o xtrace
+echo $HOME
+latest=$( readlink $HOME/origin-ci-tool/latest )
+touch $latest
+cp $latest/bin/activate $WORKSPACE/activate
+cat >> $WORKSPACE/activate <<EOF
+export OCT_CONFIG_HOME=$WORKSPACE/.config
+EOF
+
+source $WORKSPACE/activate
+mkdir -p $OCT_CONFIG_HOME
+rm -rf $OCT_CONFIG_HOME/origin-ci-tool
+oct configure ansible-client verbosity 2
+oct configure aws-client 'keypair_name' 'libra'
+oct configure aws-client 'private_key_path' '/var/lib/jenkins/.ssh/devenv.pem'

--- a/continuous-upgrade/jobs/provision-cloud-resources.sh
+++ b/continuous-upgrade/jobs/provision-cloud-resources.sh
@@ -1,0 +1,6 @@
+oct provision remote all-in-one --os "rhel" --stage "base" --provider "aws" --discrete-ssh-config --name "$JOB_NAME"_"$BUILD_NUMBER"
+rm -rf ~/continuous-upgrade
+mkdir -p ~/continuous-upgrade
+cp -fr ./.config/origin-ci-tool ~/continuous-upgrade/
+tree ~/continuous-upgrade/
+cat ~/continuous-upgrade/origin-ci-tool/inventory/.ssh_config

--- a/continuous-upgrade/jobs/provision-job.yml
+++ b/continuous-upgrade/jobs/provision-job.yml
@@ -1,0 +1,18 @@
+- job:
+    name: continuous-upgrade_provision-job
+    project-type: freestyle
+    defaults: global
+    builders:
+      - shell: 
+          !include-raw:
+              - install-oct.sh
+              - provision-cloud-resources.sh
+              - install-ocp.sh
+    publishers:
+      - email:
+          recipients: jhadvig@redhat.com skuznets@redhat.com
+          notify-every-unstable-build: true
+    triggers:
+      - reverse:
+            jobs:
+                - 'continuous-upgrade_terminate-job'

--- a/continuous-upgrade/jobs/terminate-cloud-resources.sh
+++ b/continuous-upgrade/jobs/terminate-cloud-resources.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail -o xtrace
+latest=$( readlink $HOME/origin-ci-tool/latest )
+touch $latest
+cp $latest/bin/activate $WORKSPACE/activate
+cat >> $WORKSPACE/activate <<EOF
+export OCT_CONFIG_HOME=~/continuous-upgrade/
+EOF
+
+source $WORKSPACE/activate
+oct deprovision

--- a/continuous-upgrade/jobs/terminate-job.yml
+++ b/continuous-upgrade/jobs/terminate-job.yml
@@ -1,0 +1,8 @@
+- job:
+    name: continuous-upgrade_terminate-job
+    project-type: freestyle
+    defaults: global
+    builders:
+      - shell:
+          !include-raw:
+              - terminate-cloud-resources.sh

--- a/continuous-upgrade/jobs/upgrade-job.yml
+++ b/continuous-upgrade/jobs/upgrade-job.yml
@@ -1,0 +1,18 @@
+- job:
+    name: continuous-upgrade_upgrade-job
+    project-type: freestyle
+    defaults: global
+    builders:
+      - shell:
+          !include-raw:
+              - upgrade-ocp.sh
+    publishers:
+      - email:
+          recipients: jhadvig@redhat.com skuznets@redhat.com
+          notify-every-unstable-build: true
+    triggers:
+      - reverse:
+            jobs:
+                - 'continuous-upgrade_provision-job'
+                - 'continuous-upgrade_upgrade-job'
+            result: 'success'

--- a/continuous-upgrade/jobs/upgrade-ocp.sh
+++ b/continuous-upgrade/jobs/upgrade-ocp.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+script="$( mktemp )"
+cat <<SCRIPT >"${script}"
+#!/bin/bash
+set -o errexit -o nounset -o pipefail -o xtrace
+
+sudo yum --disablerepo=* --enablerepo=openshift-int,oso-rhui-rhel-server-releases update -y atomic-openshift-utils
+cd /data/src/github.com/openshift/aos-cd-jobs/
+rpm -qa atomic-openshift
+sudo python sjb/hack/determine_install_upgrade_version.py "\$( rpm -qa atomic-openshift )" > AOS_VARS
+source AOS_VARS
+ansible-playbook  -vv                    \
+                  --become               \
+                  --become-user root     \
+                  --connection local     \
+                  --inventory sjb/inventory/ \
+                   "/usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/upgrades/v3_${ATOMIC_OPENSHIFT_UPGRADE_RELEASE_MINOR_VERSION=6}/upgrade.yml"     \
+                  -e etcd_data_dir="/tmp/etcd" \
+                  -e openshift_pkg_version="-\${ATOMIC_OPENSHIFT_UPGRADE_RELEASE_VERSION}" \
+                  -e deployment_type="openshift-enterprise" \
+                  -e oreg_url='registry.ops.openshift.com/openshift3/ose-\${component}:\${version}' \
+                  -e openshift_docker_insecure_registries="brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888" \
+                  -e openshift_docker_additional_registries="brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888,registry.ops.openshift.com"
+
+SCRIPT
+chmod +x "${script}"
+scp -F ~/continuous-upgrade/origin-ci-tool/inventory/.ssh_config "${script}" openshiftdevel:"${script}"
+ssh -F ~/continuous-upgrade/origin-ci-tool/inventory/.ssh_config -t openshiftdevel "bash -l -c \"${script}\""


### PR DESCRIPTION
Continuous upgrade will consist from three jobs:
1, Provision - install OCP on a single cluster node and trigger *Upgrade* job
2, Upgrade - upgrade OCP to latest and trigger *Upgrade* job on sucess. On failure trigger *Terminate* job
3, Terminate - terminate installed OCP node and trigger *Provision* job

Jobs are written consist from multiple scripts and will generate a single running script for each job. *Provision* and *Upgrade* jobs are `trap`ed on error and will cause triggering the *Terminate* job

@stevekuznetsov PTAL