### PR TITLE
temporarily disable conformance tests for system containers

### DIFF
--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_install_system_containers.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_install_system_containers.yml
@@ -164,7 +164,7 @@ extensions:
         sudo systemctl restart dnsmasq
         sudo systemctl status dnsmasq
         # run the tests with fingers crossed
-        OPENSHIFT_SKIP_BUILD='true' KUBECONFIG=/etc/origin/master/admin.kubeconfig TEST_ONLY='true' JUNIT_REPORT='true' SUITE=conformance make test-extended TEST_EXTENDED_ARGS="-ginkgo.skip=should\sanswer\sendpoint\sand\swildcard\squeries\sfor\sthe\scluster|should\sprovide\sDNS\sfor\spods\sfor\sHostname\sand\sSubdomain\sAnnotation|should\sprovide\sDNS\sfor\sservices|should\sprovide\sDNS\sfor\sthe\scluster|should\sexpose\sthe\sprofiling\sendpoints"
+        #OPENSHIFT_SKIP_BUILD='true' KUBECONFIG=/etc/origin/master/admin.kubeconfig TEST_ONLY='true' JUNIT_REPORT='true' SUITE=conformance make test-extended TEST_EXTENDED_ARGS="-ginkgo.skip=should\sanswer\sendpoint\sand\swildcard\squeries\sfor\sthe\scluster|should\sprovide\sDNS\sfor\spods\sfor\sHostname\sand\sSubdomain\sAnnotation|should\sprovide\sDNS\sfor\sservices|should\sprovide\sDNS\sfor\sthe\scluster|should\sexpose\sthe\sprofiling\sendpoints"
   system_journals:
     - origin-master.service
     - origin-master-api.service

--- a/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
@@ -440,7 +440,7 @@ sudo cp ci-dnsmasq.conf /etc/dnsmasq.d/ci-dnsmasq.conf
 sudo systemctl restart dnsmasq
 sudo systemctl status dnsmasq
 # run the tests with fingers crossed
-OPENSHIFT_SKIP_BUILD=&#39;true&#39; KUBECONFIG=/etc/origin/master/admin.kubeconfig TEST_ONLY=&#39;true&#39; JUNIT_REPORT=&#39;true&#39; SUITE=conformance make test-extended TEST_EXTENDED_ARGS=&#34;-ginkgo.skip=should\sanswer\sendpoint\sand\swildcard\squeries\sfor\sthe\scluster|should\sprovide\sDNS\sfor\spods\sfor\sHostname\sand\sSubdomain\sAnnotation|should\sprovide\sDNS\sfor\sservices|should\sprovide\sDNS\sfor\sthe\scluster|should\sexpose\sthe\sprofiling\sendpoints&#34;
+#OPENSHIFT_SKIP_BUILD=&#39;true&#39; KUBECONFIG=/etc/origin/master/admin.kubeconfig TEST_ONLY=&#39;true&#39; JUNIT_REPORT=&#39;true&#39; SUITE=conformance make test-extended TEST_EXTENDED_ARGS=&#34;-ginkgo.skip=should\sanswer\sendpoint\sand\swildcard\squeries\sfor\sthe\scluster|should\sprovide\sDNS\sfor\spods\sfor\sHostname\sand\sSubdomain\sAnnotation|should\sprovide\sDNS\sfor\sservices|should\sprovide\sDNS\sfor\sthe\scluster|should\sexpose\sthe\sprofiling\sendpoints&#34;
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
@@ -498,7 +498,7 @@ sudo cp ci-dnsmasq.conf /etc/dnsmasq.d/ci-dnsmasq.conf
 sudo systemctl restart dnsmasq
 sudo systemctl status dnsmasq
 # run the tests with fingers crossed
-OPENSHIFT_SKIP_BUILD=&#39;true&#39; KUBECONFIG=/etc/origin/master/admin.kubeconfig TEST_ONLY=&#39;true&#39; JUNIT_REPORT=&#39;true&#39; SUITE=conformance make test-extended TEST_EXTENDED_ARGS=&#34;-ginkgo.skip=should\sanswer\sendpoint\sand\swildcard\squeries\sfor\sthe\scluster|should\sprovide\sDNS\sfor\spods\sfor\sHostname\sand\sSubdomain\sAnnotation|should\sprovide\sDNS\sfor\sservices|should\sprovide\sDNS\sfor\sthe\scluster|should\sexpose\sthe\sprofiling\sendpoints&#34;
+#OPENSHIFT_SKIP_BUILD=&#39;true&#39; KUBECONFIG=/etc/origin/master/admin.kubeconfig TEST_ONLY=&#39;true&#39; JUNIT_REPORT=&#39;true&#39; SUITE=conformance make test-extended TEST_EXTENDED_ARGS=&#34;-ginkgo.skip=should\sanswer\sendpoint\sand\swildcard\squeries\sfor\sthe\scluster|should\sprovide\sDNS\sfor\spods\sfor\sHostname\sand\sSubdomain\sAnnotation|should\sprovide\sDNS\sfor\sservices|should\sprovide\sDNS\sfor\sthe\scluster|should\sexpose\sthe\sprofiling\sendpoints&#34;
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;


### PR DESCRIPTION
Temporarily disable all conformance tests until https://github.com/openshift/aos-cd-jobs/pull/588 and failing tests are resolved.