### PR TITLE
force logging off for origin install

### DIFF
--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
@@ -102,6 +102,7 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
+                         -e openshift_logging_install_logging=False \
                          -e deployment_type=origin  \
                          -e etcd_data_dir="${ETCD_DATA_DIR}" \
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
@@ -133,6 +134,7 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e deployment_type=origin  \
+                         -e openshift_logging_install_logging=True \
                          -e openshift_logging_image_prefix="openshift/origin-" \
                          -e openshift_hosted_logging_hostname="kibana.127.0.0.1.nip.io"           \
                          -e openshift_logging_master_public_url="https://localhost:8443"          \

--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file.yml
@@ -99,6 +99,7 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e deployment_type=origin  \
+                         -e openshift_logging_install_logging=False \
                          -e openshift_docker_log_driver=json-file \
                          -e openshift_docker_options="--log-driver=json-file" \
                          -e etcd_data_dir="${ETCD_DATA_DIR}" \
@@ -131,6 +132,7 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e deployment_type=origin  \
+                         -e openshift_logging_install_logging=True \
                          -e openshift_logging_image_prefix="openshift/origin-" \
                          -e openshift_hosted_logging_hostname="kibana.127.0.0.1.nip.io"           \
                          -e openshift_logging_master_public_url="https://localhost:8443"          \

--- a/sjb/generated/test_branch_openshift_ansible_logging.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging.xml
@@ -327,6 +327,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
+                 -e openshift_logging_install_logging=False \
                  -e deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
@@ -385,6 +386,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e deployment_type=origin  \
+                 -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
                  -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
@@ -324,6 +324,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e deployment_type=origin  \
+                 -e openshift_logging_install_logging=False \
                  -e openshift_docker_log_driver=json-file \
                  -e openshift_docker_options=&#34;--log-driver=json-file&#34; \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
@@ -383,6 +384,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e deployment_type=origin  \
+                 -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
                  -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \

--- a/sjb/generated/test_pull_request_openshift_ansible_logging.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging.xml
@@ -385,6 +385,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
+                 -e openshift_logging_install_logging=False \
                  -e deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
@@ -443,6 +444,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e deployment_type=origin  \
+                 -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
                  -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
@@ -385,6 +385,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
+                 -e openshift_logging_install_logging=False \
                  -e deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
@@ -443,6 +444,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e deployment_type=origin  \
+                 -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
                  -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
@@ -382,6 +382,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e deployment_type=origin  \
+                 -e openshift_logging_install_logging=False \
                  -e openshift_docker_log_driver=json-file \
                  -e openshift_docker_options=&#34;--log-driver=json-file&#34; \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
@@ -441,6 +442,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e deployment_type=origin  \
+                 -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
                  -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \


### PR DESCRIPTION
This goes with https://github.com/openshift/openshift-ansible/pull/5511
When this PR merges, we will need to explicitly set
`openshift_logging_install_logging=True` when installing logging - it
will not use the default in the role anymore.
This also works around the problem in the PR by forcing the origin
install to **not** install logging.