### PR TITLE
sign rhaos RPMs before puddle build

### DIFF
--- a/jobs/build/ose/scripts/merge-and-build.sh
+++ b/jobs/build/ose/scripts/merge-and-build.sh
@@ -307,6 +307,12 @@ echo
 echo -n "https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=${TASK_NUMBER}" > "${RESULTS}/openshift-ansible-brew.url"
 brew watch-task ${TASK_NUMBER}
 
+echo
+echo "=========="
+echo "Signing RPMs"
+echo "=========="
+"${WORKSPACE}/build-scripts/sign_rpms.sh" "rhaos-${OSE_VERSION}-rhel-7" "openshifthosted"
+
 pushd "${WORKSPACE}"
 COMMIT_SHA="$(git rev-parse HEAD)"
 popd


### PR DESCRIPTION
@jupierce I left off the `-candidate` as that didn't sign all the RPMs we needed with the openshift scripts build. This will it will definitely sign everything, though likely at the cost of some decent added time. We can likely just optimize and call for specific RPMs later if we need to speed it up.