### PR TITLE
Remove installation of `pip` and `junit_xml` library

### DIFF
--- a/sjb/config/common/test_cases/origin_installed_release.yml
+++ b/sjb/config/common/test_cases/origin_installed_release.yml
@@ -14,8 +14,6 @@ extensions:
       title: "install Ansible plugins"
       repository: "origin"
       script: |-
-        sudo yum install -y python-pip
-        sudo pip install junit_xml
         sudo chmod o+rw /etc/environment
         echo "ANSIBLE_JUNIT_DIR=$( pwd )/_output/scripts/ansible_junit" >> /etc/environment
         sudo mkdir -p /usr/share/ansible/plugins/callback

--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
@@ -40,8 +40,6 @@ extensions:
       title: "install Ansible plugins"
       repository: "origin"
       script: |-
-        sudo yum install -y python-pip
-        sudo pip install junit_xml
         sudo chmod o+rw /etc/environment
         echo "ANSIBLE_JUNIT_DIR=$( pwd )/_output/scripts/ansible_junit" >> /etc/environment
         sudo mkdir -p /usr/share/ansible/plugins/callback

--- a/sjb/config/test_cases/test_branch_origin_aggregated_logging_prior.yml
+++ b/sjb/config/test_cases/test_branch_origin_aggregated_logging_prior.yml
@@ -9,8 +9,6 @@ extensions:
       title: "install Ansible plugins"
       repository: "origin"
       script: |-
-        sudo yum install -y python-pip
-        sudo pip install junit_xml
         sudo chmod o+rw /etc/environment
         echo "ANSIBLE_JUNIT_DIR=$( pwd )/_output/scripts/ansible_junit" >> /etc/environment
         sudo mkdir -p /usr/share/ansible/plugins/callback

--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_install.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_install.yml
@@ -39,8 +39,6 @@ extensions:
       title: "install Ansible plugins"
       repository: "origin"
       script: |-
-        sudo yum install -y python-pip
-        sudo pip install junit_xml
         sudo chmod o+rw /etc/environment
         echo "ANSIBLE_JUNIT_DIR=$( pwd )/_output/scripts/ansible_junit" >> /etc/environment
         sudo mkdir -p /usr/share/ansible/plugins/callback

--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_install_containerized.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_install_containerized.yml
@@ -39,8 +39,6 @@ extensions:
       title: "install Ansible plugins"
       repository: "origin"
       script: |-
-        sudo yum install -y python-pip
-        sudo pip install junit_xml
         sudo chmod o+rw /etc/environment
         echo "ANSIBLE_JUNIT_DIR=$( pwd )/_output/scripts/ansible_junit" >> /etc/environment
         sudo mkdir -p /usr/share/ansible/plugins/callback

--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update.yml
@@ -56,8 +56,6 @@ extensions:
       title: "install Ansible plugins"
       repository: "origin"
       script: |-
-        sudo yum install -y python-pip
-        sudo pip install junit_xml
         sudo chmod o+rw /etc/environment
         echo "ANSIBLE_JUNIT_DIR=$( pwd )/_output/scripts/ansible_junit" >> /etc/environment
         sudo mkdir -p /usr/share/ansible/plugins/callback

--- a/sjb/generated/test_branch_openshift_ansible_logging.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging.xml
@@ -174,8 +174,6 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-sudo yum install -y python-pip
-sudo pip install junit_xml
 sudo chmod o+rw /etc/environment
 echo &#34;ANSIBLE_JUNIT_DIR=\$( pwd )/_output/scripts/ansible_junit&#34; &gt;&gt; /etc/environment
 sudo mkdir -p /usr/share/ansible/plugins/callback

--- a/sjb/generated/test_branch_origin_aggregated_logging_prior.xml
+++ b/sjb/generated/test_branch_origin_aggregated_logging_prior.xml
@@ -106,8 +106,6 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-sudo yum install -y python-pip
-sudo pip install junit_xml
 sudo chmod o+rw /etc/environment
 echo &#34;ANSIBLE_JUNIT_DIR=\$( pwd )/_output/scripts/ansible_junit&#34; &gt;&gt; /etc/environment
 sudo mkdir -p /usr/share/ansible/plugins/callback

--- a/sjb/generated/test_branch_origin_extended_builds.xml
+++ b/sjb/generated/test_branch_origin_extended_builds.xml
@@ -107,8 +107,6 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-sudo yum install -y python-pip
-sudo pip install junit_xml
 sudo chmod o+rw /etc/environment
 echo &#34;ANSIBLE_JUNIT_DIR=\$( pwd )/_output/scripts/ansible_junit&#34; &gt;&gt; /etc/environment
 sudo mkdir -p /usr/share/ansible/plugins/callback

--- a/sjb/generated/test_branch_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install.xml
@@ -186,8 +186,6 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-sudo yum install -y python-pip
-sudo pip install junit_xml
 sudo chmod o+rw /etc/environment
 echo &#34;ANSIBLE_JUNIT_DIR=\$( pwd )/_output/scripts/ansible_junit&#34; &gt;&gt; /etc/environment
 sudo mkdir -p /usr/share/ansible/plugins/callback

--- a/sjb/generated/test_branch_origin_extended_conformance_install_containerized.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_containerized.xml
@@ -186,8 +186,6 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-sudo yum install -y python-pip
-sudo pip install junit_xml
 sudo chmod o+rw /etc/environment
 echo &#34;ANSIBLE_JUNIT_DIR=\$( pwd )/_output/scripts/ansible_junit&#34; &gt;&gt; /etc/environment
 sudo mkdir -p /usr/share/ansible/plugins/callback

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
@@ -202,8 +202,6 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-sudo yum install -y python-pip
-sudo pip install junit_xml
 sudo chmod o+rw /etc/environment
 echo &#34;ANSIBLE_JUNIT_DIR=\$( pwd )/_output/scripts/ansible_junit&#34; &gt;&gt; /etc/environment
 sudo mkdir -p /usr/share/ansible/plugins/callback

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
@@ -196,8 +196,6 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-sudo yum install -y python-pip
-sudo pip install junit_xml
 sudo chmod o+rw /etc/environment
 echo &#34;ANSIBLE_JUNIT_DIR=\$( pwd )/_output/scripts/ansible_junit&#34; &gt;&gt; /etc/environment
 sudo mkdir -p /usr/share/ansible/plugins/callback

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized.xml
@@ -196,8 +196,6 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-sudo yum install -y python-pip
-sudo pip install junit_xml
 sudo chmod o+rw /etc/environment
 echo &#34;ANSIBLE_JUNIT_DIR=\$( pwd )/_output/scripts/ansible_junit&#34; &gt;&gt; /etc/environment
 sudo mkdir -p /usr/share/ansible/plugins/callback

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
@@ -212,8 +212,6 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-sudo yum install -y python-pip
-sudo pip install junit_xml
 sudo chmod o+rw /etc/environment
 echo &#34;ANSIBLE_JUNIT_DIR=\$( pwd )/_output/scripts/ansible_junit&#34; &gt;&gt; /etc/environment
 sudo mkdir -p /usr/share/ansible/plugins/callback

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
@@ -196,8 +196,6 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-sudo yum install -y python-pip
-sudo pip install junit_xml
 sudo chmod o+rw /etc/environment
 echo &#34;ANSIBLE_JUNIT_DIR=\$( pwd )/_output/scripts/ansible_junit&#34; &gt;&gt; /etc/environment
 sudo mkdir -p /usr/share/ansible/plugins/callback

--- a/sjb/generated/test_pull_request_openshift_ansible_logging.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging.xml
@@ -184,8 +184,6 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-sudo yum install -y python-pip
-sudo pip install junit_xml
 sudo chmod o+rw /etc/environment
 echo &#34;ANSIBLE_JUNIT_DIR=\$( pwd )/_output/scripts/ansible_junit&#34; &gt;&gt; /etc/environment
 sudo mkdir -p /usr/share/ansible/plugins/callback

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
@@ -184,8 +184,6 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-sudo yum install -y python-pip
-sudo pip install junit_xml
 sudo chmod o+rw /etc/environment
 echo &#34;ANSIBLE_JUNIT_DIR=\$( pwd )/_output/scripts/ansible_junit&#34; &gt;&gt; /etc/environment
 sudo mkdir -p /usr/share/ansible/plugins/callback

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_prior.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_prior.xml
@@ -116,8 +116,6 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-sudo yum install -y python-pip
-sudo pip install junit_xml
 sudo chmod o+rw /etc/environment
 echo &#34;ANSIBLE_JUNIT_DIR=\$( pwd )/_output/scripts/ansible_junit&#34; &gt;&gt; /etc/environment
 sudo mkdir -p /usr/share/ansible/plugins/callback

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
@@ -196,8 +196,6 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-sudo yum install -y python-pip
-sudo pip install junit_xml
 sudo chmod o+rw /etc/environment
 echo &#34;ANSIBLE_JUNIT_DIR=\$( pwd )/_output/scripts/ansible_junit&#34; &gt;&gt; /etc/environment
 sudo mkdir -p /usr/share/ansible/plugins/callback

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
@@ -212,8 +212,6 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-sudo yum install -y python-pip
-sudo pip install junit_xml
 sudo chmod o+rw /etc/environment
 echo &#34;ANSIBLE_JUNIT_DIR=\$( pwd )/_output/scripts/ansible_junit&#34; &gt;&gt; /etc/environment
 sudo mkdir -p /usr/share/ansible/plugins/callback


### PR DESCRIPTION
These two dependencies have been pushed into the base AMI and it is no
longer necessary to install them at test run time.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>