### PR TITLE
Fix nargs check on mirrors script: it only has 1 arg

### DIFF
--- a/build-scripts/rcm-guest/mirrors-stage-to-prod.sh
+++ b/build-scripts/rcm-guest/mirrors-stage-to-prod.sh
@@ -21,12 +21,12 @@ usage() {
 }
 
 # Make sure the repo is provided
-if [ "$#" -lt 2 ] ; then
+if [ "$#" -lt 1 ] ; then
   usage
 fi
+REPO="${1}"
 
 # Path setup for repo
-REPO="${1}"
 STG_PATH="${BASE_PATH}/${REPO}-stg"
 PROD_PATH="${BASE_PATH}/${REPO}-prod"
 


### PR DESCRIPTION
Somehow the check was looking for 2 args instead of the only 1 required...