### PR TITLE
push-release should use PUSH_LOCAL

### DIFF
--- a/sjb/config/test_cases/push_origin_release.yml
+++ b/sjb/config/test_cases/push_origin_release.yml
@@ -22,5 +22,5 @@ extensions:
       repository: "origin"
       script: |-
         sudo chmod a+rw /tmp/.docker/config.json
-        DOCKER_CONFIG=/tmp/.docker OS_PUSH_BASE_REGISTRY="docker.io/" hack/push-release.sh
+        DOCKER_CONFIG=/tmp/.docker OS_PUSH_LOCAL=1 OS_PUSH_BASE_REGISTRY="docker.io/" hack/push-release.sh
         sudo rm -rf /tmp/.docker

--- a/sjb/generated/push_origin_release.xml
+++ b/sjb/generated/push_origin_release.xml
@@ -317,7 +317,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
 sudo chmod a+rw /tmp/.docker/config.json
-DOCKER_CONFIG=/tmp/.docker OS_PUSH_BASE_REGISTRY=&#34;docker.io/&#34; hack/push-release.sh
+DOCKER_CONFIG=/tmp/.docker OS_PUSH_LOCAL=1 OS_PUSH_BASE_REGISTRY=&#34;docker.io/&#34; hack/push-release.sh
 sudo rm -rf /tmp/.docker
 SCRIPT
 chmod +x &#34;${script}&#34;


### PR DESCRIPTION
Otherwise we could accidentally retag what's in the hub

@stevekuznetsov