### PR TITLE
Make junit analysis optional

### DIFF
--- a/sjb/config/test_cases/test_pull_request_origin_integration.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_integration.yml
@@ -4,3 +4,4 @@ overrides:
   sync_repos:
     - name: "origin"
       type: "pull_request"
+  junit_analysis: False

--- a/sjb/generate.py
+++ b/sjb/generate.py
@@ -232,6 +232,7 @@ with open(output_path, "w") as output_file:
         target_repo=target_repo,
         timer=job_config.get("timer", None),
         email=job_config.get("email", None),
+        junit_analysis=job_config.get("junit_analysis", True),
         description=job_config.get("description", DEFAULT_DESCRIPTION)
     ))
 debug("[INFO] Wrote job definition to {}".format(output_path))

--- a/sjb/generated/test_pull_request_origin_integration.xml
+++ b/sjb/generated/test_pull_request_origin_integration.xml
@@ -346,12 +346,6 @@ oct deprovision</command>
       <defaultExcludes>true</defaultExcludes>
       <caseSensitive>true</caseSensitive>
     </hudson.tasks.ArtifactArchiver>
-    <hudson.tasks.junit.JUnitResultArchiver plugin="junit@1.13">
-      <testResults>.config/origin-ci-tool/logs/junit/*.xml,artifacts/**/*.xml</testResults>
-      <keepLongStdio>true</keepLongStdio>
-      <healthScaleFactor>1.0</healthScaleFactor>
-      <allowEmptyResults>true</allowEmptyResults>
-    </hudson.tasks.junit.JUnitResultArchiver>
     <hudson.plugins.s3.S3BucketPublisher plugin="s3@0.10.11-SNAPSHOT">
       <profileName>Jenkins-AWS</profileName>
       <entries>

--- a/sjb/syntax.md
+++ b/sjb/syntax.md
@@ -86,6 +86,15 @@ fails. The syntax is:
 email: [] # list of e-mail addresses
 ```
 
+## `junit_analysis`
+
+`junit_analysis` is an optional flag to enable or disable the "Publish
+JUnit test result report" post-build step. It defaults to `True`
+
+```yaml
+junit_analysis: False # JUnit analysis is disabled
+```
+
 ## `merge` and `test`
 
 `merge` and `test` are optional fields that mark the job as one that uses the

--- a/sjb/templates/test_case.xml
+++ b/sjb/templates/test_case.xml
@@ -126,12 +126,14 @@ fi
       <defaultExcludes>true</defaultExcludes>
       <caseSensitive>true</caseSensitive>
     </hudson.tasks.ArtifactArchiver>
+{%- if junit_analysis %}
     <hudson.tasks.junit.JUnitResultArchiver plugin="junit@1.13">
       <testResults>.config/origin-ci-tool/logs/junit/*.xml,artifacts/**/*.xml</testResults>
       <keepLongStdio>true</keepLongStdio>
       <healthScaleFactor>1.0</healthScaleFactor>
       <allowEmptyResults>true</allowEmptyResults>
     </hudson.tasks.junit.JUnitResultArchiver>
+{%- endif %}
     <hudson.plugins.s3.S3BucketPublisher plugin="s3@0.10.11-SNAPSHOT">
       <profileName>Jenkins-AWS</profileName>
       <entries>


### PR DESCRIPTION
Adds `junit_analysis` job config flag, defaults to `True`.

Set `junit_analysis` to `False` in `test_pull_request_origin_integration.yml` overrides