### PR TITLE
Revert "CRI-O: use docker.io/runcom/cri-o:v1.8.2 for system container"

### DIFF
--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_crio.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_crio.yml
@@ -116,7 +116,7 @@ extensions:
                          --inventory sjb/inventory/ \
                          -e deployment_type=origin  \
                          -e openshift_use_crio=True   \
-                         -e openshift_crio_systemcontainer_image_override=docker.io/runcom/cri-o:v1.8.2 \
+                         -e openshift_crio_systemcontainer_image_override=docker.io/gscrivano/cri-o-centos \
                          -e etcd_data_dir="${ETCD_DATA_DIR}" \
                          -e openshift_master_default_subdomain="${local_ip}.nip.io"             \
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \

--- a/sjb/generated/test_branch_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_crio.xml
@@ -560,7 +560,7 @@ ansible-playbook -vv --become               \
                  --inventory sjb/inventory/ \
                  -e deployment_type=origin  \
                  -e openshift_use_crio=True   \
-                 -e openshift_crio_systemcontainer_image_override=docker.io/runcom/cri-o:v1.8.2 \
+                 -e openshift_crio_systemcontainer_image_override=docker.io/gscrivano/cri-o-centos \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \

--- a/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
@@ -660,7 +660,7 @@ ansible-playbook -vv --become               \
                  --inventory sjb/inventory/ \
                  -e deployment_type=origin  \
                  -e openshift_use_crio=True   \
-                 -e openshift_crio_systemcontainer_image_override=docker.io/runcom/cri-o:v1.8.2 \
+                 -e openshift_crio_systemcontainer_image_override=docker.io/gscrivano/cri-o-centos \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \


### PR DESCRIPTION
This reverts commit a648b863129c0a0687135aa53d3306b520f8980f.

We now use the RPM based system container from @giuseppe 
@kargakis ptal