### PR TITLE
GCP PR artifact pruning is deleting existing objects, disable for now

### DIFF
--- a/sjb/config/common/test_cases/origin_release_install_gce.yml
+++ b/sjb/config/common/test_cases/origin_release_install_gce.yml
@@ -80,10 +80,10 @@ extensions:
         # pull_id will be 0 in case of a batch merge
         if [[ -n "${pull_id:-}" && "${pull_id:-}" != "0" ]]; then
           # if we've built this PR before, remove older rpm artifact directories
-          out="$( gsutil ls -d "gs://origin-ci-test/pr-logs/pull/${pull_id}/${JOB_NAME}/*/artifacts/rpms" | sort -n -t / -k 7 | head -n -2 )"
-          if [[ -n "${out}" ]]; then
-            echo "${out}" | xargs -L 1 gsutil rm -rf
-          fi
+          # out="$( gsutil ls -d "gs://origin-ci-test/pr-logs/pull/${pull_id}/${JOB_NAME}/*/artifacts/rpms" | sort -n -t / -k 7 | head -n -2 )"
+          # if [[ -n "${out}" ]]; then
+          #   echo "${out}" | xargs -L 1 gsutil rm -rf
+          # fi
         else
           # update the pointer to this location
           echo "${base_location_url}" > .latest

--- a/sjb/config/test_cases/test_pull_request_origin_launch_gce.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_launch_gce.yml
@@ -60,10 +60,10 @@ extensions:
         # pull_id will be 0 in case of a batch merge
         if [[ -n "${pull_id:-}" && "${pull_id:-}" != "0" ]]; then
           # if we've built this PR before, remove older rpm artifact directories
-          out="$( gsutil ls -d "gs://origin-ci-test/pr-logs/pull/${pull_id}/${JOB_NAME}/*/artifacts/rpms" | sort -n -t / -k 7 | head -n -2 )"
-          if [[ -n "${out}" ]]; then
-            echo "${out}" | xargs -L 1 gsutil rm -rf
-          fi
+          # out="$( gsutil ls -d "gs://origin-ci-test/pr-logs/pull/${pull_id}/${JOB_NAME}/*/artifacts/rpms" | sort -n -t / -k 7 | head -n -2 )"
+          # if [[ -n "${out}" ]]; then
+          #   echo "${out}" | xargs -L 1 gsutil rm -rf
+          # fi
         else
           # update the pointer to this location
           echo "${base_location_url}" > .latest

--- a/sjb/generated/test_branch_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce.xml
@@ -377,10 +377,10 @@ gsutil -m cp -r artifacts/rpms &#34;gs://${location}&#34;
 # pull_id will be 0 in case of a batch merge
 if [[ -n &#34;${pull_id:-}&#34; &amp;&amp; &#34;${pull_id:-}&#34; != &#34;0&#34; ]]; then
   # if we&#39;ve built this PR before, remove older rpm artifact directories
-  out=&#34;$( gsutil ls -d &#34;gs://origin-ci-test/pr-logs/pull/${pull_id}/${JOB_NAME}/*/artifacts/rpms&#34; | sort -n -t / -k 7 | head -n -2 )&#34;
-  if [[ -n &#34;${out}&#34; ]]; then
-    echo &#34;${out}&#34; | xargs -L 1 gsutil rm -rf
-  fi
+  # out=&#34;$( gsutil ls -d &#34;gs://origin-ci-test/pr-logs/pull/${pull_id}/${JOB_NAME}/*/artifacts/rpms&#34; | sort -n -t / -k 7 | head -n -2 )&#34;
+  # if [[ -n &#34;${out}&#34; ]]; then
+  #   echo &#34;${out}&#34; | xargs -L 1 gsutil rm -rf
+  # fi
 else
   # update the pointer to this location
   echo &#34;${base_location_url}&#34; &gt; .latest

--- a/sjb/generated/test_branch_origin_extended_conformance_k8s.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_k8s.xml
@@ -377,10 +377,10 @@ gsutil -m cp -r artifacts/rpms &#34;gs://${location}&#34;
 # pull_id will be 0 in case of a batch merge
 if [[ -n &#34;${pull_id:-}&#34; &amp;&amp; &#34;${pull_id:-}&#34; != &#34;0&#34; ]]; then
   # if we&#39;ve built this PR before, remove older rpm artifact directories
-  out=&#34;$( gsutil ls -d &#34;gs://origin-ci-test/pr-logs/pull/${pull_id}/${JOB_NAME}/*/artifacts/rpms&#34; | sort -n -t / -k 7 | head -n -2 )&#34;
-  if [[ -n &#34;${out}&#34; ]]; then
-    echo &#34;${out}&#34; | xargs -L 1 gsutil rm -rf
-  fi
+  # out=&#34;$( gsutil ls -d &#34;gs://origin-ci-test/pr-logs/pull/${pull_id}/${JOB_NAME}/*/artifacts/rpms&#34; | sort -n -t / -k 7 | head -n -2 )&#34;
+  # if [[ -n &#34;${out}&#34; ]]; then
+  #   echo &#34;${out}&#34; | xargs -L 1 gsutil rm -rf
+  # fi
 else
   # update the pointer to this location
   echo &#34;${base_location_url}&#34; &gt; .latest

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
@@ -435,10 +435,10 @@ gsutil -m cp -r artifacts/rpms &#34;gs://${location}&#34;
 # pull_id will be 0 in case of a batch merge
 if [[ -n &#34;${pull_id:-}&#34; &amp;&amp; &#34;${pull_id:-}&#34; != &#34;0&#34; ]]; then
   # if we&#39;ve built this PR before, remove older rpm artifact directories
-  out=&#34;$( gsutil ls -d &#34;gs://origin-ci-test/pr-logs/pull/${pull_id}/${JOB_NAME}/*/artifacts/rpms&#34; | sort -n -t / -k 7 | head -n -2 )&#34;
-  if [[ -n &#34;${out}&#34; ]]; then
-    echo &#34;${out}&#34; | xargs -L 1 gsutil rm -rf
-  fi
+  # out=&#34;$( gsutil ls -d &#34;gs://origin-ci-test/pr-logs/pull/${pull_id}/${JOB_NAME}/*/artifacts/rpms&#34; | sort -n -t / -k 7 | head -n -2 )&#34;
+  # if [[ -n &#34;${out}&#34; ]]; then
+  #   echo &#34;${out}&#34; | xargs -L 1 gsutil rm -rf
+  # fi
 else
   # update the pointer to this location
   echo &#34;${base_location_url}&#34; &gt; .latest

--- a/sjb/generated/test_pull_request_origin_extended_conformance_k8s.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_k8s.xml
@@ -440,10 +440,10 @@ gsutil -m cp -r artifacts/rpms &#34;gs://${location}&#34;
 # pull_id will be 0 in case of a batch merge
 if [[ -n &#34;${pull_id:-}&#34; &amp;&amp; &#34;${pull_id:-}&#34; != &#34;0&#34; ]]; then
   # if we&#39;ve built this PR before, remove older rpm artifact directories
-  out=&#34;$( gsutil ls -d &#34;gs://origin-ci-test/pr-logs/pull/${pull_id}/${JOB_NAME}/*/artifacts/rpms&#34; | sort -n -t / -k 7 | head -n -2 )&#34;
-  if [[ -n &#34;${out}&#34; ]]; then
-    echo &#34;${out}&#34; | xargs -L 1 gsutil rm -rf
-  fi
+  # out=&#34;$( gsutil ls -d &#34;gs://origin-ci-test/pr-logs/pull/${pull_id}/${JOB_NAME}/*/artifacts/rpms&#34; | sort -n -t / -k 7 | head -n -2 )&#34;
+  # if [[ -n &#34;${out}&#34; ]]; then
+  #   echo &#34;${out}&#34; | xargs -L 1 gsutil rm -rf
+  # fi
 else
   # update the pointer to this location
   echo &#34;${base_location_url}&#34; &gt; .latest

--- a/sjb/generated/test_pull_request_origin_launch_gce.xml
+++ b/sjb/generated/test_pull_request_origin_launch_gce.xml
@@ -348,10 +348,10 @@ gsutil -m cp -r artifacts/rpms &#34;gs://${location}&#34;
 # pull_id will be 0 in case of a batch merge
 if [[ -n &#34;${pull_id:-}&#34; &amp;&amp; &#34;${pull_id:-}&#34; != &#34;0&#34; ]]; then
   # if we&#39;ve built this PR before, remove older rpm artifact directories
-  out=&#34;$( gsutil ls -d &#34;gs://origin-ci-test/pr-logs/pull/${pull_id}/${JOB_NAME}/*/artifacts/rpms&#34; | sort -n -t / -k 7 | head -n -2 )&#34;
-  if [[ -n &#34;${out}&#34; ]]; then
-    echo &#34;${out}&#34; | xargs -L 1 gsutil rm -rf
-  fi
+  # out=&#34;$( gsutil ls -d &#34;gs://origin-ci-test/pr-logs/pull/${pull_id}/${JOB_NAME}/*/artifacts/rpms&#34; | sort -n -t / -k 7 | head -n -2 )&#34;
+  # if [[ -n &#34;${out}&#34; ]]; then
+  #   echo &#34;${out}&#34; | xargs -L 1 gsutil rm -rf
+  # fi
 else
   # update the pointer to this location
   echo &#34;${base_location_url}&#34; &gt; .latest


### PR DESCRIPTION
Disable previous build pruning until we can determine why it started
failing.