### PR TITLE
cri-o: fix skopeo copy with images w/o tags

### DIFF
--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_crio.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_crio.yml
@@ -77,7 +77,7 @@ extensions:
       title: "copy openshift images from docker storage to CRI-O storage"
       timeout: 10800
       script: |-
-        for i in $(docker images --format '{{.Repository}}:{{.Tag}}' | grep "openshift\/origin"); do
+        for i in $(docker images --format '{{.Repository}}:{{.Tag}}' | grep -v "<none>" | grep -v "latest" | grep "openshift\/origin"); do
           sudo skopeo copy docker-daemon:$i containers-storage:\[overlay@/var/lib/containers/storage+/var/run/containers/storage:overlay.override_kernel_check=1\]$i
         done
     - type: "script"

--- a/sjb/generated/test_branch_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_crio.xml
@@ -416,7 +416,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
-for i in \$(docker images --format &#39;{{.Repository}}:{{.Tag}}&#39; | grep &#34;openshift\/origin&#34;); do
+for i in \$(docker images --format &#39;{{.Repository}}:{{.Tag}}&#39; | grep -v &#34;&lt;none&gt;&#34; | grep -v &#34;latest&#34; | grep &#34;openshift\/origin&#34;); do
   sudo skopeo copy docker-daemon:\$i containers-storage:\[overlay@/var/lib/containers/storage+/var/run/containers/storage:overlay.override_kernel_check=1\]\$i
 done
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
@@ -474,7 +474,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
-for i in \$(docker images --format &#39;{{.Repository}}:{{.Tag}}&#39; | grep &#34;openshift\/origin&#34;); do
+for i in \$(docker images --format &#39;{{.Repository}}:{{.Tag}}&#39; | grep -v &#34;&lt;none&gt;&#34; | grep -v &#34;latest&#34; | grep &#34;openshift\/origin&#34;); do
   sudo skopeo copy docker-daemon:\$i containers-storage:\[overlay@/var/lib/containers/storage+/var/run/containers/storage:overlay.override_kernel_check=1\]\$i
 done
 SCRIPT


### PR DESCRIPTION
Fix this failure we've been seeing the last few days https://ci.openshift.redhat.com/jenkins/job/test_branch_origin_extended_conformance_crio/142/consoleFull#83023225458b6e51eb7608a5981914356

Signed-off-by: Antonio Murdaca <runcom@redhat.com>