### PR TITLE
Gather origin-master-api and origin-master-controllers logs as well

### DIFF
--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_gce.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_gce.yml
@@ -175,6 +175,8 @@ rectory to run."
                 artifact_dir="${base_artifact_dir}/masters/${name}"
                 mkdir -p "${artifact_dir}" "${artifact_dir}/generated" "${artifact_dir}/journals"
                 gcloud compute ssh "${instance}" -- sudo journalctl --unit origin-master.service --no-pager --all --lines=all 2>&1 > "${artifact_dir}/journals/origin-master.service" || true
+                gcloud compute ssh "${instance}" -- sudo journalctl --unit origin-master-api.service --no-pager --all --lines=all 2>&1 > "${artifact_dir}/journals/origin-master-api.service" || true
+                gcloud compute ssh "${instance}" -- sudo journalctl --unit origin-master-controllers.service --no-pager --all --lines=all 2>&1 > "${artifact_dir}/journals/origin-master-controllers.service" || true
                 gcloud compute ssh "${instance}" -- sudo journalctl --unit etcd.service          --no-pager --all --lines=all 2>&1 > "${artifact_dir}/journals/etcd.service"  || true
 
                 gcloud compute ssh "${instance}" -- oc get --raw /metrics --config=/etc/origin/master/admin.kubeconfig 2>&1 > "${artifact_dir}/generated/master-metrics.log"  || true

--- a/sjb/generated/test_branch_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce.xml
@@ -491,6 +491,8 @@ for instance in $( gcloud compute instances list --regexp &#34;.*${INSTANCE_PREF
         artifact_dir=&#34;${base_artifact_dir}/masters/${name}&#34;
         mkdir -p &#34;${artifact_dir}&#34; &#34;${artifact_dir}/generated&#34; &#34;${artifact_dir}/journals&#34;
         gcloud compute ssh &#34;${instance}&#34; -- sudo journalctl --unit origin-master.service --no-pager --all --lines=all 2&gt;&amp;1 &gt; &#34;${artifact_dir}/journals/origin-master.service&#34; || true
+        gcloud compute ssh &#34;${instance}&#34; -- sudo journalctl --unit origin-master-api.service --no-pager --all --lines=all 2&gt;&amp;1 &gt; &#34;${artifact_dir}/journals/origin-master-api.service&#34; || true
+        gcloud compute ssh &#34;${instance}&#34; -- sudo journalctl --unit origin-master-controllers.service --no-pager --all --lines=all 2&gt;&amp;1 &gt; &#34;${artifact_dir}/journals/origin-master-controllers.service&#34; || true
         gcloud compute ssh &#34;${instance}&#34; -- sudo journalctl --unit etcd.service          --no-pager --all --lines=all 2&gt;&amp;1 &gt; &#34;${artifact_dir}/journals/etcd.service&#34;  || true
 
         gcloud compute ssh &#34;${instance}&#34; -- oc get --raw /metrics --config=/etc/origin/master/admin.kubeconfig 2&gt;&amp;1 &gt; &#34;${artifact_dir}/generated/master-metrics.log&#34;  || true

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
@@ -549,6 +549,8 @@ for instance in $( gcloud compute instances list --regexp &#34;.*${INSTANCE_PREF
         artifact_dir=&#34;${base_artifact_dir}/masters/${name}&#34;
         mkdir -p &#34;${artifact_dir}&#34; &#34;${artifact_dir}/generated&#34; &#34;${artifact_dir}/journals&#34;
         gcloud compute ssh &#34;${instance}&#34; -- sudo journalctl --unit origin-master.service --no-pager --all --lines=all 2&gt;&amp;1 &gt; &#34;${artifact_dir}/journals/origin-master.service&#34; || true
+        gcloud compute ssh &#34;${instance}&#34; -- sudo journalctl --unit origin-master-api.service --no-pager --all --lines=all 2&gt;&amp;1 &gt; &#34;${artifact_dir}/journals/origin-master-api.service&#34; || true
+        gcloud compute ssh &#34;${instance}&#34; -- sudo journalctl --unit origin-master-controllers.service --no-pager --all --lines=all 2&gt;&amp;1 &gt; &#34;${artifact_dir}/journals/origin-master-controllers.service&#34; || true
         gcloud compute ssh &#34;${instance}&#34; -- sudo journalctl --unit etcd.service          --no-pager --all --lines=all 2&gt;&amp;1 &gt; &#34;${artifact_dir}/journals/etcd.service&#34;  || true
 
         gcloud compute ssh &#34;${instance}&#34; -- oc get --raw /metrics --config=/etc/origin/master/admin.kubeconfig 2&gt;&amp;1 &gt; &#34;${artifact_dir}/generated/master-metrics.log&#34;  || true


### PR DESCRIPTION
We changed single node to use two processes instead of the all-in-one. Gather the old one as well for historical purposes