### PR TITLE
Adding loader job for cicd cluster

### DIFF
--- a/continuous-upgrade/generate-jobs.sh
+++ b/continuous-upgrade/generate-jobs.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-jobs=( provision upgrade terminate cicd-upgrade )
+jobs=( provision upgrade terminate cicd-upgrade cicd-start-load cicd-dump-load-logs cicd-get-load-logs )
 
 pushd continuous-upgrade
 for job in "${jobs[@]}"; do

--- a/continuous-upgrade/generated/continuous-upgrade_cicd-dump-load-logs-job.xml
+++ b/continuous-upgrade/generated/continuous-upgrade_cicd-dump-load-logs-job.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <actions/>
+  <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+  <keepDependencies>false</keepDependencies>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <concurrentBuild>false</concurrentBuild>
+  <canRoam>true</canRoam>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <triggers class="vector">
+    <jenkins.triggers.ReverseBuildTrigger>
+      <spec/>
+      <upstreamProjects>continuous-upgrade_cicd-start-load-job</upstreamProjects>
+      <threshold>
+        <name>FAILURE</name>
+        <ordinal>2</ordinal>
+        <color>RED</color>
+        <completeBuild>true</completeBuild>
+      </threshold>
+    </jenkins.triggers.ReverseBuildTrigger>
+  </triggers>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>tail -n 150 /root/svt/reliability/logs/reliability.log
+</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers>
+    <hudson.tasks.Mailer>
+      <recipients>jhadvig@redhat.com skuznets@redhat.com jupierce@redhat.com</recipients>
+      <dontNotifyEveryUnstableBuild>false</dontNotifyEveryUnstableBuild>
+      <sendToIndividuals>false</sendToIndividuals>
+    </hudson.tasks.Mailer>
+  </publishers>
+  <buildWrappers/>
+</project>

--- a/continuous-upgrade/generated/continuous-upgrade_cicd-get-load-logs-job.xml
+++ b/continuous-upgrade/generated/continuous-upgrade_cicd-get-load-logs-job.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <actions/>
+  <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+  <keepDependencies>false</keepDependencies>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <concurrentBuild>false</concurrentBuild>
+  <canRoam>true</canRoam>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>tail -n 250 /root/svt/reliability/logs/reliability.log
+</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/continuous-upgrade/generated/continuous-upgrade_cicd-start-load-job.xml
+++ b/continuous-upgrade/generated/continuous-upgrade_cicd-start-load-job.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <actions/>
+  <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+  <keepDependencies>false</keepDependencies>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <concurrentBuild>false</concurrentBuild>
+  <canRoam>true</canRoam>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>#!/bin/bash
+set -o errexit -o nounset -o pipefail -o xtrace
+
+script=&quot;$( mktemp )&quot;
+cat &lt;&lt;SCRIPT &gt;&quot;${script}&quot;
+#!/bin/bash
+set -o errexit -o nounset -o pipefail -o xtrace
+
+# Get latest svt and aos-cd-jobs repos so the reliability test will run the latest changes
+mv /root/svt/reliability/config/users.data /root/
+rm -rf /root/svt /root/aos-cd-jobs
+git clone https://github.com/openshift/aos-cd-jobs.git
+git clone https://github.com/openshift/svt.git
+cp -Rf /root/aos-cd-jobs/continuous-upgrade/reliability-test/tasks /root/svt/reliability/config/
+cp -f /root/aos-cd-jobs/continuous-upgrade/reliability-test/config.yml /root/svt/reliability/config/
+mv /root/users.data /root/svt/reliability/config/
+
+cd /root/svt/reliability
+
+# Check if users.data is empty. If it empty then the test is not running and its safe to run the playbook.
+if [ ! -s /root/reliability/config/users.data ]; then
+    ansible-playbook  -vvv                   \
+                      --become               \
+                      --become-user root     \
+                      --inventory /root/cicd-byo-inventory \
+                      &quot;setup.yml&quot;
+fi
+
+# Logrotate the reliability test log
+if ! grep -q /root/svt/reliability/logs/reliability.log /etc/logrotate.conf; then
+cat &lt;&lt;EOT &gt;&gt; /etc/logrotate.conf
+/root/svt/reliability/logs/reliability.log {
+        size 100k
+}
+EOT
+fi
+
+./reliabilityTests.sh start
+SCRIPT
+chmod +x &quot;${script}&quot;
+eval &quot;$(ssh-agent -s)&quot;
+ssh-add ~jenkins/.ssh/cicd_cluster_key
+scp -o StrictHostKeyChecking=no   &quot;${script}&quot; root@master1.cicd.openshift.com:&quot;${script}&quot;
+ssh -A -o StrictHostKeyChecking=no -tt root@master1.cicd.openshift.com &quot;bash -l -c \&quot;${script}\&quot;&quot;
+</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers>
+    <hudson.tasks.Mailer>
+      <recipients>jhadvig@redhat.com skuznets@redhat.com jupierce@redhat.com</recipients>
+      <dontNotifyEveryUnstableBuild>false</dontNotifyEveryUnstableBuild>
+      <sendToIndividuals>false</sendToIndividuals>
+    </hudson.tasks.Mailer>
+  </publishers>
+  <buildWrappers/>
+</project>

--- a/continuous-upgrade/jobs/cicd-dump-load-logs-job.yml
+++ b/continuous-upgrade/jobs/cicd-dump-load-logs-job.yml
@@ -1,0 +1,17 @@
+- job:
+    name: continuous-upgrade_dump-load-logs-job
+    project-type: freestyle
+    defaults: global
+    builders:
+      - shell: |
+         tail -n 150 /root/svt/reliability/logs/reliability.log
+
+    publishers:
+      - email:
+          recipients: jhadvig@redhat.com skuznets@redhat.com jupierce@redhat.com
+          notify-every-unstable-build: true
+    triggers:
+      - reverse:
+            jobs:
+                - 'continuous-upgrade_cicd-start-load-job'
+            result: 'failure'

--- a/continuous-upgrade/jobs/cicd-get-load-logs-job.yml
+++ b/continuous-upgrade/jobs/cicd-get-load-logs-job.yml
@@ -1,0 +1,8 @@
+- job:
+    name: continuous-upgrade_dump-load-logs-job
+    project-type: freestyle
+    defaults: global
+    builders:
+      - shell: |
+         tail -n 250 /root/svt/reliability/logs/reliability.log
+

--- a/continuous-upgrade/jobs/cicd-start-load-job.yml
+++ b/continuous-upgrade/jobs/cicd-start-load-job.yml
@@ -1,0 +1,12 @@
+- job:
+    name: continuous-upgrade_cicd-start-load-job
+    project-type: freestyle
+    defaults: global
+    builders:
+      - shell:
+          !include-raw:
+              - cicd-start-load.sh
+    publishers:
+      - email:
+          recipients: jhadvig@redhat.com skuznets@redhat.com jupierce@redhat.com
+          notify-every-unstable-build: true

--- a/continuous-upgrade/jobs/cicd-start-load.sh
+++ b/continuous-upgrade/jobs/cicd-start-load.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail -o xtrace
+
+script="$( mktemp )"
+cat <<SCRIPT >"${script}"
+#!/bin/bash
+set -o errexit -o nounset -o pipefail -o xtrace
+
+# Get latest svt and aos-cd-jobs repos so the reliability test will run the latest changes
+mv /root/svt/reliability/config/users.data /root/
+rm -rf /root/svt /root/aos-cd-jobs
+git clone https://github.com/openshift/aos-cd-jobs.git
+git clone https://github.com/openshift/svt.git
+cp -Rf /root/aos-cd-jobs/continuous-upgrade/reliability-test/tasks /root/svt/reliability/config/
+cp -f /root/aos-cd-jobs/continuous-upgrade/reliability-test/config.yml /root/svt/reliability/config/
+mv /root/users.data /root/svt/reliability/config/
+
+cd /root/svt/reliability
+
+# Check if users.data is empty. If it empty then the test is not running and its safe to run the playbook.
+if [ ! -s /root/reliability/config/users.data ]; then
+    ansible-playbook  -vvv                   \
+                      --become               \
+                      --become-user root     \
+                      --inventory /root/cicd-byo-inventory \
+                      "setup.yml"
+fi
+
+# Logrotate the reliability test log
+if ! grep -q /root/svt/reliability/logs/reliability.log /etc/logrotate.conf; then
+cat <<EOT >> /etc/logrotate.conf
+/root/svt/reliability/logs/reliability.log {
+        size 100k
+}
+EOT
+fi
+
+./reliabilityTests.sh start
+SCRIPT
+chmod +x "${script}"
+eval "$(ssh-agent -s)"
+ssh-add ~jenkins/.ssh/cicd_cluster_key
+scp -o StrictHostKeyChecking=no   "${script}" root@master1.cicd.openshift.com:"${script}"
+ssh -A -o StrictHostKeyChecking=no -tt root@master1.cicd.openshift.com "bash -l -c \"${script}\""

--- a/continuous-upgrade/reliability-test/config.yaml
+++ b/continuous-upgrade/reliability-test/config.yaml
@@ -1,0 +1,42 @@
+---
+environment:
+  masters: 
+    - 172.31.56.85
+    - 172.31.53.112
+    - 172.31.62.48
+  nodes: 
+    - 172.31.56.85
+    - 172.31.53.112
+    - 172.31.62.48
+    - 172.31.48.64
+    - 172.31.56.112
+    - 172.31.49.95
+    - 172.31.54.53
+    - 172.31.63.146
+    - 172.31.48.44
+  etcds: 
+    - 172.31.56.85
+    - 172.31.53.112
+    - 172.31.62.48
+  routers: 
+    - 
+  authtype: htpasswd
+  port: 443
+  htpasswd: /etc/origin/master/htpasswd
+  kubeconfig: /etc/origin/master/admin.kubeconfig
+  subdomain:
+exection:
+  templates: 
+    - django-psql-example
+    - nodejs-mongodb-example
+    - cakephp-mysql-example
+    - dancer-mysql-example
+    - rails-postgresql-example
+    - eap64-mysql-s2i
+  userprefix: user
+schedule:
+  minute: 1
+  hour: 2
+  day: 10
+  week: 20
+  month: 40

--- a/continuous-upgrade/reliability-test/tasks/day
+++ b/continuous-upgrade/reliability-test/tasks/day
@@ -1,0 +1,13 @@
+### Daily tasks
+###
+login "100%" users
+create "5" user
+create "5" project
+create "1" app
+visit "100%" app
+modify "20%" project
+modify "40%" app
+scale up "80%" app
+scale down "80%" app
+delete "100%" project
+delete "100" user

--- a/continuous-upgrade/reliability-test/tasks/hour
+++ b/continuous-upgrade/reliability-test/tasks/hour
@@ -1,0 +1,9 @@
+### Hourly tasks
+###
+modify "40%" project
+modify "40%" app
+scale up "80%" app
+scale down "80%" app
+delete "50%" project
+delete "50%" user
+check project info

--- a/continuous-upgrade/reliability-test/tasks/minute
+++ b/continuous-upgrade/reliability-test/tasks/minute
@@ -1,0 +1,12 @@
+### Minute tasks
+###
+create "1" user
+login "100%" users
+create "1" project
+create "1" app
+visit "100%" app
+modify "40%" project
+modify "40%" app
+scale up "80%" app
+scale down "80%" app
+check project info

--- a/continuous-upgrade/reliability-test/tasks/month
+++ b/continuous-upgrade/reliability-test/tasks/month
@@ -1,0 +1,2 @@
+### Monthly tasks
+###

--- a/continuous-upgrade/reliability-test/tasks/pre
+++ b/continuous-upgrade/reliability-test/tasks/pre
@@ -1,0 +1,4 @@
+###  Pre tasks at beginning
+###
+delete "100%" project
+delete "100%" user

--- a/continuous-upgrade/reliability-test/tasks/test
+++ b/continuous-upgrade/reliability-test/tasks/test
@@ -1,0 +1,1 @@
+###  test tasks

--- a/continuous-upgrade/reliability-test/tasks/week
+++ b/continuous-upgrade/reliability-test/tasks/week
@@ -1,0 +1,1 @@
+### Weekly tasks


### PR DESCRIPTION
Adding three jobs:
- cicd-start-load
- cicd-dump-load-logs
- cicd-get-load-logs

#### cicd-start-load job
Will start the reliability test with the latest code from **svt** and **aos-cd-jobs** repos. **svt** repoprovides the testing framework and **aos-cd-jobs** provides config for the framework and tasks description. We need to do this cause there might be changes in the framework or configuration and we dont want to add the manually. Also the `reliability.log` file will be rotated and should not exceed 100k size.
This job will run endlessly until it fails or is being aborted. 

#### cicd-dump-load-logs
Will be triggered when cicd-start-load fails and will print last 150 lines of the logs.

#### cicd-dump-load-logs
Can be triggered on demand and will print last 250 lines of the logs.

@stevekuznetsov @jupierce @bbguimaraes PTAL