### PR TITLE
Fix master services log collection

### DIFF
--- a/tower-scripts/bin/gather-logs.sh
+++ b/tower-scripts/bin/gather-logs.sh
@@ -67,7 +67,7 @@ do_masters() {
 
     for service in $MASTER_SERVICES; do
         info "gathering logs for '$service'"
-        autokeys_loader opssh -c "$CLUSTERNAME" --v3 -t master --outdir masters/journal 'journalctl --no-pager --since "2 days ago" _SYSTEMD_UNIT='"$service"'.service'
+        autokeys_loader opssh -c "$CLUSTERNAME" --v3 -t master --outdir masters/journal/$service "journalctl --no-pager --since '2 days ago' -u $service.service"
     done
 
     # TODO: return logs from failed deployments


### PR DESCRIPTION
Fixes a bug introduced in c7db1df where logs from each master service were collected in the same dir, overwriting each other.

Also now using the `-u` option to `journalctl` to filter by service unit, so that systemd entires related to the unit are also collected.

@jupierce PTAL