### PR TITLE
Define osm_cluster_network_cidr and openshift_portal_net

### DIFF
--- a/sjb/inventory/group_vars/OSEv3/general.yml
+++ b/sjb/inventory/group_vars/OSEv3/general.yml
@@ -18,3 +18,6 @@ openshift_template_service_broker_namespaces:
   - "openshift"
 ansible_ssh_user: "ec2-user"
 enable_excluders: "false"
+osm_cluster_network_cidr: "10.128.0.0/14"
+openshift_portal_net: "172.30.0.0/16"
+osm_host_subnet_length: 9


### PR DESCRIPTION
These are now required values in order to ensure that we don't change
defaults during upgrades