### PR TITLE
[BuildAuto] Automate OpenShift Jenkins uber-plugin rebuilds

### DIFF
--- a/hacks/update-jenkins-plugins/collect-jenkins-plugins.sh
+++ b/hacks/update-jenkins-plugins/collect-jenkins-plugins.sh
@@ -2,12 +2,12 @@
 
 usage() {
     echo >&2
-    echo "Usage `basename $0` <lowest-supported-jenkins-version> <openshift-release-version> <path-to-plugins-list>" >&2
+    echo "Usage `basename $0` <lowest-supported-jenkins-version> <path-to-plugins-list>" >&2
     echo "  Where path-to-plugins-list is a line delimited list of jenkins plugins to prepare." >&2
     echo "    Example entries:   workflow-aggregator:2.1" >&2
     echo "      or use latest:   workflow-aggregator:latest" >&2
     echo >&2
-    echo " Example: ./collect-jenkins-plugins.sh  1.651.2  3.6  plugins.txt" >&2
+    echo " Example: ./collect-jenkins-plugins.sh  1.651.2  plugins.txt" >&2
     exit 1
 }
 
@@ -63,15 +63,14 @@ testvercomp () {
 
 
 # Make sure they passed something in for us
-if [ "$#" -lt 3 ] ; then
+if [ "$#" -lt 2 ] ; then
   usage
 fi
 
 # set -o xtrace
 
 JENKINS_VERSION="$1"
-RHAOS_RELEASE="$2"
-PLUGIN_LISTING="$(realpath $3)"
+PLUGIN_LISTING="$(realpath $2)"
 
 
 workingdir=$(dirname $(realpath $0))/working

--- a/jobs/build/jenkins-plugins/Jenkinsfile
+++ b/jobs/build/jenkins-plugins/Jenkinsfile
@@ -7,8 +7,7 @@ properties(
                     name: 'JENKINS_VERSION',
                     description: 'Minimum required Jenkins version',
                     $class: 'hudson.model.StringParameterDefinition'
-                    // Probably better it this was a choice, but might not be
-                    // flexible enough
+                    defaultValue: '2.43'
                 ],
                 [
                     name: 'OCP_RELEASE',
@@ -26,13 +25,13 @@ properties(
                     name: 'MAIL_LIST_SUCCESS',
                     description: 'Success Mailing List',
                     $class: 'hudson.model.StringParameterDefinition',
-                    defaultValue: 'jupierce@redhat.com,smunilla@redhat.com,cwong@redhat.com,bparees@redhat.com,pep@redhat.com'
+                    defaultValue: 'jupierce@redhat.com,smunilla@redhat.com,ahaile@redhat.com,gmontero@redhat.com,bparees@redhat.com,pep@redhat.com'
                 ],
                 [
                     name: 'MAIL_LIST_FAILURE',
                     description: 'Failure Mailing List',
                     $class: 'hudson.model.StringParameterDefinition',
-                    defaultValue: 'jupierce@redhat.com,smunilla@redhat.com,cwong@redhat.com,bparees@redhat.com,pep@redhat.com'
+                    defaultValue: 'jupierce@redhat.com,smunilla@redhat.com,ahaile@redhat.com,gmontero@redhat.com,bparees@redhat.com,pep@redhat.com'
                 ],
                 [
                     name: 'TARGET_NODE',
@@ -56,11 +55,11 @@ def mail_success() {
         to: "${MAIL_LIST_SUCCESS}",
         from: "aos-cd@redhat.com",
         replyTo: 'jupierce@redhat.com',
-        subject: "jenkins plugins RPM updated in dist-git",
+        subject: "jenkins plugins RPM for OCP ${OCP_RELEASE} updated in dist-git",
         body: """The Jenkins plugins RPM for OCP ${OCP_RELEASE} has been updated in dist-git:
 ${distgit_link}
 
-Jenkins version: ${JENKINS_VERSION}
+Minimum Jenkins version: ${JENKINS_VERSION}
 
 Plugin list:
 ${PLUGIN_LIST}
@@ -87,9 +86,8 @@ node(TARGET_NODE) {
 
     checkout scm
 
-    def buildlib = load( "pipeline-scripts/buildlib.groovy")
+    def buildlib = load( "pipeline-scripts/buildlib.groovy" )
     buildlib.kinit()       // Sets up credentials for dist-git access
-    buildlib.path_setup()  // Put scripts in env.PATH
 
     try {
         stage ("prepare workspace") {
@@ -97,18 +95,27 @@ node(TARGET_NODE) {
             // Temporary file to write the plugin list to
             tmpdir = pwd tmp:true
             plugin_file = "${tmpdir}/jenkins-plugins.txt"
+            scripts_dir = "${env.WORKSPACE}/hacks/update-jenkins-plugins"
             // Note that collect-jenkins-plugins.sh has a hardcoded output dir:
-            plugin_dir = "${env.WORKSPACE}/hacks/update-jenkins-plugins/working/hpis"
+            plugin_dir = "${scripts_dir}/working/hpis"
 
             writeFile file: plugin_file, text: PLUGIN_LIST
         }
 
         stage ("collect plugins") {
-            sh "collect-jenkins-plugins.sh ${JENKINS_VERSION} ${plugin_file}"
+            withEnv(["PATH+SCRIPTS=${scripts_dir}"]) {
+                sh "collect-jenkins-plugins.sh ${JENKINS_VERSION} ${plugin_file}"
+            }
         }
 
         stage ("update dist-git") {
-            sh "update-dist-git.sh ${JENKINS_VERSION} ${OCP_RELEASE} ${plugin_dir}"
+            withEnv(["PATH+SCRIPTS=${scripts_dir}"]) {
+                sh "update-dist-git.sh ${JENKINS_VERSION} ${OCP_RELEASE} ${plugin_dir}"
+            }
+        }
+
+        stage ("cleanup") {
+            sh "rm -rf ${plugin_dir} ${plugin_file}"
         }
 
         mail_success()

--- a/jobs/build/jenkins-plugins/Jenkinsfile
+++ b/jobs/build/jenkins-plugins/Jenkinsfile
@@ -1,0 +1,126 @@
+#!/usr/bin/env groovy
+
+properties(
+    [
+        [ $class : 'ParametersDefinitionProperty', parameterDefinitions: [
+                [
+                    name: 'JENKINS_VERSION',
+                    description: 'Minimum required Jenkins version',
+                    $class: 'hudson.model.StringParameterDefinition'
+                    // Probably better it this was a choice, but might not be
+                    // flexible enough
+                ],
+                [
+                    name: 'OCP_RELEASE',
+                    description: 'OCP target release',
+                    $class: 'hudson.model.ChoiceParameterDefinition',
+                    choices: ['3.7', '3.6', '3.5', '3.4', '3.3'].join('\n'),
+                    defaultValue: '3.7'
+                ],
+                [
+                    name: 'PLUGIN_LIST',
+                    description: 'List of plugin:version to include, one per line',
+                    $class: 'hudson.model.TextParameterDefinition'
+                ],
+                [
+                    name: 'MAIL_LIST_SUCCESS',
+                    description: 'Success Mailing List',
+                    $class: 'hudson.model.StringParameterDefinition',
+                    defaultValue: 'jupierce@redhat.com,smunilla@redhat.com,cwong@redhat.com,bparees@redhat.com,pep@redhat.com'
+                ],
+                [
+                    name: 'MAIL_LIST_FAILURE',
+                    description: 'Failure Mailing List',
+                    $class: 'hudson.model.StringParameterDefinition',
+                    defaultValue: 'jupierce@redhat.com,smunilla@redhat.com,cwong@redhat.com,bparees@redhat.com,pep@redhat.com'
+                ],
+                [
+                    name: 'TARGET_NODE',
+                    description: 'Jenkins agent node',
+                    $class: 'hudson.model.StringParameterDefinition',
+                    defaultValue: 'openshift-build-1'
+                ],
+            ]
+        ],
+        disableConcurrentBuilds()
+    ]
+)
+
+def mail_success() {
+
+    jenkins_major = JENKINS_VERSION.tokenize('.')[0].toString()
+
+    distgit_link = "http://pkgs.devel.redhat.com/cgit/rpms/jenkins-${jenkins_major}-plugins/?h=rhaos-${OCP_RELEASE}-rhel-7"
+
+    mail(
+        to: "${MAIL_LIST_SUCCESS}",
+        from: "aos-cd@redhat.com",
+        replyTo: 'jupierce@redhat.com',
+        subject: "jenkins plugins RPM updated in dist-git",
+        body: """The Jenkins plugins RPM for OCP ${OCP_RELEASE} has been updated in dist-git:
+${distgit_link}
+
+Jenkins version: ${JENKINS_VERSION}
+
+Plugin list:
+${PLUGIN_LIST}
+
+Plugin RPM update job: ${env.BUILD_URL}
+""");
+}
+
+def mail_failure(err) {
+
+    mail(
+        to: "${MAIL_LIST_FAILURE}",
+        from: "aos-cd@redhat.com",
+        replyTo: 'jupierce@redhat.com',
+        subject: "Error during jenkins plugin RPM update on dist-git",
+        body: """The job to update the jenkins plugins RPM in dist-git encountered an error:
+${err}
+
+Jenkins job: ${env.BUILD_URL}
+""");
+}
+
+node(TARGET_NODE) {
+
+    checkout scm
+
+    def buildlib = load( "pipeline-scripts/buildlib.groovy")
+    buildlib.initialize()  // Sets up credentials for dist-git access
+
+    try {
+        stage ("prepare workspace") {
+
+            scripts_dir = "${env.WORKSPACE}/hacks/update-jenkins-plugins"
+            // Temporary file to write the plugin list to
+            tmpdir = pwd tmp:true
+            plugin_file = "${tmpdir}/jenkins-plugins.txt"
+            // Note that collect-jenkins-plugins.sh has a hardcoded output dir:
+            plugin_dir = "${scripts_dir}/working/hpis"
+
+            echo "Adding the plugin scripts directory (${scripts_dir}) to PATH"
+            env.PATH = "${scripts_dir}:${env.PATH}"
+
+            writeFile file: plugin_file, text: PLUGIN_LIST
+        }
+
+        stage ("collect plugins") {
+            sh "collect-jenkins-plugins.sh ${JENKINS_VERSION} ${plugin_file}"
+        }
+
+        stage ("update dist-git") {
+            sh "update-dist-git.sh ${JENKINS_VERSION} ${OCP_RELEASE} ${plugin_dir}"
+        }
+
+        mail_success()
+
+    } catch (err) {
+
+        mail_failure(err)
+
+        // Re-throw the error in order to fail the job
+        throw err
+    }
+}

--- a/jobs/build/jenkins-plugins/Jenkinsfile
+++ b/jobs/build/jenkins-plugins/Jenkinsfile
@@ -88,20 +88,17 @@ node(TARGET_NODE) {
     checkout scm
 
     def buildlib = load( "pipeline-scripts/buildlib.groovy")
-    buildlib.initialize()  // Sets up credentials for dist-git access
+    buildlib.kinit()       // Sets up credentials for dist-git access
+    buildlib.path_setup()  // Put scripts in env.PATH
 
     try {
         stage ("prepare workspace") {
 
-            scripts_dir = "${env.WORKSPACE}/hacks/update-jenkins-plugins"
             // Temporary file to write the plugin list to
             tmpdir = pwd tmp:true
             plugin_file = "${tmpdir}/jenkins-plugins.txt"
             // Note that collect-jenkins-plugins.sh has a hardcoded output dir:
-            plugin_dir = "${scripts_dir}/working/hpis"
-
-            echo "Adding the plugin scripts directory (${scripts_dir}) to PATH"
-            env.PATH = "${scripts_dir}:${env.PATH}"
+            plugin_dir = "${env.WORKSPACE}/hacks/update-jenkins-plugins/working/hpis"
 
             writeFile file: plugin_file, text: PLUGIN_LIST
         }

--- a/jobs/build/jenkins-plugins/README.md
+++ b/jobs/build/jenkins-plugins/README.md
@@ -1,0 +1,13 @@
+This job invokes the [scripts to update the jenkins plugin RPM](../../hacks/update-jenkins-plugins/README.MD).
+
+It needs the following parameters:
+
+- Jenkins version. Used by the scripts to determine dependencies, and also used to compute the name of the RPM (version X.Y -> jenkins-X-plugin)
+
+- OCP release version. Used to determine the target dist-git branch
+
+- plugin list, one plugin per line, in the form pluginname:version (see scripts for more details)
+
+- email notification targets
+
+- jenkins slave where builds happen. This has to have access to krb credentials to access dist-git/brew

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -3,13 +3,23 @@ def commonlib = load("pipeline-scripts/commonlib.groovy")
 
 commonlib.initialize()
 
+def initialize() {
+    this.registry_login()
+    this.path_setup()
+    this.kinit()
+}
+
+// Initialize $PATH and $GOPATH
 def path_setup() {
     echo "Adding git managed script directories to PATH"
-    // ose-images.sh
+    // ose_images.sh
     env.PATH = "${pwd()}/build-scripts/ose_images:${env.PATH}"
-    // jenkins-plugins RPM build scripts
-    env.PATH = "${pwd()}/hacks/update-jenkins-plugins:${env.PATH}"
 
+    GOPATH = "${env.WORKSPACE}/go"
+    env.GOPATH = GOPATH
+    sh "rm -rf ${GOPATH}"  // Remove any cruft
+    sh "mkdir -p ${GOPATH}"
+    echo "Initialized env.GOPATH: ${env.GOPATH}"
 }
 
 def kinit() {
@@ -36,18 +46,6 @@ def registry_login() {
         sh 'chmod +x docker_login.sh'
         sh './docker_login.sh'
     }
-}
-
-def initialize() {
-    this.registry_login()
-    this.path_setup()
-    this.kinit()
-
-    GOPATH = "${env.WORKSPACE}/go"
-    env.GOPATH = GOPATH
-    sh "rm -rf ${GOPATH}"  // Remove any cruft
-    sh "mkdir -p ${GOPATH}"
-    echo "Initialized env.GOPATH: ${env.GOPATH}"
 }
 
 def initialize_openshift_dir() {


### PR DESCRIPTION
A job that invokes the `collect-jenkins-plugins.sh` and `update-dist-git.sh` scripts to create an updated `jenkins-x-plugins` RPM in dist-git and build in brew.

It uses buildlib to initialize kerberos credentials (needed by rhpkg). It doesn't need some of the steps that buildlib's `initialize` is doing, like login to registries, so suggesting to separate these init steps in the library.

@jupierce PTAL, I know some things much likely need updates, including:

- should we have a choice for the Jenkins Version parameter? If so, what choices and how are they maintained? Or just the plain string param might be enough here...
- should we move the choices for OCP release version into the library? (and update other jobs to use them)
- list for email notifications: more? less?
