### PR TITLE
Revert "Disable version checking in ansible installer"

### DIFF
--- a/sjb/inventory/group_vars/OSEv3/checks.yml
+++ b/sjb/inventory/group_vars/OSEv3/checks.yml
@@ -1,4 +1,4 @@
 ---
 openshift_check_min_host_disk_gb: 10
 openshift_check_min_host_memory_gb: 8
-openshift_disable_check: package_update,package_availability,package_version
+openshift_disable_check: package_update,package_availability


### PR DESCRIPTION
This reverts commit 9b402118edf1ea094c8c1a0ed125700e0d4ad776 which was a temporary fix for https://github.com/openshift/origin/issues/16143

With https://github.com/openshift/openshift-ansible/pull/5299 merged this check should take installed packages into account as well as available.