### PR TITLE
Allow merges with both blocker and bug severities

### DIFF
--- a/approvers/closed_approver.sh
+++ b/approvers/closed_approver.sh
@@ -8,21 +8,21 @@ if [[ $# -ne 1 ]]; then
 	echo "[ERROR] Usage: $0 SEVERITY"
 	exit 127
 else
-	severity="$1"
+	severity="${1,,}"
 	case "${severity}" in
 		"none")
 			echo "[ERROR] This branch is closed for pull requests at this time."
 			exit 1
 			;;
-		"bug")
+		*"tooling"*)
 			echo "[ERROR] This branch is closed for pull requests at this time."
 			exit 1
 			;;
-		"blocker")
+		*"blocker"*)
 			echo "[ERROR] This branch is closed for pull requests at this time."
 			exit 1
 			;;
-		"tooling")
+		*"bug"*)
 			echo "[ERROR] This branch is closed for pull requests at this time."
 			exit 1
 			;;

--- a/approvers/devcut_approver.sh
+++ b/approvers/devcut_approver.sh
@@ -8,19 +8,20 @@ if [[ $# -ne 1 ]]; then
 	echo "[ERROR] Usage: $0 SEVERITY"
 	exit 127
 else
-	severity="$1"
+	# make severity lowercase
+	severity="${1,,}"
 	case "${severity}" in
 		"none")
 			echo "[ERROR] Only bugs and blocker bugs are allowed to merge during dev-cut."
 			exit 1
 			;;
-		"bug")
+		*"tooling"*)
 			exit 0
 			;;
-		"blocker")
+		*"blocker"*)
 			exit 0
 			;;
-		"tooling")
+		*"bug"*)
 			exit 0
 			;;
 		*)

--- a/approvers/open_approver.sh
+++ b/approvers/open_approver.sh
@@ -8,18 +8,18 @@ if [[ $# -ne 1 ]]; then
 	echo "[ERROR] Usage: $0 SEVERITY"
 	exit 127
 else
-	severity="$1"
+	severity="${1,,}"
 	case "${severity}" in
 		"none")
 			exit 0
 			;;
-		"bug")
+		*"tooling"*)
 			exit 0
 			;;
-		"blocker")
+		*"blocker"*)
 			exit 0
 			;;
-		"tooling")
+		*"bug"*)
 			exit 0
 			;;
 		*)

--- a/approvers/stagecut_approver.sh
+++ b/approvers/stagecut_approver.sh
@@ -8,21 +8,22 @@ if [[ $# -ne 1 ]]; then
 	echo "[ERROR] Usage: $0 SEVERITY"
 	exit 127
 else
-	severity="$1"
+	# make severity lowercase
+	severity="${1,,}"
 	case "${severity}" in
 		"none")
 			echo "[ERROR] Only blocker bugs are allowed to merge during stage-cut."
 			exit 1
 			;;
-		"bug")
+		*"tooling"*)
+			exit 0
+			;;
+		*"blocker"*)
+			exit 0
+			;;
+		*"bug"*)
 			echo "[ERROR] Only blocker bugs are allowed to merge during stage-cut."
 			exit 1
-			;;
-		"blocker")
-			exit 0
-			;;
-		"tooling")
-			exit 0
 			;;
 		*)
 			echo "[ERROR] Unknown severity '${severity}': only one of 'none', 'bug', 'blocker', or 'tooling' allowed."


### PR DESCRIPTION
Today rosie will not merge a BZ if it has
```
[merge][severity: bug]
[merge][severity: blocker]
```
because "bug,blocker" is not a valid state.

This PR will instead look for the severity anywhere in the string.

It does mean that a PR with:
```
[merge][severity: elephantblockermonkey]
```
Will get counted as a blocker. We could make it better, but it just
didn't seem worth it to me...