### PR TITLE
Cover case when target branch is pointing to release branch

### DIFF
--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update.yml
@@ -5,6 +5,10 @@ extensions:
     - name: "openshift-ansible"
     - name: "aos-cd-jobs"
   actions:
+    - type: "forward_parameters"
+      parameters:
+        - ORIGIN_TARGET_BRANCH
+        - OPENSHIFT_ANSIBLE_TARGET_BRANCH
     - type: "script"
       title: "determine the release commit for origin images"
       repository: "origin"
@@ -37,7 +41,7 @@ extensions:
         pkg_name="origin"
         echo $pkg_name > PKG_NAME
         echo "openshift-ansible openshift-ansible-callback-plugins openshift-ansible-docs openshift-ansible-filter-plugins openshift-ansible-lookup-plugins openshift-ansible-playbooks openshift-ansible-roles" > OPENSHIFT_ANSIBLE_PKGS
-        sudo python sjb/hack/determine_install_upgrade_version.py $( cat OPENSHIFT_ANSIBLE_BUILT_VERSION ) > OPENSHIFT_ANSIBLE_VARS
+        sudo python sjb/hack/determine_install_upgrade_version.py $( cat OPENSHIFT_ANSIBLE_BUILT_VERSION ) --dependency_branch ${ORIGIN_TARGET_BRANCH} > OPENSHIFT_ANSIBLE_VARS
         source OPENSHIFT_ANSIBLE_VARS
         versioned_packages_to_install=""
         if [[ ${ATOMIC_OPENSHIFT_UTILS_INSTALL_MINOR_VERSION} -le 4 ]]
@@ -80,7 +84,7 @@ extensions:
             exit 1
         fi
         echo "${deployment_type}" > DEPLOYMENT_TYPE
-        sudo python sjb/hack/determine_install_upgrade_version.py $( cat ORIGIN_BUILT_VERSION ) > ORIGIN_VARS
+        sudo python sjb/hack/determine_install_upgrade_version.py $( cat ORIGIN_BUILT_VERSION ) --dependency_branch ${OPENSHIFT_ANSIBLE_TARGET_BRANCH} > ORIGIN_VARS
         source ORIGIN_VARS
         source OPENSHIFT_ANSIBLE_VARS
         echo "=== Installing ${pkg_name}-${ORIGIN_INSTALL_VERSION} ==="
@@ -104,12 +108,17 @@ extensions:
       title: "build an origin release"
       repository: "origin"
       script: |-
-        hack/build-base-images.sh
-        OS_BUILD_ENV_PRESERVE=_output/local hack/env OS_ONLY_BUILD_PLATFORMS='linux/amd64' hack/build-rpm-release.sh
-        sudo systemctl restart docker
-        hack/build-images.sh
-        sed -i 's|go/src|data/src|' _output/local/releases/rpms/origin-local-release.repo
-        sudo cp _output/local/releases/rpms/origin-local-release.repo /etc/yum.repos.d/
+        if [[ ${OPENSHIFT_ANSIBLE_TARGET_BRANCH} == "master" ]]
+        then
+          hack/build-base-images.sh
+          OS_BUILD_ENV_PRESERVE=_output/local hack/env OS_ONLY_BUILD_PLATFORMS='linux/amd64' hack/build-rpm-release.sh
+          sudo systemctl restart docker
+          hack/build-images.sh
+          sed -i 's|go/src|data/src|' _output/local/releases/rpms/origin-local-release.repo
+          sudo cp _output/local/releases/rpms/origin-local-release.repo /etc/yum.repos.d/
+        else
+          echo "OPENSHIFT_ANSIBLE_TARGET_BRANCH points to ${OPENSHIFT_ANSIBLE_TARGET_BRANCH} branch, skipping build of Origin release."
+        fi
     - type: "script"
       title: "upgrade openshift-ansible to release"
       repository: "aos-cd-jobs"

--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update.yml
@@ -71,6 +71,21 @@ extensions:
         done
         sudo sed -r -i -e 's/^#?stdout_callback.*/stdout_callback = default_with_output_lists/' -e 's/^#?callback_whitelist.*/callback_whitelist = generate_junit/' /etc/ansible/ansible.cfg
     - type: "script"
+      title: "build an origin release"
+      repository: "origin"
+      script: |-
+        if [[ ${OPENSHIFT_ANSIBLE_TARGET_BRANCH} == "master" ]]
+        then
+          hack/build-base-images.sh
+          OS_BUILD_ENV_PRESERVE=_output/local hack/env OS_ONLY_BUILD_PLATFORMS='linux/amd64' hack/build-rpm-release.sh
+          sudo systemctl restart docker
+          hack/build-images.sh
+          sed -i 's|go/src|data/src|' _output/local/releases/rpms/origin-local-release.repo
+          sudo cp _output/local/releases/rpms/origin-local-release.repo /etc/yum.repos.d/
+        else
+          echo "OPENSHIFT_ANSIBLE_TARGET_BRANCH points to ${OPENSHIFT_ANSIBLE_TARGET_BRANCH} branch, skipping build of Origin release."
+        fi
+    - type: "script"
       title: "install origin"
       repository: "aos-cd-jobs"
       script: |-
@@ -104,21 +119,6 @@ extensions:
                           -e openshift_pkg_version="-${ORIGIN_INSTALL_VERSION}"         \
                           -e etcd_data_dir="${ETCD_DATA_DIR}"                           \
                           -e deployment_type=$( cat ./DEPLOYMENT_TYPE)
-    - type: "script"
-      title: "build an origin release"
-      repository: "origin"
-      script: |-
-        if [[ ${OPENSHIFT_ANSIBLE_TARGET_BRANCH} == "master" ]]
-        then
-          hack/build-base-images.sh
-          OS_BUILD_ENV_PRESERVE=_output/local hack/env OS_ONLY_BUILD_PLATFORMS='linux/amd64' hack/build-rpm-release.sh
-          sudo systemctl restart docker
-          hack/build-images.sh
-          sed -i 's|go/src|data/src|' _output/local/releases/rpms/origin-local-release.repo
-          sudo cp _output/local/releases/rpms/origin-local-release.repo /etc/yum.repos.d/
-        else
-          echo "OPENSHIFT_ANSIBLE_TARGET_BRANCH points to ${OPENSHIFT_ANSIBLE_TARGET_BRANCH} branch, skipping build of Origin release."
-        fi
     - type: "script"
       title: "upgrade openshift-ansible to release"
       repository: "aos-cd-jobs"

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
@@ -122,6 +122,14 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
+SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: FORWARD PARAMETERS TO THE REMOTE HOST ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: FORWARD PARAMETERS TO THE REMOTE HOST [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod o+rw /etc/environment
+ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;ORIGIN_TARGET_BRANCH=${ORIGIN_TARGET_BRANCH:-}&#39; &gt;&gt; /etc/environment&#34;
+ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;OPENSHIFT_ANSIBLE_TARGET_BRANCH=${OPENSHIFT_ANSIBLE_TARGET_BRANCH:-}&#39; &gt;&gt; /etc/environment&#34;
+</command>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
+          <command>#!/bin/bash
 SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: DETERMINE THE RELEASE COMMIT FOR ORIGIN IMAGES ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: DETERMINE THE RELEASE COMMIT FOR ORIGIN IMAGES [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
@@ -174,7 +182,7 @@ cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
 pkg_name=&#34;origin&#34;
 echo \$pkg_name &gt; PKG_NAME
 echo &#34;openshift-ansible openshift-ansible-callback-plugins openshift-ansible-docs openshift-ansible-filter-plugins openshift-ansible-lookup-plugins openshift-ansible-playbooks openshift-ansible-roles&#34; &gt; OPENSHIFT_ANSIBLE_PKGS
-sudo python sjb/hack/determine_install_upgrade_version.py \$( cat OPENSHIFT_ANSIBLE_BUILT_VERSION ) &gt; OPENSHIFT_ANSIBLE_VARS
+sudo python sjb/hack/determine_install_upgrade_version.py \$( cat OPENSHIFT_ANSIBLE_BUILT_VERSION ) --dependency_branch \${ORIGIN_TARGET_BRANCH} &gt; OPENSHIFT_ANSIBLE_VARS
 source OPENSHIFT_ANSIBLE_VARS
 versioned_packages_to_install=&#34;&#34;
 if [[ \${ATOMIC_OPENSHIFT_UTILS_INSTALL_MINOR_VERSION} -le 4 ]]
@@ -235,7 +243,7 @@ else
     exit 1
 fi
 echo &#34;\${deployment_type}&#34; &gt; DEPLOYMENT_TYPE
-sudo python sjb/hack/determine_install_upgrade_version.py \$( cat ORIGIN_BUILT_VERSION ) &gt; ORIGIN_VARS
+sudo python sjb/hack/determine_install_upgrade_version.py \$( cat ORIGIN_BUILT_VERSION ) --dependency_branch \${OPENSHIFT_ANSIBLE_TARGET_BRANCH} &gt; ORIGIN_VARS
 source ORIGIN_VARS
 source OPENSHIFT_ANSIBLE_VARS
 echo &#34;=== Installing \${pkg_name}-\${ORIGIN_INSTALL_VERSION} ===&#34;
@@ -268,12 +276,17 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-hack/build-base-images.sh
-OS_BUILD_ENV_PRESERVE=_output/local hack/env OS_ONLY_BUILD_PLATFORMS=&#39;linux/amd64&#39; hack/build-rpm-release.sh
-sudo systemctl restart docker
-hack/build-images.sh
-sed -i &#39;s|go/src|data/src|&#39; _output/local/releases/rpms/origin-local-release.repo
-sudo cp _output/local/releases/rpms/origin-local-release.repo /etc/yum.repos.d/
+if [[ \${OPENSHIFT_ANSIBLE_TARGET_BRANCH} == &#34;master&#34; ]]
+then
+  hack/build-base-images.sh
+  OS_BUILD_ENV_PRESERVE=_output/local hack/env OS_ONLY_BUILD_PLATFORMS=&#39;linux/amd64&#39; hack/build-rpm-release.sh
+  sudo systemctl restart docker
+  hack/build-images.sh
+  sed -i &#39;s|go/src|data/src|&#39; _output/local/releases/rpms/origin-local-release.repo
+  sudo cp _output/local/releases/rpms/origin-local-release.repo /etc/yum.repos.d/
+else
+  echo &#34;OPENSHIFT_ANSIBLE_TARGET_BRANCH points to \${OPENSHIFT_ANSIBLE_TARGET_BRANCH} branch, skipping build of Origin release.&#34;
+fi
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
@@ -227,6 +227,30 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
+SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: BUILD AN ORIGIN RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: BUILD AN ORIGIN RELEASE [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+script=&#34;$( mktemp )&#34;
+cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
+#!/bin/bash
+set -o errexit -o nounset -o pipefail -o xtrace
+cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
+if [[ \${OPENSHIFT_ANSIBLE_TARGET_BRANCH} == &#34;master&#34; ]]
+then
+  hack/build-base-images.sh
+  OS_BUILD_ENV_PRESERVE=_output/local hack/env OS_ONLY_BUILD_PLATFORMS=&#39;linux/amd64&#39; hack/build-rpm-release.sh
+  sudo systemctl restart docker
+  hack/build-images.sh
+  sed -i &#39;s|go/src|data/src|&#39; _output/local/releases/rpms/origin-local-release.repo
+  sudo cp _output/local/releases/rpms/origin-local-release.repo /etc/yum.repos.d/
+else
+  echo &#34;OPENSHIFT_ANSIBLE_TARGET_BRANCH points to \${OPENSHIFT_ANSIBLE_TARGET_BRANCH} branch, skipping build of Origin release.&#34;
+fi
+SCRIPT
+chmod +x &#34;${script}&#34;
+scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
+ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;${script}\&#34;&#34; </command>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
+          <command>#!/bin/bash
 SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL ORIGIN ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL ORIGIN [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
@@ -263,30 +287,6 @@ ansible-playbook  -vv                \
                   -e openshift_pkg_version=&#34;-\${ORIGIN_INSTALL_VERSION}&#34;         \
                   -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34;                           \
                   -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)
-SCRIPT
-chmod +x &#34;${script}&#34;
-scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;${script}\&#34;&#34; </command>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-          <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: BUILD AN ORIGIN RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: BUILD AN ORIGIN RELEASE [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-script=&#34;$( mktemp )&#34;
-cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
-#!/bin/bash
-set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-if [[ \${OPENSHIFT_ANSIBLE_TARGET_BRANCH} == &#34;master&#34; ]]
-then
-  hack/build-base-images.sh
-  OS_BUILD_ENV_PRESERVE=_output/local hack/env OS_ONLY_BUILD_PLATFORMS=&#39;linux/amd64&#39; hack/build-rpm-release.sh
-  sudo systemctl restart docker
-  hack/build-images.sh
-  sed -i &#39;s|go/src|data/src|&#39; _output/local/releases/rpms/origin-local-release.repo
-  sudo cp _output/local/releases/rpms/origin-local-release.repo /etc/yum.repos.d/
-else
-  echo &#34;OPENSHIFT_ANSIBLE_TARGET_BRANCH points to \${OPENSHIFT_ANSIBLE_TARGET_BRANCH} branch, skipping build of Origin release.&#34;
-fi
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
@@ -132,6 +132,14 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
+SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: FORWARD PARAMETERS TO THE REMOTE HOST ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: FORWARD PARAMETERS TO THE REMOTE HOST [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod o+rw /etc/environment
+ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;ORIGIN_TARGET_BRANCH=${ORIGIN_TARGET_BRANCH:-}&#39; &gt;&gt; /etc/environment&#34;
+ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;OPENSHIFT_ANSIBLE_TARGET_BRANCH=${OPENSHIFT_ANSIBLE_TARGET_BRANCH:-}&#39; &gt;&gt; /etc/environment&#34;
+</command>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
+          <command>#!/bin/bash
 SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: DETERMINE THE RELEASE COMMIT FOR ORIGIN IMAGES ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: DETERMINE THE RELEASE COMMIT FOR ORIGIN IMAGES [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
@@ -184,7 +192,7 @@ cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
 pkg_name=&#34;origin&#34;
 echo \$pkg_name &gt; PKG_NAME
 echo &#34;openshift-ansible openshift-ansible-callback-plugins openshift-ansible-docs openshift-ansible-filter-plugins openshift-ansible-lookup-plugins openshift-ansible-playbooks openshift-ansible-roles&#34; &gt; OPENSHIFT_ANSIBLE_PKGS
-sudo python sjb/hack/determine_install_upgrade_version.py \$( cat OPENSHIFT_ANSIBLE_BUILT_VERSION ) &gt; OPENSHIFT_ANSIBLE_VARS
+sudo python sjb/hack/determine_install_upgrade_version.py \$( cat OPENSHIFT_ANSIBLE_BUILT_VERSION ) --dependency_branch \${ORIGIN_TARGET_BRANCH} &gt; OPENSHIFT_ANSIBLE_VARS
 source OPENSHIFT_ANSIBLE_VARS
 versioned_packages_to_install=&#34;&#34;
 if [[ \${ATOMIC_OPENSHIFT_UTILS_INSTALL_MINOR_VERSION} -le 4 ]]
@@ -245,7 +253,7 @@ else
     exit 1
 fi
 echo &#34;\${deployment_type}&#34; &gt; DEPLOYMENT_TYPE
-sudo python sjb/hack/determine_install_upgrade_version.py \$( cat ORIGIN_BUILT_VERSION ) &gt; ORIGIN_VARS
+sudo python sjb/hack/determine_install_upgrade_version.py \$( cat ORIGIN_BUILT_VERSION ) --dependency_branch \${OPENSHIFT_ANSIBLE_TARGET_BRANCH} &gt; ORIGIN_VARS
 source ORIGIN_VARS
 source OPENSHIFT_ANSIBLE_VARS
 echo &#34;=== Installing \${pkg_name}-\${ORIGIN_INSTALL_VERSION} ===&#34;
@@ -278,12 +286,17 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-hack/build-base-images.sh
-OS_BUILD_ENV_PRESERVE=_output/local hack/env OS_ONLY_BUILD_PLATFORMS=&#39;linux/amd64&#39; hack/build-rpm-release.sh
-sudo systemctl restart docker
-hack/build-images.sh
-sed -i &#39;s|go/src|data/src|&#39; _output/local/releases/rpms/origin-local-release.repo
-sudo cp _output/local/releases/rpms/origin-local-release.repo /etc/yum.repos.d/
+if [[ \${OPENSHIFT_ANSIBLE_TARGET_BRANCH} == &#34;master&#34; ]]
+then
+  hack/build-base-images.sh
+  OS_BUILD_ENV_PRESERVE=_output/local hack/env OS_ONLY_BUILD_PLATFORMS=&#39;linux/amd64&#39; hack/build-rpm-release.sh
+  sudo systemctl restart docker
+  hack/build-images.sh
+  sed -i &#39;s|go/src|data/src|&#39; _output/local/releases/rpms/origin-local-release.repo
+  sudo cp _output/local/releases/rpms/origin-local-release.repo /etc/yum.repos.d/
+else
+  echo &#34;OPENSHIFT_ANSIBLE_TARGET_BRANCH points to \${OPENSHIFT_ANSIBLE_TARGET_BRANCH} branch, skipping build of Origin release.&#34;
+fi
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
@@ -237,6 +237,30 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
+SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: BUILD AN ORIGIN RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: BUILD AN ORIGIN RELEASE [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+script=&#34;$( mktemp )&#34;
+cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
+#!/bin/bash
+set -o errexit -o nounset -o pipefail -o xtrace
+cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
+if [[ \${OPENSHIFT_ANSIBLE_TARGET_BRANCH} == &#34;master&#34; ]]
+then
+  hack/build-base-images.sh
+  OS_BUILD_ENV_PRESERVE=_output/local hack/env OS_ONLY_BUILD_PLATFORMS=&#39;linux/amd64&#39; hack/build-rpm-release.sh
+  sudo systemctl restart docker
+  hack/build-images.sh
+  sed -i &#39;s|go/src|data/src|&#39; _output/local/releases/rpms/origin-local-release.repo
+  sudo cp _output/local/releases/rpms/origin-local-release.repo /etc/yum.repos.d/
+else
+  echo &#34;OPENSHIFT_ANSIBLE_TARGET_BRANCH points to \${OPENSHIFT_ANSIBLE_TARGET_BRANCH} branch, skipping build of Origin release.&#34;
+fi
+SCRIPT
+chmod +x &#34;${script}&#34;
+scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
+ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;${script}\&#34;&#34; </command>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
+          <command>#!/bin/bash
 SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL ORIGIN ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL ORIGIN [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
@@ -273,30 +297,6 @@ ansible-playbook  -vv                \
                   -e openshift_pkg_version=&#34;-\${ORIGIN_INSTALL_VERSION}&#34;         \
                   -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34;                           \
                   -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)
-SCRIPT
-chmod +x &#34;${script}&#34;
-scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;${script}\&#34;&#34; </command>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-          <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: BUILD AN ORIGIN RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: BUILD AN ORIGIN RELEASE [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-script=&#34;$( mktemp )&#34;
-cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
-#!/bin/bash
-set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-if [[ \${OPENSHIFT_ANSIBLE_TARGET_BRANCH} == &#34;master&#34; ]]
-then
-  hack/build-base-images.sh
-  OS_BUILD_ENV_PRESERVE=_output/local hack/env OS_ONLY_BUILD_PLATFORMS=&#39;linux/amd64&#39; hack/build-rpm-release.sh
-  sudo systemctl restart docker
-  hack/build-images.sh
-  sed -i &#39;s|go/src|data/src|&#39; _output/local/releases/rpms/origin-local-release.repo
-  sudo cp _output/local/releases/rpms/origin-local-release.repo /etc/yum.repos.d/
-else
-  echo &#34;OPENSHIFT_ANSIBLE_TARGET_BRANCH points to \${OPENSHIFT_ANSIBLE_TARGET_BRANCH} branch, skipping build of Origin release.&#34;
-fi
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
@@ -132,6 +132,14 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
+SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: FORWARD PARAMETERS TO THE REMOTE HOST ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: FORWARD PARAMETERS TO THE REMOTE HOST [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod o+rw /etc/environment
+ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;ORIGIN_TARGET_BRANCH=${ORIGIN_TARGET_BRANCH:-}&#39; &gt;&gt; /etc/environment&#34;
+ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;OPENSHIFT_ANSIBLE_TARGET_BRANCH=${OPENSHIFT_ANSIBLE_TARGET_BRANCH:-}&#39; &gt;&gt; /etc/environment&#34;
+</command>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
+          <command>#!/bin/bash
 SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: DETERMINE THE RELEASE COMMIT FOR ORIGIN IMAGES ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: DETERMINE THE RELEASE COMMIT FOR ORIGIN IMAGES [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
@@ -184,7 +192,7 @@ cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
 pkg_name=&#34;origin&#34;
 echo \$pkg_name &gt; PKG_NAME
 echo &#34;openshift-ansible openshift-ansible-callback-plugins openshift-ansible-docs openshift-ansible-filter-plugins openshift-ansible-lookup-plugins openshift-ansible-playbooks openshift-ansible-roles&#34; &gt; OPENSHIFT_ANSIBLE_PKGS
-sudo python sjb/hack/determine_install_upgrade_version.py \$( cat OPENSHIFT_ANSIBLE_BUILT_VERSION ) &gt; OPENSHIFT_ANSIBLE_VARS
+sudo python sjb/hack/determine_install_upgrade_version.py \$( cat OPENSHIFT_ANSIBLE_BUILT_VERSION ) --dependency_branch \${ORIGIN_TARGET_BRANCH} &gt; OPENSHIFT_ANSIBLE_VARS
 source OPENSHIFT_ANSIBLE_VARS
 versioned_packages_to_install=&#34;&#34;
 if [[ \${ATOMIC_OPENSHIFT_UTILS_INSTALL_MINOR_VERSION} -le 4 ]]
@@ -245,7 +253,7 @@ else
     exit 1
 fi
 echo &#34;\${deployment_type}&#34; &gt; DEPLOYMENT_TYPE
-sudo python sjb/hack/determine_install_upgrade_version.py \$( cat ORIGIN_BUILT_VERSION ) &gt; ORIGIN_VARS
+sudo python sjb/hack/determine_install_upgrade_version.py \$( cat ORIGIN_BUILT_VERSION ) --dependency_branch \${OPENSHIFT_ANSIBLE_TARGET_BRANCH} &gt; ORIGIN_VARS
 source ORIGIN_VARS
 source OPENSHIFT_ANSIBLE_VARS
 echo &#34;=== Installing \${pkg_name}-\${ORIGIN_INSTALL_VERSION} ===&#34;
@@ -278,12 +286,17 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-hack/build-base-images.sh
-OS_BUILD_ENV_PRESERVE=_output/local hack/env OS_ONLY_BUILD_PLATFORMS=&#39;linux/amd64&#39; hack/build-rpm-release.sh
-sudo systemctl restart docker
-hack/build-images.sh
-sed -i &#39;s|go/src|data/src|&#39; _output/local/releases/rpms/origin-local-release.repo
-sudo cp _output/local/releases/rpms/origin-local-release.repo /etc/yum.repos.d/
+if [[ \${OPENSHIFT_ANSIBLE_TARGET_BRANCH} == &#34;master&#34; ]]
+then
+  hack/build-base-images.sh
+  OS_BUILD_ENV_PRESERVE=_output/local hack/env OS_ONLY_BUILD_PLATFORMS=&#39;linux/amd64&#39; hack/build-rpm-release.sh
+  sudo systemctl restart docker
+  hack/build-images.sh
+  sed -i &#39;s|go/src|data/src|&#39; _output/local/releases/rpms/origin-local-release.repo
+  sudo cp _output/local/releases/rpms/origin-local-release.repo /etc/yum.repos.d/
+else
+  echo &#34;OPENSHIFT_ANSIBLE_TARGET_BRANCH points to \${OPENSHIFT_ANSIBLE_TARGET_BRANCH} branch, skipping build of Origin release.&#34;
+fi
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
@@ -237,6 +237,30 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
+SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: BUILD AN ORIGIN RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: BUILD AN ORIGIN RELEASE [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+script=&#34;$( mktemp )&#34;
+cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
+#!/bin/bash
+set -o errexit -o nounset -o pipefail -o xtrace
+cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
+if [[ \${OPENSHIFT_ANSIBLE_TARGET_BRANCH} == &#34;master&#34; ]]
+then
+  hack/build-base-images.sh
+  OS_BUILD_ENV_PRESERVE=_output/local hack/env OS_ONLY_BUILD_PLATFORMS=&#39;linux/amd64&#39; hack/build-rpm-release.sh
+  sudo systemctl restart docker
+  hack/build-images.sh
+  sed -i &#39;s|go/src|data/src|&#39; _output/local/releases/rpms/origin-local-release.repo
+  sudo cp _output/local/releases/rpms/origin-local-release.repo /etc/yum.repos.d/
+else
+  echo &#34;OPENSHIFT_ANSIBLE_TARGET_BRANCH points to \${OPENSHIFT_ANSIBLE_TARGET_BRANCH} branch, skipping build of Origin release.&#34;
+fi
+SCRIPT
+chmod +x &#34;${script}&#34;
+scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
+ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;${script}\&#34;&#34; </command>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
+          <command>#!/bin/bash
 SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL ORIGIN ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL ORIGIN [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
@@ -273,30 +297,6 @@ ansible-playbook  -vv                \
                   -e openshift_pkg_version=&#34;-\${ORIGIN_INSTALL_VERSION}&#34;         \
                   -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34;                           \
                   -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)
-SCRIPT
-chmod +x &#34;${script}&#34;
-scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;${script}\&#34;&#34; </command>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-          <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: BUILD AN ORIGIN RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: BUILD AN ORIGIN RELEASE [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-script=&#34;$( mktemp )&#34;
-cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
-#!/bin/bash
-set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-if [[ \${OPENSHIFT_ANSIBLE_TARGET_BRANCH} == &#34;master&#34; ]]
-then
-  hack/build-base-images.sh
-  OS_BUILD_ENV_PRESERVE=_output/local hack/env OS_ONLY_BUILD_PLATFORMS=&#39;linux/amd64&#39; hack/build-rpm-release.sh
-  sudo systemctl restart docker
-  hack/build-images.sh
-  sed -i &#39;s|go/src|data/src|&#39; _output/local/releases/rpms/origin-local-release.repo
-  sudo cp _output/local/releases/rpms/origin-local-release.repo /etc/yum.repos.d/
-else
-  echo &#34;OPENSHIFT_ANSIBLE_TARGET_BRANCH points to \${OPENSHIFT_ANSIBLE_TARGET_BRANCH} branch, skipping build of Origin release.&#34;
-fi
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/hack/determine_install_upgrade_version.py
+++ b/sjb/hack/determine_install_upgrade_version.py
@@ -1,6 +1,7 @@
 import yum
 import sys
 import os.path
+import argparse
 import rpmUtils.miscutils as rpmutils
 
 # Remove duplicate packages from different repositories
@@ -33,29 +34,27 @@ def get_matching_versions(input_pkg_name, available_pkgs, search_version):
 		print("[ERROR] Can not determine install and upgrade version for the `" + input_pkg_name + "` package", sys.stderr)
 		sys.exit(1)
 
-# Get only install(last) version from version list
-def get_install_version(version_list):
+# Get only last version from version list
+def get_last_version(version_list):
 	return version_list[-1]
 
 # Return minor version of provided package version-release pair
 def get_minor_version(pkg_version_release):
 	return pkg_version_release.split('.', 2)[1]
 
-# Return version of provided package version-release pair
-def get_version(pkg_version_release):
-	return pkg_version_release.split('-', 2)[0]
-
 # Print install, upgrade and upgrade_release versions of desired package to STDOUT.
 # The upgrade version will be printed only in case there is more then one version of packages previous minor release. 
-def print_version_vars(install_version):
+def print_version_vars(install_version, upgrade_version):
 	used_pkg_name = pkg_name.upper().replace("-", "_")
 	print (used_pkg_name + "_INSTALL_VERSION=" + install_version)
 	print (used_pkg_name + "_INSTALL_MINOR_VERSION=" + get_minor_version(install_version))
-	print (used_pkg_name + "_UPGRADE_RELEASE_VERSION=" + pkg_version + "-" + pkg_release)
-	print (used_pkg_name + "_UPGRADE_RELEASE_MINOR_VERSION=" + get_minor_version(pkg_version + "-" + pkg_release))
+	print (used_pkg_name + "_UPGRADE_RELEASE_VERSION=" + upgrade_version)
+	print (used_pkg_name + "_UPGRADE_RELEASE_MINOR_VERSION=" + get_minor_version(upgrade_version))
 
-def determine_search_version(pkg_name, pkg_version):
-	major, minor, rest = pkg_version.split('.', 2)
+def determine_install_version(pkg_name, pkg_version):
+	parsed_version = pkg_version.split('.')
+	major = parsed_version[0]
+	minor = parsed_version[1]
 	# Cause of the origin version schema change we had to manually change the version just for this 
 	# case where we should look for 1.5.x versions if the built version is origin-3.6.x 
 	if pkg_name == "origin" and major == "3" and minor == "6":
@@ -64,14 +63,32 @@ def determine_search_version(pkg_name, pkg_version):
 	return search_version
 
 if __name__ == "__main__":
-	if len(sys.argv) != 2:
-	    print ("[ERROR] No NEVRA provided!", sys.stderr)
-	    sys.exit(3)
-	input_pkg = sys.argv[1]
-	pkg_name, pkg_version, pkg_release, pkg_epoch, pkg_arch = rpmutils.splitFilename(input_pkg)
+	parser = argparse.ArgumentParser()
+	parser.add_argument("input_pkg", type=str, help="Package NEVRA")
+	parser.add_argument("--dependency_branch", type=str, default='master', help="Dependency target branch")
+	args = parser.parse_args()
+
+	pkg_name, pkg_version, pkg_release, pkg_epoch, pkg_arch = rpmutils.splitFilename(args.input_pkg)
+
+	# If dependency target branch is specified for a release or an enterprise release use that version so proper install
+	# and upgrade version are set.
+	#
+	# example: OPENSHIFT_ANSIBLE_TARGET_BRANCH - release-1.5
+	#          ORIGIN_TARGET_BRANCH            - master
+	#
+	#          ORIGIN_INSTALL_VERSION=1.4.1-1.el7
+	#          ORIGIN_INSTALL_MINOR_VERSION=4
+	#          ORIGIN_UPGRADE_RELEASE_VERSION=1.5.1-1.el7
+	#          ORIGIN_UPGRADE_RELEASE_MINOR_VERSION=5
+	#
+	if args.dependency_branch.startswith("release") or args.dependency_branch.startswith("enterprise"):
+		pkg_version = args.dependency_branch.split("-")[1]
+	else:
+		major, minor, rest = pkg_version.split('.', 2)
+		pkg_version = '.'.join([major, minor])
 
 	if any(char.isalpha() for char in pkg_version):
-		print ("[ERROR] Incorrect package nevra format: " + input_pkg, sys.stderr)
+		print ("[ERROR] Incorrect package nevra format: " + args.input_pkg, sys.stderr)
 		sys.exit(2)
 
 	yb = yum.YumBase()
@@ -84,9 +101,14 @@ if __name__ == "__main__":
 	yb.conf.disable_excludes = ["all"]
 	sys.stdout = old_stdout
 	available_pkgs = rpmutils.unique(yb.doPackageLists('available', patterns=[pkg_name], showdups=True).available)
-	search_version = determine_search_version(pkg_name, pkg_version)
 	available_pkgs = remove_duplicate_pkgs(available_pkgs)
 	available_pkgs.sort(lambda x, y: rpmutils.compareEVR((x.epoch, x.version, x.release), (y.epoch, y.version, y.release)))
-	matching_pkgs = get_matching_versions(pkg_name, available_pkgs, search_version)
-	install_version = get_install_version(matching_pkgs)
-	print_version_vars(install_version)
+
+	search_install_version = determine_install_version(pkg_name, pkg_version)
+
+	matching_install_pkgs = get_matching_versions(pkg_name, available_pkgs, search_install_version)
+	matching_upgrade_pkgs = get_matching_versions(pkg_name, available_pkgs, pkg_version)
+	install_version = get_last_version(matching_install_pkgs)
+	upgrade_version = get_last_version(matching_upgrade_pkgs)
+
+	print_version_vars(install_version, upgrade_version)

--- a/sjb/hack/determine_install_upgrade_version_test.py
+++ b/sjb/hack/determine_install_upgrade_version_test.py
@@ -79,27 +79,43 @@ class DetermineSearchVersionTestCase(unittest.TestCase):
 
 	def test_origin_with_standard_versioning_schema(self):
 		""" when the origin version is higher then the first version of the new origin versioning schema - origin-3.6 """
-		self.assertEqual(determine_search_version("origin", "3.7.0"), "3.6")
+		self.assertEqual(determine_install_version("origin", "3.7.0"), "3.6")
+
+	def test_origin_with_short_standard_versioning_schema(self):
+		""" when the origin version is in short format and higher then the first version of the new origin versioning schema - origin-3.6 """
+		self.assertEqual(determine_install_version("origin", "3.7"), "3.6")
 
 	def test_origin_with_standard_to_legacy_versioning_schema(self):
 		""" when the origin version is the first from the new origin versioning schema - origin-3.6 """
-		self.assertEqual(determine_search_version("origin", "3.6.0"), "1.5")
+		self.assertEqual(determine_install_version("origin", "3.6.0"), "1.5")
+
+	def test_origin_with_short_standard_to_legacy_versioning_schema(self):
+		""" when the origin version is in short format and first from the new origin versioning schema - origin-3.6 """
+		self.assertEqual(determine_install_version("origin", "3.6"), "1.5")
 
 	def test_origin_with_legacy_schema(self):
 		""" when the origin version is in the old versioning schema """
-		self.assertEqual(determine_search_version("origin", "1.5.0"), "1.4")
+		self.assertEqual(determine_install_version("origin", "1.5.0"), "1.4")
+
+	def test_origin_with_short_legacy_schema(self):
+		""" when the origin version is in short and old versioning schema """
+		self.assertEqual(determine_install_version("origin", "1.5"), "1.4")
 
 	def test_openshift_ansible_with_standard_versioning_schema(self):
 		""" when openshift-ansible, which doesnt have different versioning schema, is in 3.7 version  """
-		self.assertEqual(determine_search_version("openshift-ansible", "3.7.0"), "3.6")
+		self.assertEqual(determine_install_version("openshift-ansible", "3.7.0"), "3.6")
 
 	def test_openshift_ansible_with_standard_to_legacy_versioning_schema(self):
 		""" when openshift-ansible, which doesnt have different versioning schema is in 3.6 version """
-		self.assertEqual(determine_search_version("openshift-ansible", "3.6.0"), "3.5")
+		self.assertEqual(determine_install_version("openshift-ansible", "3.6.0"), "3.5")
+
+	def test_openshift_ansible_with_short_standard_to_legacy_versioning_schema(self):
+		""" when openshift-ansible, which doesnt have different versioning schema, is in short format and in 3.6 version """
+		self.assertEqual(determine_install_version("openshift-ansible", "3.6"), "3.5")
 
 	def test_openshift_ansible_with_legacy_versioning_schema(self):
 		""" when openshift-ansible, which doesnt have different versioning schema is in 3.4 version """
-		self.assertEqual(determine_search_version("openshift-ansible", "3.5.0"), "3.4")
+		self.assertEqual(determine_install_version("openshift-ansible", "3.5.0"), "3.4")
 
 class GetInstallVersionTestCase(unittest.TestCase):
 	"Test for `determine_install_upgrade_version.py`"
@@ -108,38 +124,25 @@ class GetInstallVersionTestCase(unittest.TestCase):
 		""" when multiple matching version are present in released versions """
 		matching_versions = ["1.2.0-1.el7", "1.2.2-1.el7", "1.2.5-1.el7"]
 		install_version = "1.2.5-1.el7"
-		self.assertEqual(get_install_version(matching_versions), install_version)
+		self.assertEqual(get_last_version(matching_versions), install_version)
 
 	def test_with_single_matching_release_version(self):
 		""" when only a single matching version is present in released versions """
 		matching_versions = ["1.5.0-1.4.el7"]
 		install_version = "1.5.0-1.4.el7"
-		self.assertEqual(get_install_version(matching_versions), install_version)
+		self.assertEqual(get_last_version(matching_versions), install_version)
 
 	def test_with_multiple_matching_pre_release_versions(self):
 		""" when multiple matching pre-release version are present in pre-released versions """
 		matching_versions = ["1.2.0-0.el7", "1.2.2-0.el7", "1.2.5-0.el7"]
 		install_version = "1.2.5-0.el7"
-		self.assertEqual(get_install_version(matching_versions), install_version)
+		self.assertEqual(get_last_version(matching_versions), install_version)
 
 	def test_with_single_matching_pre_release_version(self):
 		""" when only single matching pre-release version is present in pre-released versions """
 		matching_versions = ["1.5.0-0.4.el7"]
 		install_version = "1.5.0-0.4.el7"
-		self.assertEqual(get_install_version(matching_versions), install_version)
-
-class GetVersionTestCase(unittest.TestCase):
-	"Test for `determine_install_upgrade_version.py`"
-
-	def test_get_version(self):
-		""" when package version is picked its version-release pair """
-		version_release = "1.5.0-0.4.el7"
-		self.assertEqual(get_version(version_release), "1.5.0")
-
-	def test_get_minor_version(self):
-		""" when package minor version is picked its version-release pair """
-		version_release = "1.5.0-0.4.el7"
-		self.assertEqual(get_minor_version(version_release), "5")
+		self.assertEqual(get_last_version(matching_versions), install_version)
 
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
Fixing use case when either openshift-ansible or origin target branch was pointing to a release branch and we ended up installing/upgrading different versions of those two pkgs.
[Example](https://ci.openshift.redhat.com/jenkins/job/test_pull_request_openshift_ansible_extended_conformance_install_update/270/consoleFull): 
```
+ source ORIGIN_VARS
++ ORIGIN_INSTALL_VERSION=1.5.1-1.el7
++ ORIGIN_INSTALL_MINOR_VERSION=5
++ ORIGIN_UPGRADE_RELEASE_VERSION=3.6.0-0.alpha.1.1013.322171b
++ ORIGIN_UPGRADE_RELEASE_MINOR_VERSION=6
+ source OPENSHIFT_ANSIBLE_VARS
++ ATOMIC_OPENSHIFT_UTILS_INSTALL_VERSION=3.4.94-1.git.0.fe1fe27.el7
++ ATOMIC_OPENSHIFT_UTILS_INSTALL_MINOR_VERSION=4
++ ATOMIC_OPENSHIFT_UTILS_UPGRADE_RELEASE_VERSION=3.5.79-1.git.0.f5f10f5.el7
++ ATOMIC_OPENSHIFT_UTILS_UPGRADE_RELEASE_MINOR_VERSION=5
```

For that reason I've added an optional `--dependency_branch` flag which represents the target branch of the dependency repository. So for example if the PR is targeting  `OPENSHIFT_ANSIBLE_TARGET_BRANCH=release-1.5` we have to install `origin-1.4-x` and upgrade to `origin-1.5.x` and vice versa (if ORIGIN_TARGET_BRANCH=release-1.5 the install version of atomic-openshift-utils should be `1.4.x` and the upgrade version `1.5.x`) so the versions are matching.

Updated  `determine_install_upgrade_version.py` script && its TCs && install_udatte job

@stevekuznetsov PTAL  