### PR TITLE
Switch to null string check

### DIFF
--- a/build-scripts/ose_images/ose_images.sh
+++ b/build-scripts/ose_images/ose_images.sh
@@ -476,7 +476,7 @@ wait_for_all_builds() {
   cat ${workingdir}/logs/buildfailed
   echo
   buildfailed=`ls -1 ${workingdir}/logs/failed-logs/`
-  if [ "${buildfailed}" -ne "" ] ; then
+  if [ -n "${buildfailed}" ] ; then
     echo "=== FULL FAILED LOGS ==="
     ls -1 ${workingdir}/logs/failed-logs/ | while read line
     do


### PR DESCRIPTION
Was doing an integer check on the output of `ls` instead of a null string check. 
@jupierce 