### PR TITLE
Add build stage for service-catalog user-broker binary

### DIFF
--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update.yml
@@ -83,6 +83,12 @@ extensions:
         sed -i 's|go/src|data/src|' _output/local/releases/rpms/origin-local-release.repo
         sudo cp _output/local/releases/rpms/origin-local-release.repo /etc/yum.repos.d/
     - type: "script"
+      title: "build service-catalog user-broker image"
+      repository: "origin"
+      timeout: 1800
+      script: |-
+        REGISTRY=openshift/ NO_DOCKER=1 make -C cmd/service-catalog/go/src/github.com/kubernetes-incubator/service-catalog user-broker
+    - type: "script"
       title: "install origin"
       repository: "aos-cd-jobs"
       timeout: 1800


### PR DESCRIPTION
Part of openshift/origin#16220 - adds a stage to the extended_conformance_install_update job that builds the service catalog test broker binary