### PR TITLE
Remove use of OS_BUILD_ENV_TMP_VOLUME

### DIFF
--- a/sjb/config/test_cases/test_branch_origin_cmd.yml
+++ b/sjb/config/test_cases/test_branch_origin_cmd.yml
@@ -8,4 +8,4 @@ extensions:
       title: "run test-cmd"
       repository: "origin"
       script: |-
-        OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/scripts OS_BUILD_ENV_TMP_VOLUME='/tmp' hack/env JUNIT_REPORT='true' make test-cmd -k
+        OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/scripts hack/env JUNIT_REPORT='true' make test-cmd -k

--- a/sjb/config/test_cases/test_branch_origin_integration.yml
+++ b/sjb/config/test_cases/test_branch_origin_integration.yml
@@ -9,4 +9,4 @@ extensions:
       repository: "origin"
       timeout: 7200
       script: |-
-        OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_TMP_VOLUME='/tmp' hack/env JUNIT_REPORT='true' make test-tools test-integration
+        OS_BUILD_ENV_PULL_IMAGE=true hack/env JUNIT_REPORT='true' make test-tools test-integration

--- a/sjb/generated/test_branch_origin_cmd.xml
+++ b/sjb/generated/test_branch_origin_cmd.xml
@@ -255,7 +255,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/scripts OS_BUILD_ENV_TMP_VOLUME=&#39;/tmp&#39; hack/env JUNIT_REPORT=&#39;true&#39; make test-cmd -k
+OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/scripts hack/env JUNIT_REPORT=&#39;true&#39; make test-cmd -k
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_integration.xml
+++ b/sjb/generated/test_branch_origin_integration.xml
@@ -255,7 +255,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_TMP_VOLUME=&#39;/tmp&#39; hack/env JUNIT_REPORT=&#39;true&#39; make test-tools test-integration
+OS_BUILD_ENV_PULL_IMAGE=true hack/env JUNIT_REPORT=&#39;true&#39; make test-tools test-integration
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_cmd.xml
+++ b/sjb/generated/test_pull_request_origin_cmd.xml
@@ -313,7 +313,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/scripts OS_BUILD_ENV_TMP_VOLUME=&#39;/tmp&#39; hack/env JUNIT_REPORT=&#39;true&#39; make test-cmd -k
+OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/scripts hack/env JUNIT_REPORT=&#39;true&#39; make test-cmd -k
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_integration.xml
+++ b/sjb/generated/test_pull_request_origin_integration.xml
@@ -313,7 +313,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_TMP_VOLUME=&#39;/tmp&#39; hack/env JUNIT_REPORT=&#39;true&#39; make test-tools test-integration
+OS_BUILD_ENV_PULL_IMAGE=true hack/env JUNIT_REPORT=&#39;true&#39; make test-tools test-integration
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;


### PR DESCRIPTION
https://github.com/openshift/origin/pull/16686 removes the tmp volume from hack/env, this PR removes references to the no longer used OS_BUILD_ENV_TMP_VOLUME variable.