### PR TITLE
Fixes for aws-ami

### DIFF
--- a/jobs/build/aws-ami/Jenkinsfile
+++ b/jobs/build/aws-ami/Jenkinsfile
@@ -42,30 +42,19 @@ if ( MOCK.toBoolean() ) {
 }
 
 node(TARGET_NODE) {
-
-    set_workspace()
-
-    stage('build') {
-        try {
-
-            sh(script: '''if [ -d "${WORKSPACE}/openshift-ansible" ]; then 
-                cd ${WORKSPACE}/openshift-ansible ; 
-                git pull; 
-            else
-                git clone https://github.com/openshift/openshift-ansible
-            fi
-
-            cd ${WORKSPACE}
-
-            ''')
-
+    try {
+        set_workspace()
+        stage('clone') {
+            dir('openshift-ansible') {
+                git 'https://github.com/openshift/openshift-ansible.git'
+            }
+        }
+        stage('build') {
             // create the provisioning_vars.yml file to use as inventory
-            withEnv(["AWS_PROFILE=${WORKSPACE}/.aws/credentials", "PATH=${pwd()}/${PATH}",
-                     "RELEASE_VERSION=${RELEASE_VERSION}", "DEPLOYMENT_TYPE=${DEPLOYMENT_TYPE}",
-                     "BASE_AMI_ID=${BASE_AMI_ID}", "CLUSTERID=${CLUSTERID}",
-                     "AWS_SSH_KEY_USER=${AWS_SSH_KEY_USER}","YUM_BASE_URL=${YUM_BASE_URL}","BASE_AMI_NAME=${BASE_AMI_NAME}"]) {
-                withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'cloud-provider-creds']]) {
-                    writeFile file:"${WORKSPACE}/provisioning_vars.yml", text:"""---
+            withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'cloud-provider-creds']]) {
+                writeFile(
+                    file: 'provisioning_vars.yml',
+                    text: """---
 openshift_aws_create_vpc: False
 openshift_deployment_type: ${DEPLOYMENT_TYPE}
 openshift_aws_clusterid: ${CLUSTERID}
@@ -81,30 +70,28 @@ openshift_cloudprovider_aws_access_key: ${env.AWS_ACCESS_KEY_ID}
 openshift_cloudprovider_aws_secret_key: ${env.AWS_SECRET_ACCESS_KEY}
 openshift_aws_base_ami_name: ${BASE_AMI_NAME}
 openshift_additional_repos: [{'name': 'openshift-repo', 'id': 'openshift-repo',  'baseurl': '${env.YUM_BASE_URL}', 'enabled': 'yes', 'gpgcheck': 0, 'sslverify': 'no', 'sslclientcert': '/var/lib/yum/client-cert.pem', 'sslclientkey': '/var/lib/yum/client-key.pem', 'gpgkey': 'https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted'},{'sslverify': False, 'name': 'fastdata', 'sslclientkey': '/var/lib/yum/client-key.pem', 'enabled': True, 'gpgkey': 'https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-release https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-beta https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted', 'sslclientcert': '/var/lib/yum/client-cert.pem', 'baseurl': 'https://mirror.ops.rhcloud.com/enterprise/rhel/rhel-7-fast-datapath-rpms/', 'file': 'fastdata-ovs', 'gpgcheck': False, 'description': 'Fastdata provides the official builds of OVS OpenShift supports'}]
-"""
-
-                    sshagent(["${AWS_SSH_KEY_USER}"]) {
-                        // need to load aws credentials
-                        withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'ami-build-creds']]) {
-                        sh("cat ${WORKSPACE}/provisioning_vars.yml")
-                        sh(script: "ANSIBLE_HOST_KEY_CHECKING=False AWS_ACCESS_KEY_ID=${env.AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${env.AWS_SECRET_ACCESS_KEY} ansible-playbook ${WORKSPACE}/openshift-ansible/playbooks/aws/openshift-cluster/build_ami.yml -e @${WORKSPACE}/provisioning_vars.yml -vvv")
-                        }
+""")
+            }
+            sh 'cat provisioning_vars.yml'
+            withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'ami-build-creds']]) {
+                withEnv(['ANSIBLE_HOST_KEY_CHECKING=False']) {
+                    sshagent([AWS_SSH_KEY_USER]) {
+                        sh 'ansible-playbook openshift-ansible/playbooks/aws/openshift-cluster/build_ami.yml -e @provisioning_vars.yml -vvv'
                     }
                 }
             }
-        } catch ( err ) {
-            // Replace flow control with: https://jenkins.io/blog/2016/12/19/declarative-pipeline-beta/ when available
-            mail(to: "${MAIL_LIST_FAILURE}",
-                    from: "kwoodson@redhat.com",
-                    subject: "Error building aws ami",
-                    body: """Encoutered an error while running build_ami.yml: ${err}
+        }
+    } catch ( err ) {
+        // Replace flow control with: https://jenkins.io/blog/2016/12/19/declarative-pipeline-beta/ when available
+        mail(to: "${MAIL_LIST_FAILURE}",
+                from: 'aos-cd@redhat.com',
+                subject: "Error building aws ami",
+                body: """Encoutered an error while running build_ami.yml: ${err}
 
 
 Jenkins job: ${env.BUILD_URL}
 """);
-            // Re-throw the error in order to fail the job
-            throw err
-        }
-
+        // Re-throw the error in order to fail the job
+        throw err
     }
 }

--- a/jobs/build/aws-ami/Jenkinsfile
+++ b/jobs/build/aws-ami/Jenkinsfile
@@ -44,10 +44,20 @@ if ( MOCK.toBoolean() ) {
 node(TARGET_NODE) {
     try {
         set_workspace()
+        def buildlib = null
         stage('clone') {
+            checkout scm
+            buildlib = load('pipeline-scripts/buildlib.groovy')
             dir('openshift-ansible') {
                 git 'https://github.com/openshift/openshift-ansible.git'
             }
+        }
+        stage('venv') {
+            sh '''
+[ -e env/ ] || virtualenv env/
+env/bin/pip install --upgrade pip
+env/bin/pip install --upgrade ansible boto
+'''
         }
         stage('build') {
             // create the provisioning_vars.yml file to use as inventory
@@ -76,7 +86,9 @@ openshift_additional_repos: [{'name': 'openshift-repo', 'id': 'openshift-repo', 
             withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'ami-build-creds']]) {
                 withEnv(['ANSIBLE_HOST_KEY_CHECKING=False']) {
                     sshagent([AWS_SSH_KEY_USER]) {
-                        sh 'ansible-playbook openshift-ansible/playbooks/aws/openshift-cluster/build_ami.yml -e @provisioning_vars.yml -vvv'
+                        buildlib.with_virtualenv('env') {
+                            sh 'ansible-playbook openshift-ansible/playbooks/aws/openshift-cluster/build_ami.yml -e @provisioning_vars.yml -vvv'
+                        }
                     }
                 }
             }

--- a/jobs/build/aws-ami/Jenkinsfile
+++ b/jobs/build/aws-ami/Jenkinsfile
@@ -25,7 +25,7 @@ properties(
                                                     openshift-enterprise      Openshift Enterpriseonline <br>
                                     ''',
                                     name: 'DEPLOYMENT_TYPE'],
-                                 [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'opstest', description: 'Clusterid to set for ami build. Also used for VPC and other settings', name: 'CLUSTERID'],
+                                 [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'default', description: 'Clusterid to set for ami build. Also used for VPC and other settings', name: 'CLUSTERID'],
                                  [$class: 'hudson.model.StringParameterDefinition', defaultValue: '3.7.0', description: 'Release version (matches version in branch name for release builds)', name: 'RELEASE_VERSION'],
                                  [$class: 'BooleanParameterDefinition', defaultValue: false, description: 'Mock run to pickup new Jenkins parameters?.', name: 'MOCK'],
                                  [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'ami-068a787c', description: 'Base AMI id to build from.', name: 'BASE_AMI_ID'],


### PR DESCRIPTION
@kwoodson, @jupierce: I'm opening this PR to start the discussion.

It contains only minor fixes to the pipeline, no major change in functionality.
I was able to reproduce the problem we had in prod on my machine and I believe
it happens because some of the things referenced in it do not exist (or my
account and the account we use in prod don't have access to it).

With those replaced with the ones we use for devenvs (see last commit) the job
is able to advance, provision the instance and start the node setup.  It now
fails when applying the `openshift_excluder` role (but that may be because of
the different base ami, I'll keep investigating).