### PR TITLE
cri-o: force image from docker.io for now

### DIFF
--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_crio.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_crio.yml
@@ -58,6 +58,7 @@ extensions:
                          --inventory sjb/inventory/ \
                          -e deployment_type=origin  \
                          -e openshift_use_crio=True   \
+                         -e openshift_crio_systemcontainer_image_registry_override=docker.io/gscrivano \
                          -e etcd_data_dir="${ETCD_DATA_DIR}" \
                          -e openshift_master_default_subdomain="${local_ip}.nip.io"             \
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \

--- a/sjb/generated/test_branch_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_crio.xml
@@ -198,6 +198,7 @@ ansible-playbook -vv --become               \
                  --inventory sjb/inventory/ \
                  -e deployment_type=origin  \
                  -e openshift_use_crio=True   \
+                 -e openshift_crio_systemcontainer_image_registry_override=docker.io/gscrivano \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \


### PR DESCRIPTION
https://github.com/openshift/openshift-ansible/pull/5310 was merged
before the image for RHEL was ready.  Until that it is done, force the
image from docker.io.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>