### PR TITLE
Fixes for release branch cut

### DIFF
--- a/jobs/build/openshift-scripts/Jenkinsfile
+++ b/jobs/build/openshift-scripts/Jenkinsfile
@@ -42,7 +42,7 @@ properties(
 echo "${TARGET_NODE}, MAIL_LIST_SUCCESS:[${MAIL_LIST_SUCCESS}], MAIL_LIST_FAILURE:[${MAIL_LIST_FAILURE}], FORCE_REBUILD:${FORCE_REBUILD}, BUILD_MODE:${BUILD_MODE}"
 
 if ( MOCK.toBoolean() ) {
-    error( "Ran in mock mode" )
+    error( "Ran in mock mode to pick up any new parameters" )
 }
 
 if ( BUILD_MODE == "release" && BRANCH == "" ) {

--- a/jobs/build/ose/Jenkinsfile
+++ b/jobs/build/ose/Jenkinsfile
@@ -77,11 +77,16 @@ enterprise:pre-release    {origin,origin-web-console,openshift-ansible}/release-
 online:int                {origin,origin-web-console,openshift-ansible}/master -> online-int yum repo<br>
 online:stg                {origin,origin-web-console,openshift-ansible}/stage -> online-stg yum repo<br>
 ''', name: 'BUILD_MODE'],
+                          [$class: 'BooleanParameterDefinition', defaultValue: false, description: 'Mock run to pickup new Jenkins parameters?.', name: 'MOCK'],
                   ]
             ],
             disableConcurrentBuilds()
         ]
 )
+
+if ( MOCK.toBoolean() ) {
+    error( "Ran in mock mode to pick up any new parameters" )
+}
 
 // Force Jenkins to fail early if this is the first time this job has been run/and or new parameters have not been discovered.
 echo "${TARGET_NODE}, ${OSE_MAJOR}.${OSE_MINOR}, MAIL_LIST_SUCCESS:[${MAIL_LIST_SUCCESS}], MAIL_LIST_FAILURE:[${MAIL_LIST_FAILURE}], BUILD_MODE:${BUILD_MODE}, EARLY_LATEST_HACK:${EARLY_LATEST_HACK}"

--- a/jobs/build/stagecut/Jenkinsfile
+++ b/jobs/build/stagecut/Jenkinsfile
@@ -17,11 +17,19 @@ node('buildvm-devops') {
               parameterDefinitions:
                       [
                               [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'git@github.com:openshift/origin.git  git@github.com:openshift/origin-web-console.git git@github.com:openshift/ose.git git@github.com:openshift/openshift-ansible.git', description: 'Repositories to fork to stage', name: 'REPOS'],
+                              [$class: 'hudson.model.StringParameterDefinition', defaultValue: '', description: 'Non-default version source (e.g. 3.6) or blank for master branches', name: 'SOURCE_VERSION'],
                               [$class: 'hudson.model.StringParameterDefinition', defaultValue: '', description: 'Last sprint number (e.g. "130"); stage-### will be used to archive any previous stage branch', name: 'LAST_SPRINT_NUMBER'],
                               [$class: 'hudson.model.BooleanParameterDefinition', defaultValue: false, description: 'Synch master to stage only (do not backup old stage branch)? Run only if stagecut is already in progress.', name: 'DESTRUCTIVE_SYNCH'],
+                              [$class: 'BooleanParameterDefinition', defaultValue: false, description: 'Run in non-commit test?.', name: 'TEST_MODE'],
+                              [$class: 'BooleanParameterDefinition', defaultValue: false, description: 'Mock run to pickup new Jenkins parameters?.', name: 'MOCK'],
                       ]
              ]]
     )
+
+    if ( MOCK.toBoolean() ) {
+        error( "Ran in mock mode to pick up any new parameters" )
+    }
+
     checkout scm
     
     set_workspace()
@@ -35,6 +43,8 @@ node('buildvm-devops') {
     }
 
     sshagent(['openshift-bot']) { // errata puddle must run with the permissions of openshift-bot to succeed
+        env.TEST_MODE="${TEST_MODE}"
+        env.SOURCE_VERSION="${SOURCE_VERSION}"
         env.DESTRUCTIVE_SYNCH = "${DESTRUCTIVE_SYNCH}"
         sh "./scripts/stagecut.sh ${LAST_SPRINT_NUMBER} ${REPOS}"
     }


### PR DESCRIPTION
We have windows of time where we want to build something non-master for online:int, so allow that to occur. This can happen after a release branch cut but before we are done with pushing builds out to production. 