### PR TITLE
Switch rotage keys job from buildvm to openshift-build-1

### DIFF
--- a/jobs/cluster/rotate-log-access-key/Jenkinsfile
+++ b/jobs/cluster/rotate-log-access-key/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-node('buildvm-devops') {
+node('openshift-build-1') {
 
     properties([
             [   $class: 'ParametersDefinitionProperty',


### PR DESCRIPTION
buildvm-devops is gone, switching the node of the job to rotate ssh keys for log access.