### PR TITLE
logging - reduce es memory limit for testing

### DIFF
--- a/sjb/inventory/group_vars/OSEv3/logging.yml
+++ b/sjb/inventory/group_vars/OSEv3/logging.yml
@@ -1,8 +1,8 @@
 ---
 openshift_logging_use_mux: false
-openshift_logging_use_mux_client: false
-openshift_logging_mux_allow_external: false
 openshift_logging_use_ops: true
 openshift_logging_es_log_appenders:
   - "console"
 openshift_logging_fluentd_journal_read_from_head: false
+openshift_logging_es_memory_limit: "4Gi"
+openshift_logging_es_ops_memory_limit: "4Gi"


### PR DESCRIPTION
Use a 4Gi memory limit for logging testing.  This will allow us
to test with https://github.com/openshift/openshift-ansible/pull/5119
Once this PR merges, then we can merge 5119 and logging tests should
be able to resume.
@stevekuznetsov @portante @jcantrill @sdodson ptal