### PR TITLE
Remove path sanity check on rcm-guest

### DIFF
--- a/build-scripts/rcm-guest/mirrors-stage-to-prod.sh
+++ b/build-scripts/rcm-guest/mirrors-stage-to-prod.sh
@@ -30,13 +30,6 @@ REPO="${1}"
 STG_PATH="${BASE_PATH}/${REPO}-stg"
 PROD_PATH="${BASE_PATH}/${REPO}-prod"
 
-# sanity check the repo name: just checking repo-stg, assuming that repo-prod
-# would exist if repo-stg does
-if [ ! -d "${STG_PATH}" ]; then
-    echo "ERROR: the provided repo (${REPO}) stage path (${STG_PATH}) does not exist." >&2
-    exit 1
-fi
-
 # SSH client cmdline setup
 if [ "$(whoami)" == "ocp-build" ]; then
   BOT_USER="-l jenkins_aos_cd_bot"


### PR DESCRIPTION
The mirror script can't check for path existence on rcm-guest, as the target paths are on the mirrors. Removing the sanity check here... it shouldn't be much of a problem, specially when the script is invoked from the jenkins job, as the arguments are picked from a set list of valid choices...

@jupierce thanks for the patience merging fixes...