### PR TITLE
dockertested: disable docker_image_availability check

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ A custom XML generator lives under the `sjb/` directory. This generator is meant
 bridge the gap between monolithic scripts inside of Freestyle Jenkins Jobs and segmented Jenkins Pipelines driven by source-
 controlled Groovy scripts and libraries.
 
-The generator understand a small set of `action`s, each of which is underpinned by a Python module under
+The generator understands a small set of `action`s, each of which is underpinned by a Python module under
 [`sjb/actions/`](sjb/actions). A configuration YAML file is read in by [`sjb/generate.py`](sjb/generate.py) and used to generate a
 set of input variables to the [Jinja job template XML](sjb/templates/test_case.xml). Jobs can depend on a parent to reuse
 configuration.

--- a/jobs/package-dockertested/install-origin-release.sh
+++ b/jobs/package-dockertested/install-origin-release.sh
@@ -22,8 +22,9 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e deployment_type=origin  \
-                 -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"                \
+                 -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
                  -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
+                 -e openshift_disable_check=docker_image_availability,package_update    \
                  /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
 sudo chmod a+x /etc/ /etc/origin/ /etc/origin/master/
 sudo chmod a+rw /etc/origin/master/admin.kubeconfig


### PR DESCRIPTION
This check tries to install and use skopeo, which in this environment
does not work due to https://github.com/openshift/aos-cd-jobs/issues/361
Disable the check for now until we can fix the job a better way.

The package_update check is already disabled elsewhere so carry that forward.