### PR TITLE
Add flag to assume yes when installing chrome

### DIFF
--- a/sjb/config/test_cases/test_branch_origin_web_console.yml
+++ b/sjb/config/test_cases/test_branch_origin_web_console.yml
@@ -11,7 +11,7 @@ extensions:
       script: |-
         sudo yum --disablerepo=\* --enablerepo=origin-local-release,oso-rhui-rhel-server-releases install -y origin-clients
         wget https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm
-        sudo yum install ./google-chrome-stable_current_*.rpm
+        sudo yum install ./google-chrome-stable_current_*.rpm -y
         oc cluster up --version=latest --public-hostname=localhost --loglevel=5 --server-loglevel=5
     - type: "script"
       title: "run web console tests"


### PR DESCRIPTION
Follow to #706, adding the `-y` flag to install chrome.

Tested the command in a local VM first.

@stevekuznetsov @spadgett 
