### PR TITLE
moving popd so tito is in correct dir

### DIFF
--- a/jobs/build/ose/scripts/merge-and-build.sh
+++ b/jobs/build/ose/scripts/merge-and-build.sh
@@ -319,7 +319,6 @@ else
     fi
   fi
 fi
-popd
 
 echo
 echo "=========="
@@ -347,6 +346,7 @@ echo "TASK URL: https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=${TA
 echo
 echo -n "https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=${TASK_NUMBER}" > "${RESULTS}/openshift-ansible-brew.url"
 brew watch-task ${TASK_NUMBER}
+popd
 
 echo
 echo "=========="


### PR DESCRIPTION
@jupierce a pushd was added and it was popd' out of before tito ran, which had reverse what the cd openshift-ansible/ line did.