### PR TITLE
Use custom script to invoke registry extended test suite

### DIFF
--- a/sjb/config/test_cases/test_pull_request_origin_extended_image_registry.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_extended_image_registry.yml
@@ -10,5 +10,25 @@ extensions:
       title: "run extended tests"
       repository: "origin"
       script: |-
+        for pth in ${OS_ROOT:-} "$(pwd)" "$(dirname ${BASH_SOURCE})" "/data/src/github.com/openshift/origin"; do
+          if [[ -e "${pth}/hack/lib/init.sh" && -e "${pth}/test/extended/setup.sh" ]]; then
+            export OS_ROOT="${pth}"
+            break
+          fi
+        done
+
         OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/extended.test hack/env make build-extended-test
-        OPENSHIFT_SKIP_BUILD='true' KUBECONFIG=/etc/origin/master/admin.kubeconfig TEST_ONLY=true JUNIT_REPORT='true' make test-extended SUITE=core FOCUS="\[Feature:Image|\[registry\]"
+
+        export OPENSHIFT_SKIP_BUILD=true
+        export KUBECONFIG=/etc/origin/master/admin.kubeconfig
+        export TEST_ONLY=true
+        export JUNIT_REPORT=true
+
+        source "${OS_ROOT}/hack/lib/init.sh"
+        source "${OS_ROOT}/test/extended/setup.sh"
+
+        export TEST_REPORT_FILE_NAME=registry_suite
+        export FOCUS="\[Feature:Image|\[registry\]"
+
+        os::log::info "Running registry extended tests serially"
+        os::test::extended::run -- -test.timeout 6h ${TEST_EXTENDED_ARGS:-}

--- a/sjb/generate.sh
+++ b/sjb/generate.sh
@@ -4,12 +4,17 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+bin="python"
+if which python2 >/dev/null 2>&1; then
+    bin="python2"
+fi
+
 pushd sjb >/dev/null
 for spec in config/test_cases/*.yml; do
-	python -m generate "${spec}" "test"
+	"${bin}" -m generate "${spec}" "test"
 done
 
 for spec in config/test_suites/*.yml; do
-	python -m generate "${spec}" "suite"
+	"${bin}" -m generate "${spec}" "suite"
 done
 popd >/dev/null

--- a/sjb/generated/test_pull_request_origin_extended_image_registry.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_registry.xml
@@ -395,8 +395,28 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
+for pth in \${OS_ROOT:-} &#34;\$(pwd)&#34; &#34;\$(dirname \${BASH_SOURCE})&#34; &#34;/data/src/github.com/openshift/origin&#34;; do
+  if [[ -e &#34;\${pth}/hack/lib/init.sh&#34; &amp;&amp; -e &#34;\${pth}/test/extended/setup.sh&#34; ]]; then
+    export OS_ROOT=&#34;\${pth}&#34;
+    break
+  fi
+done
+
 OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/extended.test hack/env make build-extended-test
-OPENSHIFT_SKIP_BUILD=&#39;true&#39; KUBECONFIG=/etc/origin/master/admin.kubeconfig TEST_ONLY=true JUNIT_REPORT=&#39;true&#39; make test-extended SUITE=core FOCUS=&#34;\[Feature:Image|\[registry\]&#34;
+
+export OPENSHIFT_SKIP_BUILD=true
+export KUBECONFIG=/etc/origin/master/admin.kubeconfig
+export TEST_ONLY=true
+export JUNIT_REPORT=true
+
+source &#34;\${OS_ROOT}/hack/lib/init.sh&#34;
+source &#34;\${OS_ROOT}/test/extended/setup.sh&#34;
+
+export TEST_REPORT_FILE_NAME=registry_suite
+export FOCUS=&#34;\[Feature:Image|\[registry\]&#34;
+
+os::log::info &#34;Running registry extended tests serially&#34;
+os::test::extended::run -- -test.timeout 6h \${TEST_EXTENDED_ARGS:-}
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;


### PR DESCRIPTION
The `test/extended/core.sh` script does not allow to properly focus only the desired tests to run.

This script contains the necessary bits from the `core.sh` scripts to setup the environment and run just the registry tests.

Once openshift/origin#16846 merges, the registry tests won't be runnable using the extended test scripts because most of them are run serially.