### PR TITLE
origin_aggregated_logging: set oauth proxy image for tests

### DIFF
--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
@@ -140,6 +140,7 @@ extensions:
                          -e debug_level=2           \
                          -e openshift_logging_install_logging=True \
                          -e openshift_logging_image_prefix="openshift/origin-" \
+                         -e openshift_logging_elasticsearch_proxy_image_prefix="docker.io/openshift/" \
                          -e openshift_hosted_logging_hostname="kibana.127.0.0.1.nip.io"           \
                          -e openshift_logging_master_public_url="https://localhost:8443"          \
                          -e openshift_master_logging_public_url="https://kibana.127.0.0.1.nip.io" \

--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file.yml
@@ -136,6 +136,7 @@ extensions:
                          -e openshift_logging_install_logging=True \
                          -e debug_level=2           \
                          -e openshift_logging_image_prefix="openshift/origin-" \
+                         -e openshift_logging_elasticsearch_proxy_image_prefix="docker.io/openshift/" \
                          -e openshift_hosted_logging_hostname="kibana.127.0.0.1.nip.io"           \
                          -e openshift_logging_master_public_url="https://localhost:8443"          \
                          -e openshift_master_logging_public_url="https://kibana.127.0.0.1.nip.io" \

--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
@@ -136,6 +136,7 @@ extensions:
                          -e debug_level=2           \
                          -e openshift_logging_install_logging=True \
                          -e openshift_logging_image_prefix="openshift/origin-" \
+                         -e openshift_logging_elasticsearch_proxy_image_prefix="docker.io/openshift/" \
                          -e openshift_hosted_logging_hostname="kibana.127.0.0.1.nip.io"           \
                          -e openshift_logging_master_public_url="https://localhost:8443"          \
                          -e openshift_master_logging_public_url="https://kibana.127.0.0.1.nip.io" \

--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible_json_file.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible_json_file.yml
@@ -138,6 +138,7 @@ extensions:
                          -e debug_level=2           \
                          -e openshift_logging_install_logging=True \
                          -e openshift_logging_image_prefix="openshift/origin-" \
+                         -e openshift_logging_elasticsearch_proxy_image_prefix="docker.io/openshift/" \
                          -e openshift_hosted_logging_hostname="kibana.127.0.0.1.nip.io"           \
                          -e openshift_logging_master_public_url="https://localhost:8443"          \
                          -e openshift_master_logging_public_url="https://kibana.127.0.0.1.nip.io" \

--- a/sjb/generated/test_branch_openshift_ansible_logging.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging.xml
@@ -490,6 +490,7 @@ ansible-playbook -vv --become               \
                  -e debug_level=2           \
                  -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
+                 -e openshift_logging_elasticsearch_proxy_image_prefix=&#34;docker.io/openshift/&#34; \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
                  -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \
                  -e openshift_master_logging_public_url=&#34;https://kibana.127.0.0.1.nip.io&#34; \

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
@@ -486,6 +486,7 @@ ansible-playbook -vv --become               \
                  -e openshift_logging_install_logging=True \
                  -e debug_level=2           \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
+                 -e openshift_logging_elasticsearch_proxy_image_prefix=&#34;docker.io/openshift/&#34; \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
                  -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \
                  -e openshift_master_logging_public_url=&#34;https://kibana.127.0.0.1.nip.io&#34; \

--- a/sjb/generated/test_pull_request_openshift_ansible_logging.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging.xml
@@ -548,6 +548,7 @@ ansible-playbook -vv --become               \
                  -e debug_level=2           \
                  -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
+                 -e openshift_logging_elasticsearch_proxy_image_prefix=&#34;docker.io/openshift/&#34; \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
                  -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \
                  -e openshift_master_logging_public_url=&#34;https://kibana.127.0.0.1.nip.io&#34; \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
@@ -543,6 +543,7 @@ ansible-playbook -vv --become               \
                  -e debug_level=2           \
                  -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
+                 -e openshift_logging_elasticsearch_proxy_image_prefix=&#34;docker.io/openshift/&#34; \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
                  -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \
                  -e openshift_master_logging_public_url=&#34;https://kibana.127.0.0.1.nip.io&#34; \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
@@ -545,6 +545,7 @@ ansible-playbook -vv --become               \
                  -e debug_level=2           \
                  -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
+                 -e openshift_logging_elasticsearch_proxy_image_prefix=&#34;docker.io/openshift/&#34; \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
                  -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \
                  -e openshift_master_logging_public_url=&#34;https://kibana.127.0.0.1.nip.io&#34; \


### PR DESCRIPTION
The oauth-proxy doesn't belong to origin aggregated logging project and does not get built during the `build_images.sh` phase of our tests.

It does not share image prefix with our other images, and therefore should be referenced fully. When setting `openshift_logging_image_prefix`, we should make sure the `openshift_logging_elasticsearch_proxy_image_prefix` also exists.

These should be upstream images working defaults:
```
docker.io/openshift/oauth-proxy:v1.0.0
docker.io/openshift/origin-logging-auth-proxy:latest
docker.io/openshift/origin-logging-curator:latest
docker.io/openshift/origin-logging-elasticsearch:latest
docker.io/openshift/origin-logging-fluentd:latest
docker.io/openshift/origin-logging-kibana:latest
```

when setting `openshift_logging_image_prefix=openshift/origin-`, it overwrites these defaults for all images and breaks the oauth-proxy
```
  openshift/origin-oauth-proxy:v1.0.0     <-- doesn't exist
( docker.io/openshift/oauth-proxy:v1.0.0  <-- exists )
```
and it requires setting `openshift_logging_elasticsearch_proxy_image_prefix=docker.io/openshift/`

This is not very elegant solution, it would be better if the upstream image prefixes were consistent just like our downstream prefixes are, but currently I don't see any other fix. We could also take oauth-proxy under logging team's wings and build it along the other logging images, but I was informed this is not desired.

https://hub.docker.com/r/openshift/oauth-proxy/