### PR TITLE
Rename the `tooling` severity to `lowrisk`

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ When running `[merge]` on a PR, developers will optionally be able to add `[seve
  - none ( `[merge]` )
  - bug ( `[merge][severity: bug]` )
  - blocker ( `[merge][severity: blocker]` )
- - tooling ( `[merge][severity: tooling]` )
+ - low-risk ( `[merge][severity: lowrisk]` )
 
-The `tooling` severity is special in that all approvers other than the [`closed_approver.sh`](approvers/closed_approver.sh), will
+The `lowrisk` severity is special in that all approvers other than the [`closed_approver.sh`](approvers/closed_approver.sh), will
 allow merges with it. Developers should use this tag when they are making changes to code in the repository that does not make up
 any part of the shipped product and therefore does not have any chance of impacting deployments.
 
@@ -137,7 +137,7 @@ There will be four possible designations for any branch in your repo:
     <td>None</td>
     <td>Bug</td>
     <td>Blocker</td>
-    <td>Tooling</td>
+    <td>Low-Risk</td>
   </tr>
   <tr>
     <td rowspan="4">Branch Stage<br></td>

--- a/approvers/closed_approver.sh
+++ b/approvers/closed_approver.sh
@@ -14,7 +14,7 @@ else
 			echo "[ERROR] This branch is closed for pull requests at this time."
 			exit 1
 			;;
-		*"tooling"*)
+		*"lowrisk"*)
 			echo "[ERROR] This branch is closed for pull requests at this time."
 			exit 1
 			;;
@@ -27,7 +27,7 @@ else
 			exit 1
 			;;
 		*)
-			echo "[ERROR] Unknown severity '${severity}': only one of 'none', 'bug', 'blocker', or 'tooling' allowed."
+			echo "[ERROR] Unknown severity '${severity}': only one of 'none', 'bug', 'blocker', or 'lowrisk' allowed."
 			exit 127
 	esac
 fi

--- a/approvers/devcut_approver.sh
+++ b/approvers/devcut_approver.sh
@@ -15,7 +15,7 @@ else
 			echo "[ERROR] Only bugs and blocker bugs are allowed to merge during dev-cut."
 			exit 1
 			;;
-		*"tooling"*)
+		*"lowrisk"*)
 			exit 0
 			;;
 		*"blocker"*)
@@ -25,7 +25,7 @@ else
 			exit 0
 			;;
 		*)
-			echo "[ERROR] Unknown severity '${severity}': only one of 'none', 'bug', 'blocker', or 'tooling' allowed."
+			echo "[ERROR] Unknown severity '${severity}': only one of 'none', 'bug', 'blocker', or 'lowrisk' allowed."
 			exit 127
 	esac
 fi

--- a/approvers/open_approver.sh
+++ b/approvers/open_approver.sh
@@ -13,7 +13,7 @@ else
 		"none")
 			exit 0
 			;;
-		*"tooling"*)
+		*"lowrisk"*)
 			exit 0
 			;;
 		*"blocker"*)
@@ -23,7 +23,7 @@ else
 			exit 0
 			;;
 		*)
-			echo "[ERROR] Unknown severity '${severity}': only one of 'none', 'bug', 'blocker', or 'tooling' allowed."
+			echo "[ERROR] Unknown severity '${severity}': only one of 'none', 'bug', 'blocker', or 'lowrisk' allowed."
 			exit 127
 	esac
 fi

--- a/approvers/stagecut_approver.sh
+++ b/approvers/stagecut_approver.sh
@@ -15,7 +15,7 @@ else
 			echo "[ERROR] Only blocker bugs are allowed to merge during stage-cut."
 			exit 1
 			;;
-		*"tooling"*)
+		*"lowrisk"*)
 			exit 0
 			;;
 		*"blocker"*)
@@ -26,7 +26,7 @@ else
 			exit 1
 			;;
 		*)
-			echo "[ERROR] Unknown severity '${severity}': only one of 'none', 'bug', 'blocker', or 'tooling' allowed."
+			echo "[ERROR] Unknown severity '${severity}': only one of 'none', 'bug', 'blocker', or 'lowrisk' allowed."
 			exit 127
 	esac
 fi


### PR DESCRIPTION
It has been pointed out that people are already starting to use the
`blocker` severity to get around this system. We need to allow them to
use the `lowrisk` tag to communicate more clearly their intent for
merging during stage-cut.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @bparees 