### PR TITLE
Removing use of --include ; rely on unmanaged dirs in oit

### DIFF
--- a/jobs/build/ocp/Jenkinsfile
+++ b/jobs/build/ocp/Jenkinsfile
@@ -501,10 +501,6 @@ node(TARGET_NODE) {
           buildlib.write_sources_file()
           buildlib.oit """
 --working-dir ${OIT_WORKING} --group 'openshift-${BUILD_VERSION}'
---include aos3-installation-docker
---include jenkins-slave-base-rhel7-docker
---include jenkins-slave-maven-rhel7-docker
---include jenkins-slave-nodejs-rhel7-docker
 distgits:rebase --sources ${env.WORKSPACE}/sources.yml --version v${NEW_VERSION}
 --release ${NEW_DOCKERFILE_RELEASE}
 --message 'Updating Dockerfile version and release v${NEW_VERSION}-${NEW_DOCKERFILE_RELEASE}' --push
@@ -557,12 +553,8 @@ https://pkgs.devel.redhat.com/cgit/${distgit}/tree/Dockerfile?id=${val.sha}
 
             buildlib.oit """
 --working-dir ${OIT_WORKING} --group openshift-${BUILD_VERSION}
---include aos3-installation-docker
---include jenkins-slave-base-rhel7-docker
---include jenkins-slave-maven-rhel7-docker
---include jenkins-slave-nodejs-rhel7-docker
 distgits:build-images
---push-to-defaults --repo_type unsigned
+--push-to-defaults --repo-type unsigned
 """
         }
 

--- a/jobs/build/ose/scripts/merge-and-build.sh
+++ b/jobs/build/ose/scripts/merge-and-build.sh
@@ -383,10 +383,6 @@ openshift-ansible: ${OPENSHIFT_ANSIBLE_DIR}
 EOF
 
 ${OIT_PATH} --user=ocp-build --metadata-dir ${OIT_DIR} --working-dir ${OIT_WORKING} --group openshift-${OSE_VERSION} \
---include aos3-installation-docker \
---optional-include jenkins-slave-base-rhel7-docker \
---optional-include jenkins-slave-maven-rhel7-docker \
---optional-include jenkins-slave-nodejs-rhel7-docker \
 distgits:rebase --sources ${OIT_WORKING}/sources.yml --version v${VERSION} \
 --release 1 \
 --message "Updating Dockerfile version and release v${VERSION}-1" --push
@@ -404,12 +400,8 @@ echo "Build OIT images"
 echo "=========="
 
 ${OIT_PATH} --user=ocp-build --metadata-dir ${OIT_DIR} --working-dir ${OIT_WORKING} --group openshift-${OSE_VERSION} \
---include aos3-installation-docker \
---optional-include jenkins-slave-base-rhel7-docker \
---optional-include jenkins-slave-maven-rhel7-docker \
---optional-include jenkins-slave-nodejs-rhel7-docker \
 distgits:build-images \
---push-to-defaults --repo_type unsigned
+--push-to-defaults --repo-type unsigned
 
 echo
 echo "=========="

--- a/jobs/build/refresh-images/Jenkinsfile
+++ b/jobs/build/refresh-images/Jenkinsfile
@@ -117,10 +117,6 @@ node('openshift-build-1') {
 /*                
                 buildlib.oit """
 --working-dir ${OIT_WORKING} --group 'openshift-${OSE_MAJOR}.${OSE_MINOR}'
---include aos3-installation-docker
---optional-include jenkins-slave-base-rhel7-docker
---optional-include jenkins-slave-maven-rhel7-docker
---optional-include jenkins-slave-nodejs-rhel7-docker
 distgits:update-dockerfile
   ${oit_update_docker_args}
   --message 'Updating for image refresh'
@@ -129,12 +125,8 @@ distgits:update-dockerfile
 
               buildlib.oit """
 --working-dir ${OIT_WORKING} --group openshift-${OSE_MAJOR}.${OSE_MINOR}
---include aos3-installation-docker
---optional-include jenkins-slave-base-rhel7-docker
---optional-include jenkins-slave-maven-rhel7-docker
---optional-include jenkins-slave-nodejs-rhel7-docker
 distgits:build-images
---push-to-defaults --repo_type signed
+--push-to-defaults --repo-type signed
 """
   */
                 


### PR DESCRIPTION
fyi @adammhaile . Most image config.yml files in oit will be moved to an "unmanaged" directory so that we don't have to keep all of these --include / --optional-include parameters up to date as images are transitioned. We just move group/openshiftX.Y/unmanaged/distgit_name -> ../images/distgit_name in order to move an image over to oit management. 