### PR TITLE
Set perms for log access key in shared-secrets

### DIFF
--- a/jobs/cluster/rotate-log-access-key/Jenkinsfile
+++ b/jobs/cluster/rotate-log-access-key/Jenkinsfile
@@ -100,6 +100,7 @@ MAIL_LIST_FAILURE: ${MAIL_LIST_FAILURE}
         stage('Push new key to shared secrets repo') {
             sshagent([OSE_CREDENTIALS]) {
                 sh """
+chmod 400 ${KEY_FILE}
 git add ${KEY_FILE}
 git commit -m "New SSH key to gather cluster logs"
 git push origin HEAD:rotating_keys


### PR DESCRIPTION
ssh client checks that the private key has restrictive perms, so we need to fix perms on the key file before pushing it to the shared-secrets repo.

AFAICT there's no way to set these directly during `writeFile`, so setting these as part of the push script.

@jupierce FYI
