### PR TITLE
Add clean_nodes_docker.yml playbook

### DIFF
--- a/hacks/cluster_cleanup/clean_nodes_docker.yml
+++ b/hacks/cluster_cleanup/clean_nodes_docker.yml
@@ -1,0 +1,54 @@
+# This playbook wraps the similarly named role in openshift-ansible.
+#
+# It's idempotent and safe to run repeatedly.  If the node's storage driver
+# is already overlay2, the ephemeral storage is left untouched.
+#
+# The role itself wipes all ephemeral storage with "atomic storage reset", so
+# this playbook drains nodes before invoking the role.
+#
+# Usage example:
+#
+#  ansible-playbook clean_nodes_docker.yml -e cli_clusterid=CLUSTERNAME
+#
+
+- hosts: localhost
+  gather_facts: no
+  become: no
+  user: root
+
+  tasks:
+
+  - name: Check for required variables
+    fail:
+      msg: "Please define {{ item }}"
+    when: "{{ item }} is undefined"
+    with_items:
+    - cli_clusterid
+    run_once: True
+
+##############################################
+# Cleanup compute nodes
+##############################################
+
+- hosts: "oo_clusterid_{{ cli_clusterid }}:&oo_subhosttype_compute"
+  become: no
+  user: root
+  serial: 10%
+
+  vars:
+    roles_path: "{{ HOME }}/git/openshift-tools/ansible/roles"
+
+  roles:
+  - role: openshift_node_schedulable
+    osns_is_schedulable: False
+    osns_drain: True
+    osns_cluster_master: "{{ groups['oo_hosttype_master'] | intersect(groups['oo_clusterid_' ~ oo_clusterid]) | first }}"
+
+  - role: reset_docker_storage
+
+  - role: os_reboot_server
+
+  - role: openshift_node_schedulable
+    osns_is_schedulable: True
+    osns_cluster_master: "{{ groups['oo_hosttype_master'] | intersect(groups['oo_clusterid_' ~ oo_clusterid]) | first }}"
+

--- a/hacks/cluster_cleanup/roles/reset_docker_storage/defaults/main.yml
+++ b/hacks/cluster_cleanup/roles/reset_docker_storage/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+openshift_local_volume_root: "/var/lib/origin/openshift.local.volumes"

--- a/hacks/cluster_cleanup/roles/reset_docker_storage/meta/main.yml
+++ b/hacks/cluster_cleanup/roles/reset_docker_storage/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+- role: openshift_facts

--- a/hacks/cluster_cleanup/roles/reset_docker_storage/tasks/main.yml
+++ b/hacks/cluster_cleanup/roles/reset_docker_storage/tasks/main.yml
@@ -1,0 +1,63 @@
+---
+
+- name: Install or update atomic
+  package:
+    name: atomic
+    state: latest
+
+- openshift_facts:
+    role: common
+
+- name: Stop services
+  service:
+    name: "{{ item }}"
+    state: stopped
+  with_items:
+  - "{{ openshift.common.service_type }}-node"
+  - "{{ openshift.docker.service_name }}"
+
+- name: Remove immutable flag on /var/lib/docker/volumes
+  command: chattr -i /var/lib/docker/volumes
+  ignore_errors: yes
+
+- name: List mounted filesystems
+  command: mount
+  register: mounts
+  changed_when: False
+
+- name: Collect mount points
+  set_fact:
+    mount_points: "{{ mount_points | default([]) + [ item.split()[2] ] }}"
+  with_items: "{{ mounts.stdout_lines }}"
+
+- name: Unmount OpenShift local volumes
+  mount:
+    path: "{{ item }}"
+    state: unmounted
+  when: "{{ openshift_local_volume_root in item }}"
+  with_items: "{{ mount_points }}"
+
+- name: Delete OpenShift local volume root
+  file:
+    path: "{{ openshift_local_volume_root }}"
+    state: absent
+
+- name: Reset docker storage
+  command: atomic storage reset
+
+- name: Run docker-storage-setup
+  command: docker-storage-setup
+
+- name: Recreate /var/lib/docker/volumes
+  file:
+    path: /var/lib/docker/volumes
+    state: directory
+
+- name: "Start {{ openshift.docker.service_name }}"
+  service:
+    name: "{{ openshift.docker.service_name }}"
+    state: started
+
+- name: Pull ose-pod image from OpenShift registry
+  docker_image:
+    name: "{{ openshift.node.registry_url | replace('${component}', 'pod') | replace('${version}', openshift.common.version) }}"


### PR DESCRIPTION
By @jupierce's request, this playbook imitates the [`clean_nodes_docker.sh`](https://github.com/openshift/aos-cd-jobs/blob/master/hacks/cluster_cleanup/clean_nodes_docker.sh) shell script but drains each node before running.

It's designed to use the tower inventory:
```
$ ansible-playbook clean_nodes_docker.yml -e cli_clusterid=starter-us-east-1
```

This commit ended up being kinda huge because I had to copy over several roles from [`openshift-tools`](https://github.com/openshift/openshift-tools/) and [`openshift-ansible`](https://github.com/openshift/openshift-ansible/), which suggests maybe `openshift-tools` would be a better place for this.

The bits I wrote are:
 * `clean_nodes_docker.yml`
 * `roles/reset_docker_storage`