### PR TITLE
get list of repos using repolist all, and parse out the exclamation point

### DIFF
--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
@@ -79,7 +79,7 @@ extensions:
            # disable all of the centos repos except for the one for the
            # version being tested - this assumes a devenv environment where
            # all of the repos are installed
-           for repo in $( sudo yum repolist | awk '/^centos-paas-sig-openshift-origin/ {print $1}' ) ; do
+           for repo in $( sudo yum repolist all | awk '/^[!]?centos-paas-sig-openshift-origin/ {print gensub(/^!/,"",1,$1)}' ) ; do
               case $repo in
                  centos-paas-sig-openshift-origin${repover}-rpms) sudo yum-config-manager --enable $repo > /dev/null ;;
                  *) sudo yum-config-manager --disable $repo > /dev/null ;;
@@ -89,7 +89,7 @@ extensions:
            echo "${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
            echo "${closest_tag:1}" | cut -d'.' -f1,2 > ${jobs_repo}/ORIGIN_RELEASE
            # disable local origin repo
-           sudo yum-config-manager --disable origin-local-release
+           sudo yum-config-manager --disable origin-local-release > /dev/null
            # hackety hackety hack hack - pre-releases use a *wack[y]* versioning scheme
            if ( sudo yum install --assumeno origin${pkgver} 2>&1 || : ) | grep -q 'No package .* available' ; then
               # just ask yum what the heck the version is

--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file.yml
@@ -72,7 +72,7 @@ extensions:
            # disable all of the centos repos except for the one for the
            # version being tested - this assumes a devenv environment where
            # all of the repos are installed
-           for repo in $( sudo yum repolist | awk '/^centos-paas-sig-openshift-origin/ {print $1}' ) ; do
+           for repo in $( sudo yum repolist all | awk '/^[!]?centos-paas-sig-openshift-origin/ {print gensub(/^!/,"",1,$1)}' ) ; do
               case $repo in
                  centos-paas-sig-openshift-origin${repover}-rpms) sudo yum-config-manager --enable $repo > /dev/null ;;
                  *) sudo yum-config-manager --disable $repo > /dev/null ;;
@@ -81,7 +81,7 @@ extensions:
            echo "${closest_tag}" > ${jobs_repo}/ORIGIN_COMMIT
            echo "${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
            # disable local origin repo
-           sudo yum-config-manager --disable origin-local-release
+           sudo yum-config-manager --disable origin-local-release > /dev/null
            if ( sudo yum install --assumeno origin${pkgver} 2>&1 || : ) | grep -q 'No package .* available' ; then
               # just ask yum what the heck the version is
               pkgver=$( ( sudo yum install --assumeno origin 2>&1 || : ) | awk '$1 == "x86_64" {print $2}' )

--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
@@ -74,7 +74,7 @@ extensions:
            # disable all of the centos repos except for the one for the
            # version being tested - this assumes a devenv environment where
            # all of the repos are installed
-           for repo in $( sudo yum repolist | awk '/^centos-paas-sig-openshift-origin/ {print $1}' ) ; do
+           for repo in $( sudo yum repolist all | awk '/^[!]?centos-paas-sig-openshift-origin/ {print gensub(/^!/,"",1,$1)}' ) ; do
               case $repo in
                  centos-paas-sig-openshift-origin${repover}-rpms) sudo yum-config-manager --enable $repo > /dev/null ;;
                  *) sudo yum-config-manager --disable $repo > /dev/null ;;
@@ -83,7 +83,7 @@ extensions:
            echo "${closest_tag}" > ${jobs_repo}/ORIGIN_COMMIT
            echo "${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
            # disable local origin repo
-           sudo yum-config-manager --disable origin-local-release
+           sudo yum-config-manager --disable origin-local-release > /dev/null
            if ( sudo yum install --assumeno origin${pkgver} 2>&1 || : ) | grep -q 'No package .* available' ; then
               # just ask yum what the heck the version is
               pkgver=$( ( sudo yum install --assumeno origin 2>&1 || : ) | awk '$1 == "x86_64" {print $2}' )

--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible_json_file.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible_json_file.yml
@@ -74,7 +74,7 @@ extensions:
            # disable all of the centos repos except for the one for the
            # version being tested - this assumes a devenv environment where
            # all of the repos are installed
-           for repo in $( sudo yum repolist | awk '/^centos-paas-sig-openshift-origin/ {print $1}' ) ; do
+           for repo in $( sudo yum repolist all | awk '/^[!]?centos-paas-sig-openshift-origin/ {print gensub(/^!/,"",1,$1)}' ) ; do
               case $repo in
                  centos-paas-sig-openshift-origin${repover}-rpms) sudo yum-config-manager --enable $repo > /dev/null ;;
                  *) sudo yum-config-manager --disable $repo > /dev/null ;;
@@ -83,7 +83,7 @@ extensions:
            echo "${closest_tag}" > ${jobs_repo}/ORIGIN_COMMIT
            echo "${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
            # disable local origin repo
-           sudo yum-config-manager --disable origin-local-release
+           sudo yum-config-manager --disable origin-local-release > /dev/null
            if ( sudo yum install --assumeno origin${pkgver} 2>&1 || : ) | grep -q 'No package .* available' ; then
               # just ask yum what the heck the version is
               pkgver=$( ( sudo yum install --assumeno origin 2>&1 || : ) | awk '$1 == "x86_64" {print $2}' )

--- a/sjb/generated/test_branch_openshift_ansible_logging.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging.xml
@@ -484,7 +484,7 @@ elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
    # disable all of the centos repos except for the one for the
    # version being tested - this assumes a devenv environment where
    # all of the repos are installed
-   for repo in \$( sudo yum repolist | awk &#39;/^centos-paas-sig-openshift-origin/ {print \$1}&#39; ) ; do
+   for repo in \$( sudo yum repolist all | awk &#39;/^[!]?centos-paas-sig-openshift-origin/ {print gensub(/^!/,&#34;&#34;,1,\$1)}&#39; ) ; do
       case \$repo in
          centos-paas-sig-openshift-origin\${repover}-rpms) sudo yum-config-manager --enable \$repo &gt; /dev/null ;;
          *) sudo yum-config-manager --disable \$repo &gt; /dev/null ;;
@@ -494,7 +494,7 @@ elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
    echo &#34;\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
    echo &#34;\${closest_tag:1}&#34; | cut -d&#39;.&#39; -f1,2 &gt; \${jobs_repo}/ORIGIN_RELEASE
    # disable local origin repo
-   sudo yum-config-manager --disable origin-local-release
+   sudo yum-config-manager --disable origin-local-release &gt; /dev/null
    # hackety hackety hack hack - pre-releases use a *wack[y]* versioning scheme
    if ( sudo yum install --assumeno origin\${pkgver} 2&gt;&amp;1 || : ) | grep -q &#39;No package .* available&#39; ; then
       # just ask yum what the heck the version is

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
@@ -477,7 +477,7 @@ elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
    # disable all of the centos repos except for the one for the
    # version being tested - this assumes a devenv environment where
    # all of the repos are installed
-   for repo in \$( sudo yum repolist | awk &#39;/^centos-paas-sig-openshift-origin/ {print \$1}&#39; ) ; do
+   for repo in \$( sudo yum repolist all | awk &#39;/^[!]?centos-paas-sig-openshift-origin/ {print gensub(/^!/,&#34;&#34;,1,\$1)}&#39; ) ; do
       case \$repo in
          centos-paas-sig-openshift-origin\${repover}-rpms) sudo yum-config-manager --enable \$repo &gt; /dev/null ;;
          *) sudo yum-config-manager --disable \$repo &gt; /dev/null ;;
@@ -486,7 +486,7 @@ elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
    echo &#34;\${closest_tag}&#34; &gt; \${jobs_repo}/ORIGIN_COMMIT
    echo &#34;\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
    # disable local origin repo
-   sudo yum-config-manager --disable origin-local-release
+   sudo yum-config-manager --disable origin-local-release &gt; /dev/null
    if ( sudo yum install --assumeno origin\${pkgver} 2&gt;&amp;1 || : ) | grep -q &#39;No package .* available&#39; ; then
       # just ask yum what the heck the version is
       pkgver=\$( ( sudo yum install --assumeno origin 2&gt;&amp;1 || : ) | awk &#39;\$1 == &#34;x86_64&#34; {print \$2}&#39; )

--- a/sjb/generated/test_pull_request_openshift_ansible_logging.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging.xml
@@ -500,7 +500,7 @@ elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
    # disable all of the centos repos except for the one for the
    # version being tested - this assumes a devenv environment where
    # all of the repos are installed
-   for repo in \$( sudo yum repolist | awk &#39;/^centos-paas-sig-openshift-origin/ {print \$1}&#39; ) ; do
+   for repo in \$( sudo yum repolist all | awk &#39;/^[!]?centos-paas-sig-openshift-origin/ {print gensub(/^!/,&#34;&#34;,1,\$1)}&#39; ) ; do
       case \$repo in
          centos-paas-sig-openshift-origin\${repover}-rpms) sudo yum-config-manager --enable \$repo &gt; /dev/null ;;
          *) sudo yum-config-manager --disable \$repo &gt; /dev/null ;;
@@ -510,7 +510,7 @@ elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
    echo &#34;\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
    echo &#34;\${closest_tag:1}&#34; | cut -d&#39;.&#39; -f1,2 &gt; \${jobs_repo}/ORIGIN_RELEASE
    # disable local origin repo
-   sudo yum-config-manager --disable origin-local-release
+   sudo yum-config-manager --disable origin-local-release &gt; /dev/null
    # hackety hackety hack hack - pre-releases use a *wack[y]* versioning scheme
    if ( sudo yum install --assumeno origin\${pkgver} 2&gt;&amp;1 || : ) | grep -q &#39;No package .* available&#39; ; then
       # just ask yum what the heck the version is

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
@@ -536,7 +536,7 @@ elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
    # disable all of the centos repos except for the one for the
    # version being tested - this assumes a devenv environment where
    # all of the repos are installed
-   for repo in \$( sudo yum repolist | awk &#39;/^centos-paas-sig-openshift-origin/ {print \$1}&#39; ) ; do
+   for repo in \$( sudo yum repolist all | awk &#39;/^[!]?centos-paas-sig-openshift-origin/ {print gensub(/^!/,&#34;&#34;,1,\$1)}&#39; ) ; do
       case \$repo in
          centos-paas-sig-openshift-origin\${repover}-rpms) sudo yum-config-manager --enable \$repo &gt; /dev/null ;;
          *) sudo yum-config-manager --disable \$repo &gt; /dev/null ;;
@@ -545,7 +545,7 @@ elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
    echo &#34;\${closest_tag}&#34; &gt; \${jobs_repo}/ORIGIN_COMMIT
    echo &#34;\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
    # disable local origin repo
-   sudo yum-config-manager --disable origin-local-release
+   sudo yum-config-manager --disable origin-local-release &gt; /dev/null
    if ( sudo yum install --assumeno origin\${pkgver} 2&gt;&amp;1 || : ) | grep -q &#39;No package .* available&#39; ; then
       # just ask yum what the heck the version is
       pkgver=\$( ( sudo yum install --assumeno origin 2&gt;&amp;1 || : ) | awk &#39;\$1 == &#34;x86_64&#34; {print \$2}&#39; )

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
@@ -536,7 +536,7 @@ elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
    # disable all of the centos repos except for the one for the
    # version being tested - this assumes a devenv environment where
    # all of the repos are installed
-   for repo in \$( sudo yum repolist | awk &#39;/^centos-paas-sig-openshift-origin/ {print \$1}&#39; ) ; do
+   for repo in \$( sudo yum repolist all | awk &#39;/^[!]?centos-paas-sig-openshift-origin/ {print gensub(/^!/,&#34;&#34;,1,\$1)}&#39; ) ; do
       case \$repo in
          centos-paas-sig-openshift-origin\${repover}-rpms) sudo yum-config-manager --enable \$repo &gt; /dev/null ;;
          *) sudo yum-config-manager --disable \$repo &gt; /dev/null ;;
@@ -545,7 +545,7 @@ elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
    echo &#34;\${closest_tag}&#34; &gt; \${jobs_repo}/ORIGIN_COMMIT
    echo &#34;\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
    # disable local origin repo
-   sudo yum-config-manager --disable origin-local-release
+   sudo yum-config-manager --disable origin-local-release &gt; /dev/null
    if ( sudo yum install --assumeno origin\${pkgver} 2&gt;&amp;1 || : ) | grep -q &#39;No package .* available&#39; ; then
       # just ask yum what the heck the version is
       pkgver=\$( ( sudo yum install --assumeno origin 2&gt;&amp;1 || : ) | awk &#39;\$1 == &#34;x86_64&#34; {print \$2}&#39; )


### PR DESCRIPTION
There is a job that runs before logging starts that disables
all of the centos-paas repos, and doing a yum repolist all
has an output like this:

    !centos-paas-sig-openshift-origin13-rpms                    C disabled
    !centos-paas-sig-openshift-origin14-rpms                    C disabled
    !centos-paas-sig-openshift-origin15-rpms                    C disabled
    !centos-paas-sig-openshift-origin36-rpms                    C disabled
    !centos-paas-sig-openshift-origin37-rpms                    C disabled

So have to add a bit of extra logic to look for `!centos-paas-...` and
strip off the exclamation point.
This makes logging CI work again.
@stevekuznetsov @jcantrill