### PR TITLE
Target online branches during release builds

### DIFF
--- a/build-scripts/ose_images/ose.conf
+++ b/build-scripts/ose_images/ose.conf
@@ -9,6 +9,10 @@ else
     BASE_GIT_REPO_BRANCH="enterprise-${MAJOR_RELEASE}"
 fi
 
+if [ -z "$ONLINE_DOCKERFILE_BRANCH" ]; then
+    ONLINE_DOCKERFILE_BRANCH="master"
+fi
+
 BASE_GIT_REPO="git@github.com:openshift/ose.git#${BASE_GIT_REPO_BRANCH}"
 
 # _type should default to "rpms". Only override when necessary.
@@ -191,10 +195,10 @@ dict_git_compare['openshift-sti-perl-docker']="https://github.com/openshift/sti-
 dict_git_compare['openshift-sti-php-docker']="https://github.com/openshift/sti-php sti-php/5.5 Dockerfile.rhel7 match_git"
 dict_git_compare['openshift-sti-python-docker']="https://github.com/openshift/sti-python sti-python/3.3 Dockerfile.rhel7 match_git"
 dict_git_compare['openshift-sti-ruby-docker']="https://github.com/openshift/sti-ruby sti-ruby/2.0 Dockerfile.rhel7 match_git"
-dict_git_compare['oso-accountant-docker']="git@github.com:openshift/online.git#master online/accountant Dockerfile match_git"
-dict_git_compare['oso-notifications-docker']="git@github.com:openshift/online.git#master online/notifications Dockerfile match_git"
-dict_git_compare['oso-reconciler-docker']="git@github.com:openshift/online.git#master online/intercom-account-reconciler Dockerfile match_git"
-dict_git_compare['oso-user-analytics-docker']="git@github.com:openshift/online.git#master online/user-analytics Dockerfile match_git"
+dict_git_compare['oso-accountant-docker']="git@github.com:openshift/online.git#${ONLINE_DOCKERFILE_BRANCH} online/accountant Dockerfile match_git"
+dict_git_compare['oso-notifications-docker']="git@github.com:openshift/online.git#${ONLINE_DOCKERFILE_BRANCH} online/notifications Dockerfile match_git"
+dict_git_compare['oso-reconciler-docker']="git@github.com:openshift/online.git#${ONLINE_DOCKERFILE_BRANCH} online/intercom-account-reconciler Dockerfile match_git"
+dict_git_compare['oso-user-analytics-docker']="git@github.com:openshift/online.git#${ONLINE_DOCKERFILE_BRANCH} online/user-analytics Dockerfile match_git"
 dict_git_compare['playbook2image-docker']="git@github.com:openshift/playbook2image.git playbook2image Dockerfile.rhel7 match_git"
 dict_git_compare['registry-console-docker']="None None Dockerfile dockerfile_only"
 dict_git_compare['rh-dotnetcore10-docker']="None None Dockerfile dockerfile_only"

--- a/jobs/build/openshift-online/scripts/merge-and-build-openshift-scripts.sh
+++ b/jobs/build/openshift-online/scripts/merge-and-build-openshift-scripts.sh
@@ -91,6 +91,10 @@ else
         SPEC_VERSION_COUNT=6
     fi
 
+    # Feeds into ose.conf in order to target correct Dockerfiles
+    ONLINE_DOCKERFILE_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+    export ONLINE_DOCKERFILE_BRANCH
+
     VOUT="$(get_version_fields ${SPEC_VERSION_COUNT})"
     if [ "$?" != "0" ]; then
       echo "Error determining version fields: $VOUT"


### PR DESCRIPTION
Allows Jenkins job to specify branch to build Dockerfiles from the online repo. 