### PR TITLE
Wrap log obtaining jobs with ssh

### DIFF
--- a/continuous-upgrade/generated/continuous-upgrade_cicd-dump-load-logs-job.xml
+++ b/continuous-upgrade/generated/continuous-upgrade_cicd-dump-load-logs-job.xml
@@ -23,7 +23,18 @@
   </triggers>
   <builders>
     <hudson.tasks.Shell>
-      <command>tail -n 150 /root/svt/reliability/logs/reliability.log
+      <command>set -o errexit -o nounset -o pipefail -o xtrace
+script=&quot;$( mktemp )&quot;
+cat &lt;&lt;SCRIPT &gt;&quot;${script}&quot;
+#!/bin/bash
+set -o errexit -o nounset -o pipefail -o xtrace
+tail -n 150 /root/svt/reliability/logs/reliability.log
+SCRIPT
+chmod +x &quot;${script}&quot;
+eval &quot;$(ssh-agent -s)&quot;
+ssh-add ~jenkins/.ssh/cicd_cluster_key
+scp -o StrictHostKeyChecking=no   &quot;${script}&quot; root@master1.cicd.openshift.com:&quot;${script}&quot;
+ssh -A -o StrictHostKeyChecking=no -tt root@master1.cicd.openshift.com &quot;bash -l -c \&quot;${script}\&quot;&quot;
 </command>
     </hudson.tasks.Shell>
   </builders>

--- a/continuous-upgrade/generated/continuous-upgrade_cicd-get-load-logs-job.xml
+++ b/continuous-upgrade/generated/continuous-upgrade_cicd-get-load-logs-job.xml
@@ -11,7 +11,18 @@
   <scm class="hudson.scm.NullSCM"/>
   <builders>
     <hudson.tasks.Shell>
-      <command>tail -n 250 /root/svt/reliability/logs/reliability.log
+      <command>set -o errexit -o nounset -o pipefail -o xtrace
+script=&quot;$( mktemp )&quot;
+cat &lt;&lt;SCRIPT &gt;&quot;${script}&quot;
+#!/bin/bash
+set -o errexit -o nounset -o pipefail -o xtrace
+tail -n 250 /root/svt/reliability/logs/reliability.log
+SCRIPT
+chmod +x &quot;${script}&quot;
+eval &quot;$(ssh-agent -s)&quot;
+ssh-add ~jenkins/.ssh/cicd_cluster_key
+scp -o StrictHostKeyChecking=no   &quot;${script}&quot; root@master1.cicd.openshift.com:&quot;${script}&quot;
+ssh -A -o StrictHostKeyChecking=no -tt root@master1.cicd.openshift.com &quot;bash -l -c \&quot;${script}\&quot;&quot;
 </command>
     </hudson.tasks.Shell>
   </builders>

--- a/continuous-upgrade/jobs/cicd-dump-load-logs-job.yml
+++ b/continuous-upgrade/jobs/cicd-dump-load-logs-job.yml
@@ -4,7 +4,18 @@
     defaults: global
     builders:
       - shell: |
+         set -o errexit -o nounset -o pipefail -o xtrace
+         script="$( mktemp )"
+         cat <<SCRIPT >"${script}"
+         #!/bin/bash
+         set -o errexit -o nounset -o pipefail -o xtrace
          tail -n 150 /root/svt/reliability/logs/reliability.log
+         SCRIPT
+         chmod +x "${script}"
+         eval "$(ssh-agent -s)"
+         ssh-add ~jenkins/.ssh/cicd_cluster_key
+         scp -o StrictHostKeyChecking=no   "${script}" root@master1.cicd.openshift.com:"${script}"
+         ssh -A -o StrictHostKeyChecking=no -tt root@master1.cicd.openshift.com "bash -l -c \"${script}\""
 
     publishers:
       - email:

--- a/continuous-upgrade/jobs/cicd-get-load-logs-job.yml
+++ b/continuous-upgrade/jobs/cicd-get-load-logs-job.yml
@@ -4,5 +4,16 @@
     defaults: global
     builders:
       - shell: |
+         set -o errexit -o nounset -o pipefail -o xtrace
+         script="$( mktemp )"
+         cat <<SCRIPT >"${script}"
+         #!/bin/bash
+         set -o errexit -o nounset -o pipefail -o xtrace
          tail -n 250 /root/svt/reliability/logs/reliability.log
+         SCRIPT
+         chmod +x "${script}"
+         eval "$(ssh-agent -s)"
+         ssh-add ~jenkins/.ssh/cicd_cluster_key
+         scp -o StrictHostKeyChecking=no   "${script}" root@master1.cicd.openshift.com:"${script}"
+         ssh -A -o StrictHostKeyChecking=no -tt root@master1.cicd.openshift.com "bash -l -c \"${script}\""
 


### PR DESCRIPTION
This is an additional modification for the `continuous-upgrade_cicd-dump-load-logs-job` and `continuous-upgrade_cicd-get-load-logs-job` jobs cause we need to ssh and run the log obtaining commands on the cicd master

@jupierce PTAL