### PR TITLE
Cluster log gathering improvements

### DIFF
--- a/jobs/cluster/rotate-log-access-key/Jenkinsfile
+++ b/jobs/cluster/rotate-log-access-key/Jenkinsfile
@@ -100,7 +100,6 @@ MAIL_LIST_FAILURE: ${MAIL_LIST_FAILURE}
         stage('Push new key to shared secrets repo') {
             sshagent([OSE_CREDENTIALS]) {
                 sh """
-chmod 400 ${KEY_FILE}
 git add ${KEY_FILE}
 git commit -m "New SSH key to gather cluster logs"
 git push origin HEAD:rotating_keys


### PR DESCRIPTION
`git` doesn't really keep track of file access modes, only if they are executable. So, this reverts commit aaf6c6c (chmod on the generated key) as it was useless — and actually harmful as it left the workspace in a problematic state, preventing further writes to the file.

Also some changes to the cluster log gathering script based on initial feedback:

- collect journal from more services (OVS-related on nodes, etcd on masters)
- collect metrics from master and nodes
- add progress reporting via stderr
- don't collect pods/events from all namespaces

@jupierce PTAL thanks