### PR TITLE
Check for network_manager.yml

### DIFF
--- a/jobs/package-dockertested/install-origin-release.sh
+++ b/jobs/package-dockertested/install-origin-release.sh
@@ -11,12 +11,14 @@ git log -1 --pretty=%h >> "${jobs_repo}/ORIGIN_COMMIT"
 ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo "-${OS_RPM_VERSION}-${OS_RPM_RELEASE}" ) >> "${jobs_repo}/ORIGIN_PKG_VERSION"
 
 cd /data/src/github.com/openshift/aos-cd-jobs
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
-                 /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+if [ -f /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml ]; then
+        ansible-playbook -vv --become               \
+                         --become-user root         \
+                         --connection local         \
+                         --inventory sjb/inventory/ \
+                         -e deployment_type=origin  \
+                         /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \

--- a/sjb/config/common/test_cases/origin_installed_release.yml
+++ b/sjb/config/common/test_cases/origin_installed_release.yml
@@ -34,12 +34,14 @@ extensions:
       repository: "aos-cd-jobs"
       script: |-
         local_ip="$( curl http://169.254.169.254/latest/meta-data/local-ipv4 )"
-        ansible-playbook -vv --become               \
-                         --become-user root         \
-                         --connection local         \
-                         --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
-                         /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+        if [ -f /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml ]; then
+            ansible-playbook -vv --become               \
+                             --become-user root         \
+                             --connection local         \
+                             --inventory sjb/inventory/ \
+                             -e deployment_type=origin  \
+                             /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+        fi
         ansible-playbook -vv --become               \
                          --become-user root         \
                          --connection local         \

--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
@@ -59,12 +59,14 @@ extensions:
       title: "install origin"
       repository: "aos-cd-jobs"
       script: |-
-        ansible-playbook -vv --become               \
-                         --become-user root         \
-                         --connection local         \
-                         --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
-                         /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+        if [ -f /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml ]; then
+            ansible-playbook -vv --become               \
+                             --become-user root         \
+                             --connection local         \
+                             --inventory sjb/inventory/ \
+                             -e deployment_type=origin  \
+                             /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+        fi
         ansible-playbook -vv --become               \
                          --become-user root         \
                          --connection local         \

--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_install.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_install.yml
@@ -58,12 +58,14 @@ extensions:
       title: "install origin"
       repository: "aos-cd-jobs"
       script: |-
-        ansible-playbook -vv --become               \
-                         --become-user root         \
-                         --connection local         \
-                         --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
-                         /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+        if [ -f /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml ]; then
+            ansible-playbook -vv --become               \
+                             --become-user root         \
+                             --connection local         \
+                             --inventory sjb/inventory/ \
+                             -e deployment_type=origin  \
+                             /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+        fi
         ansible-playbook -vv --become               \
                          --become-user root         \
                          --connection local         \

--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_install_containerized.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_install_containerized.yml
@@ -58,13 +58,15 @@ extensions:
       title: "install origin"
       repository: "aos-cd-jobs"
       script: |-
-        ansible-playbook -vv --become               \
-                         --become-user root         \
-                         --connection local         \
-                         --inventory sjb/inventory/ \
-                         -e containerized=true      \
-                         -e deployment_type=origin  \
-                         /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+        if [ -f /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml ]; then
+            ansible-playbook -vv --become               \
+                             --become-user root         \
+                             --connection local         \
+                             --inventory sjb/inventory/ \
+                             -e containerized=true      \
+                             -e deployment_type=origin  \
+                             /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+        fi
         ansible-playbook -vv --become               \
                          --become-user root         \
                          --connection local         \

--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update.yml
@@ -101,13 +101,15 @@ extensions:
         source ORIGIN_VARS
         source OPENSHIFT_ANSIBLE_VARS
         echo "=== Installing ${pkg_name}-${ORIGIN_INSTALL_VERSION} ==="
-        ansible-playbook  -vv                \
-                          --become           \
-                          --become-user root \
-                          --connection local \
-                          --inventory sjb/inventory/ \
-                          /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml \
-                          -e deployment_type=$( cat ./DEPLOYMENT_TYPE)
+        if [ -f /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml ]; then
+            ansible-playbook  -vv                \
+                              --become           \
+                              --become-user root \
+                              --connection local \
+                              --inventory sjb/inventory/ \
+                              /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml \
+                              -e deployment_type=$( cat ./DEPLOYMENT_TYPE)
+        fi
         ansible-playbook  -vv                \
                           --become           \
                           --become-user root \

--- a/sjb/generated/test_branch_openshift_ansible_logging.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging.xml
@@ -211,12 +211,14 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
-                 /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+if [ -f /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml ]; then
+    ansible-playbook -vv --become               \
+                     --become-user root         \
+                     --connection local         \
+                     --inventory sjb/inventory/ \
+                     -e deployment_type=origin  \
+                     /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \

--- a/sjb/generated/test_branch_origin_extended_builds.xml
+++ b/sjb/generated/test_branch_origin_extended_builds.xml
@@ -145,12 +145,14 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
 local_ip=&#34;\$( curl http://169.254.169.254/latest/meta-data/local-ipv4 )&#34;
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
-                 /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+if [ -f /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml ]; then
+    ansible-playbook -vv --become               \
+                     --become-user root         \
+                     --connection local         \
+                     --inventory sjb/inventory/ \
+                     -e deployment_type=origin  \
+                     /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \

--- a/sjb/generated/test_branch_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install.xml
@@ -223,12 +223,14 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
-                 /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+if [ -f /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml ]; then
+    ansible-playbook -vv --become               \
+                     --become-user root         \
+                     --connection local         \
+                     --inventory sjb/inventory/ \
+                     -e deployment_type=origin  \
+                     /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \

--- a/sjb/generated/test_branch_origin_extended_conformance_install_containerized.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_containerized.xml
@@ -223,13 +223,15 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e containerized=true      \
-                 -e deployment_type=origin  \
-                 /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+if [ -f /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml ]; then
+    ansible-playbook -vv --become               \
+                     --become-user root         \
+                     --connection local         \
+                     --inventory sjb/inventory/ \
+                     -e containerized=true      \
+                     -e deployment_type=origin  \
+                     /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
@@ -269,13 +269,15 @@ sudo python sjb/hack/determine_install_upgrade_version.py \$( cat ORIGIN_BUILT_V
 source ORIGIN_VARS
 source OPENSHIFT_ANSIBLE_VARS
 echo &#34;=== Installing \${pkg_name}-\${ORIGIN_INSTALL_VERSION} ===&#34;
-ansible-playbook  -vv                \
-                  --become           \
-                  --become-user root \
-                  --connection local \
-                  --inventory sjb/inventory/ \
-                  /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml \
-                  -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)
+if [ -f /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml ]; then
+    ansible-playbook  -vv                \
+                      --become           \
+                      --become-user root \
+                      --connection local \
+                      --inventory sjb/inventory/ \
+                      /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml \
+                      -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)
+fi
 ansible-playbook  -vv                \
                   --become           \
                   --become-user root \

--- a/sjb/generated/test_branch_origin_extended_image_ecosystem.xml
+++ b/sjb/generated/test_branch_origin_extended_image_ecosystem.xml
@@ -145,12 +145,14 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
 local_ip=&#34;\$( curl http://169.254.169.254/latest/meta-data/local-ipv4 )&#34;
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
-                 /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+if [ -f /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml ]; then
+    ansible-playbook -vv --become               \
+                     --become-user root         \
+                     --connection local         \
+                     --inventory sjb/inventory/ \
+                     -e deployment_type=origin  \
+                     /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
@@ -233,12 +233,14 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
-                 /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+if [ -f /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml ]; then
+    ansible-playbook -vv --become               \
+                     --become-user root         \
+                     --connection local         \
+                     --inventory sjb/inventory/ \
+                     -e deployment_type=origin  \
+                     /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized.xml
@@ -233,13 +233,15 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e containerized=true      \
-                 -e deployment_type=origin  \
-                 /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+if [ -f /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml ]; then
+    ansible-playbook -vv --become               \
+                     --become-user root         \
+                     --connection local         \
+                     --inventory sjb/inventory/ \
+                     -e containerized=true      \
+                     -e deployment_type=origin  \
+                     /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
@@ -279,13 +279,15 @@ sudo python sjb/hack/determine_install_upgrade_version.py \$( cat ORIGIN_BUILT_V
 source ORIGIN_VARS
 source OPENSHIFT_ANSIBLE_VARS
 echo &#34;=== Installing \${pkg_name}-\${ORIGIN_INSTALL_VERSION} ===&#34;
-ansible-playbook  -vv                \
-                  --become           \
-                  --become-user root \
-                  --connection local \
-                  --inventory sjb/inventory/ \
-                  /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml \
-                  -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)
+if [ -f /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml ]; then
+    ansible-playbook  -vv                \
+                      --become           \
+                      --become-user root \
+                      --connection local \
+                      --inventory sjb/inventory/ \
+                      /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml \
+                      -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)
+fi
 ansible-playbook  -vv                \
                   --become           \
                   --become-user root \

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
@@ -233,12 +233,14 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
-                 /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+if [ -f /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml ]; then
+    ansible-playbook -vv --become               \
+                     --become-user root         \
+                     --connection local         \
+                     --inventory sjb/inventory/ \
+                     -e deployment_type=origin  \
+                     /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \

--- a/sjb/generated/test_pull_request_openshift_ansible_logging.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging.xml
@@ -221,12 +221,14 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
-                 /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+if [ -f /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml ]; then
+    ansible-playbook -vv --become               \
+                     --become-user root         \
+                     --connection local         \
+                     --inventory sjb/inventory/ \
+                     -e deployment_type=origin  \
+                     /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
@@ -221,12 +221,14 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
-                 /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+if [ -f /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml ]; then
+    ansible-playbook -vv --become               \
+                     --become-user root         \
+                     --connection local         \
+                     --inventory sjb/inventory/ \
+                     -e deployment_type=origin  \
+                     /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
@@ -233,12 +233,14 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
-                 /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+if [ -f /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml ]; then
+    ansible-playbook -vv --become               \
+                     --become-user root         \
+                     --connection local         \
+                     --inventory sjb/inventory/ \
+                     -e deployment_type=origin  \
+                     /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
@@ -279,13 +279,15 @@ sudo python sjb/hack/determine_install_upgrade_version.py \$( cat ORIGIN_BUILT_V
 source ORIGIN_VARS
 source OPENSHIFT_ANSIBLE_VARS
 echo &#34;=== Installing \${pkg_name}-\${ORIGIN_INSTALL_VERSION} ===&#34;
-ansible-playbook  -vv                \
-                  --become           \
-                  --become-user root \
-                  --connection local \
-                  --inventory sjb/inventory/ \
-                  /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml \
-                  -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)
+if [ -f /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml ]; then
+    ansible-playbook  -vv                \
+                      --become           \
+                      --become-user root \
+                      --connection local \
+                      --inventory sjb/inventory/ \
+                      /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml \
+                      -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)
+fi
 ansible-playbook  -vv                \
                   --become           \
                   --become-user root \


### PR DESCRIPTION
For openshift-ansible 1.3 and lower we dont have the `network_manager.yml` playbook. For that reason are some jobs (that are installing those version) are failing, eg: https://ci.openshift.redhat.com/jenkins/view/All/job/test_pull_request_openshift_ansible_extended_conformance_install_update/444/consoleFull#-172450789458b6e51eb7608a5981914356

Added a check for that playbook.
@stevekuznetsov  PTAL