### PR TITLE
Expand log gathering script with optional node list

### DIFF
--- a/tower-scripts/bin/gather-logs.sh
+++ b/tower-scripts/bin/gather-logs.sh
@@ -1,43 +1,81 @@
 #!/usr/bin/env bash
 
-if [ "$#" -ne 1 ]; then
-  echo "Usage: `basename $0` <clusterid>"
+if [ "$#" -lt 1 ]; then
+  echo "Usage: `basename $0` CLUSTERID [node]..."
   echo "Output will be a tarball of cluster logs. Do not pipe to stdout."
   exit 1
 fi
 
-# List of services that will be added to the download
-MASTER_SERVICES="docker atomic-openshift-master-api atomic-openshift-master-controllers atomic-openshift-node"
-
-# This will print out the contents of the $MASTER_SERVICES variable onto the same line
-# with the _SYSTEMD_UNIT=<service>.service by turning them into an array,
-# This will be useful in the future when we allow the selection to have all service logs collated
-# in one file.
-# This is unused for now.
-MASTER_SERVICES_LIST=$(for i in ${!MASTER_SERVICES[@]}; do echo -n "_SYSTEMD_UNIT=${MASTER_SERVICES[i]}.service "; done)
-
-######################
-# GLOBAL VARS
 CLUSTERNAME="$1"
-PRIMARY_MASTER=$(ansible "oo_clusterid_${CLUSTERNAME}:&oo_version_3:&oo_master_primary" --list-hosts | tail -1 | sed 's/ //g')
-BASEDIR=$(mktemp -p /tmp -d gather-logs.XXXXXXXX)
+shift
+NODES="$@"
+
+# List of services whose journal will be added to the download
+MASTER_SERVICES="atomic-openshift-master-api atomic-openshift-master-controllers"
+NODE_SERVICES="docker atomic-openshift-node"
+
+BASEDIR=$(mktemp -p /var/tmp -d gather-logs.XXXXXXXX)
+ALL_CLUSTER_NODES=$(ossh --list | grep "^${CLUSTERNAME}")
+
+# Translate an OpenShift node name to its inventory hostname, e.g.
+# ip-172-31-69-53.us-east-2.compute.internal -> free-stg-node-infra-70a4e
+inventory_name() {
+    node_name=$1
+
+    # Allow direct specification of the node's inventory name
+    # (i.e. no translation needed)
+    if (echo $ALL_CLUSTER_NODES | grep -wo "^$node_name"); then
+	return
+    fi
+
+    # extract ip from the node name, e.g
+    # ip-172-31-69-53.us-east-2.compute.internal -> 172.31.69.53
+    node_ip=$(echo $node_name | cut -d\. -f1 | sed -e 's/-/./g' -e 's/ip.//')
+
+    # find the node's inventory name using its IP
+    echo $ALL_CLUSTER_NODES | grep $node_ip | awk '{print $1}'
+}
+
+# Collect information from masters
+do_masters() {
+    for service in $MASTER_SERVICES; do
+        outdir="journal/masters/$service"
+        mkdir -p "$outdir"
+        autokeys_loader opssh -c "$CLUSTERNAME" --v3 -t master --outdir "$outdir" 'journalctl --no-pager --since "2 days ago" _SYSTEMD_UNIT='"$service"'.service'
+    done
+
+    primary_master=$(ansible "oo_clusterid_${CLUSTERNAME}:&oo_version_3:&oo_master_primary" --list-hosts | tail -1 | sed 's/ //g')
+    mkdir -p "reports"
+    # TODO: make namespace configurable
+    # TODO: return logs from failed deployments
+    autokeys_loader ossh "root@${primary_master}" -c "oc get pods --all-namespaces" > reports/pods.txt
+    autokeys_loader ossh "root@${primary_master}" -c "oc get events --all-namespaces" > reports/events.txt
+}
+
+# Collect information from one node
+do_node() {
+    node=$1
+
+    invnode=$(inventory_name $node)
+    if [ -z $invnode ]; then
+	# unknown node / not part of this cluster
+	return
+    fi
+    for service in $NODE_SERVICES; do
+        outdir="journal/nodes/$node"
+        mkdir -p "$outdir"
+        autokeys_loader ossh root@$invnode -c "journalctl --since '2 days ago' -u ${service}.service" > $outdir/$service
+    done
+}
 
 ######################
 # Begin Script
 pushd "$BASEDIR" > /dev/null
     {
-        for service in $MASTER_SERVICES; do
-            outdir="journal/masters/$service"
-            mkdir -p "$outdir"
-            autokeys_loader opssh -c "$CLUSTERNAME" --v3 -t master --outdir "$outdir" 'journalctl --no-pager --since "2 days ago" _SYSTEMD_UNIT='"$service"'.service'
-        done
-
-        mkdir -p "reports"
-        # TODO: make namespace configurable
-        # TODO: return logs from failed deployments
-        autokeys_loader ossh "root@${PRIMARY_MASTER}" -c "oc get pods --all-namespaces" > reports/pods.txt
-        autokeys_loader ossh "root@${PRIMARY_MASTER}" -c "oc status -v --all-namespaces" > reports/status.txt
-        autokeys_loader ossh "root@${PRIMARY_MASTER}" -c "oc get events --all-namespaces" > reports/events.txt
+	do_masters
+	for node in $NODES; do
+	    do_node $node
+	done
     } > "$BASEDIR/gather-logs.debug" 2>&1
 
     tar zcf - *


### PR DESCRIPTION
Allow the user to specify an optional list of nodes from which to collect logs.

This is a minimalist change, aiming to keep the previous functionality intact and only add the additional log collection for node logs: journal for `docker` and `atomic-openshift-node`.

However, some changes have been made to the previous functionality:

- node-related logs (`docker` and `atomic-openshift-node` journal) are *not* collected by default from masters. You can explicitly add the masters as part of the node list to get these logs
- `oc status --all-namespaces` is not collected. I think it's not really useful and is an overhead. I can add it back, but TBH I'd prefer to also remove `oc get {pod,event} --all-namespaces`: on decently sized clusters this might be more problematic than helpful, no?
- using `/var/tmp` instead of `/tmp` for temporary storage, in case data grows a bit too much.

We probably will need more changes to what's being collected, but will wait for feedback about that before changing more.

@jupierce PTAL
