### PR TITLE
Add cluster smoke test job and run it during upgrades

### DIFF
--- a/jobs/starter/rotate-log-access-key/Jenkinsfile
+++ b/jobs/starter/rotate-log-access-key/Jenkinsfile
@@ -43,7 +43,7 @@ node('openshift-build-1') {
                     ],
                     [
                         $class: 'hudson.model.StringParameterDefinition',
-                        defaultValue: 'pep@redhat.com',
+                        defaultValue: 'jupierce@redhat.com,pep@redhat.com',
                         description: 'Failure Mailing List',
                         name: 'MAIL_LIST_FAILURE'
                     ],

--- a/jobs/starter/smoke-test/Jenkinsfile
+++ b/jobs/starter/smoke-test/Jenkinsfile
@@ -1,0 +1,92 @@
+#!/usr/bin/env groovy
+
+// A Job to run a smoke test in a cluster
+// 
+// It invokes the 'smoketest' operation of 'cicd-control.sh' for the specified cluster.
+// Optionally emails test results.
+
+@Library('aos_cd_ops') _
+
+// Ask the shared library which clusters this job should act on
+cluster_choice = aos_cd_ops_data.getClusterList("${env.BRANCH_NAME}").join("\n")  // Jenkins expects choice parameter to be linefeed delimited
+
+properties([
+        [   $class: 'ParametersDefinitionProperty',
+            parameterDefinitions: [
+                [
+                    $class: 'hudson.model.ChoiceParameterDefinition',
+                    choices: "${cluster_choice}",
+                    name: 'CLUSTER_SPEC',
+                    description: 'Cluster to run tests on',
+                ],
+                [
+                    $class: 'hudson.model.BooleanParameterDefinition',
+                    defaultValue: false,
+                    description: 'Send email notifications',
+                    name: 'MAIL_RESULTS'
+                ],
+                [
+                    $class: 'hudson.model.StringParameterDefinition',
+                    defaultValue: 'aos-devel@redhat.com',
+                    description: 'Success Mailing List',
+                    name: 'MAIL_LIST_SUCCESS'
+                ],
+                [
+                    $class: 'hudson.model.StringParameterDefinition',
+                    defaultValue: 'aos-qe@redhat.com',
+                    description: 'Failure Mailing List',
+                    name: 'MAIL_LIST_FAILURE'
+                ],
+            ]
+        ],
+    ]
+)
+
+node('openshift-build-1') {
+
+    def deploylib = load( "pipeline-scripts/deploylib.groovy" )
+    deploylib.initialize(CLUSTER_SPEC)
+
+    try {
+
+        stage( 'smoketest' ) {
+            sshagent([CLUSTER_ENV]) {
+                smoketest = deploylib.run("smoketest", null, true)
+                echo smoketest
+            }
+        }
+
+        if ( MAIL_RESULTS.toBoolean() ) {
+            mail(
+                to: "${MAIL_LIST_SUCCESS}",
+                from: "aos-cd@redhat.com",
+                replyTo: 'jupierce@redhat.com',
+                subject: "Cluster smoke test succeeded: ${CLUSTER_NAME}",
+                body: """\
+Jenkins job: ${env.BUILD_URL}
+
+Smoke test output:
+${smoketest}
+""");
+
+        }
+
+    } catch ( err ) {
+        if ( MAIL_RESULTS.toBoolean() ) {
+            mail(to: "${MAIL_LIST_FAILURE}",
+                from: "aos-cd@redhat.com",
+                subject: "Error during smoke test on cluster ${CLUSTER_NAME}",
+                body: """Encountered an error: ${err}
+
+Jenkins job: ${env.BUILD_URL}
+
+Smoke test output:
+${smoketest}
+""");
+        }
+
+        // Re-throw the error in order to fail the job
+        throw err
+    }
+
+}

--- a/jobs/starter/smoke-test/README.md
+++ b/jobs/starter/smoke-test/README.md
@@ -1,0 +1,4 @@
+A job to run a smoke test on a cluster.
+
+This is basically a wrapper to call "cicd-control.sh smoketest" (via ssh to
+bastion) on a selected cluster.

--- a/jobs/starter/upgrade/Jenkinsfile
+++ b/jobs/starter/upgrade/Jenkinsfile
@@ -1,16 +1,18 @@
 #!/usr/bin/env groovy
 
-def mail_success(list,detail) {
+def mail_success(list,detail,warn) {
+    body = "Cluster ${CLUSTER_NAME} upgrade details:\n"
+    if ( warn ) {
+        body += "\nWARNING: post-upgrade smoke test was not successful: ${warn}\n"
+    }
+    body += "\n${detail}\n\nJenkins job: ${env.BUILD_URL}\n"
     mail(
         to: "${list}",
         from: "aos-cd@redhat.com",
         replyTo: 'jupierce@redhat.com',
         subject: "[aos-devel] Cluster upgrade complete: ${CLUSTER_NAME}",
-        body: """\
-${detail}
-
-Jenkins job: ${env.BUILD_URL}
-""");
+        body: body
+    );
 }
 
 @Library('aos_cd_ops') _
@@ -61,7 +63,7 @@ node('openshift-build-1') {
                 echo "Cluster status BEFORE upgrade:"
                 deploylib.run("status")
             }
-            
+
             stage( "enable maintenance" ) {
                 // deploylib.run( "enable-statuspage" )
                 deploylib.run( "enable-zabbix-maint" )
@@ -80,7 +82,7 @@ node('openshift-build-1') {
                 deploylib.run( "enable-config-loop" )
                 deploylib.run( "run-config-loop" )
             }
-            
+
             stage( "disable maintenance" ) {
                 deploylib.run( "disable-zabbix-maint" )
                 //deploylib.run( "disable-statuspage" )
@@ -93,21 +95,33 @@ node('openshift-build-1') {
             }
 
             stage( "smoketest" ) {
-                // run smoketest job here, try{}catch to determine if it failed and  include details of job in success email
+                warn = null
+                smoketest = build job: 'starter%2Fsmoketest', propagate: false,
+                                  parameters: [
+                                      [$class: 'StringParameterValue', name: 'CLUSTER_SPEC', value: CLUSTER_SPEC],
+                                      [$class: 'BooleanParameterValue', name: 'MAIL_RESULTS', value: false],
+                                  ]
+
+                POST_STATUS += "\nSmoke test results: ${smoketest.result}\n"
+
+                if ( smoketest.resultIsWorseOrEqualTo( "UNSTABLE" ) ) {
+                    warn = smoketest.absoluteUrl
+                }
             }
 
             minorUpdate = [ 'test-key', 'cicd' ].contains( CLUSTER_NAME ) || MODE == "quiet"
 
             if ( MODE != "silent" ) {
                 // Replace flow control with: https://jenkins.io/blog/2016/12/19/declarative-pipeline-beta/ when available
-                mail_success(minorUpdate?MAIL_LIST_SUCCESS_MINOR:MAIL_LIST_SUCCESS, POST_STATUS)
+                mail_success(minorUpdate?MAIL_LIST_SUCCESS_MINOR:MAIL_LIST_SUCCESS, POST_STATUS, warn)
+                // just testing
             }
 
             stage ( "performance check" ) {
                 /* // Disabled until SVT works out issues in their test.
                 if ( ( CLUSTER_NAME == "free-int" || CLUSTER_NAME =="test-key" ) && ( OPERATION == "install" || OPERATION == "reinstall" || OPERATION == "upgrade" )  ) {
                     // Run perf1 test on free-int
-                    build job: 'cluster%2Fperf',
+                    build job: 'starter%2Fperf',
                         propagate: false,
                         parameters: [
                             [$class: 'hudson.model.StringParameterValue', name: 'CLUSTER_NAME', value: CLUSTER_NAME],


### PR DESCRIPTION
This adds a new job to run smoke tests on a cluster, and calls that job during the upgrade job to run a smoke test after a cluster has been upgraded.

The PR also contains some minor changes to the smoke test script itself - one of them is actually required: `oc get pod | grep Running` is prone to races resulting on a script failure, and instead of adding another `sleep` this uses `oc rollout status -w` instead which should be more reliable and appropriate.

Also taking the opportunity to update an unrelated job: just fixing the destination address for notifications of key rotation failures.