### PR TITLE
egress/router path for 3.6 and beyond

### DIFF
--- a/build-scripts/ose_images/ose.conf
+++ b/build-scripts/ose_images/ose.conf
@@ -161,10 +161,10 @@ dict_git_compare['openshift-enterprise-deployer-docker']="${BASE_GIT_REPO} ose/i
 dict_git_compare['openshift-enterprise-docker']="${BASE_GIT_REPO} ose/images/origin Dockerfile match_git"
 dict_git_compare['openshift-enterprise-docker-builder-docker']="${BASE_GIT_REPO} ose/images/builder/docker/docker-builder Dockerfile match_git"
 dict_git_compare['openshift-enterprise-dockerregistry-docker']="${BASE_GIT_REPO} ose/images/dockerregistry Dockerfile match_git"
-if [ ${MAJOR_RELEASE} == "3.2" ] || [ ${MAJOR_RELEASE} == "3.3" || [ ${MAJOR_RELEASE} == "3.4" ] ; then
-  dict_git_compare['openshift-enterprise-egress-router-docker']="${BASE_GIT_REPO} ose/images/egress/router Dockerfile match_git"
-else
+if [ ${MAJOR_RELEASE} == "3.2" ] || [ ${MAJOR_RELEASE} == "3.3" || [ ${MAJOR_RELEASE} == "3.4" ] || [ ${MAJOR_RELEASE} == "3.5" ] ; then
   dict_git_compare['openshift-enterprise-egress-router-docker']="${BASE_GIT_REPO} ose/images/router/egress Dockerfile match_git"
+else
+  dict_git_compare['openshift-enterprise-egress-router-docker']="${BASE_GIT_REPO} ose/images/egress/router Dockerfile match_git"
 fi
 if [ ${MAJOR_RELEASE} == "3.1" ] || [ ${MAJOR_RELEASE} == "3.2" ] ; then
   dict_git_compare['openshift-enterprise-haproxy-router-base-docker']="${BASE_GIT_REPO} ose/images/router/haproxy-base Dockerfile match_git"


### PR DESCRIPTION
Path changed to egress/router in 3.6 and beyond.
@jupierce 