### PR TITLE
Consolidate console reports under /test/reports

### DIFF
--- a/sjb/config/test_cases/test_branch_origin_web_console.yml
+++ b/sjb/config/test_cases/test_branch_origin_web_console.yml
@@ -30,3 +30,4 @@ extensions:
     - "/data/src/github.com/openshift/origin-web-console/test/tmp/screenshots/"
     - "/data/src/github.com/openshift/origin-web-console/test/coverage/"
     - "/data/src/github.com/openshift/origin-web-console/test/junit/"
+    - "/data/src/github.com/openshift/origin-web-console/test/reports/"


### PR DESCRIPTION
I want to consolidate all of our reports under `test/reports`, that way we can easily add/remove/change these w/o having to update the `aos-cd-jobs` repo.

Currently we have no tests sending output to `test/reports` aside from this [WIP](https://github.com/openshift/origin-web-console/pull/2277), but I intend to update this in future PRs.

@stevekuznetsov 