### PR TITLE
Update jobs

### DIFF
--- a/sjb/actions/child_jobs.py
+++ b/sjb/actions/child_jobs.py
@@ -35,7 +35,7 @@ _CHILD_JOB_ACTION_TEMPLATE = Template("""    <com.tikal.jenkins.plugins.multijob
       <target>{{ child_job }}/</target>
       <excludes></excludes>
       <selector class="hudson.plugins.copyartifact.SpecificBuildSelector">
-        <buildNumber>${{ '{' }}{{ child_job | upper }}_BUILD_NUMBER}</buildNumber>
+        <buildNumber>${{ '{' }}{{ child_job | replace('-','_') | upper }}_BUILD_NUMBER}</buildNumber>
       </selector>
       <optional>true</optional>
       <doNotFingerprintArtifacts>true</doNotFingerprintArtifacts>
@@ -44,7 +44,7 @@ _CHILD_JOB_ACTION_TEMPLATE = Template("""    <com.tikal.jenkins.plugins.multijob
     <hudson.tasks.Shell>
       <command># record the log from the downstream job here for FCM parsing
 {%- for child_job in child_jobs %}
-cat /var/lib/jenkins/jobs/{{ child_job }}/builds/${{ '{' }}{{ child_job | upper }}_BUILD_NUMBER}/log
+cat /var/lib/jenkins/jobs/{{ child_job }}/builds/${{ '{' }}{{ child_job | replace('-','_') | upper }}_BUILD_NUMBER}/log
 {%- endfor %}
       </command>
     </hudson.tasks.Shell>""")

--- a/sjb/generated/merge_pull_request_openshift_ansible.xml
+++ b/sjb/generated/merge_pull_request_openshift_ansible.xml
@@ -204,7 +204,7 @@ cat /var/lib/jenkins/jobs/test_pull_request_openshift_ansible_extended_conforman
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-test_pull_requests --merge_pull_request &quot;${OPENSHIFT_ANSIBLE_PULL_ID}&quot; --repo openshift-ansible --config ~/.test_pull_requests_openshift_ansible.json
+test_pull_requests --merge_pull_request &quot;${OPENSHIFT_ANSIBLE_PULL_ID}&quot; --repo openshift-ansible --config ~/test_pull_requests/openshift-ansible.json
           </command>
         </hudson.tasks.Shell>
       </buildSteps>

--- a/sjb/generated/merge_pull_request_origin.xml
+++ b/sjb/generated/merge_pull_request_origin.xml
@@ -270,7 +270,7 @@ cat /var/lib/jenkins/jobs/test_pull_request_origin_extended_networking_minimal/b
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-test_pull_requests --merge_pull_request &quot;${ORIGIN_PULL_ID}&quot; --repo origin --config ~/.test_pull_requests_origin.json
+test_pull_requests --merge_pull_request &quot;${ORIGIN_PULL_ID}&quot; --repo origin --config ~/test_pull_requests/origin.json
           </command>
         </hudson.tasks.Shell>
       </buildSteps>

--- a/sjb/generated/merge_pull_request_origin_aggregated_logging.xml
+++ b/sjb/generated/merge_pull_request_origin_aggregated_logging.xml
@@ -138,7 +138,7 @@ cat /var/lib/jenkins/jobs/test-origin-aggregated-logging/builds/${TEST-ORIGIN-AG
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-test_pull_requests --merge_pull_request &quot;${ORIGIN_AGGREGATED_LOGGING_PULL_ID}&quot; --repo origin-aggregated-logging --config ~/.test_pull_requests_origin_aggregated_logging.json
+test_pull_requests --merge_pull_request &quot;${ORIGIN_AGGREGATED_LOGGING_PULL_ID}&quot; --repo origin-aggregated-logging --config ~/test_pull_requests/origin-aggregated-logging.json
           </command>
         </hudson.tasks.Shell>
       </buildSteps>

--- a/sjb/generated/merge_pull_request_origin_aggregated_logging.xml
+++ b/sjb/generated/merge_pull_request_origin_aggregated_logging.xml
@@ -120,7 +120,7 @@ approve.sh origin-aggregated-logging &quot;${ORIGIN_AGGREGATED_LOGGING_TARGET_BR
       <target>test-origin-aggregated-logging/</target>
       <excludes></excludes>
       <selector class="hudson.plugins.copyartifact.SpecificBuildSelector">
-        <buildNumber>${TEST-ORIGIN-AGGREGATED-LOGGING_BUILD_NUMBER}</buildNumber>
+        <buildNumber>${TEST_ORIGIN_AGGREGATED_LOGGING_BUILD_NUMBER}</buildNumber>
       </selector>
       <optional>true</optional>
       <doNotFingerprintArtifacts>true</doNotFingerprintArtifacts>
@@ -128,7 +128,7 @@ approve.sh origin-aggregated-logging &quot;${ORIGIN_AGGREGATED_LOGGING_TARGET_BR
     <hudson.tasks.Shell>
       <command># record the log from the downstream job here for FCM parsing
 cat /var/lib/jenkins/jobs/test_pull_request_origin_aggregated_logging_ansible/builds/${TEST_PULL_REQUEST_ORIGIN_AGGREGATED_LOGGING_ANSIBLE_BUILD_NUMBER}/log
-cat /var/lib/jenkins/jobs/test-origin-aggregated-logging/builds/${TEST-ORIGIN-AGGREGATED-LOGGING_BUILD_NUMBER}/log
+cat /var/lib/jenkins/jobs/test-origin-aggregated-logging/builds/${TEST_ORIGIN_AGGREGATED_LOGGING_BUILD_NUMBER}/log
       </command>
     </hudson.tasks.Shell>
   </builders>

--- a/sjb/generated/test_pull_request_openshift_ansible.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible.xml
@@ -193,7 +193,7 @@ cat /var/lib/jenkins/jobs/test_pull_request_openshift_ansible_extended_conforman
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-test_pull_requests --mark_test_success &quot;${OPENSHIFT_ANSIBLE_PULL_ID}&quot; --repo openshift-ansible --config ~/.test_pull_requests_openshift_ansible.json || true
+test_pull_requests --mark_test_success &quot;${OPENSHIFT_ANSIBLE_PULL_ID}&quot; --repo openshift-ansible --config ~/test_pull_requests/openshift-ansible.json || true
           </command>
         </hudson.tasks.Shell>
       </buildSteps>

--- a/sjb/generated/test_pull_request_origin.xml
+++ b/sjb/generated/test_pull_request_origin.xml
@@ -259,7 +259,7 @@ cat /var/lib/jenkins/jobs/test_pull_request_origin_extended_networking_minimal/b
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-test_pull_requests --mark_test_success &quot;${ORIGIN_PULL_ID}&quot; --repo origin --config ~/.test_pull_requests_origin.json || true
+test_pull_requests --mark_test_success &quot;${ORIGIN_PULL_ID}&quot; --repo origin --config ~/test_pull_requests/origin.json || true
           </command>
         </hudson.tasks.Shell>
       </buildSteps>

--- a/sjb/generated/test_pull_request_origin_aggregated_logging.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging.xml
@@ -127,7 +127,7 @@ cat /var/lib/jenkins/jobs/test-origin-aggregated-logging/builds/${TEST-ORIGIN-AG
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-test_pull_requests --mark_test_success &quot;${ORIGIN_AGGREGATED_LOGGING_PULL_ID}&quot; --repo origin-aggregated-logging --config ~/.test_pull_requests_origin_aggregated_logging.json || true
+test_pull_requests --mark_test_success &quot;${ORIGIN_AGGREGATED_LOGGING_PULL_ID}&quot; --repo origin-aggregated-logging --config ~/test_pull_requests/origin-aggregated-logging.json || true
           </command>
         </hudson.tasks.Shell>
       </buildSteps>

--- a/sjb/generated/test_pull_request_origin_aggregated_logging.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging.xml
@@ -109,7 +109,7 @@
       <target>test-origin-aggregated-logging/</target>
       <excludes></excludes>
       <selector class="hudson.plugins.copyartifact.SpecificBuildSelector">
-        <buildNumber>${TEST-ORIGIN-AGGREGATED-LOGGING_BUILD_NUMBER}</buildNumber>
+        <buildNumber>${TEST_ORIGIN_AGGREGATED_LOGGING_BUILD_NUMBER}</buildNumber>
       </selector>
       <optional>true</optional>
       <doNotFingerprintArtifacts>true</doNotFingerprintArtifacts>
@@ -117,7 +117,7 @@
     <hudson.tasks.Shell>
       <command># record the log from the downstream job here for FCM parsing
 cat /var/lib/jenkins/jobs/test_pull_request_origin_aggregated_logging_ansible/builds/${TEST_PULL_REQUEST_ORIGIN_AGGREGATED_LOGGING_ANSIBLE_BUILD_NUMBER}/log
-cat /var/lib/jenkins/jobs/test-origin-aggregated-logging/builds/${TEST-ORIGIN-AGGREGATED-LOGGING_BUILD_NUMBER}/log
+cat /var/lib/jenkins/jobs/test-origin-aggregated-logging/builds/${TEST_ORIGIN_AGGREGATED_LOGGING_BUILD_NUMBER}/log
       </command>
     </hudson.tasks.Shell>
   </builders>

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
@@ -359,7 +359,7 @@ oct deprovision</command>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-test_pull_requests --mark_test_success &quot;${ORIGIN_AGGREGATED_LOGGING_PULL_ID}&quot; --repo origin-aggregated-logging --config ~/.test_pull_requests_origin_aggregated_logging.json || true
+test_pull_requests --mark_test_success &quot;${ORIGIN_AGGREGATED_LOGGING_PULL_ID}&quot; --repo origin-aggregated-logging --config ~/test_pull_requests/origin-aggregated-logging.json || true
           </command>
         </hudson.tasks.Shell>
       </buildSteps>

--- a/sjb/templates/test_case.xml
+++ b/sjb/templates/test_case.xml
@@ -90,7 +90,7 @@ approve.sh {{ target_repo }} &quot;${{ '{' }}{{ target_repo | replace('-', '_') 
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-test_pull_requests --mark_test_success &quot;${{ '{' }}{{ target_repo | replace('-', '_') | upper }}_PULL_ID}&quot; --repo {{ target_repo }} --config ~/.test_pull_requests_{{ target_repo | replace('-', '_') }}.json || true
+test_pull_requests --mark_test_success &quot;${{ '{' }}{{ target_repo | replace('-', '_') | upper }}_PULL_ID}&quot; --repo {{ target_repo }} --config ~/test_pull_requests/{{ target_repo }}.json || true
           </command>
         </hudson.tasks.Shell>
       </buildSteps>
@@ -105,7 +105,7 @@ test_pull_requests --mark_test_success &quot;${{ '{' }}{{ target_repo | replace(
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-test_pull_requests --merge_pull_request &quot;${{ '{' }}{{ target_repo | replace('-', '_') | upper }}_PULL_ID}&quot; --repo {{ target_repo }} --config ~/.test_pull_requests_{{ target_repo | replace('-', '_') }}.json
+test_pull_requests --merge_pull_request &quot;${{ '{' }}{{ target_repo | replace('-', '_') | upper }}_PULL_ID}&quot; --repo {{ target_repo }} --config ~/test_pull_requests/{{ target_repo }}.json
           </command>
         </hudson.tasks.Shell>
       </buildSteps>


### PR DESCRIPTION
Clean up invocation of test-pull-requests

Recent changes to how we place the test-pull-requests configuration on
the Jenkins master filesystem mean that we can simplify the calls to
this utility from our jobs.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Handle jobs with dashes when they are sub-jobs

When we generate the environment variable names for sub-job build
numbers we need to handle jobs with dashes in their names, as dashes are
not valid characters in Bash variable names, so Jenkins will replace the
dashes with underscores.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---


@richm second commit in here fixes your issue