### PR TITLE
allow use of mux, es external for testing

### DIFF
--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
@@ -133,6 +133,10 @@ extensions:
                          -e openshift_hosted_logging_hostname="kibana.127.0.0.1.nip.io"           \
                          -e openshift_logging_master_public_url="https://localhost:8443"          \
                          -e openshift_master_logging_public_url="https://kibana.127.0.0.1.nip.io" \
+                         -e openshift_logging_use_mux=True                                        \
+                         -e openshift_logging_mux_allow_external=True                             \
+                         -e openshift_logging_es_allow_external=True                              \
+                         -e openshift_logging_es_ops_allow_external=True                          \
                          /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/openshift-logging.yml \
                          --skip-tags=update_master_config
     - type: "script"

--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file.yml
@@ -135,6 +135,10 @@ extensions:
                          -e openshift_hosted_logging_hostname="kibana.127.0.0.1.nip.io"           \
                          -e openshift_logging_master_public_url="https://localhost:8443"          \
                          -e openshift_master_logging_public_url="https://kibana.127.0.0.1.nip.io" \
+                         -e openshift_logging_use_mux=True                                        \
+                         -e openshift_logging_mux_allow_external=True                             \
+                         -e openshift_logging_es_allow_external=True                              \
+                         -e openshift_logging_es_ops_allow_external=True                          \
                          /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/openshift-logging.yml \
                          --skip-tags=update_master_config
     - type: "script"

--- a/sjb/generated/test_branch_openshift_ansible_logging.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging.xml
@@ -385,6 +385,10 @@ ansible-playbook -vv --become               \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
                  -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \
                  -e openshift_master_logging_public_url=&#34;https://kibana.127.0.0.1.nip.io&#34; \
+                 -e openshift_logging_use_mux=True                                        \
+                 -e openshift_logging_mux_allow_external=True                             \
+                 -e openshift_logging_es_allow_external=True                              \
+                 -e openshift_logging_es_ops_allow_external=True                          \
                  /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/openshift-logging.yml \
                  --skip-tags=update_master_config
 SCRIPT

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
@@ -387,6 +387,10 @@ ansible-playbook -vv --become               \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
                  -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \
                  -e openshift_master_logging_public_url=&#34;https://kibana.127.0.0.1.nip.io&#34; \
+                 -e openshift_logging_use_mux=True                                        \
+                 -e openshift_logging_mux_allow_external=True                             \
+                 -e openshift_logging_es_allow_external=True                              \
+                 -e openshift_logging_es_ops_allow_external=True                          \
                  /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/openshift-logging.yml \
                  --skip-tags=update_master_config
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_logging.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging.xml
@@ -443,6 +443,10 @@ ansible-playbook -vv --become               \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
                  -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \
                  -e openshift_master_logging_public_url=&#34;https://kibana.127.0.0.1.nip.io&#34; \
+                 -e openshift_logging_use_mux=True                                        \
+                 -e openshift_logging_mux_allow_external=True                             \
+                 -e openshift_logging_es_allow_external=True                              \
+                 -e openshift_logging_es_ops_allow_external=True                          \
                  /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/openshift-logging.yml \
                  --skip-tags=update_master_config
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
@@ -443,6 +443,10 @@ ansible-playbook -vv --become               \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
                  -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \
                  -e openshift_master_logging_public_url=&#34;https://kibana.127.0.0.1.nip.io&#34; \
+                 -e openshift_logging_use_mux=True                                        \
+                 -e openshift_logging_mux_allow_external=True                             \
+                 -e openshift_logging_es_allow_external=True                              \
+                 -e openshift_logging_es_ops_allow_external=True                          \
                  /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/openshift-logging.yml \
                  --skip-tags=update_master_config
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
@@ -445,6 +445,10 @@ ansible-playbook -vv --become               \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
                  -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \
                  -e openshift_master_logging_public_url=&#34;https://kibana.127.0.0.1.nip.io&#34; \
+                 -e openshift_logging_use_mux=True                                        \
+                 -e openshift_logging_mux_allow_external=True                             \
+                 -e openshift_logging_es_allow_external=True                              \
+                 -e openshift_logging_es_ops_allow_external=True                          \
                  /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/openshift-logging.yml \
                  --skip-tags=update_master_config
 SCRIPT


### PR DESCRIPTION
This will cause the mux dc and service to be created,
and the routes for es and es-ops.  However, fluentd will
not be configured to use mux by default, but mux tests can
use it.  The es and es-ops routes aren't used, but at least this
will exercise the ansible code that creates them.
@stevekuznetsov @jcantrill @nhosoi PTAL
[test]