### PR TITLE
remove unnecessary docker volumes to free disk space

### DIFF
--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_install_system_containers.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_install_system_containers.yml
@@ -22,6 +22,8 @@ extensions:
         hack/build-images.sh
         sed -i 's|go/src|data/src|' _output/local/releases/rpms/origin-local-release.repo
         sudo cp _output/local/releases/rpms/origin-local-release.repo /etc/yum.repos.d/
+        # free docker volumes (otherwise it can lead to node disk pressure)
+        docker volume rm $(docker volume ls -q | grep origin-build)
     - type: "script"
       title: "build an openshift-ansible release"
       repository: "openshift-ansible"

--- a/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
@@ -227,6 +227,8 @@ cat ORIGIN_TAG &gt; _output/local/releases/.commit
 hack/build-images.sh
 sed -i &#39;s|go/src|data/src|&#39; _output/local/releases/rpms/origin-local-release.repo
 sudo cp _output/local/releases/rpms/origin-local-release.repo /etc/yum.repos.d/
+# free docker volumes (otherwise it can lead to node disk pressure)
+docker volume rm \$(docker volume ls -q | grep origin-build)
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
@@ -285,6 +285,8 @@ cat ORIGIN_TAG &gt; _output/local/releases/.commit
 hack/build-images.sh
 sed -i &#39;s|go/src|data/src|&#39; _output/local/releases/rpms/origin-local-release.repo
 sudo cp _output/local/releases/rpms/origin-local-release.repo /etc/yum.repos.d/
+# free docker volumes (otherwise it can lead to node disk pressure)
+docker volume rm \$(docker volume ls -q | grep origin-build)
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;


### PR DESCRIPTION
If a VM disk space is not big enough the docker volumes that were
used to build the origin images may lead to kubelet disk pressure.