### PR TITLE
Simplify job

### DIFF
--- a/sjb/config/test_cases/test_branch_image_registry_integration.yml
+++ b/sjb/config/test_cases/test_branch_image_registry_integration.yml
@@ -9,4 +9,4 @@ extensions:
       title: "run image-registry integration tests"
       repository: "image-registry"
       script: |-
-        OS_BUILD_ENV_TMP_VOLUME='/tmp' hack/env JUNIT_REPORT='true' make test-integration
+        make test-integration

--- a/sjb/generated/test_branch_image_registry_integration.xml
+++ b/sjb/generated/test_branch_image_registry_integration.xml
@@ -296,7 +296,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/image-registry&#34;
-OS_BUILD_ENV_TMP_VOLUME=&#39;/tmp&#39; hack/env JUNIT_REPORT=&#39;true&#39; make test-integration
+make test-integration
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_image_registry_integration.xml
+++ b/sjb/generated/test_pull_request_image_registry_integration.xml
@@ -354,7 +354,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/image-registry&#34;
-OS_BUILD_ENV_TMP_VOLUME=&#39;/tmp&#39; hack/env JUNIT_REPORT=&#39;true&#39; make test-integration
+make test-integration
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;


### PR DESCRIPTION
The previous version of the job created an incorrect environment, which led to errors:

```
+ OS_BUILD_ENV_TMP_VOLUME=/tmp
+ hack/env JUNIT_REPORT=true make test-integration
go test ./test/integration/...
# _/go/github.com/openshift/image-registry/test/integration/imagelayers
test/integration/imagelayers/imagelayers_test.go:12:2: cannot find package "github.com/docker/distribution" in any of:
	/usr/lib/golang/src/github.com/docker/distribution (from $GOROOT)
	/go/src/github.com/docker/distribution (from $GOPATH)
FAIL	_/go/github.com/openshift/image-registry/test/integration/imagelayers [setup failed]
```
@kargakis please review