### PR TITLE
Disable package_availability check

### DIFF
--- a/jobs/package-dockertested/install-origin-release.sh
+++ b/jobs/package-dockertested/install-origin-release.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-set -o errexit 
-set -o nounset 
-set -o pipefail 
+set -o errexit
+set -o nounset
+set -o pipefail
 set -o xtrace
 
 cd /data/src/github.com/openshift/origin
@@ -24,7 +24,7 @@ ansible-playbook -vv --become               \
                  -e deployment_type=origin  \
                  -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
                  -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
-                 -e openshift_disable_check=docker_image_availability,package_update    \
+                 -e openshift_disable_check=docker_image_availability,package_update,package_availability    \
                  /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
 sudo chmod a+x /etc/ /etc/origin/ /etc/origin/master/
 sudo chmod a+rw /etc/origin/master/admin.kubeconfig

--- a/sjb/inventory/group_vars/OSEv3/checks.yml
+++ b/sjb/inventory/group_vars/OSEv3/checks.yml
@@ -1,4 +1,4 @@
 ---
 openshift_check_min_host_disk_gb: 10
 openshift_check_min_host_memory_gb: 8
-openshift_disable_check: package_update
+openshift_disable_check: package_update,package_availability


### PR DESCRIPTION
These cause the install to fail early on and it's hard to tell if this would actually cause the install to fail or if this is just a weird artifact of our CI processes.

https://ci.openshift.redhat.com/jenkins/job/test_pull_request_openshift_ansible/293/consoleFull#77170979858b6e51eb7608a5981914356

```
Failure summary:

  1. Host:     localhost
     Play:     Verify Requirements
     Task:     openshift_health_check
     Message:  One or more checks failed
     Details:  check "package_availability":
               Could not perform a yum update.
               Errors from dependency resolution:
                 2:docker-1.12.6-39.1.git6ffd653.el7.x86_64 requires atomic-registries
                 2:docker-1.12.6-39.1.git6ffd653.el7.x86_64 requires container-storage-setup >= 0.3.0-1
               You should resolve these issues before proceeding with an install.
               You may need to remove or downgrade packages or enable/disable yum repositories.

The execution of "/usr/share/ansible/openshift-ansible/playbooks/byo/config.yml"
includes checks designed to fail early if the requirements
of the playbook are not met. One or more of these checks
failed. To disregard these results, you may choose to
disable failing checks by setting an Ansible variable:

   openshift_disable_check=package_availability

Failing check names are shown in the failure details above.
Some checks may be configurable by variables if your requirements
are different from the defaults; consult check documentation.
Variables can be set in the inventory or passed on the
command line using the -e flag to ansible-playbook.
```