### PR TITLE
Moving oit_working into Jenkins workspace

### DIFF
--- a/jobs/build/ocp/Jenkinsfile
+++ b/jobs/build/ocp/Jenkinsfile
@@ -132,11 +132,11 @@ node(TARGET_NODE) {
     buildlib.initialize()
     echo "Initializing build: #${currentBuild.number} - ${BUILD_VERSION}.?? (${BUILD_MODE})"
 
-    OIT_WORKING = "${pwd(tmp:true)}/oit_working"
-    // create working if not exists
+    # oit_working must be in WORKSPACE in order to have artifacts archived
+    OIT_WORKING = "${WORKSPACE}/oit_working"
+    //Clear out previous work
+    sh "rm -rf ${OIT_WORKING}"
     sh "mkdir -p ${OIT_WORKING}"
-    //Clear out if previously in use
-    sh "rm -rf ${OIT_WORKING}/*"
 
     try {
         sshagent([SSH_KEY_ID]) { // To work on real repos, buildlib operations must run with the permissions of openshift-bot
@@ -641,8 +641,8 @@ distgits:build-images
         throw err
     } finally {
         try {
-            archiveArtifacts allowEmptyArchive: true, artifacts: "${OIT_WORKING}/*.log"
-            archiveArtifacts allowEmptyArchive: true, artifacts: "${OIT_WORKING}/brew-logs/**"
+            archiveArtifacts allowEmptyArchive: true, artifacts: "oit_working/*.log"
+            archiveArtifacts allowEmptyArchive: true, artifacts: "oit_working/brew-logs/**"
         } catch( aae ) {}
     }
 

--- a/jobs/build/ose/Jenkinsfile
+++ b/jobs/build/ose/Jenkinsfile
@@ -134,7 +134,13 @@ node(TARGET_NODE) {
 
     set_workspace()
 
-    env.OIT_WORKING = "${pwd(tmp:true)}/oit_working/"
+    # oit_working must be in WORKSPACE in order to have artifacts archived
+    OIT_WORKING = "${WORKSPACE}/oit_working"
+    env.OIT_WORKING = OIT_WORKING
+    //Clear out previous work
+    sh "rm -rf ${OIT_WORKING}"
+    sh "mkdir -p ${OIT_WORKING}"
+
     stage('Merge and build') {
         try {
 
@@ -183,6 +189,11 @@ Jenkins job: ${env.BUILD_URL}
 """);
             // Re-throw the error in order to fail the job
             throw err
+        } finally {
+            try {
+                archiveArtifacts allowEmptyArchive: true, artifacts: "oit_working/*.log"
+                archiveArtifacts allowEmptyArchive: true, artifacts: "oit_working/brew-logs/**"
+            } catch( aae ) {}
         }
 
     }

--- a/jobs/build/ose/scripts/merge-and-build.sh
+++ b/jobs/build/ose/scripts/merge-and-build.sh
@@ -86,11 +86,6 @@ if [ -d "${RESULTS}" ]; then
 fi
 mkdir -p "${RESULTS}"
 
-if [ -d "${OIT_WORKING}" ]; then
-  rm -rf "${OIT_WORKING}"
-fi
-mkdir -p "${OIT_WORKING}"
-
 WORKPATH="${BUILDPATH}/src/github.com/openshift/"
 mkdir -p ${WORKPATH}
 cd ${BUILDPATH}

--- a/jobs/build/refresh-images/Jenkinsfile
+++ b/jobs/build/refresh-images/Jenkinsfile
@@ -73,12 +73,12 @@ node('openshift-build-1') {
     stage( "enterprise-images repo" ) {
         buildlib.initialize_enterprise_images_dir()
     }
-    
-    OIT_WORKING = "${pwd(tmp:true)}/oit_working"
-    // create working if not exists
+
+    # oit_working must be in WORKSPACE in order to have artifacts archived
+    OIT_WORKING = "${WORKSPACE}/oit_working"
+    //Clear out previous work
+    sh "rm -rf ${OIT_WORKING}"
     sh "mkdir -p ${OIT_WORKING}"
-    //Clear out if previously in use
-    sh "rm -rf ${OIT_WORKING}/*"
 
     stage('Refresh Images') {
         try {
@@ -160,8 +160,8 @@ Jenkins job: ${env.BUILD_URL}
             throw err
         } finally {
             try {
-                archiveArtifacts allowEmptyArchive: true, artifacts: "${OIT_WORKING}/*.log"
-                archiveArtifacts allowEmptyArchive: true, artifacts: "${OIT_WORKING}/brew-logs/**"
+                archiveArtifacts allowEmptyArchive: true, artifacts: "oit_working/*.log"
+                archiveArtifacts allowEmptyArchive: true, artifacts: "oit_working/brew-logs/**"
             } catch( aae ) {}
         }
 


### PR DESCRIPTION
@adammhaile fyi

I want to archive artifacts in the Jenkins job (Jenkins will keep archived files files around until the job run is deleted). Jenkins apparently only allows archiveArtifacts to collect files directly in the workspace. Moving the directory into the workspace should be no functional change. 