### PR TITLE
[ops] Maintain ssh key to gather cluster logs

### DIFF
--- a/jobs/cluster/rotate-log-access-key/Jenkinsfile
+++ b/jobs/cluster/rotate-log-access-key/Jenkinsfile
@@ -1,0 +1,122 @@
+#!/usr/bin/env groovy
+
+node('buildvm-devops') {
+
+    properties([
+            [   $class: 'ParametersDefinitionProperty',
+                parameterDefinitions: [
+                    [
+                        $class: 'hudson.model.StringParameterDefinition',
+                        name: 'BASTION_HOST',
+                        description: 'Bastion host\'s hostname',
+                        defaultValue: 'use-tower2.ops.rhcloud.com'
+                    ],
+                    [
+                        $class: 'hudson.model.StringParameterDefinition',
+                        name: 'BASTION_USER',
+                        description: 'Bastion host\'s username',
+                        defaultValue: 'opsmedic'
+                    ],
+                    [
+                        $class: 'hudson.model.StringParameterDefinition',
+                        name: 'BASTION_CREDENTIALS',
+                        description: 'Jenkins Credentials to ssh to bastion host for key gen',
+                        defaultValue: 'rotate_logs_key'
+                    ],
+                    [
+                        $class: 'hudson.model.StringParameterDefinition',
+                        name: 'SECRETS_REPO',
+                        description: 'Git repo for shared secrets',
+                        defaultValue: 'git@github.com:openshift/shared-secrets.git'
+                    ],
+                    [
+                        $class: 'hudson.model.StringParameterDefinition',
+                        name: 'OSE_CREDENTIALS',
+                        description: 'Credentials for the secrets repository',
+                        defaultValue: 'openshift-bot'
+                    ],
+                    [
+                        $class: 'hudson.model.StringParameterDefinition',
+                        name: 'KEY_FILE',
+                        description: 'Relative path to the key file inside the secrets repo',
+                        defaultValue: 'online/logs_access_key'
+                    ],
+                    [
+                        $class: 'hudson.model.StringParameterDefinition',
+                        defaultValue: 'pep@redhat.com',
+                        description: 'Failure Mailing List',
+                        name: 'MAIL_LIST_FAILURE'
+                    ],
+                ]
+            ],
+            pipelineTriggers([[
+                        $class: 'TimerTrigger',
+                        spec: 'H 0 * * 1'  // every Monday around midnight
+                    ]])
+        ]
+    )
+
+    // Force Jenkins to fail early if this is the first time this job has been run/and or new parameters have not been discovered.
+    echo '''Parameters:
+BASTION_HOST:[${BASTION_HOST}],
+BASTION_USER:[${BASTION_USER}],
+BASTION_CREDENTIALS:[${BASTION_CREDENTIALS}],
+SECRETS_REPO:[${SECRETS_REPO}],
+OSE_CREDENTIALS:[${OSE_CREDENTIALS}],
+KEY_FILE:[${KEY_FILE}],
+MAIL_LIST_FAILURE:[${MAIL_LIST_FAILURE}]
+'''
+
+    try {
+
+        stage('Checkout secrets repo') {
+            checkout(
+                $class: 'GitSCM',
+                userRemoteConfigs: [
+                    [
+                        name: 'origin',
+                        url: SECRETS_REPO,
+                        credentialsId: OSE_CREDENTIALS
+                    ]
+                ],
+                branches: [[ name: '*/master' ]]
+            )
+        }
+
+        stage('Generate and install/rotate Key') {
+            def new_key = null
+            sshagent([BASTION_CREDENTIALS]) {
+                echo "Generate new key and rotate authorized_keys"
+                // This is performed by the command associated to this user/key, see
+                // tower-scripts/bin/rotate-log-access-key.sh
+                new_key = sh (
+                    script: "ssh -o StrictHostKeyChecking=no ${BASTION_USER}@${BASTION_HOST}",
+                    returnStdout: true
+                )
+            }
+            writeFile file: KEY_FILE, text: new_key
+        }
+
+        stage('Push new key to shared secrets repo') {
+            sshagent([OSE_CREDENTIALS]) {
+                sh '''
+git add ${KEY_FILE}
+git commit -m "New SSH key to gather cluster logs"
+git push origin HEAD:master
+'''
+            }
+        }
+
+    } catch ( err ) {
+        mail(to: "${MAIL_LIST_FAILURE}",
+            from: "aos-cd@redhat.com",
+            subject: "Error during SSH key rotation for cluster log collection",
+            body: """Encoutered an error: ${err}
+
+Jenkins job: ${env.BUILD_URL}
+""");
+        // Re-throw the error in order to fail the job
+        throw err
+    }
+}
+

--- a/jobs/cluster/rotate-log-access-key/README.md
+++ b/jobs/cluster/rotate-log-access-key/README.md
@@ -1,0 +1,2 @@
+Manages the creation and rotation of ssh keys related to log collection
+from clusters.

--- a/tower-scripts/bin/rotate-log-access-key.sh
+++ b/tower-scripts/bin/rotate-log-access-key.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -o errexit
+
+# A script that generates SSH keys for opsmedic's ~/.ssh/authorized_keys
+# that will be used for cluster log gathering, and rotates them keeping
+# the last key there.
+#
+# The keys managed by this script look like this in authorized_keys:
+#
+#    command="gather-logs" ssh-rsa AAA...Ob logs_access_key_week_22-YMD-H:M:S
+#
+# where '22' is the week's number. The keys are expected to be rotated weekly,
+# so this is a way to check if there's already a key for this week.
+#
+# The script does not enforce that though and it just issues a warning
+# in case an existing key for this week is present.
+#
+# The new SSH private key is printed to stdout, meant to be collected by
+# a Jenkins pipeline running this script.
+
+# Default values for options
+AUTHKEYS_FILE="/home/opsmedic/.ssh/authorized_keys"
+KEY_COMMENT_PREFIX="logs_access_key_week"
+KEY_COMMAND="/usr/bin/verify-gather-logs-operations.py"
+
+# Prepare the comment part of the ssh key to help us identify the key:
+# Keep in separate vars because "prefix_WEEKNUM" is what lets us look for the
+# presence of a key for this week
+KEY_COMMENT="${KEY_COMMENT_PREFIX}_$(date +%V)"
+KEY_TIMESTAMP=$(date +%Y%m%d-%H:%M:%S)
+
+# Warn (via stderr) if a key for this week is already there
+if grep -q ${KEY_COMMENT} ${AUTHKEYS_FILE}; then
+   >&2 echo "WARNING: a key for this week already existed, this will rotate out older keys"
+fi
+
+# Set up temporary working space.
+# WORKDIR will be deleted when the script terminates
+TMPDIR="$HOME/aos-cd/tmp"
+mkdir -p "${TMPDIR}"
+WORKDIR=$(mktemp -d -p "${TMPDIR}")
+WORKFILE=${WORKDIR}/authorized_keys
+NEWKEY_FILE=${WORKDIR}/generated_key
+
+function on_exit() {
+    rm -rf "${WORKDIR}"
+}
+trap on_exit EXIT
+
+# Backup current key file
+cp -f ${AUTHKEYS_FILE} ${AUTHKEYS_FILE}.bak
+cp    ${AUTHKEYS_FILE} ${WORKFILE}
+
+# Rotate keys: leave only the last of the log-gathering keys in the file.
+# If there's only 1 or 0 keys in authorized_keys we don't have to rotate
+# so we leave the file as is.
+if [ "$(grep ${KEY_COMMENT_PREFIX} ${WORKFILE} | wc -l)" -gt 1 ]; then
+    LAST_KEY_ID=$(grep ${KEY_COMMENT_PREFIX} ${WORKFILE} |
+		      tail -1 | awk '{print $4}')
+    # Remove all log gathering keys...
+    grep -v ${KEY_COMMENT_PREFIX} ${WORKFILE} > ${AUTHKEYS_FILE} || true
+    # ... and copy just the last one
+    grep ${LAST_KEY_ID} ${WORKFILE} >> ${AUTHKEYS_FILE}
+fi
+
+# Generate new key and add it to authorized_keys
+/usr/bin/ssh-keygen -N '' -q \
+		    -C "${KEY_COMMENT}-${KEY_TIMESTAMP}" -f ${NEWKEY_FILE}
+
+echo "command=\"${KEY_COMMAND}\" $(cat ${NEWKEY_FILE}.pub)" >> ${AUTHKEYS_FILE}
+
+# Finish: output the newly generated key
+cat ${NEWKEY_FILE}


### PR DESCRIPTION
A script that rotates the ssh key in `~opsmedic/.ssh/authorized_keys` that is associated to the log collection script, and a Jenkins pipeline to drive it.

The script maintains ssh keys whose comment looks like `logs_access_key_week_XX-timestamp`, where *XX* is the current week's number. This is because by default it checks if a key for this week is already present and aborts (can be `--force`'d).

Once a week a new key is generated and pushed to openshift's shared-secrets repo.

The currently active key and the previous one are kept in `authorized_keys`.
