### PR TITLE
Move ANSIBLE_JUNIT_DIR to /tmp

### DIFF
--- a/continuous-upgrade/actions/install_junit.sh
+++ b/continuous-upgrade/actions/install_junit.sh
@@ -3,8 +3,9 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+set -o xtrace
 
-cd "/usr/share"
+cd "/tmp"
 sudo yum install -y python-pip
 sudo pip install junit_xml
 sudo chmod o+rw /etc/environment
@@ -12,9 +13,9 @@ echo "ANSIBLE_JUNIT_DIR=$( pwd )/ansible_junit" >> /etc/environment
 export ANSIBLE_JUNIT_DIR="$( pwd )/ansible_junit"
 echo "${ANSIBLE_JUNIT_DIR}"
 mkdir -p "${ANSIBLE_JUNIT_DIR}"
-mkdir -p /usr/share/ansible/plugins/callback
+sudo mkdir -p /usr/share/ansible/plugins/callback
 for plugin in 'default_with_output_lists' 'generate_junit'; do
    wget "https://raw.githubusercontent.com/openshift/origin-ci-tool/master/oct/ansible/oct/callback_plugins/${plugin}.py"
-   mv "${plugin}.py" /usr/share/ansible/plugins/callback
+   sudo mv "${plugin}.py" /usr/share/ansible/plugins/callback
 done
 sudo sed -r -i -e 's/^#?stdout_callback.*/stdout_callback = default_with_output_lists/' -e 's/^#?callback_whitelist.*/callback_whitelist = generate_junit/' /etc/ansible/ansible.cfg

--- a/continuous-upgrade/generated/continuous-upgrade_cicd-upgrade-job.xml
+++ b/continuous-upgrade/generated/continuous-upgrade_cicd-upgrade-job.xml
@@ -49,7 +49,7 @@ ssh -A -o StrictHostKeyChecking=no -tt root@master1.cicd.openshift.com &quot;ans
 scp -o StrictHostKeyChecking=no   &quot;${script}&quot; root@master1.cicd.openshift.com:&quot;${script}&quot;
 ssh -A -o StrictHostKeyChecking=no -tt root@master1.cicd.openshift.com &quot;bash -l -c \&quot;${script}\&quot;&quot;
 
-scp -o StrictHostKeyChecking=no -r root@master1.cicd.openshift.com:/usr/share/ansible_junit &quot;${WORKSPACE}&quot;
+scp -o StrictHostKeyChecking=no -r root@master1.cicd.openshift.com:/tmp/ansible_junit &quot;${WORKSPACE}&quot;
 script=&quot;$( mktemp )&quot;
 cat &lt;&lt;SCRIPT &gt;&quot;${script}&quot;
 #!/bin/bash

--- a/continuous-upgrade/generated/continuous-upgrade_upgrade-job.xml
+++ b/continuous-upgrade/generated/continuous-upgrade_upgrade-job.xml
@@ -51,7 +51,7 @@ SCRIPT
 chmod +x &quot;${script}&quot;
 scp -F ~/continuous-upgrade/origin-ci-tool/inventory/.ssh_config &quot;${script}&quot; openshiftdevel:&quot;${script}&quot;
 ssh -F ~/continuous-upgrade/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &quot;bash -l -c \&quot;${script}\&quot;&quot;
-scp -F ~/continuous-upgrade/origin-ci-tool/inventory/.ssh_config -r openshiftdevel:/usr/share/ansible_junit &quot;${WORKSPACE}&quot;
+scp -F ~/continuous-upgrade/origin-ci-tool/inventory/.ssh_config -r openshiftdevel:/tmp/ansible_junit &quot;${WORKSPACE}&quot;
 
 script=&quot;$( mktemp )&quot;
 cat &lt;&lt;SCRIPT &gt;&quot;${script}&quot;

--- a/continuous-upgrade/jobs/cicd-download-artifacts.sh
+++ b/continuous-upgrade/jobs/cicd-download-artifacts.sh
@@ -1,4 +1,4 @@
-scp -o StrictHostKeyChecking=no -r root@master1.cicd.openshift.com:/usr/share/ansible_junit "${WORKSPACE}"
+scp -o StrictHostKeyChecking=no -r root@master1.cicd.openshift.com:/tmp/ansible_junit "${WORKSPACE}"
 script="$( mktemp )"
 cat <<SCRIPT >"${script}"
 #!/bin/bash

--- a/continuous-upgrade/jobs/download-artifacts.sh
+++ b/continuous-upgrade/jobs/download-artifacts.sh
@@ -1,4 +1,4 @@
-scp -F ~/continuous-upgrade/origin-ci-tool/inventory/.ssh_config -r openshiftdevel:/usr/share/ansible_junit "${WORKSPACE}"
+scp -F ~/continuous-upgrade/origin-ci-tool/inventory/.ssh_config -r openshiftdevel:/tmp/ansible_junit "${WORKSPACE}"
 
 script="$( mktemp )"
 cat <<SCRIPT >"${script}"


### PR DESCRIPTION
@stevekuznetsov I had to move the ANSIBLE_JUNIT_DIR to `/tmp` cause in the `/usr/share` a non-root user cant create folder. Also tried to put the  `/home/ec2-user/` but the when running the `install_junit.sh` I get permission denied failure when creating the folder cause the script is run by `origin` user. So put into `/tmp` and looks like that solves the issue.

PTAL