### PR TITLE
Send spam to aos-cicd instead of aos-devel

### DIFF
--- a/jobs/build/ocp/Jenkinsfile
+++ b/jobs/build/ocp/Jenkinsfile
@@ -11,7 +11,7 @@ properties(
                           [$class: 'hudson.model.ChoiceParameterDefinition', choices: "git@github.com:openshift\ngit@github.com:jupierce\ngit@github.com:jupierce-aos-cd-bot\ngit@github.com:adammhaile-aos-cd-bot", defaultValue: 'git@github.com:openshift', description: 'Github base for repos', name: 'GITHUB_BASE'],
                           [$class: 'hudson.model.ChoiceParameterDefinition', choices: "openshift-bot\naos-cd-test\njupierce-aos-cd-bot\nadammhaile-aos-cd-bot", defaultValue: 'aos-cd-test', description: 'SSH credential id to use', name: 'SSH_KEY_ID'],
                           [$class: 'hudson.model.ChoiceParameterDefinition', choices: "3.7\n3.6\n3.5\n3.4\n3.3", defaultValue: '3.7', description: 'OCP Version to build', name: 'BUILD_VERSION'],
-                          [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'aos-devel@redhat.com, aos-qe@redhat.com,jupierce@redhat.com,smunilla@redhat.com,ahaile@redhat.com', description: 'Success Mailing List', name: 'MAIL_LIST_SUCCESS'],
+                          [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'aos-cicd@redhat.com, aos-qe@redhat.com,jupierce@redhat.com,smunilla@redhat.com,ahaile@redhat.com', description: 'Success Mailing List', name: 'MAIL_LIST_SUCCESS'],
                           [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'jupierce@redhat.com,smunilla@redhat.com,ahaile@redhat.com', description: 'Failure Mailing List', name: 'MAIL_LIST_FAILURE'],
                           [$class: 'hudson.model.BooleanParameterDefinition', defaultValue: false, description: 'Enable intra-day build hack for CL team CI?', name: 'EARLY_LATEST_HACK'],
                           [$class: 'hudson.model.ChoiceParameterDefinition', choices: "release\npre-release\nonline:int\nonline:stg", description:
@@ -60,7 +60,7 @@ def mail_success( version ) {
             to: "${MAIL_LIST_SUCCESS}",
             from: "aos-cd@redhat.com",
             replyTo: 'smunilla@redhat.com',
-            subject: "[aos-devel] New build for OpenShift ${target}: ${version}",
+            subject: "[aos-cicd] New build for OpenShift ${target}: ${version}",
             body: """\
 OpenShift Version: v${version}
 ${inject_notes}

--- a/jobs/build/openshift-online/Jenkinsfile
+++ b/jobs/build/openshift-online/Jenkinsfile
@@ -15,7 +15,7 @@ properties(
                  parameterDefinitions:
                          [
                                  [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'openshift-build-1', description: 'Jenkins agent node', name: 'TARGET_NODE'],
-                                 [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'aos-devel@redhat.com, aos-qe@redhat.com', description: 'Success Mailing List', name: 'MAIL_LIST_SUCCESS'],
+                                 [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'aos-cicd@redhat.com, aos-qe@redhat.com', description: 'Success Mailing List', name: 'MAIL_LIST_SUCCESS'],
                                  [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'jupierce@redhat.com,tdawson@redhat.com,smunilla@redhat.com,sedgar@redhat.com,vdinh@redhat.com,ahaile@redhat.com', description: 'Failure Mailing List', name: 'MAIL_LIST_FAILURE'],
                                  [$class: 'hudson.model.BooleanParameterDefinition', defaultValue: false, description: 'Force rebuild even if no changes are detected?', name: 'FORCE_REBUILD'],
                                  [$class: 'hudson.model.ChoiceParameterDefinition',

--- a/jobs/build/ose-pipeline/Jenkinsfile
+++ b/jobs/build/ose-pipeline/Jenkinsfile
@@ -13,7 +13,7 @@ def try_wrapper(failure_func, f) {
 def mail_success(version) {
     mail(
         to: 'jupierce@redhat.com',
-        subject: "[aos-devel] New AtomicOpenShift Puddle for OSE: ${version}",
+        subject: "[aos-cicd] New AtomicOpenShift Puddle for OSE: ${version}",
         body: """\
 v${version}
 Images have been built for this puddle

--- a/jobs/build/ose/Jenkinsfile
+++ b/jobs/build/ose/Jenkinsfile
@@ -55,7 +55,7 @@ def mail_success(version) {
         to: "${MAIL_LIST_SUCCESS}",
         from: "aos-cd@redhat.com",
         replyTo: 'smunilla@redhat.com',
-        subject: "[aos-devel] New build for OpenShift ${target}: ${version}",
+        subject: "[aos-cicd] New build for OpenShift ${target}: ${version}",
         body: """\
 OpenShift Version: v${version}
 
@@ -85,7 +85,7 @@ properties(
                           [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'openshift-build-1', description: 'Jenkins agent node', name: 'TARGET_NODE'],
                           [$class: 'hudson.model.StringParameterDefinition', defaultValue: '', description: 'OSE Major Version', name: 'OSE_MAJOR'],
                           [$class: 'hudson.model.StringParameterDefinition', defaultValue: '', description: 'OSE Minor Version', name: 'OSE_MINOR'],
-                          [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'aos-devel@redhat.com, aos-qe@redhat.com,jupierce@redhat.com,smunilla@redhat.com,ahaile@redhat.com', description: 'Success Mailing List', name: 'MAIL_LIST_SUCCESS'],
+                          [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'aos-cicd@redhat.com, aos-qe@redhat.com,jupierce@redhat.com,smunilla@redhat.com,ahaile@redhat.com', description: 'Success Mailing List', name: 'MAIL_LIST_SUCCESS'],
                           [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'jupierce@redhat.com,smunilla@redhat.com,ahaile@redhat.com', description: 'Failure Mailing List', name: 'MAIL_LIST_FAILURE'],
                           [$class: 'hudson.model.BooleanParameterDefinition', defaultValue: false, description: 'Enable intra-day build hack for CL team CI?', name: 'EARLY_LATEST_HACK'],
                           [$class: 'hudson.model.ChoiceParameterDefinition', choices: "enterprise\nenterprise:pre-release\nonline:int\nonline:stg", description:

--- a/jobs/package-dockertested/Jenkinsfile
+++ b/jobs/package-dockertested/Jenkinsfile
@@ -158,7 +158,7 @@ node('openshift-build-1') {
 				}
 				stage ('Send out an e-mail about new versions') {
 					mail (
-						to: 'aos-devel@redhat.com',
+						to: 'aos-cicd@redhat.com',
 						cc: 'skuznets@redhat.com',
 						subject: "${docker_rpm} and dependencies pushed to dockertested repository",
 						body: """The latest job[1] marked the following RPMs as successful:

--- a/jobs/starter/operation/Jenkinsfile
+++ b/jobs/starter/operation/Jenkinsfile
@@ -5,7 +5,7 @@ def mail_success(list) {
         to: "${list}",
         from: "aos-cd@redhat.com",
         replyTo: 'jupierce@redhat.com',
-        subject: "[aos-devel] Cluster ${OPERATION} complete: ${CLUSTER_NAME}",
+        subject: "[aos-cicd] Cluster ${OPERATION} complete: ${CLUSTER_NAME}",
         body: """\
 Jenkins job: ${env.BUILD_URL}
 """);
@@ -25,7 +25,7 @@ properties(
                           [$class: 'hudson.model.ChoiceParameterDefinition', choices: "${cluster_choice}", name: 'CLUSTER_SPEC', description: 'The specification of the cluster to affect'],
                           [$class: 'hudson.model.ChoiceParameterDefinition', choices: "build-ci-msg\ncommit-config-loop\ndelete\ndisable-config-loop\ndisable-statuspage\ndisable-zabbix-maint\nenable-config-loop\nenable-statuspage\nenable-zabbix-maint\ngenerate-byo-inventory\ninstall\nlegacy-upgrade\nonline-deployer\nperf1\nperf2\nperf3\npre-check\nrun-config-loop\nsmoketest\nstatus\nupdate-inventory\nupdate-yum-extra-repos\nupgrade\nupgrade-control-plane\nupgrade-logging\nupgrade-metrics\nupgrade-nodes\n", name: 'OPERATION', description: 'Operation to perform'],
                           [$class: 'hudson.model.TextParameterDefinition', defaultValue: '', description: 'Additional options (key=value linefeed delimited)', name: 'ADDITIONAL_OPTS'],
-                          [$class: 'hudson.model.ChoiceParameterDefinition', choices: "interactive\nquiet\nsilent\nautomatic", name: 'MODE', description: 'Select automatic to prevent input prompt. Select quiet to prevent aos-devel emails. Select silent to prevent any success email.'],
+                          [$class: 'hudson.model.ChoiceParameterDefinition', choices: "interactive\nquiet\nsilent\nautomatic", name: 'MODE', description: 'Select automatic to prevent input prompt. Select quiet to prevent aos-cicd emails. Select silent to prevent any success email.'],
                           [$class: 'hudson.model.BooleanParameterDefinition', defaultValue: false, description: 'Mock run to pickup new Jenkins parameters?', name: 'MOCK'],
                   ]
          ]]

--- a/jobs/starter/perf/Jenkinsfile
+++ b/jobs/starter/perf/Jenkinsfile
@@ -27,7 +27,7 @@ node('openshift-build-1') {
                               [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'mifiedle@redhat.com, jupierce@redhat.com, vlaad@redhat.com', description: 'Failure Mailing List', name: 'MAIL_LIST_FAILURE'],
                               [$class: 'hudson.model.ChoiceParameterDefinition', choices: "${cluster_choice}", name: 'CLUSTER_SPEC', description: 'The name of the cluster specification to target'],
                               [$class: 'hudson.model.ChoiceParameterDefinition', choices: "perf1\nperf2\nperf3", name: 'OPERATION', description: 'Test to perform'],
-                              [$class: 'hudson.model.ChoiceParameterDefinition', choices: "interactive\nquiet\nsilent\nautomatic", name: 'MODE', description: 'Select automatic to prevent input prompt. Select quiet to prevent aos-devel emails. Select silent to prevent any success email.'],
+                              [$class: 'hudson.model.ChoiceParameterDefinition', choices: "interactive\nquiet\nsilent\nautomatic", name: 'MODE', description: 'Select automatic to prevent input prompt. Select quiet to prevent aos-cicd emails. Select silent to prevent any success email.'],
                               [$class: 'hudson.model.BooleanParameterDefinition', defaultValue: false, description: 'Mock run to pickup new Jenkins parameters?', name: 'MOCK'],
                       ]
              ]]

--- a/jobs/starter/smoke-test/Jenkinsfile
+++ b/jobs/starter/smoke-test/Jenkinsfile
@@ -27,7 +27,7 @@ properties([
                 ],
                 [
                     $class: 'hudson.model.StringParameterDefinition',
-                    defaultValue: 'aos-devel@redhat.com',
+                    defaultValue: 'aos-cicd@redhat.com',
                     description: 'Success Mailing List',
                     name: 'MAIL_LIST_SUCCESS'
                 ],

--- a/jobs/starter/sprint-control/Jenkinsfile
+++ b/jobs/starter/sprint-control/Jenkinsfile
@@ -13,7 +13,7 @@ config = input(
                 [$class: 'hudson.model.StringParameterDefinition', defaultValue: "00/00/${year}", description: 'Date of first upgrade for dev-preview-stg (usually third Tuesday of the sprint)', name: 'stg_upgrades_start'],
                 [$class: 'hudson.model.StringParameterDefinition', defaultValue: "00/00/${year}", description: 'Date of last upgrade for dev-preview-stg (usually third Friday of the sprint)', name: 'stg_upgrades_stop'],
                 [$class: 'hudson.model.StringParameterDefinition', defaultValue: "00/00/${year}", description: 'Date of upgrade for dev-preview-prod (usually first Monday of \'next\' sprint); This process will not be performed without user input.', name: 'prod_upgrade'],
-                [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'aos-devel@redhat.com, aos-qe@redhat.com', description: 'Success Mailing List', name: 'MAIL_LIST_SUCCESS'],
+                [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'aos-cicd@redhat.com, aos-qe@redhat.com', description: 'Success Mailing List', name: 'MAIL_LIST_SUCCESS'],
                 [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'jupierce@redhat.com,tdawson@redhat.com,smunilla@redhat.com,mwoodson@redhat.com,chmurphy@redhat.com', description: 'Failure Mailing List', name: 'MAIL_LIST_FAILURE'],
                 [$class: 'BooleanParameterDefinition', defaultValue: false, description: 'Force immediate action (do not wait for disruption hour)?.', name: 'force'],
                 [$class: 'BooleanParameterDefinition', defaultValue: false, description: 'Run in test mode?', name: 'test_mode'],
@@ -364,7 +364,7 @@ def status_notify(subject,msg) {
             to: "${config.MAIL_LIST_SUCCESS}",
             from: "aos-cd@redhat.com",
             replyTo: 'jpierce@redhat.com',
-            subject: "[aos-devel] [sprint-${config.sprint_name}] ${subject}",
+            subject: "[aos-cicd] [sprint-${config.sprint_name}] ${subject}",
             body: """\
 ${msg}
 

--- a/jobs/starter/upgrade/Jenkinsfile
+++ b/jobs/starter/upgrade/Jenkinsfile
@@ -10,7 +10,7 @@ def mail_success(list,detail,warn) {
         to: "${list}",
         from: "aos-cd@redhat.com",
         replyTo: 'jupierce@redhat.com',
-        subject: "[aos-devel] Cluster upgrade complete: ${CLUSTER_NAME}",
+        subject: "[aos-cicd] Cluster upgrade complete: ${CLUSTER_NAME}",
         body: body
     );
 }
@@ -24,11 +24,11 @@ properties(
         [[$class              : 'ParametersDefinitionProperty',
           parameterDefinitions:
                   [
-                          [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'aos-devel@redhat.com, aos-qe@redhat.com, devtools-saas@redhat.com', description: 'Success Mailing List', name: 'MAIL_LIST_SUCCESS'],
+                          [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'aos-cicd@redhat.com, aos-qe@redhat.com, devtools-saas@redhat.com', description: 'Success Mailing List', name: 'MAIL_LIST_SUCCESS'],
                           [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'jupierce@redhat.com, mwoodson@redhat.com', description: 'Success for minor cluster operation', name: 'MAIL_LIST_SUCCESS_MINOR'],
                           [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'jupierce@redhat.com, mwoodson@redhat.com', description: 'Failure Mailing List', name: 'MAIL_LIST_FAILURE'],
                           [$class: 'hudson.model.ChoiceParameterDefinition', choices: "${cluster_choice}", name: 'CLUSTER_SPEC', description: 'The specification of the cluster to affect'],
-                          [$class: 'hudson.model.ChoiceParameterDefinition', choices: "interactive\nquiet\nsilent\nautomatic", name: 'MODE', description: 'Select automatic to prevent input prompt. Select quiet to prevent aos-devel emails. Select silent to prevent any success email.'],
+                          [$class: 'hudson.model.ChoiceParameterDefinition', choices: "interactive\nquiet\nsilent\nautomatic", name: 'MODE', description: 'Select automatic to prevent input prompt. Select quiet to prevent aos-cicd emails. Select silent to prevent any success email.'],
                           [$class: 'hudson.model.StringParameterDefinition', defaultValue: '', description: 'OpenShift version (e.g. 3.6.173.0.37-1.git.0.fd828e7.el7)', name: 'OPENSHIFT_VERSION'],
                           [$class: 'hudson.model.StringParameterDefinition', defaultValue: '', description: 'Docker version (e.g. 1.12.6-48.git0fdc778.el7)', name: 'DOCKER_VERSION'],
                           [$class: 'hudson.model.TextParameterDefinition', defaultValue: '', description: 'Additional options (key=value linefeed delimited)', name: 'ADDITIONAL_OPTS'],


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @jupierce @adammhaile 

done with

```
$ sed -i 's/aos-devel/aos-cicd/g' $( find ./jobs/ -name Jenkinsfile )
```