### PR TITLE
Adding logging_proxy_image_prefix and version to inventory file due t…

### DIFF
--- a/sjb/inventory/group_vars/OSEv3/logging.yml
+++ b/sjb/inventory/group_vars/OSEv3/logging.yml
@@ -30,3 +30,8 @@ openshift_logging_kibana_proxy_cpu_request: "100m"
 openshift_logging_kibana_proxy_memory_limit: "64Mi"
 openshift_logging_mux_cpu_request: "400m"
 openshift_logging_mux_memory_limit: "256Mi"
+
+# TODO: remove this once we have oauth-proxy images built that are in step
+#       with the logging images (version and prefix)
+openshift_logging_elasticsearch_proxy_image_prefix: "docker.io/openshift/"
+openshift_logging_elasticsearch_proxy_image_version: "v1.0.0"


### PR DESCRIPTION
…o lack of image named origin-oauth-proxy:latest

@richm @stevekuznetsov 
This will allow the logging test in https://github.com/openshift/openshift-ansible/pull/6037
to pass because it will point to an existing image.

It should not impact any other PRs as these values match the current defaults loaded from `roles/openshift_logging_elasticsearch/vars/default_images.yml`