### PR TITLE
Improve stg->prod promotion pipeline

### DIFF
--- a/build-scripts/rcm-guest/mirrors-stage-to-prod.sh
+++ b/build-scripts/rcm-guest/mirrors-stage-to-prod.sh
@@ -2,18 +2,63 @@
 #
 # Copy the latest stage, to latest prod, on the mirrors
 #
-############
-# VARIABLES
-############
-MYUID="$(id -u)"
-if [ "${MYUID}" == "55003" ] ; then
+
+set -eu
+
+# Settings
+BASE_PATH="/srv/enterprise"
+MIRROR_SSH_SERVER="use-mirror-upload.ops.rhcloud.com"
+SSH_OPTIONS="-o StrictHostKeychecking=no"
+
+usage() {
+  echo
+  echo "Usage `basename $0` <repo>"
+  echo
+  echo "repo: the path component of the content to sync within ${BASE_PATH}"
+  echo "  e.g. 'online', 'online-openshift-scripts'"
+  echo
+  exit 1
+}
+
+# Make sure the repo is provided
+if [ "$#" -lt 2 ] ; then
+  usage
+fi
+
+# Path setup for repo
+REPO="${1}"
+STG_PATH="${BASE_PATH}/${REPO}-stg"
+PROD_PATH="${BASE_PATH}/${REPO}-prod"
+
+# sanity check the repo name: just checking repo-stg, assuming that repo-prod
+# would exist if repo-stg does
+if [ ! -d ${STG_PATH] ]; then
+    echo "ERROR: the provided repo (${REPO}) stage path (${STG_PATH}) does not exist." >&2
+    exit 1
+fi
+
+# SSH client cmdline setup
+if [ "$(whoami)" == "ocp-build" ]; then
   BOT_USER="-l jenkins_aos_cd_bot"
 else
   BOT_USER=""
 fi
+MIRROR_SSH="ssh ${BOT_USER} ${SSH_OPTIONS} ${MIRROR_SSH_SERVER}"
 
-ssh ${BOT_USER} -o StrictHostKeychecking=no use-mirror-upload.ops.rhcloud.com 'LASTDIR=$(readlink /srv/enterprise/online-stg/latest) ; echo ${LASTDIR} ; cd /srv/enterprise/online-prod/ ;  if [ -d ${LASTDIR} ] ; then echo Already Done; else cp -r --link ../online-stg/${LASTDIR} ${LASTDIR} ; rm -f latest ; ln -s ${LASTDIR} latest ; fi'
-ssh ${BOT_USER} -o StrictHostKeychecking=no use-mirror-upload.ops.rhcloud.com /usr/local/bin/push.enterprise.sh -v
+############
+# Push
+############
 
-ssh ${BOT_USER} -o StrictHostKeychecking=no use-mirror-upload.ops.rhcloud.com 'LASTDIR=$(date +%Y-%m-%d) ; echo ${LASTDIR} ; cd /srv/libra/online-prod/ ;  if [ -d ${LASTDIR} ] ; then echo Already Done; else mkdir -p ${LASTDIR}/x86_64/ ; cp -r --link ../rhel-7-libra-stage/x86_64/ ${LASTDIR}/x86_64/os ; rm -f latest ; ln -s ${LASTDIR} latest ; fi'
-ssh ${BOT_USER} -o StrictHostKeychecking=no use-mirror-upload.ops.rhcloud.com /usr/local/bin/push.libra.sh online-prod -v
+$MIRROR_SSH sh -s <<EOF
+  LASTDIR=$(readlink ${STG_PATH}/latest)
+  echo "latest in stg points to: ${LASTDIR}"
+  cd ${PROD_PATH}
+  if [ -d ${LASTDIR} ] ; then
+     echo "${LASTDIR} already exists in prod, nothing to do"
+  else
+     cp -r --link ${STG_PATH}/${LASTDIR} ${LASTDIR}
+     rm -f latest
+     ln -s ${LASTDIR} latest
+     /usr/local/bin/push.enterprise.sh -v
+  fi
+EOF

--- a/jobs/sprint/stage-to-prod/Jenkinsfile
+++ b/jobs/sprint/stage-to-prod/Jenkinsfile
@@ -1,73 +1,118 @@
 #!/usr/bin/env groovy
 
-// https://issues.jenkins-ci.org/browse/JENKINS-33511
-def set_workspace() {
-    if(env.WORKSPACE == null) {
-        env.WORKSPACE = pwd()
-    }
-}
+final MAIL_FROM = 'aos-cd@redhat.com'
+final REPLY_TO = 'smunilla@redhat.com'
 
-def version(f) {
-    def matcher = readFile(f) =~ /Version:\s+([.0-9]+)/
-    matcher ? matcher[0][1] : null
-}
+final repos = [
+    //  repo-name: repo-path within /srv/enterprise
+    OCP:           'online',
+    OnlineScripts: 'online-openshift-scripts'
+]
+
+properties([
+        [ $class : 'ParametersDefinitionProperty',
+            parameterDefinitions: [
+                [
+                    name: 'CONTENT',
+                    $class: 'hudson.model.ChoiceParameterDefinition',
+                    choices: repos.keySet().join('\n'),
+                    defaultValue: 'OCP',
+                    description: 'Select the content to promote'
+                ],
+                [
+                    name: 'MODE',
+                    $class: 'hudson.model.ChoiceParameterDefinition',
+                    choices: ['interactive', 'automatic', 'quiet'].join('\n'),
+                    defaultValue: 'interactive',
+                    description: 'Select automatic to prevent confirmation prompt. Select quiet to prevent notification emails (implies automatic).'
+                ],
+                [
+                    name: 'MAIL_LIST_SUCCESS',
+                    $class: 'hudson.model.StringParameterDefinition',
+                    defaultValue: 'jupierce@redhat.com,smunilla@redhat.com',
+                    description: 'Success Mailing List'
+                ],
+                [
+                    name: 'MAIL_LIST_FAILURE',
+                    $class: 'hudson.model.StringParameterDefinition',
+                    defaultValue: 'jupierce@redhat.com,smunilla@redhat.com',
+                    description: 'Failure Mailing List'
+                ],
+                [
+                    name: 'MOCK',
+                    $class: 'hudson.model.BooleanParameterDefinition',
+                    defaultValue: false,
+                    description: 'Mock run to pickup new Jenkins parameters?',
+                ],
+                [
+                    name: 'TARGET_NODE',
+                    description: 'Jenkins agent node',
+                    $class: 'hudson.model.StringParameterDefinition',
+                    defaultValue: 'openshift-build-1'
+                ],
+            ]
+        ]
+    ]
+)
 
 def mail_success() {
-    mail(
-        to: "${MAIL_LIST_SUCCESS}",
-        from: "aos-cd@redhat.com",
-        replyTo: 'smunilla@redhat.com',
-        subject: "Stage has been synced to prod",
-        body: """\
+    if ( MODE != 'quiet' ) {
+        mail(
+            to: "${MAIL_LIST_SUCCESS}",
+            from: MAIL_FROM,
+            replyTo: REPLY_TO,
+            subject: "Stage has been synced to prod",
+            body: """
 For details see the jenkins job.
 Jenkins job: ${env.BUILD_URL}
 """);
+    }
 }
 
-node('openshift-build-1') {
-
-    // Expose properties for a parameterized build
-    properties(
-            [[$class              : 'ParametersDefinitionProperty',
-              parameterDefinitions:
-                      [
-                               [$class: 'hudson.model.BooleanParameterDefinition', defaultValue: false, description: 'Really sync Stage to Prod?', name: 'CONFIRM_STAGE_TO_PROD'],
-
-                              [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'jupierce@redhat.com,smunilla@redhat.com', description: 'Success Mailing List', name: 'MAIL_LIST_SUCCESS'],
-                              [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'jupierce@redhat.com,smunilla@redhat.com', description: 'Failure Mailing List', name: 'MAIL_LIST_FAILURE'],
-                      ]
-             ]]
-    )
-    
-    // Force Jenkins to fail early if this is the first time this job has been run/and or new parameters have not been discovered.
-    echo "Confirm:${CONFIRM_STAGE_TO_PROD}, MAIL_LIST_SUCCESS:[${MAIL_LIST_SUCCESS}], MAIL_LIST_FAILURE:[${MAIL_LIST_FAILURE}]"
-
-    set_workspace()
-    stage('Stage to Prod') {
-        try {
-           
-           if(CONFIRM_STAGE_TO_PROD == "true") {
-               sshagent(['openshift-bot']) { // errata puddle must run with the permissions of openshift-bot to succeed
-                    sh "ssh ocp-build@rcm-guest.app.eng.bos.redhat.com /mnt/rcm-guest/puddles/RHAOS/scripts/mirrors-stage-to-prod.sh"
-                }
-
-                // Replace flow control with: https://jenkins.io/blog/2016/12/19/declarative-pipeline-beta/ when available
-                mail_success()
-            }
-
-        } catch ( err ) {
-            // Replace flow control with: https://jenkins.io/blog/2016/12/19/declarative-pipeline-beta/ when available
-            mail(to: "${MAIL_LIST_FAILURE}",
-                    from: "aos-cd@redhat.com",
-                    subject: "Error syncing stage to prod on mirrors",
-                    body: """Encoutered an error while syncing stage to prod on mirrors: ${err}
-
+def mail_failure = { err ->
+    if ( MODE != 'quiet' ) {
+        mail(
+            to: "${MAIL_LIST_FAILURE}",
+            from: MAIL_FROM,
+            replyTo: REPLY_TO,
+            subject: "Error syncing stage to prod on mirrors",
+            body: """Encoutered an error while syncing stage to prod on mirrors: ${err}
 
 Jenkins job: ${env.BUILD_URL}
 """);
-            // Re-throw the error in order to fail the job
-            throw err
+    }
+}
+
+def try_wrapper(failure_func, f) {
+    try {
+        f.call()
+    } catch (err) {
+        failure_func(err)
+        // Re-throw the error in order to fail the job
+        throw err
+    }
+}
+
+node(TARGET_NODE) {
+
+    checkout scm
+    def buildlib = load( "pipeline-scripts/buildlib.groovy" )
+
+    try_wrapper(mail_failure) {
+
+        stage('Confirm') {
+            repo = repos[CONTENT]
+            echo "Latest ${CONTENT} will be promoted from stage (${repo}-stg) to production (${repo}-prod)."
+            if ( MODE != "automatic" ) {
+                input "Do you want to proceed?"
+            }
         }
 
+        stage('Stage to Prod') {
+            sshagent(['openshift-bot']) { // errata puddle must run with the permissions of openshift-bot to succeed
+                buildlib.invoke_on_rcm_guest('mirrors-stage-to-prod.sh', repo)
+            }
+            mail_success()
+        }
     }
 }


### PR DESCRIPTION
This is for [the corresponding trello card](https://trello.com/c/mo3Vr0TF/341-2-buildauto-improve-stg-prod-promotion-pipeline-add-online):

- Tidy up the `mirrors-stage-to-prod.sh` script, remove the push of `/srv/libra/*`, and add an option to specify the repo to push (i.e. which dir under `/srv/enterprise`).
- Use buildlib in `Jenkinsfile` to stream de script to rcm-guest
- Enable promotion of online-openshift-scripts as well as OCP
- Request confirmation before proeceeding

@jupierce PTAL.