### PR TITLE
CRI-O: remove broken docker images filter

### DIFF
--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_crio.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_crio.yml
@@ -86,7 +86,7 @@ extensions:
       title: "copy openshift images from docker storage to CRI-O storage"
       timeout: 10800
       script: |-
-        for i in $(docker images --filter 'reference=openshift/origin-*' --format '{{.Repository}}:{{.Tag}}'); do
+        for i in $(docker images --format '{{.Repository}}:{{.Tag}}' | grep "openshift\/origin"); do
           sudo skopeo copy docker-daemon:$i containers-storage:$i
         done
     - type: "script"

--- a/sjb/generated/test_branch_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_crio.xml
@@ -261,7 +261,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
-for i in \$(docker images --filter &#39;reference=openshift/origin-*&#39; --format &#39;{{.Repository}}:{{.Tag}}&#39;); do
+for i in \$(docker images --format &#39;{{.Repository}}:{{.Tag}}&#39; | grep &#34;openshift\/origin&#34;); do
   sudo skopeo copy docker-daemon:\$i containers-storage:\$i
 done
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
@@ -358,7 +358,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
-for i in \$(docker images --filter &#39;reference=openshift/origin-*&#39; --format &#39;{{.Repository}}:{{.Tag}}&#39;); do
+for i in \$(docker images --format &#39;{{.Repository}}:{{.Tag}}&#39; | grep &#34;openshift\/origin&#34;); do
   sudo skopeo copy docker-daemon:\$i containers-storage:\$i
 done
 SCRIPT


### PR DESCRIPTION
Turns out the "reference" filter isn't available in docker 1.12.x which
is used in the Origin CI. Replace that with a grep. For reference teh
error was:
```
++ docker images --filter 'reference=openshift/origin-*' --format
'{{.Repository}}:{{.Tag}}'
Error response from daemon: Invalid filter 'reference'
+ set +o xtrace
```
Signed-off-by: Antonio Murdaca <runcom@redhat.com>