### PR TITLE
preinstall checks: disable package_update

### DIFF
--- a/sjb/inventory/group_vars/OSEv3/checks.yml
+++ b/sjb/inventory/group_vars/OSEv3/checks.yml
@@ -1,3 +1,4 @@
 ---
 openshift_check_min_host_disk_gb: 10
 openshift_check_min_host_memory_gb: 8
+openshift_disable_check: package_update


### PR DESCRIPTION
Unfortunately yum repo state is not completely reliable, and this check
is a little too sensitive to issues that might not be problems with the
actual install run so it causes test flakes (or outages depending on
whether the yum repo breakage is a flake/ongoing).