### PR TITLE
Decrease master and node log level for logging tests

### DIFF
--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
@@ -106,6 +106,7 @@ extensions:
                          --inventory sjb/inventory/ \
                          -e openshift_logging_install_logging=False \
                          -e deployment_type=origin  \
+                         -e debug_level=2           \
                          -e etcd_data_dir="${ETCD_DATA_DIR}" \
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
@@ -136,6 +137,7 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e deployment_type=origin  \
+                         -e debug_level=2           \
                          -e openshift_logging_install_logging=True \
                          -e openshift_logging_image_prefix="openshift/origin-" \
                          -e openshift_hosted_logging_hostname="kibana.127.0.0.1.nip.io"           \

--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file.yml
@@ -99,6 +99,7 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e deployment_type=origin  \
+                         -e debug_level=2           \
                          -e openshift_logging_install_logging=False \
                          -e openshift_docker_log_driver=json-file \
                          -e openshift_docker_options="--log-driver=json-file" \
@@ -133,6 +134,7 @@ extensions:
                          --inventory sjb/inventory/ \
                          -e deployment_type=origin  \
                          -e openshift_logging_install_logging=True \
+                         -e debug_level=2           \
                          -e openshift_logging_image_prefix="openshift/origin-" \
                          -e openshift_hosted_logging_hostname="kibana.127.0.0.1.nip.io"           \
                          -e openshift_logging_master_public_url="https://localhost:8443"          \

--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
@@ -95,6 +95,7 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e deployment_type=origin  \
+                         -e debug_level=2           \
                          /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
         ansible-playbook -vv --become               \
                          --become-user root         \
@@ -132,6 +133,7 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e deployment_type=origin  \
+                         -e debug_level=2           \
                          -e openshift_logging_install_logging=True \
                          -e openshift_logging_image_prefix="openshift/origin-" \
                          -e openshift_hosted_logging_hostname="kibana.127.0.0.1.nip.io"           \

--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible_json_file.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible_json_file.yml
@@ -102,6 +102,7 @@ extensions:
                          --inventory sjb/inventory/ \
                          -e openshift_logging_install_logging=False \
                          -e deployment_type=origin  \
+                         -e debug_level=2           \
                          -e openshift_docker_log_driver=json-file \
                          -e openshift_docker_options="--log-driver=json-file" \
                          -e etcd_data_dir="${ETCD_DATA_DIR}" \
@@ -134,6 +135,7 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e deployment_type=origin  \
+                         -e debug_level=2           \
                          -e openshift_logging_install_logging=True \
                          -e openshift_logging_image_prefix="openshift/origin-" \
                          -e openshift_hosted_logging_hostname="kibana.127.0.0.1.nip.io"           \

--- a/sjb/generated/test_branch_openshift_ansible_logging.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging.xml
@@ -429,6 +429,7 @@ ansible-playbook -vv --become               \
                  --inventory sjb/inventory/ \
                  -e openshift_logging_install_logging=False \
                  -e deployment_type=origin  \
+                 -e debug_level=2           \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
@@ -486,6 +487,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e deployment_type=origin  \
+                 -e debug_level=2           \
                  -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
@@ -422,6 +422,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e deployment_type=origin  \
+                 -e debug_level=2           \
                  -e openshift_logging_install_logging=False \
                  -e openshift_docker_log_driver=json-file \
                  -e openshift_docker_options=&#34;--log-driver=json-file&#34; \
@@ -483,6 +484,7 @@ ansible-playbook -vv --become               \
                  --inventory sjb/inventory/ \
                  -e deployment_type=origin  \
                  -e openshift_logging_install_logging=True \
+                 -e debug_level=2           \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
                  -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \

--- a/sjb/generated/test_pull_request_openshift_ansible_logging.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging.xml
@@ -487,6 +487,7 @@ ansible-playbook -vv --become               \
                  --inventory sjb/inventory/ \
                  -e openshift_logging_install_logging=False \
                  -e deployment_type=origin  \
+                 -e debug_level=2           \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
@@ -544,6 +545,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e deployment_type=origin  \
+                 -e debug_level=2           \
                  -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
@@ -475,6 +475,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e deployment_type=origin  \
+                 -e debug_level=2           \
                  /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/network_manager.yml
 ansible-playbook -vv --become               \
                  --become-user root         \
@@ -539,6 +540,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e deployment_type=origin  \
+                 -e debug_level=2           \
                  -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
@@ -482,6 +482,7 @@ ansible-playbook -vv --become               \
                  --inventory sjb/inventory/ \
                  -e openshift_logging_install_logging=False \
                  -e deployment_type=origin  \
+                 -e debug_level=2           \
                  -e openshift_docker_log_driver=json-file \
                  -e openshift_docker_options=&#34;--log-driver=json-file&#34; \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
@@ -541,6 +542,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e deployment_type=origin  \
+                 -e debug_level=2           \
                  -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \


### PR DESCRIPTION
The working theory is that debug_level of 5 is overwhelming the logging
stack in an already overloaded host