### PR TITLE
Fix inventory name lookup for node log gathering

### DIFF
--- a/tower-scripts/bin/gather-logs.sh
+++ b/tower-scripts/bin/gather-logs.sh
@@ -36,7 +36,7 @@ inventory_name() {
 
     # Allow direct specification of the node's inventory name
     # (i.e. no translation needed)
-    if (echo $ALL_CLUSTER_NODES | grep -wo "^$node_name"); then
+    if (echo "${ALL_CLUSTER_NODES}" | grep -Eo "^$node_name\s"); then
 	return
     fi
 
@@ -44,8 +44,8 @@ inventory_name() {
     # ip-172-31-69-53.us-east-2.compute.internal -> 172.31.69.53
     node_ip=$(echo $node_name | cut -d\. -f1 | sed -e 's/-/./g' -e 's/ip.//')
 
-    # find the node's inventory name using its IP
-    echo $ALL_CLUSTER_NODES | grep $node_ip | awk '{print $1}'
+    # find the node's inventory name from its IP
+    echo "${ALL_CLUSTER_NODES}" | grep $node_ip | awk '{print $1}'
 }
 
 # Collect information from masters


### PR DESCRIPTION
Found a couple of problems in the script's inventory lookup: 

- if you pass a node name like `free-stg` it would match all hosts starting with `free-stg`
- improper handling of the list of hosts

This fixes both.

@jupierce PTAL 