### PR TITLE
Removed extraneous destination data in message.

### DIFF
--- a/tower-scripts/bin/build-ci-msg.py
+++ b/tower-scripts/bin/build-ci-msg.py
@@ -74,7 +74,6 @@ if test_mode:
 msg = """owner=Continuous Delivery
 email=jupierce@redhat.com
 CI_TYPE=component-build-done
-destination=/topic/CI
 product=%s
 cluster_name=%s
 description=OSO cluster upgraded


### PR DESCRIPTION
The destination (/topic/CI) is no longer needed for the new UMB protocol, as it's already defined in the Jenkins file. 