### PR TITLE
Removed commented block for OCP message sending over UMB.

### DIFF
--- a/jobs/build/ocp/Jenkinsfile
+++ b/jobs/build/ocp/Jenkinsfile
@@ -91,8 +91,7 @@ https://github.com/openshift/openshift-ansible/commits/openshift-ansible-${NEW_V
 ${OA_CHANGELOG}
 """);
 
-    // Commented out pending successful verification of UMB migration
-    /*try {
+    try {
         sendCIMessage( messageContent: "New build for OpenShift ${target}: ${version}",
 
                 messageProperties: """build_mode=${BUILD_MODE}
@@ -107,7 +106,7 @@ brew_task_url_openshift_ansible=${OA_BREW_URL}
         )
     } catch ( mex ) {
         mex.printStackTrace()
-    }*/
+    }
 }
 
 // Will be used to track which atomic-openshift build was tagged before we ran.


### PR DESCRIPTION
Now that UMB messages are successfully received across the jenkins ci bus, the OCP message sending is now uncommented. 