### PR TITLE
check if playbooks/prerequisites.yml exists before running it

### DIFF
--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update.yml
@@ -98,13 +98,16 @@ extensions:
       title: "origin prerequisites"
       repository: "aos-cd-jobs"
       script: |-
-        ansible-playbook -vv --become               \
-                         --become-user root         \
-                         --connection local         \
-                         --inventory sjb/inventory/ \
-                         -e containerized=true      \
-                         -e deployment_type=origin  \
-                         /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
+        # Remove the check once the openshift-ansible-playbooks-3.7 is built with the missing playbook
+        if [ -f /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml ]; then
+          ansible-playbook -vv --become               \
+                           --become-user root         \
+                           --connection local         \
+                           --inventory sjb/inventory/ \
+                           -e containerized=true      \
+                           -e deployment_type=origin  \
+                           /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
+        fi
     - type: "script"
       title: "install origin"
       repository: "aos-cd-jobs"

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
@@ -564,13 +564,16 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e containerized=true      \
-                 -e deployment_type=origin  \
-                 /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
+# Remove the check once the openshift-ansible-playbooks-3.7 is built with the missing playbook
+if [ -f /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml ]; then
+  ansible-playbook -vv --become               \
+                   --become-user root         \
+                   --connection local         \
+                   --inventory sjb/inventory/ \
+                   -e containerized=true      \
+                   -e deployment_type=origin  \
+                   /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
+fi
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
@@ -622,13 +622,16 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e containerized=true      \
-                 -e deployment_type=origin  \
-                 /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
+# Remove the check once the openshift-ansible-playbooks-3.7 is built with the missing playbook
+if [ -f /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml ]; then
+  ansible-playbook -vv --become               \
+                   --become-user root         \
+                   --connection local         \
+                   --inventory sjb/inventory/ \
+                   -e containerized=true      \
+                   -e deployment_type=origin  \
+                   /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
+fi
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
@@ -622,13 +622,16 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e containerized=true      \
-                 -e deployment_type=origin  \
-                 /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
+# Remove the check once the openshift-ansible-playbooks-3.7 is built with the missing playbook
+if [ -f /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml ]; then
+  ansible-playbook -vv --become               \
+                   --become-user root         \
+                   --connection local         \
+                   --inventory sjb/inventory/ \
+                   -e containerized=true      \
+                   -e deployment_type=origin  \
+                   /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
+fi
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;


### PR DESCRIPTION
Temporary check to unblock the install->upgrade CI until the ``openshift-ansible-playbooks-3.7.*`` provides the missing playbook. 