### PR TITLE
Revert "cri-o: force image from docker.io for now"

### DIFF
--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_crio.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_crio.yml
@@ -99,7 +99,6 @@ extensions:
                          --inventory sjb/inventory/ \
                          -e deployment_type=origin  \
                          -e openshift_use_crio=True   \
-                         -e openshift_crio_systemcontainer_image_registry_override=docker.io/gscrivano \
                          -e etcd_data_dir="${ETCD_DATA_DIR}" \
                          -e openshift_master_default_subdomain="${local_ip}.nip.io"             \
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \

--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_crio.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_crio.yml
@@ -99,6 +99,7 @@ extensions:
                          --inventory sjb/inventory/ \
                          -e deployment_type=origin  \
                          -e openshift_use_crio=True   \
+                         -e openshift_crio_systemcontainer_image_override=docker.io/gscrivano/cri-o-centos \
                          -e etcd_data_dir="${ETCD_DATA_DIR}" \
                          -e openshift_master_default_subdomain="${local_ip}.nip.io"             \
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \

--- a/sjb/generated/test_branch_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_crio.xml
@@ -403,6 +403,7 @@ ansible-playbook -vv --become               \
                  --inventory sjb/inventory/ \
                  -e deployment_type=origin  \
                  -e openshift_use_crio=True   \
+                 -e openshift_crio_systemcontainer_image_override=docker.io/gscrivano/cri-o-centos \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \

--- a/sjb/generated/test_branch_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_crio.xml
@@ -403,7 +403,6 @@ ansible-playbook -vv --become               \
                  --inventory sjb/inventory/ \
                  -e deployment_type=origin  \
                  -e openshift_use_crio=True   \
-                 -e openshift_crio_systemcontainer_image_registry_override=docker.io/gscrivano \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \

--- a/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
@@ -461,7 +461,6 @@ ansible-playbook -vv --become               \
                  --inventory sjb/inventory/ \
                  -e deployment_type=origin  \
                  -e openshift_use_crio=True   \
-                 -e openshift_crio_systemcontainer_image_registry_override=docker.io/gscrivano \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \

--- a/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
@@ -461,6 +461,7 @@ ansible-playbook -vv --become               \
                  --inventory sjb/inventory/ \
                  -e deployment_type=origin  \
                  -e openshift_use_crio=True   \
+                 -e openshift_crio_systemcontainer_image_override=docker.io/gscrivano/cri-o-centos \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \


### PR DESCRIPTION
We have an official build now.

Closes: https://github.com/openshift/aos-cd-jobs/issues/627

This reverts commit 5f61ec496b6691d16b75e48d4215ef9c3f16a219.