### PR TITLE
Use the rotating_keys branch to store logs ssh key

### DIFF
--- a/jobs/cluster/rotate-log-access-key/Jenkinsfile
+++ b/jobs/cluster/rotate-log-access-key/Jenkinsfile
@@ -79,7 +79,7 @@ MAIL_LIST_FAILURE: ${MAIL_LIST_FAILURE}
                         credentialsId: OSE_CREDENTIALS
                     ]
                 ],
-                branches: [[ name: '*/master' ]]
+                branches: [[ name: '*/rotating_keys' ]]
             )
         }
 
@@ -102,7 +102,7 @@ MAIL_LIST_FAILURE: ${MAIL_LIST_FAILURE}
                 sh """
 git add ${KEY_FILE}
 git commit -m "New SSH key to gather cluster logs"
-git push origin HEAD:master
+git push origin HEAD:rotating_keys
 """
             }
         }


### PR DESCRIPTION
As discussed with John Lamb, the job to rotate the ssh key to access cluster logs will be stored here:

https://github.com/openshift/shared-secrets/tree/rotating_keys

instead of the `master` branch.

@jupierce PTAL