### PR TITLE
List all packages

### DIFF
--- a/sjb/hack/determine_install_upgrade_version.py
+++ b/sjb/hack/determine_install_upgrade_version.py
@@ -114,7 +114,10 @@ if __name__ == "__main__":
 	# listing of origin or docker pkgs will be disabled, based on the enabled excluder.
 	yb.conf.disable_excludes = ["all"]
 	sys.stdout = old_stdout
-	available_pkgs = rpmutils.unique(yb.doPackageLists('available', patterns=[pkg_name], showdups=True).available)
+
+	generic_holder = yb.doPackageLists('all', patterns=[pkg_name], showdups=True)
+	available_pkgs = rpmutils.unique(generic_holder.available + generic_holder.installed)
+
 	available_pkgs = remove_duplicate_pkgs(available_pkgs)
 	available_pkgs = sort_pkgs(available_pkgs)
 

--- a/sjb/hack/determine_install_upgrade_version_test.py
+++ b/sjb/hack/determine_install_upgrade_version_test.py
@@ -153,8 +153,8 @@ class SortPackagesTestCase(unittest.TestCase):
 
 	def test_sort_packages_with_exceptional_origin_pkg(self):
 		""" when sorting origin packages with exceptional origin-3.6.0-0.0.alpha.0.1 package """
-		test_pkgs = ["origin-3.6.0-0.0.alpha.0.1", "origin-3.6.0-0.alpha.0.2"]
-		properly_sorted_pkgs = ["origin-3.6.0-0.alpha.0.2"]
+		test_pkgs = ["origin-3.6.0-0.0.alpha.0.1.el7", "origin-3.6.0-0.alpha.0.2.el7"]
+		properly_sorted_pkgs = ["origin-3.6.0-0.alpha.0.2.el7"]
 		test_pkgs_obj = TestPackage.create_test_packages(test_pkgs)
 		properly_sorted_pkgs_obj = TestPackage.create_test_packages(properly_sorted_pkgs)
 		sorted_test_pkgs_obj = sort_pkgs(test_pkgs_obj)
@@ -167,8 +167,7 @@ class SortPackagesTestCase(unittest.TestCase):
 		test_pkgs_obj = TestPackage.create_test_packages(test_pkgs)
 		properly_sorted_pkgs_obj = TestPackage.create_test_packages(properly_sorted_pkgs)
 		sorted_test_pkgs_obj = sort_pkgs(test_pkgs_obj)
-		self.assertTrue(sorted_test_pkgs_obj[0], properly_sorted_pkgs_obj[0])
-		self.assertTrue(sorted_test_pkgs_obj[1], properly_sorted_pkgs_obj[1])
+		self.assertEqual(sorted_test_pkgs_obj, properly_sorted_pkgs_obj)
 
 	def test_sort_packages_with_different_minor_version(self):
 		""" when sorting origin packages with different minor version """
@@ -177,8 +176,7 @@ class SortPackagesTestCase(unittest.TestCase):
 		test_pkgs_obj = TestPackage.create_test_packages(test_pkgs)
 		properly_sorted_pkgs_obj = TestPackage.create_test_packages(properly_sorted_pkgs)
 		sorted_test_pkgs_obj = sort_pkgs(test_pkgs_obj)
-		self.assertTrue(sorted_test_pkgs_obj[0], properly_sorted_pkgs_obj[0])
-		self.assertTrue(sorted_test_pkgs_obj[1], properly_sorted_pkgs_obj[1])
+		self.assertEqual(sorted_test_pkgs_obj, properly_sorted_pkgs_obj)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
even those that are already installed, so in case the determining the upgrade version, the latest version is already installed just print the same version.
Unfortunately the yumBase cant provide all the packages so we have to do union of all the available + the installed.

@stevekuznetsov PTAL   