### PR TITLE
use yum to find pkg verrel if tag doesn't work

### DIFF
--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
@@ -90,6 +90,14 @@ extensions:
            echo "${closest_tag:1}" | cut -d'.' -f1,2 > ${jobs_repo}/ORIGIN_RELEASE
            # disable local origin repo
            sudo yum-config-manager --disable origin-local-release
+           # hackety hackety hack hack - pre-releases use a *wack[y]* versioning scheme
+           if ( sudo yum install --assumeno origin${pkgver} 2>&1 || : ) | grep -q 'No package .* available' ; then
+              # just ask yum what the heck the version is
+              pkgver=$( ( sudo yum install --assumeno origin 2>&1 || : ) | awk '$1 == "x86_64" {print $2}' )
+              echo "-${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
+           else
+              echo package origin${pkgver} is available
+           fi
         else
            echo Error: unknown base branch $curbranch: please resubmit PR on master or a release-x.y branch
         fi

--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file.yml
@@ -82,6 +82,13 @@ extensions:
            echo "${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
            # disable local origin repo
            sudo yum-config-manager --disable origin-local-release
+           if ( sudo yum install --assumeno origin${pkgver} 2>&1 || : ) | grep -q 'No package .* available' ; then
+              # just ask yum what the heck the version is
+              pkgver=$( ( sudo yum install --assumeno origin 2>&1 || : ) | awk '$1 == "x86_64" {print $2}' )
+              echo "-${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
+           else
+              echo package origin${pkgver} is available
+           fi
         else
            echo Error: unknown base branch $curbranch: please resubmit PR on master or a release-x.y branch
         fi

--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
@@ -84,6 +84,13 @@ extensions:
            echo "${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
            # disable local origin repo
            sudo yum-config-manager --disable origin-local-release
+           if ( sudo yum install --assumeno origin${pkgver} 2>&1 || : ) | grep -q 'No package .* available' ; then
+              # just ask yum what the heck the version is
+              pkgver=$( ( sudo yum install --assumeno origin 2>&1 || : ) | awk '$1 == "x86_64" {print $2}' )
+              echo "-${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
+           else
+              echo package origin${pkgver} is available
+           fi
         else
            echo Error: unknown base branch $curbranch: please resubmit PR on master or a release-x.y branch
         fi

--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible_json_file.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible_json_file.yml
@@ -84,6 +84,13 @@ extensions:
            echo "${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
            # disable local origin repo
            sudo yum-config-manager --disable origin-local-release
+           if ( sudo yum install --assumeno origin${pkgver} 2>&1 || : ) | grep -q 'No package .* available' ; then
+              # just ask yum what the heck the version is
+              pkgver=$( ( sudo yum install --assumeno origin 2>&1 || : ) | awk '$1 == "x86_64" {print $2}' )
+              echo "-${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
+           else
+              echo package origin${pkgver} is available
+           fi
         else
            echo Error: unknown base branch $curbranch: please resubmit PR on master or a release-x.y branch
         fi

--- a/sjb/generated/test_branch_openshift_ansible_logging.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging.xml
@@ -457,6 +457,14 @@ elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
    echo &#34;\${closest_tag:1}&#34; | cut -d&#39;.&#39; -f1,2 &gt; \${jobs_repo}/ORIGIN_RELEASE
    # disable local origin repo
    sudo yum-config-manager --disable origin-local-release
+   # hackety hackety hack hack - pre-releases use a *wack[y]* versioning scheme
+   if ( sudo yum install --assumeno origin\${pkgver} 2&gt;&amp;1 || : ) | grep -q &#39;No package .* available&#39; ; then
+      # just ask yum what the heck the version is
+      pkgver=\$( ( sudo yum install --assumeno origin 2&gt;&amp;1 || : ) | awk &#39;\$1 == &#34;x86_64&#34; {print \$2}&#39; )
+      echo &#34;-\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
+   else
+      echo package origin\${pkgver} is available
+   fi
 else
    echo Error: unknown base branch \$curbranch: please resubmit PR on master or a release-x.y branch
 fi

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
@@ -449,6 +449,13 @@ elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
    echo &#34;\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
    # disable local origin repo
    sudo yum-config-manager --disable origin-local-release
+   if ( sudo yum install --assumeno origin\${pkgver} 2&gt;&amp;1 || : ) | grep -q &#39;No package .* available&#39; ; then
+      # just ask yum what the heck the version is
+      pkgver=\$( ( sudo yum install --assumeno origin 2&gt;&amp;1 || : ) | awk &#39;\$1 == &#34;x86_64&#34; {print \$2}&#39; )
+      echo &#34;-\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
+   else
+      echo package origin\${pkgver} is available
+   fi
 else
    echo Error: unknown base branch \$curbranch: please resubmit PR on master or a release-x.y branch
 fi

--- a/sjb/generated/test_pull_request_openshift_ansible_logging.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging.xml
@@ -473,6 +473,14 @@ elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
    echo &#34;\${closest_tag:1}&#34; | cut -d&#39;.&#39; -f1,2 &gt; \${jobs_repo}/ORIGIN_RELEASE
    # disable local origin repo
    sudo yum-config-manager --disable origin-local-release
+   # hackety hackety hack hack - pre-releases use a *wack[y]* versioning scheme
+   if ( sudo yum install --assumeno origin\${pkgver} 2&gt;&amp;1 || : ) | grep -q &#39;No package .* available&#39; ; then
+      # just ask yum what the heck the version is
+      pkgver=\$( ( sudo yum install --assumeno origin 2&gt;&amp;1 || : ) | awk &#39;\$1 == &#34;x86_64&#34; {print \$2}&#39; )
+      echo &#34;-\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
+   else
+      echo package origin\${pkgver} is available
+   fi
 else
    echo Error: unknown base branch \$curbranch: please resubmit PR on master or a release-x.y branch
 fi

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
@@ -508,6 +508,13 @@ elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
    echo &#34;\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
    # disable local origin repo
    sudo yum-config-manager --disable origin-local-release
+   if ( sudo yum install --assumeno origin\${pkgver} 2&gt;&amp;1 || : ) | grep -q &#39;No package .* available&#39; ; then
+      # just ask yum what the heck the version is
+      pkgver=\$( ( sudo yum install --assumeno origin 2&gt;&amp;1 || : ) | awk &#39;\$1 == &#34;x86_64&#34; {print \$2}&#39; )
+      echo &#34;-\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
+   else
+      echo package origin\${pkgver} is available
+   fi
 else
    echo Error: unknown base branch \$curbranch: please resubmit PR on master or a release-x.y branch
 fi

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
@@ -508,6 +508,13 @@ elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
    echo &#34;\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
    # disable local origin repo
    sudo yum-config-manager --disable origin-local-release
+   if ( sudo yum install --assumeno origin\${pkgver} 2&gt;&amp;1 || : ) | grep -q &#39;No package .* available&#39; ; then
+      # just ask yum what the heck the version is
+      pkgver=\$( ( sudo yum install --assumeno origin 2&gt;&amp;1 || : ) | awk &#39;\$1 == &#34;x86_64&#34; {print \$2}&#39; )
+      echo &#34;-\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
+   else
+      echo package origin\${pkgver} is available
+   fi
 else
    echo Error: unknown base branch \$curbranch: please resubmit PR on master or a release-x.y branch
 fi


### PR DESCRIPTION
use yum to find pkg verrel if tag doesn't work
This is a hack, but I don't know what else to do until the package
verrel for the 3.7 branch packages are a little more reasonable