### PR TITLE
logging use oc cluster up to deploy openshift

### DIFF
--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
@@ -19,33 +19,14 @@ extensions:
         fi
         hack/build-images.sh
     - type: "script"
-      title: "build an openshift-ansible release"
-      repository: "openshift-ansible"
+      title: "install Ansible and other packages needed for OpenShift Ansible tasks"
+      repository: "origin-aggregated-logging"
       script: |-
-        tito_tmp_dir="tito"
-        rm -rf "${tito_tmp_dir}"
-        mkdir -p "${tito_tmp_dir}"
-        tito tag --offline --accept-auto-changelog
-        tito build --output="${tito_tmp_dir}" --rpm --test --offline --quiet
-        createrepo "${tito_tmp_dir}/noarch"
-        cat << EOR > ./openshift-ansible-local-release.repo
-        [openshift-ansible-local-release]
-        baseurl = file://$( pwd )/${tito_tmp_dir}/noarch
-        gpgcheck = 0
-        name = OpenShift Ansible Release from Local Source
-        EOR
-        sudo cp ./openshift-ansible-local-release.repo /etc/yum.repos.d
-    - type: "script"
-      title: "install the openshift-ansible release"
-      repository: "openshift-ansible"
-      script: |-
-        last_tag="$( git describe --tags --abbrev=0 --exact-match HEAD )"
-        last_commit="$( git log -n 1 --pretty=%h )"
-        sudo yum install -y "atomic-openshift-utils${last_tag/openshift-ansible/}.git.0.${last_commit}.el7"
-        rpm -V "atomic-openshift-utils${last_tag/openshift-ansible/}.git.0.${last_commit}.el7"
+        sudo yum install -y ansible python2 python-six tar java-1.8.0-openjdk-headless httpd-tools \
+           libselinux-python python-passlib python-pip
     - type: "script"
       title: "install Ansible plugins"
-      repository: "origin"
+      repository: "origin-aggregated-logging"
       script: |-
         sudo chmod o+rw /etc/environment
         echo "ANSIBLE_JUNIT_DIR=$( pwd )/_output/scripts/ansible_junit" >> /etc/environment
@@ -56,20 +37,17 @@ extensions:
         done
         sudo sed -r -i -e 's/^#?stdout_callback.*/stdout_callback = default_with_output_lists/' -e 's/^#?callback_whitelist.*/callback_whitelist = generate_junit/' /etc/ansible/ansible.cfg
     - type: "script"
-      title: "determine the release commit for origin images and version for rpms"
-      repository: "origin"
+      title: "ensure the correct package repositories are used for the correct release"
+      repository: "origin-aggregated-logging"
       script: |-
         # is logging using master or a release branch?
-        pushd "/data/src/github.com/openshift/origin-aggregated-logging/"
         curbranch=$( git rev-parse --abbrev-ref HEAD )
-        popd
-        jobs_repo="/data/src/github.com/openshift/aos-cd-jobs/"
         if [[ "${curbranch}" == master ]] ; then
-           git log -1 --pretty=%h >> "${jobs_repo}/ORIGIN_COMMIT"
-           ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo "-${OS_RPM_VERSION}-${OS_RPM_RELEASE}" ) >> "${jobs_repo}/ORIGIN_PKG_VERSION"
-           ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo "${OS_GIT_MAJOR}.${OS_GIT_MINOR}" | sed "s/+//" ) >> "${jobs_repo}/ORIGIN_RELEASE"
+           # enable centos-openshift-origin and centos-openshift-origin-testing
+           # assume everything else has been disabled
+           sudo yum-config-manager --enable centos-openshift-origin > /dev/null
+           sudo yum-config-manager --enable centos-openshift-origin-testing > /dev/null
         elif [[ "${curbranch}" =~ ^release-* ]] ; then
-           pushd "/data/src/github.com/openshift/origin-aggregated-logging/"
            # get repo ver from branch name
            repover=$( echo "${curbranch}" | sed -e 's/release-//' -e 's/[.]//' )
            # get version from tag
@@ -85,107 +63,141 @@ extensions:
                  *) sudo yum-config-manager --disable $repo > /dev/null ;;
               esac
            done
-           echo "${closest_tag}" > ${jobs_repo}/ORIGIN_COMMIT
-           echo "${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
-           echo "${closest_tag:1}" | cut -d'.' -f1,2 > ${jobs_repo}/ORIGIN_RELEASE
-           # disable local origin repo
            sudo yum-config-manager --disable origin-local-release > /dev/null
-           # hackety hackety hack hack - pre-releases use a *wack[y]* versioning scheme
-           if ( sudo yum install --assumeno origin${pkgver} 2>&1 || : ) | grep -q 'No package .* available' ; then
-              # just ask yum what the heck the version is
-              pkgver=$( ( sudo yum install --assumeno origin 2>&1 || : ) | awk '$1 == "x86_64" {print $2}' )
-              echo "-${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
-           else
-              echo package origin${pkgver} is available
-           fi
         else
            echo Error: unknown base branch $curbranch: please resubmit PR on master or a release-x.y branch
         fi
     - type: "script"
-      title: "origin prerequisites"
-      repository: "aos-cd-jobs"
+      title: "configure system to run oc cluster up and run it"
+      repository: "origin-aggregated-logging"
       script: |-
-        ansible-playbook -vv --become               \
-                         --become-user root         \
-                         --connection local         \
-                         --inventory sjb/inventory/ \
-                         -e containerized=true      \
-                         -e deployment_type=origin  \
-                         /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
-    - type: "script"
-      title: "install origin"
-      repository: "aos-cd-jobs"
-      script: |-
-        playbook_base='/usr/share/ansible/openshift-ansible/playbooks/'
-        if [[ -s "${playbook_base}/openshift-node/network_manager.yml" ]]; then
-            playbook="${playbook_base}openshift-node/network_manager.yml"
-        else
-            playbook="${playbook_base}byo/openshift-node/network_manager.yml"
+        # https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md#overview
+        # 3.8 has a problem with fail-swap-on - not a valid flag
+        sudo yum install -y origin-clients docker /usr/bin/firewall-cmd
+        sudo yum info origin-clients
+        sudo systemctl enable firewalld
+        sudo systemctl start firewalld
+        sudo sysctl -w net.ipv4.ip_forward=1
+
+        # set up docker for local registry
+        if ! sudo grep -q '^INSECURE_REGISTRY=' /etc/sysconfig/docker ; then
+          # not present - easy - just add it
+          echo "INSECURE_REGISTRY='--insecure-registry=172.30.0.0/16'" | sudo tee -a /etc/sysconfig/docker > /dev/null
+        elif ! sudo grep -q '^INSECURE_REGISTRY=.*--insecure-registry=172.30.0.0/16' /etc/sysconfig/docker ; then
+          # already there - just add our registry - assumes 1 single line
+          sudo sed -e "/^INSECURE_REGISTRY=/s,[']$, --insecure-registry 172.30.0.0/16'," -i /etc/sysconfig/docker
         fi
-        ansible-playbook -vv --become               \
-                         --become-user root         \
-                         --connection local         \
-                         --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
-                         ${playbook}
-        ansible-playbook -vv --become               \
-                         --become-user root         \
-                         --connection local         \
-                         --inventory sjb/inventory/ \
-                         -e openshift_logging_install_logging=False \
-                         -e deployment_type=origin  \
-                         -e debug_level=2           \
-                         -e etcd_data_dir="${ETCD_DATA_DIR}" \
-                         -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
-                         -e openshift_release="$( cat ./ORIGIN_RELEASE )"                       \
-                         -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
-                         /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
+
+        # set docker log driver correctly
+        if ! sudo grep -q '^OPTIONS=' /etc/sysconfig/docker ; then
+          # not present - easy - just add it
+          echo "OPTIONS='--log-driver=${LOG_DRIVER:-journald}'" | sudo tee -a /etc/sysconfig/docker > /dev/null
+        elif ! sudo grep -q '^OPTIONS=.*--log-driver' /etc/sysconfig/docker ; then
+          # already there - just add our value - assumes 1 single line
+          sudo sed -e "/^OPTIONS=/s,[']$, --log-driver=${LOG_DRIVER:-journald}'," -i /etc/sysconfig/docker
+        else
+          # already there with value - change the value
+          sudo sed -e "/^OPTIONS=/s/--log-driver=[-_a-zA-Z0-9][-_a-zA-Z0-9]*/--log-driver=${LOG_DRIVER:-journald}/" -i /etc/sysconfig/docker
+        fi
+
+        sudo systemctl daemon-reload
+        sudo systemctl restart docker
+
+        subnet=$( sudo docker network inspect -f "{{range .IPAM.Config }}{{ .Subnet }}{{end}}" bridge )
+        sudo firewall-cmd --permanent --new-zone dockerc
+        sudo firewall-cmd --permanent --zone dockerc --add-source $subnet
+        sudo firewall-cmd --permanent --zone dockerc --add-port 8443/tcp
+        sudo firewall-cmd --permanent --zone dockerc --add-port 53/udp
+        sudo firewall-cmd --permanent --zone dockerc --add-port 8053/udp
+        sudo firewall-cmd --reload
+        # this is specific to AWS - other platforms will need to get public ip and hostname elsewhere
+        metadata_endpoint="http://169.254.169.254/latest/meta-data"
+        public_hostname="$( curl -s "${metadata_endpoint}/public-hostname" )"
+        public_ip="$( curl -s "${metadata_endpoint}/public-ipv4" )"
+        sudo oc cluster up --public-hostname="${public_hostname}" --routing-suffix="${public_ip}.xip.io"
+        # change the config
+        # allow externalIPs, and kibana UI access
+        SERVER_CONFIG_DIR=/var/lib/origin/openshift.local.config
+        # add loggingPublicURL so the OpenShift UI Console will include a link for Kibana
+        # this part stolen from util.sh configure_os_server()
+        sudo cp ${SERVER_CONFIG_DIR}/master/master-config.yaml ${SERVER_CONFIG_DIR}/master/master-config.orig.yaml
+        ocver=$( oc version | awk -F'[ v.-]+' '/^oc / {print $2 $3 $4}' )
+        patchcmd="sudo oc ex config patch"
+        if [ $ocver -lt 380 ] ; then
+            patchcmd="docker exec origin openshift ex config patch"
+        fi
+        $patchcmd ${SERVER_CONFIG_DIR}/master/master-config.orig.yaml \
+            --patch="{\"assetConfig\": {\"loggingPublicURL\": \"https://kibana.${public_ip}.xip.io\"}}" | \
+            sudo tee ${SERVER_CONFIG_DIR}/master/master-config.yaml > /dev/null
+        sudo cp ${SERVER_CONFIG_DIR}/master/master-config.yaml ${SERVER_CONFIG_DIR}/master/master-config.save.yaml
+        $patchcmd ${SERVER_CONFIG_DIR}/master/master-config.save.yaml \
+            --patch="{\"networkConfig\": {\"externalIPNetworkCIDRs\": [\"0.0.0.0/0\"]}}" | \
+            sudo tee ${SERVER_CONFIG_DIR}/master/master-config.yaml > /dev/null
+        # restart cluster so changes will take effect
+        sudo oc cluster down
+        # have to restart docker while oc cluster is down, after it has been initialized, or inter-pod
+        # networking does not work
+        sudo systemctl restart docker
+        sudo oc cluster up --use-existing-config --public-hostname="${public_hostname}" --routing-suffix="${public_ip}.xip.io"
     - type: "script"
       title: "expose the kubeconfig"
       script: |-
+        if [ ! -d $HOME/.kube ] ; then
+          mkdir $HOME/.kube
+        fi
+        sudo cp /var/lib/origin/openshift.local.config/master/admin.kubeconfig $HOME/.kube/config
+        sudo chown $USER $HOME/.kube/config
+        sudo mkdir -p /etc/origin/master
+        sudo cp /var/lib/origin/openshift.local.config/master/admin.kubeconfig /etc/origin/master/admin.kubeconfig
         sudo chmod a+x /etc/ /etc/origin/ /etc/origin/master/
         sudo chmod a+rw /etc/origin/master/admin.kubeconfig
     - type: "script"
-      title: "ensure built version of origin is installed"
-      timeout: 600
-      repository: "origin"
-      script: |-
-        pushd "/data/src/github.com/openshift/origin-aggregated-logging/"
-        curbranch=$( git rev-parse --abbrev-ref HEAD )
-        popd
-        if [[ "${curbranch}" == master ]] ; then
-           origin_package="$( source hack/lib/init.sh; os::build::rpm::format_nvra )"
-           rpm -V "${origin_package}"
-        fi
-    - type: "script"
       title: "install origin-aggregated-logging"
-      repository: "aos-cd-jobs"
+      repository: "openshift-ansible"
       script: |-
-        playbook_base='/usr/share/ansible/openshift-ansible/playbooks/'
+        OS_A_C_J_DIR=/data/src/github.com/openshift/aos-cd-jobs
+        pushd $OS_A_C_J_DIR > /dev/null
+        # cannot use the networking related parameters with cluster up deployment
+        if [ -f sjb/inventory/group_vars/OSEv3/general.yml ] ; then
+            sed -e '/^osm_cluster_network_cidr/d' \
+                -e '/^openshift_portal_net/d' \
+                -e '/^osm_host_subnet_length/d' \
+                -i sjb/inventory/group_vars/OSEv3/general.yml
+        else
+            echo ERROR: no such file $OS_A_C_J_DIR/sjb/inventory/group_vars/OSEv3/general.yml
+            exit 1
+        fi
+        popd > /dev/null
+        # this is specific to AWS - other platforms will need to get public ip and hostname elsewhere
+        metadata_endpoint="http://169.254.169.254/latest/meta-data"
+        public_hostname="$( curl -s "${metadata_endpoint}/public-hostname" )"
+        public_ip="$( curl -s "${metadata_endpoint}/public-ipv4" )"
+        playbook_base='playbooks/'
         if [[ -s "${playbook_base}openshift-logging/config.yml" ]]; then
             playbook="${playbook_base}openshift-logging/config.yml"
         else
             playbook="${playbook_base}byo/openshift-cluster/openshift-logging.yml"
         fi
+        # richm 20171205 - causes this:
+        # RuntimeError: maximum recursion depth exceeded in cmp
+        # -e openshift_logging_install_eventrouter=True
         ansible-playbook -vv --become               \
                          --become-user root         \
                          --connection local         \
-                         --inventory sjb/inventory/ \
+                         --inventory $OS_A_C_J_DIR/sjb/inventory/ \
                          -e deployment_type=origin  \
                          -e debug_level=2           \
                          -e openshift_logging_install_logging=True \
                          -e openshift_logging_image_prefix="openshift/origin-" \
                          -e openshift_logging_elasticsearch_proxy_image_prefix="docker.io/openshift/" \
-                         -e openshift_hosted_logging_hostname="kibana.127.0.0.1.nip.io"           \
-                         -e openshift_logging_master_public_url="https://localhost:8443"          \
-                         -e openshift_master_logging_public_url="https://kibana.127.0.0.1.nip.io" \
+                         -e openshift_hosted_logging_hostname="kibana.${public_ip}.xip.io"            \
+                         -e openshift_logging_kibana_ops_hostname="kibana-ops.${public_ip}.xip.io"    \
+                         -e openshift_logging_master_public_url="https://${public_hostname}:8443"     \
+                         -e openshift_master_logging_public_url="https://kibana.${public_ip}.xip.io"  \
                          -e openshift_logging_use_mux=True                                        \
                          -e openshift_logging_mux_allow_external=True                             \
                          -e openshift_logging_es_allow_external=True                              \
                          -e openshift_logging_es_ops_allow_external=True                          \
-                         -e openshift_logging_install_eventrouter=True                            \
-                         -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"                 \
-                         -e openshift_release="$( cat ./ORIGIN_RELEASE )"                         \
                          ${playbook} \
                          --skip-tags=update_master_config
     - type: "script"

--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file.yml
@@ -11,35 +11,22 @@ extensions:
       title: "build an origin-aggregated-logging release"
       repository: "origin-aggregated-logging"
       script: |-
+        if [[ "${REPO_NAME:-}" == "openshift-ansible" ]]; then
+          if [[ -n "${PULL_REFS:-}" ]]; then
+            export OPENSHIFT_ANSIBLE_TARGET_BRANCH="${PULL_REFS%%:*}"
+          fi
+          git checkout ${OPENSHIFT_ANSIBLE_TARGET_BRANCH}
+        fi
         hack/build-images.sh
     - type: "script"
-      title: "build an openshift-ansible release"
-      repository: "openshift-ansible"
+      title: "install Ansible and other packages needed for OpenShift Ansible tasks"
+      repository: "origin-aggregated-logging"
       script: |-
-        tito_tmp_dir="tito"
-        rm -rf "${tito_tmp_dir}"
-        mkdir -p "${tito_tmp_dir}"
-        tito tag --offline --accept-auto-changelog
-        tito build --output="${tito_tmp_dir}" --rpm --test --offline --quiet
-        createrepo "${tito_tmp_dir}/noarch"
-        cat << EOR > ./openshift-ansible-local-release.repo
-        [openshift-ansible-local-release]
-        baseurl = file://$( pwd )/${tito_tmp_dir}/noarch
-        gpgcheck = 0
-        name = OpenShift Ansible Release from Local Source
-        EOR
-        sudo cp ./openshift-ansible-local-release.repo /etc/yum.repos.d
-    - type: "script"
-      title: "install the openshift-ansible release"
-      repository: "openshift-ansible"
-      script: |-
-        last_tag="$( git describe --tags --abbrev=0 --exact-match HEAD )"
-        last_commit="$( git log -n 1 --pretty=%h )"
-        sudo yum install -y "atomic-openshift-utils${last_tag/openshift-ansible/}.git.0.${last_commit}.el7"
-        rpm -V "atomic-openshift-utils${last_tag/openshift-ansible/}.git.0.${last_commit}.el7"
+        sudo yum install -y ansible python2 python-six tar java-1.8.0-openjdk-headless httpd-tools \
+           libselinux-python python-passlib python-pip
     - type: "script"
       title: "install Ansible plugins"
-      repository: "origin"
+      repository: "origin-aggregated-logging"
       script: |-
         sudo chmod o+rw /etc/environment
         echo "ANSIBLE_JUNIT_DIR=$( pwd )/_output/scripts/ansible_junit" >> /etc/environment
@@ -50,19 +37,17 @@ extensions:
         done
         sudo sed -r -i -e 's/^#?stdout_callback.*/stdout_callback = default_with_output_lists/' -e 's/^#?callback_whitelist.*/callback_whitelist = generate_junit/' /etc/ansible/ansible.cfg
     - type: "script"
-      title: "determine the release commit for origin images and version for rpms"
-      repository: "origin"
+      title: "ensure the correct package repositories are used for the correct release"
+      repository: "origin-aggregated-logging"
       script: |-
         # is logging using master or a release branch?
-        pushd "/data/src/github.com/openshift/origin-aggregated-logging/"
         curbranch=$( git rev-parse --abbrev-ref HEAD )
-        popd
-        jobs_repo="/data/src/github.com/openshift/aos-cd-jobs/"
         if [[ "${curbranch}" == master ]] ; then
-           git log -1 --pretty=%h >> "${jobs_repo}/ORIGIN_COMMIT"
-           ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo "-${OS_RPM_VERSION}-${OS_RPM_RELEASE}" ) >> "${jobs_repo}/ORIGIN_PKG_VERSION"
+           # enable centos-openshift-origin and centos-openshift-origin-testing
+           # assume everything else has been disabled
+           sudo yum-config-manager --enable centos-openshift-origin > /dev/null
+           sudo yum-config-manager --enable centos-openshift-origin-testing > /dev/null
         elif [[ "${curbranch}" =~ ^release-* ]] ; then
-           pushd "/data/src/github.com/openshift/origin-aggregated-logging/"
            # get repo ver from branch name
            repover=$( echo "${curbranch}" | sed -e 's/release-//' -e 's/[.]//' )
            # get version from tag
@@ -78,104 +63,141 @@ extensions:
                  *) sudo yum-config-manager --disable $repo > /dev/null ;;
               esac
            done
-           echo "${closest_tag}" > ${jobs_repo}/ORIGIN_COMMIT
-           echo "${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
-           # disable local origin repo
            sudo yum-config-manager --disable origin-local-release > /dev/null
-           if ( sudo yum install --assumeno origin${pkgver} 2>&1 || : ) | grep -q 'No package .* available' ; then
-              # just ask yum what the heck the version is
-              pkgver=$( ( sudo yum install --assumeno origin 2>&1 || : ) | awk '$1 == "x86_64" {print $2}' )
-              echo "-${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
-           else
-              echo package origin${pkgver} is available
-           fi
         else
            echo Error: unknown base branch $curbranch: please resubmit PR on master or a release-x.y branch
         fi
     - type: "script"
-      title: "origin prerequisites"
-      repository: "aos-cd-jobs"
+      title: "configure system to run oc cluster up and run it"
+      repository: "origin-aggregated-logging"
       script: |-
-        ansible-playbook -vv --become               \
-                         --become-user root         \
-                         --connection local         \
-                         --inventory sjb/inventory/ \
-                         -e containerized=true      \
-                         -e deployment_type=origin  \
-                         /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
-    - type: "script"
-      title: "install origin"
-      repository: "aos-cd-jobs"
-      script: |-
-        playbook_base='/usr/share/ansible/openshift-ansible/playbooks/'
-        if [[ -s "${playbook_base}/openshift-node/network_manager.yml" ]]; then
-            playbook="${playbook_base}openshift-node/network_manager.yml"
-        else
-            playbook="${playbook_base}byo/openshift-node/network_manager.yml"
+        # https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md#overview
+        # 3.8 has a problem with fail-swap-on - not a valid flag
+        sudo yum install -y origin-clients docker /usr/bin/firewall-cmd
+        sudo yum info origin-clients
+        sudo systemctl enable firewalld
+        sudo systemctl start firewalld
+        sudo sysctl -w net.ipv4.ip_forward=1
+
+        # set up docker for local registry
+        if ! sudo grep -q '^INSECURE_REGISTRY=' /etc/sysconfig/docker ; then
+          # not present - easy - just add it
+          echo "INSECURE_REGISTRY='--insecure-registry=172.30.0.0/16'" | sudo tee -a /etc/sysconfig/docker > /dev/null
+        elif ! sudo grep -q '^INSECURE_REGISTRY=.*--insecure-registry=172.30.0.0/16' /etc/sysconfig/docker ; then
+          # already there - just add our registry - assumes 1 single line
+          sudo sed -e "/^INSECURE_REGISTRY=/s,[']$, --insecure-registry 172.30.0.0/16'," -i /etc/sysconfig/docker
         fi
-        ansible-playbook -vv --become               \
-                         --become-user root         \
-                         --connection local         \
-                         --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
-                         ${playbook}
-        ansible-playbook -vv --become               \
-                         --become-user root         \
-                         --connection local         \
-                         --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
-                         -e debug_level=2           \
-                         -e openshift_logging_install_logging=False \
-                         -e openshift_docker_log_driver=json-file \
-                         -e openshift_docker_options="--log-driver=json-file" \
-                         -e etcd_data_dir="${ETCD_DATA_DIR}" \
-                         -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
-                         -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
-                         /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
+
+        # set docker log driver correctly
+        if ! sudo grep -q '^OPTIONS=' /etc/sysconfig/docker ; then
+          # not present - easy - just add it
+          echo "OPTIONS='--log-driver=${LOG_DRIVER:-json-file}'" | sudo tee -a /etc/sysconfig/docker > /dev/null
+        elif ! sudo grep -q '^OPTIONS=.*--log-driver' /etc/sysconfig/docker ; then
+          # already there - just add our value - assumes 1 single line
+          sudo sed -e "/^OPTIONS=/s,[']$, --log-driver=${LOG_DRIVER:-json-file}'," -i /etc/sysconfig/docker
+        else
+          # already there with value - change the value
+          sudo sed -e "/^OPTIONS=/s/--log-driver=[-_a-zA-Z0-9][-_a-zA-Z0-9]*/--log-driver=${LOG_DRIVER:-json-file}/" -i /etc/sysconfig/docker
+        fi
+
+        sudo systemctl daemon-reload
+        sudo systemctl restart docker
+
+        subnet=$( sudo docker network inspect -f "{{range .IPAM.Config }}{{ .Subnet }}{{end}}" bridge )
+        sudo firewall-cmd --permanent --new-zone dockerc
+        sudo firewall-cmd --permanent --zone dockerc --add-source $subnet
+        sudo firewall-cmd --permanent --zone dockerc --add-port 8443/tcp
+        sudo firewall-cmd --permanent --zone dockerc --add-port 53/udp
+        sudo firewall-cmd --permanent --zone dockerc --add-port 8053/udp
+        sudo firewall-cmd --reload
+        # this is specific to AWS - other platforms will need to get public ip and hostname elsewhere
+        metadata_endpoint="http://169.254.169.254/latest/meta-data"
+        public_hostname="$( curl -s "${metadata_endpoint}/public-hostname" )"
+        public_ip="$( curl -s "${metadata_endpoint}/public-ipv4" )"
+        sudo oc cluster up --public-hostname="${public_hostname}" --routing-suffix="${public_ip}.xip.io"
+        # change the config
+        # allow externalIPs, and kibana UI access
+        SERVER_CONFIG_DIR=/var/lib/origin/openshift.local.config
+        # add loggingPublicURL so the OpenShift UI Console will include a link for Kibana
+        # this part stolen from util.sh configure_os_server()
+        sudo cp ${SERVER_CONFIG_DIR}/master/master-config.yaml ${SERVER_CONFIG_DIR}/master/master-config.orig.yaml
+        ocver=$( oc version | awk -F'[ v.-]+' '/^oc / {print $2 $3 $4}' )
+        patchcmd="sudo oc ex config patch"
+        if [ $ocver -lt 380 ] ; then
+            patchcmd="docker exec origin openshift ex config patch"
+        fi
+        $patchcmd ${SERVER_CONFIG_DIR}/master/master-config.orig.yaml \
+            --patch="{\"assetConfig\": {\"loggingPublicURL\": \"https://kibana.${public_ip}.xip.io\"}}" | \
+            sudo tee ${SERVER_CONFIG_DIR}/master/master-config.yaml > /dev/null
+        sudo cp ${SERVER_CONFIG_DIR}/master/master-config.yaml ${SERVER_CONFIG_DIR}/master/master-config.save.yaml
+        $patchcmd ${SERVER_CONFIG_DIR}/master/master-config.save.yaml \
+            --patch="{\"networkConfig\": {\"externalIPNetworkCIDRs\": [\"0.0.0.0/0\"]}}" | \
+            sudo tee ${SERVER_CONFIG_DIR}/master/master-config.yaml > /dev/null
+        # restart cluster so changes will take effect
+        sudo oc cluster down
+        # have to restart docker while oc cluster is down, after it has been initialized, or inter-pod
+        # networking does not work
+        sudo systemctl restart docker
+        sudo oc cluster up --use-existing-config --public-hostname="${public_hostname}" --routing-suffix="${public_ip}.xip.io"
     - type: "script"
       title: "expose the kubeconfig"
       script: |-
+        if [ ! -d $HOME/.kube ] ; then
+          mkdir $HOME/.kube
+        fi
+        sudo cp /var/lib/origin/openshift.local.config/master/admin.kubeconfig $HOME/.kube/config
+        sudo chown $USER $HOME/.kube/config
+        sudo mkdir -p /etc/origin/master
+        sudo cp /var/lib/origin/openshift.local.config/master/admin.kubeconfig /etc/origin/master/admin.kubeconfig
         sudo chmod a+x /etc/ /etc/origin/ /etc/origin/master/
         sudo chmod a+rw /etc/origin/master/admin.kubeconfig
     - type: "script"
-      title: "ensure built version of origin is installed"
-      timeout: 600
-      repository: "origin"
-      script: |-
-        pushd "/data/src/github.com/openshift/origin-aggregated-logging/"
-        curbranch=$( git rev-parse --abbrev-ref HEAD )
-        popd
-        if [[ "${curbranch}" == master ]] ; then
-           origin_package="$( source hack/lib/init.sh; os::build::rpm::format_nvra )"
-           rpm -V "${origin_package}"
-        fi
-    - type: "script"
       title: "install origin-aggregated-logging"
-      repository: "aos-cd-jobs"
+      repository: "openshift-ansible"
       script: |-
-        playbook_base='/usr/share/ansible/openshift-ansible/playbooks/'
+        OS_A_C_J_DIR=/data/src/github.com/openshift/aos-cd-jobs
+        pushd $OS_A_C_J_DIR > /dev/null
+        # cannot use the networking related parameters with cluster up deployment
+        if [ -f sjb/inventory/group_vars/OSEv3/general.yml ] ; then
+            sed -e '/^osm_cluster_network_cidr/d' \
+                -e '/^openshift_portal_net/d' \
+                -e '/^osm_host_subnet_length/d' \
+                -i sjb/inventory/group_vars/OSEv3/general.yml
+        else
+            echo ERROR: no such file $OS_A_C_J_DIR/sjb/inventory/group_vars/OSEv3/general.yml
+            exit 1
+        fi
+        popd > /dev/null
+        # this is specific to AWS - other platforms will need to get public ip and hostname elsewhere
+        metadata_endpoint="http://169.254.169.254/latest/meta-data"
+        public_hostname="$( curl -s "${metadata_endpoint}/public-hostname" )"
+        public_ip="$( curl -s "${metadata_endpoint}/public-ipv4" )"
+        playbook_base='playbooks/'
         if [[ -s "${playbook_base}openshift-logging/config.yml" ]]; then
             playbook="${playbook_base}openshift-logging/config.yml"
         else
             playbook="${playbook_base}byo/openshift-cluster/openshift-logging.yml"
         fi
+        # richm 20171205 - causes this:
+        # RuntimeError: maximum recursion depth exceeded in cmp
+        # -e openshift_logging_install_eventrouter=True
         ansible-playbook -vv --become               \
                          --become-user root         \
                          --connection local         \
-                         --inventory sjb/inventory/ \
+                         --inventory $OS_A_C_J_DIR/sjb/inventory/ \
                          -e deployment_type=origin  \
-                         -e openshift_logging_install_logging=True \
                          -e debug_level=2           \
+                         -e openshift_logging_install_logging=True \
                          -e openshift_logging_image_prefix="openshift/origin-" \
                          -e openshift_logging_elasticsearch_proxy_image_prefix="docker.io/openshift/" \
-                         -e openshift_hosted_logging_hostname="kibana.127.0.0.1.nip.io"           \
-                         -e openshift_logging_master_public_url="https://localhost:8443"          \
-                         -e openshift_master_logging_public_url="https://kibana.127.0.0.1.nip.io" \
+                         -e openshift_hosted_logging_hostname="kibana.${public_ip}.xip.io"            \
+                         -e openshift_logging_kibana_ops_hostname="kibana-ops.${public_ip}.xip.io"    \
+                         -e openshift_logging_master_public_url="https://${public_hostname}:8443"     \
+                         -e openshift_master_logging_public_url="https://kibana.${public_ip}.xip.io"  \
                          -e openshift_logging_use_mux=True                                        \
                          -e openshift_logging_mux_allow_external=True                             \
                          -e openshift_logging_es_allow_external=True                              \
                          -e openshift_logging_es_ops_allow_external=True                          \
-                         -e openshift_logging_install_eventrouter=True                            \
                          ${playbook} \
                          --skip-tags=update_master_config
     - type: "script"

--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
@@ -3,7 +3,6 @@ parent: 'common/test_cases/origin_built_release.yml'
 overrides:
   sync_repos:
     - name: "origin-aggregated-logging"
-      type: "pull_request"
     - name: "openshift-ansible"
     - name: "aos-cd-jobs"
 extensions:
@@ -14,34 +13,14 @@ extensions:
       script: |-
         hack/build-images.sh
     - type: "script"
-      title: "build an openshift-ansible release"
-      repository: "openshift-ansible"
+      title: "install Ansible and other packages needed for OpenShift Ansible tasks"
+      repository: "origin-aggregated-logging"
       script: |-
-        git checkout "${PULL_REFS%%:*}"
-        tito_tmp_dir="tito"
-        rm -rf "${tito_tmp_dir}"
-        mkdir -p "${tito_tmp_dir}"
-        tito tag --offline --accept-auto-changelog
-        tito build --output="${tito_tmp_dir}" --rpm --test --offline --quiet
-        createrepo "${tito_tmp_dir}/noarch"
-        cat << EOR > ./openshift-ansible-local-release.repo
-        [openshift-ansible-local-release]
-        baseurl = file://$( pwd )/${tito_tmp_dir}/noarch
-        gpgcheck = 0
-        name = OpenShift Ansible Release from Local Source
-        EOR
-        sudo cp ./openshift-ansible-local-release.repo /etc/yum.repos.d
-    - type: "script"
-      title: "install the openshift-ansible release"
-      repository: "openshift-ansible"
-      script: |-
-        last_tag="$( git describe --tags --abbrev=0 --exact-match HEAD )"
-        last_commit="$( git log -n 1 --pretty=%h )"
-        sudo yum install -y "atomic-openshift-utils${last_tag/openshift-ansible/}.git.0.${last_commit}.el7"
-        rpm -V "atomic-openshift-utils${last_tag/openshift-ansible/}.git.0.${last_commit}.el7"
+        sudo yum install -y ansible python2 python-six tar java-1.8.0-openjdk-headless httpd-tools \
+           libselinux-python python-passlib python-pip
     - type: "script"
       title: "install Ansible plugins"
-      repository: "origin"
+      repository: "origin-aggregated-logging"
       script: |-
         sudo chmod o+rw /etc/environment
         echo "ANSIBLE_JUNIT_DIR=$( pwd )/_output/scripts/ansible_junit" >> /etc/environment
@@ -52,19 +31,17 @@ extensions:
         done
         sudo sed -r -i -e 's/^#?stdout_callback.*/stdout_callback = default_with_output_lists/' -e 's/^#?callback_whitelist.*/callback_whitelist = generate_junit/' /etc/ansible/ansible.cfg
     - type: "script"
-      title: "determine the release commit for origin images and version for rpms"
-      repository: "origin"
+      title: "ensure the correct package repositories are used for the correct release"
+      repository: "origin-aggregated-logging"
       script: |-
         # is logging using master or a release branch?
-        pushd "/data/src/github.com/openshift/origin-aggregated-logging/"
         curbranch=$( git rev-parse --abbrev-ref HEAD )
-        popd
-        jobs_repo="/data/src/github.com/openshift/aos-cd-jobs/"
         if [[ "${curbranch}" == master ]] ; then
-           git log -1 --pretty=%h >> "${jobs_repo}/ORIGIN_COMMIT"
-           ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo "-${OS_RPM_VERSION}-${OS_RPM_RELEASE}" ) >> "${jobs_repo}/ORIGIN_PKG_VERSION"
+           # enable centos-openshift-origin and centos-openshift-origin-testing
+           # assume everything else has been disabled
+           sudo yum-config-manager --enable centos-openshift-origin > /dev/null
+           sudo yum-config-manager --enable centos-openshift-origin-testing > /dev/null
         elif [[ "${curbranch}" =~ ^release-* ]] ; then
-           pushd "/data/src/github.com/openshift/origin-aggregated-logging/"
            # get repo ver from branch name
            repover=$( echo "${curbranch}" | sed -e 's/release-//' -e 's/[.]//' )
            # get version from tag
@@ -80,102 +57,141 @@ extensions:
                  *) sudo yum-config-manager --disable $repo > /dev/null ;;
               esac
            done
-           echo "${closest_tag}" > ${jobs_repo}/ORIGIN_COMMIT
-           echo "${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
-           # disable local origin repo
            sudo yum-config-manager --disable origin-local-release > /dev/null
-           if ( sudo yum install --assumeno origin${pkgver} 2>&1 || : ) | grep -q 'No package .* available' ; then
-              # just ask yum what the heck the version is
-              pkgver=$( ( sudo yum install --assumeno origin 2>&1 || : ) | awk '$1 == "x86_64" {print $2}' )
-              echo "-${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
-           else
-              echo package origin${pkgver} is available
-           fi
         else
            echo Error: unknown base branch $curbranch: please resubmit PR on master or a release-x.y branch
         fi
     - type: "script"
-      title: "origin prerequisites"
-      repository: "aos-cd-jobs"
+      title: "configure system to run oc cluster up and run it"
+      repository: "origin-aggregated-logging"
       script: |-
-        ansible-playbook -vv --become               \
-                         --become-user root         \
-                         --connection local         \
-                         --inventory sjb/inventory/ \
-                         -e containerized=true      \
-                         -e deployment_type=origin  \
-                         /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
-    - type: "script"
-      title: "install origin"
-      repository: "aos-cd-jobs"
-      script: |-
-        playbook_base='/usr/share/ansible/openshift-ansible/playbooks/'
-        if [[ -s "${playbook_base}/openshift-node/network_manager.yml" ]]; then
-            playbook="${playbook_base}openshift-node/network_manager.yml"
-        else
-            playbook="${playbook_base}byo/openshift-node/network_manager.yml"
+        # https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md#overview
+        # 3.8 has a problem with fail-swap-on - not a valid flag
+        sudo yum install -y origin-clients docker /usr/bin/firewall-cmd
+        sudo yum info origin-clients
+        sudo systemctl enable firewalld
+        sudo systemctl start firewalld
+        sudo sysctl -w net.ipv4.ip_forward=1
+
+        # set up docker for local registry
+        if ! sudo grep -q '^INSECURE_REGISTRY=' /etc/sysconfig/docker ; then
+          # not present - easy - just add it
+          echo "INSECURE_REGISTRY='--insecure-registry=172.30.0.0/16'" | sudo tee -a /etc/sysconfig/docker > /dev/null
+        elif ! sudo grep -q '^INSECURE_REGISTRY=.*--insecure-registry=172.30.0.0/16' /etc/sysconfig/docker ; then
+          # already there - just add our registry - assumes 1 single line
+          sudo sed -e "/^INSECURE_REGISTRY=/s,[']$, --insecure-registry 172.30.0.0/16'," -i /etc/sysconfig/docker
         fi
-        ansible-playbook -vv --become               \
-                         --become-user root         \
-                         --connection local         \
-                         --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
-                         -e debug_level=2           \
-                         ${playbook}
-        ansible-playbook -vv --become               \
-                         --become-user root         \
-                         --connection local         \
-                         --inventory sjb/inventory/ \
-                         -e openshift_logging_install_logging=False \
-                         -e deployment_type=origin  \
-                         -e etcd_data_dir="${ETCD_DATA_DIR}" \
-                         -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
-                         -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
-                         /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
+
+        # set docker log driver correctly
+        if ! sudo grep -q '^OPTIONS=' /etc/sysconfig/docker ; then
+          # not present - easy - just add it
+          echo "OPTIONS='--log-driver=${LOG_DRIVER:-journald}'" | sudo tee -a /etc/sysconfig/docker > /dev/null
+        elif ! sudo grep -q '^OPTIONS=.*--log-driver' /etc/sysconfig/docker ; then
+          # already there - just add our value - assumes 1 single line
+          sudo sed -e "/^OPTIONS=/s,[']$, --log-driver=${LOG_DRIVER:-journald}'," -i /etc/sysconfig/docker
+        else
+          # already there with value - change the value
+          sudo sed -e "/^OPTIONS=/s/--log-driver=[-_a-zA-Z0-9][-_a-zA-Z0-9]*/--log-driver=${LOG_DRIVER:-journald}/" -i /etc/sysconfig/docker
+        fi
+
+        sudo systemctl daemon-reload
+        sudo systemctl restart docker
+
+        subnet=$( sudo docker network inspect -f "{{range .IPAM.Config }}{{ .Subnet }}{{end}}" bridge )
+        sudo firewall-cmd --permanent --new-zone dockerc
+        sudo firewall-cmd --permanent --zone dockerc --add-source $subnet
+        sudo firewall-cmd --permanent --zone dockerc --add-port 8443/tcp
+        sudo firewall-cmd --permanent --zone dockerc --add-port 53/udp
+        sudo firewall-cmd --permanent --zone dockerc --add-port 8053/udp
+        sudo firewall-cmd --reload
+        # this is specific to AWS - other platforms will need to get public ip and hostname elsewhere
+        metadata_endpoint="http://169.254.169.254/latest/meta-data"
+        public_hostname="$( curl -s "${metadata_endpoint}/public-hostname" )"
+        public_ip="$( curl -s "${metadata_endpoint}/public-ipv4" )"
+        sudo oc cluster up --public-hostname="${public_hostname}" --routing-suffix="${public_ip}.xip.io"
+        # change the config
+        # allow externalIPs, and kibana UI access
+        SERVER_CONFIG_DIR=/var/lib/origin/openshift.local.config
+        # add loggingPublicURL so the OpenShift UI Console will include a link for Kibana
+        # this part stolen from util.sh configure_os_server()
+        sudo cp ${SERVER_CONFIG_DIR}/master/master-config.yaml ${SERVER_CONFIG_DIR}/master/master-config.orig.yaml
+        ocver=$( oc version | awk -F'[ v.-]+' '/^oc / {print $2 $3 $4}' )
+        patchcmd="sudo oc ex config patch"
+        if [ $ocver -lt 380 ] ; then
+            patchcmd="docker exec origin openshift ex config patch"
+        fi
+        $patchcmd ${SERVER_CONFIG_DIR}/master/master-config.orig.yaml \
+            --patch="{\"assetConfig\": {\"loggingPublicURL\": \"https://kibana.${public_ip}.xip.io\"}}" | \
+            sudo tee ${SERVER_CONFIG_DIR}/master/master-config.yaml > /dev/null
+        sudo cp ${SERVER_CONFIG_DIR}/master/master-config.yaml ${SERVER_CONFIG_DIR}/master/master-config.save.yaml
+        $patchcmd ${SERVER_CONFIG_DIR}/master/master-config.save.yaml \
+            --patch="{\"networkConfig\": {\"externalIPNetworkCIDRs\": [\"0.0.0.0/0\"]}}" | \
+            sudo tee ${SERVER_CONFIG_DIR}/master/master-config.yaml > /dev/null
+        # restart cluster so changes will take effect
+        sudo oc cluster down
+        # have to restart docker while oc cluster is down, after it has been initialized, or inter-pod
+        # networking does not work
+        sudo systemctl restart docker
+        sudo oc cluster up --use-existing-config --public-hostname="${public_hostname}" --routing-suffix="${public_ip}.xip.io"
     - type: "script"
       title: "expose the kubeconfig"
       script: |-
+        if [ ! -d $HOME/.kube ] ; then
+          mkdir $HOME/.kube
+        fi
+        sudo cp /var/lib/origin/openshift.local.config/master/admin.kubeconfig $HOME/.kube/config
+        sudo chown $USER $HOME/.kube/config
+        sudo mkdir -p /etc/origin/master
+        sudo cp /var/lib/origin/openshift.local.config/master/admin.kubeconfig /etc/origin/master/admin.kubeconfig
         sudo chmod a+x /etc/ /etc/origin/ /etc/origin/master/
         sudo chmod a+rw /etc/origin/master/admin.kubeconfig
     - type: "script"
-      title: "ensure built version of origin is installed"
-      timeout: 600
-      repository: "origin"
-      script: |-
-        pushd "/data/src/github.com/openshift/origin-aggregated-logging/"
-        curbranch=$( git rev-parse --abbrev-ref HEAD )
-        popd
-        if [[ "${curbranch}" == master ]] ; then
-           origin_package="$( source hack/lib/init.sh; os::build::rpm::format_nvra )"
-           rpm -V "${origin_package}"
-        fi
-    - type: "script"
       title: "install origin-aggregated-logging"
-      repository: "aos-cd-jobs"
+      repository: "openshift-ansible"
       script: |-
-        playbook_base='/usr/share/ansible/openshift-ansible/playbooks/'
+        OS_A_C_J_DIR=/data/src/github.com/openshift/aos-cd-jobs
+        pushd $OS_A_C_J_DIR > /dev/null
+        # cannot use the networking related parameters with cluster up deployment
+        if [ -f sjb/inventory/group_vars/OSEv3/general.yml ] ; then
+            sed -e '/^osm_cluster_network_cidr/d' \
+                -e '/^openshift_portal_net/d' \
+                -e '/^osm_host_subnet_length/d' \
+                -i sjb/inventory/group_vars/OSEv3/general.yml
+        else
+            echo ERROR: no such file $OS_A_C_J_DIR/sjb/inventory/group_vars/OSEv3/general.yml
+            exit 1
+        fi
+        popd > /dev/null
+        # this is specific to AWS - other platforms will need to get public ip and hostname elsewhere
+        metadata_endpoint="http://169.254.169.254/latest/meta-data"
+        public_hostname="$( curl -s "${metadata_endpoint}/public-hostname" )"
+        public_ip="$( curl -s "${metadata_endpoint}/public-ipv4" )"
+        playbook_base='playbooks/'
         if [[ -s "${playbook_base}openshift-logging/config.yml" ]]; then
             playbook="${playbook_base}openshift-logging/config.yml"
         else
             playbook="${playbook_base}byo/openshift-cluster/openshift-logging.yml"
         fi
+        # richm 20171205 - causes this:
+        # RuntimeError: maximum recursion depth exceeded in cmp
+        # -e openshift_logging_install_eventrouter=True
         ansible-playbook -vv --become               \
                          --become-user root         \
                          --connection local         \
-                         --inventory sjb/inventory/ \
+                         --inventory $OS_A_C_J_DIR/sjb/inventory/ \
                          -e deployment_type=origin  \
                          -e debug_level=2           \
                          -e openshift_logging_install_logging=True \
                          -e openshift_logging_image_prefix="openshift/origin-" \
                          -e openshift_logging_elasticsearch_proxy_image_prefix="docker.io/openshift/" \
-                         -e openshift_hosted_logging_hostname="kibana.127.0.0.1.nip.io"           \
-                         -e openshift_logging_master_public_url="https://localhost:8443"          \
-                         -e openshift_master_logging_public_url="https://kibana.127.0.0.1.nip.io" \
+                         -e openshift_hosted_logging_hostname="kibana.${public_ip}.xip.io"            \
+                         -e openshift_logging_kibana_ops_hostname="kibana-ops.${public_ip}.xip.io"    \
+                         -e openshift_logging_master_public_url="https://${public_hostname}:8443"     \
+                         -e openshift_master_logging_public_url="https://kibana.${public_ip}.xip.io"  \
                          -e openshift_logging_use_mux=True                                        \
                          -e openshift_logging_mux_allow_external=True                             \
                          -e openshift_logging_es_allow_external=True                              \
                          -e openshift_logging_es_ops_allow_external=True                          \
-                         -e openshift_logging_install_eventrouter=True                            \
                          ${playbook} \
                          --skip-tags=update_master_config
     - type: "script"

--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible_json_file.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible_json_file.yml
@@ -3,7 +3,6 @@ parent: 'common/test_cases/origin_built_release.yml'
 overrides:
   sync_repos:
     - name: "origin-aggregated-logging"
-      type: "pull_request"
     - name: "openshift-ansible"
     - name: "aos-cd-jobs"
 extensions:
@@ -14,34 +13,14 @@ extensions:
       script: |-
         hack/build-images.sh
     - type: "script"
-      title: "build an openshift-ansible release"
-      repository: "openshift-ansible"
+      title: "install Ansible and other packages needed for OpenShift Ansible tasks"
+      repository: "origin-aggregated-logging"
       script: |-
-        git checkout "${PULL_REFS%%:*}"
-        tito_tmp_dir="tito"
-        rm -rf "${tito_tmp_dir}"
-        mkdir -p "${tito_tmp_dir}"
-        tito tag --offline --accept-auto-changelog
-        tito build --output="${tito_tmp_dir}" --rpm --test --offline --quiet
-        createrepo "${tito_tmp_dir}/noarch"
-        cat << EOR > ./openshift-ansible-local-release.repo
-        [openshift-ansible-local-release]
-        baseurl = file://$( pwd )/${tito_tmp_dir}/noarch
-        gpgcheck = 0
-        name = OpenShift Ansible Release from Local Source
-        EOR
-        sudo cp ./openshift-ansible-local-release.repo /etc/yum.repos.d
-    - type: "script"
-      title: "install the openshift-ansible release"
-      repository: "openshift-ansible"
-      script: |-
-        last_tag="$( git describe --tags --abbrev=0 --exact-match HEAD )"
-        last_commit="$( git log -n 1 --pretty=%h )"
-        sudo yum install -y "atomic-openshift-utils${last_tag/openshift-ansible/}.git.0.${last_commit}.el7"
-        rpm -V "atomic-openshift-utils${last_tag/openshift-ansible/}.git.0.${last_commit}.el7"
+        sudo yum install -y ansible python2 python-six tar java-1.8.0-openjdk-headless httpd-tools \
+           libselinux-python python-passlib python-pip
     - type: "script"
       title: "install Ansible plugins"
-      repository: "origin"
+      repository: "origin-aggregated-logging"
       script: |-
         sudo chmod o+rw /etc/environment
         echo "ANSIBLE_JUNIT_DIR=$( pwd )/_output/scripts/ansible_junit" >> /etc/environment
@@ -52,19 +31,17 @@ extensions:
         done
         sudo sed -r -i -e 's/^#?stdout_callback.*/stdout_callback = default_with_output_lists/' -e 's/^#?callback_whitelist.*/callback_whitelist = generate_junit/' /etc/ansible/ansible.cfg
     - type: "script"
-      title: "determine the release commit for origin images and version for rpms"
-      repository: "origin"
+      title: "ensure the correct package repositories are used for the correct release"
+      repository: "origin-aggregated-logging"
       script: |-
         # is logging using master or a release branch?
-        pushd "/data/src/github.com/openshift/origin-aggregated-logging/"
         curbranch=$( git rev-parse --abbrev-ref HEAD )
-        popd
-        jobs_repo="/data/src/github.com/openshift/aos-cd-jobs/"
         if [[ "${curbranch}" == master ]] ; then
-           git log -1 --pretty=%h >> "${jobs_repo}/ORIGIN_COMMIT"
-           ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo "-${OS_RPM_VERSION}-${OS_RPM_RELEASE}" ) >> "${jobs_repo}/ORIGIN_PKG_VERSION"
+           # enable centos-openshift-origin and centos-openshift-origin-testing
+           # assume everything else has been disabled
+           sudo yum-config-manager --enable centos-openshift-origin > /dev/null
+           sudo yum-config-manager --enable centos-openshift-origin-testing > /dev/null
         elif [[ "${curbranch}" =~ ^release-* ]] ; then
-           pushd "/data/src/github.com/openshift/origin-aggregated-logging/"
            # get repo ver from branch name
            repover=$( echo "${curbranch}" | sed -e 's/release-//' -e 's/[.]//' )
            # get version from tag
@@ -80,104 +57,141 @@ extensions:
                  *) sudo yum-config-manager --disable $repo > /dev/null ;;
               esac
            done
-           echo "${closest_tag}" > ${jobs_repo}/ORIGIN_COMMIT
-           echo "${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
-           # disable local origin repo
            sudo yum-config-manager --disable origin-local-release > /dev/null
-           if ( sudo yum install --assumeno origin${pkgver} 2>&1 || : ) | grep -q 'No package .* available' ; then
-              # just ask yum what the heck the version is
-              pkgver=$( ( sudo yum install --assumeno origin 2>&1 || : ) | awk '$1 == "x86_64" {print $2}' )
-              echo "-${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
-           else
-              echo package origin${pkgver} is available
-           fi
         else
            echo Error: unknown base branch $curbranch: please resubmit PR on master or a release-x.y branch
         fi
     - type: "script"
-      title: "origin prerequisites"
-      repository: "aos-cd-jobs"
+      title: "configure system to run oc cluster up and run it"
+      repository: "origin-aggregated-logging"
       script: |-
-        ansible-playbook -vv --become               \
-                         --become-user root         \
-                         --connection local         \
-                         --inventory sjb/inventory/ \
-                         -e containerized=true      \
-                         -e deployment_type=origin  \
-                         /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
-    - type: "script"
-      title: "install origin"
-      repository: "aos-cd-jobs"
-      script: |-
-        playbook_base='/usr/share/ansible/openshift-ansible/playbooks/'
-        if [[ -s "${playbook_base}/openshift-node/network_manager.yml" ]]; then
-            playbook="${playbook_base}openshift-node/network_manager.yml"
-        else
-            playbook="${playbook_base}byo/openshift-node/network_manager.yml"
+        # https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md#overview
+        # 3.8 has a problem with fail-swap-on - not a valid flag
+        sudo yum install -y origin-clients docker /usr/bin/firewall-cmd
+        sudo yum info origin-clients
+        sudo systemctl enable firewalld
+        sudo systemctl start firewalld
+        sudo sysctl -w net.ipv4.ip_forward=1
+
+        # set up docker for local registry
+        if ! sudo grep -q '^INSECURE_REGISTRY=' /etc/sysconfig/docker ; then
+          # not present - easy - just add it
+          echo "INSECURE_REGISTRY='--insecure-registry=172.30.0.0/16'" | sudo tee -a /etc/sysconfig/docker > /dev/null
+        elif ! sudo grep -q '^INSECURE_REGISTRY=.*--insecure-registry=172.30.0.0/16' /etc/sysconfig/docker ; then
+          # already there - just add our registry - assumes 1 single line
+          sudo sed -e "/^INSECURE_REGISTRY=/s,[']$, --insecure-registry 172.30.0.0/16'," -i /etc/sysconfig/docker
         fi
-        ansible-playbook -vv --become               \
-                         --become-user root         \
-                         --connection local         \
-                         --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
-                         ${playbook}
-        ansible-playbook -vv --become               \
-                         --become-user root         \
-                         --connection local         \
-                         --inventory sjb/inventory/ \
-                         -e openshift_logging_install_logging=False \
-                         -e deployment_type=origin  \
-                         -e debug_level=2           \
-                         -e openshift_docker_log_driver=json-file \
-                         -e openshift_docker_options="--log-driver=json-file" \
-                         -e etcd_data_dir="${ETCD_DATA_DIR}" \
-                         -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
-                         -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
-                         /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
+
+        # set docker log driver correctly
+        if ! sudo grep -q '^OPTIONS=' /etc/sysconfig/docker ; then
+          # not present - easy - just add it
+          echo "OPTIONS='--log-driver=${LOG_DRIVER:-json-file}'" | sudo tee -a /etc/sysconfig/docker > /dev/null
+        elif ! sudo grep -q '^OPTIONS=.*--log-driver' /etc/sysconfig/docker ; then
+          # already there - just add our value - assumes 1 single line
+          sudo sed -e "/^OPTIONS=/s,[']$, --log-driver=${LOG_DRIVER:-json-file}'," -i /etc/sysconfig/docker
+        else
+          # already there with value - change the value
+          sudo sed -e "/^OPTIONS=/s/--log-driver=[-_a-zA-Z0-9][-_a-zA-Z0-9]*/--log-driver=${LOG_DRIVER:-json-file}/" -i /etc/sysconfig/docker
+        fi
+
+        sudo systemctl daemon-reload
+        sudo systemctl restart docker
+
+        subnet=$( sudo docker network inspect -f "{{range .IPAM.Config }}{{ .Subnet }}{{end}}" bridge )
+        sudo firewall-cmd --permanent --new-zone dockerc
+        sudo firewall-cmd --permanent --zone dockerc --add-source $subnet
+        sudo firewall-cmd --permanent --zone dockerc --add-port 8443/tcp
+        sudo firewall-cmd --permanent --zone dockerc --add-port 53/udp
+        sudo firewall-cmd --permanent --zone dockerc --add-port 8053/udp
+        sudo firewall-cmd --reload
+        # this is specific to AWS - other platforms will need to get public ip and hostname elsewhere
+        metadata_endpoint="http://169.254.169.254/latest/meta-data"
+        public_hostname="$( curl -s "${metadata_endpoint}/public-hostname" )"
+        public_ip="$( curl -s "${metadata_endpoint}/public-ipv4" )"
+        sudo oc cluster up --public-hostname="${public_hostname}" --routing-suffix="${public_ip}.xip.io"
+        # change the config
+        # allow externalIPs, and kibana UI access
+        SERVER_CONFIG_DIR=/var/lib/origin/openshift.local.config
+        # add loggingPublicURL so the OpenShift UI Console will include a link for Kibana
+        # this part stolen from util.sh configure_os_server()
+        sudo cp ${SERVER_CONFIG_DIR}/master/master-config.yaml ${SERVER_CONFIG_DIR}/master/master-config.orig.yaml
+        ocver=$( oc version | awk -F'[ v.-]+' '/^oc / {print $2 $3 $4}' )
+        patchcmd="sudo oc ex config patch"
+        if [ $ocver -lt 380 ] ; then
+            patchcmd="docker exec origin openshift ex config patch"
+        fi
+        $patchcmd ${SERVER_CONFIG_DIR}/master/master-config.orig.yaml \
+            --patch="{\"assetConfig\": {\"loggingPublicURL\": \"https://kibana.${public_ip}.xip.io\"}}" | \
+            sudo tee ${SERVER_CONFIG_DIR}/master/master-config.yaml > /dev/null
+        sudo cp ${SERVER_CONFIG_DIR}/master/master-config.yaml ${SERVER_CONFIG_DIR}/master/master-config.save.yaml
+        $patchcmd ${SERVER_CONFIG_DIR}/master/master-config.save.yaml \
+            --patch="{\"networkConfig\": {\"externalIPNetworkCIDRs\": [\"0.0.0.0/0\"]}}" | \
+            sudo tee ${SERVER_CONFIG_DIR}/master/master-config.yaml > /dev/null
+        # restart cluster so changes will take effect
+        sudo oc cluster down
+        # have to restart docker while oc cluster is down, after it has been initialized, or inter-pod
+        # networking does not work
+        sudo systemctl restart docker
+        sudo oc cluster up --use-existing-config --public-hostname="${public_hostname}" --routing-suffix="${public_ip}.xip.io"
     - type: "script"
       title: "expose the kubeconfig"
       script: |-
+        if [ ! -d $HOME/.kube ] ; then
+          mkdir $HOME/.kube
+        fi
+        sudo cp /var/lib/origin/openshift.local.config/master/admin.kubeconfig $HOME/.kube/config
+        sudo chown $USER $HOME/.kube/config
+        sudo mkdir -p /etc/origin/master
+        sudo cp /var/lib/origin/openshift.local.config/master/admin.kubeconfig /etc/origin/master/admin.kubeconfig
         sudo chmod a+x /etc/ /etc/origin/ /etc/origin/master/
         sudo chmod a+rw /etc/origin/master/admin.kubeconfig
     - type: "script"
-      title: "ensure built version of origin is installed"
-      timeout: 600
-      repository: "origin"
-      script: |-
-        pushd "/data/src/github.com/openshift/origin-aggregated-logging/"
-        curbranch=$( git rev-parse --abbrev-ref HEAD )
-        popd
-        if [[ "${curbranch}" == master ]] ; then
-           origin_package="$( source hack/lib/init.sh; os::build::rpm::format_nvra )"
-           rpm -V "${origin_package}"
-        fi
-    - type: "script"
       title: "install origin-aggregated-logging"
-      repository: "aos-cd-jobs"
+      repository: "openshift-ansible"
       script: |-
-        playbook_base='/usr/share/ansible/openshift-ansible/playbooks/'
+        OS_A_C_J_DIR=/data/src/github.com/openshift/aos-cd-jobs
+        pushd $OS_A_C_J_DIR > /dev/null
+        # cannot use the networking related parameters with cluster up deployment
+        if [ -f sjb/inventory/group_vars/OSEv3/general.yml ] ; then
+            sed -e '/^osm_cluster_network_cidr/d' \
+                -e '/^openshift_portal_net/d' \
+                -e '/^osm_host_subnet_length/d' \
+                -i sjb/inventory/group_vars/OSEv3/general.yml
+        else
+            echo ERROR: no such file $OS_A_C_J_DIR/sjb/inventory/group_vars/OSEv3/general.yml
+            exit 1
+        fi
+        popd > /dev/null
+        # this is specific to AWS - other platforms will need to get public ip and hostname elsewhere
+        metadata_endpoint="http://169.254.169.254/latest/meta-data"
+        public_hostname="$( curl -s "${metadata_endpoint}/public-hostname" )"
+        public_ip="$( curl -s "${metadata_endpoint}/public-ipv4" )"
+        playbook_base='playbooks/'
         if [[ -s "${playbook_base}openshift-logging/config.yml" ]]; then
             playbook="${playbook_base}openshift-logging/config.yml"
         else
             playbook="${playbook_base}byo/openshift-cluster/openshift-logging.yml"
         fi
+        # richm 20171205 - causes this:
+        # RuntimeError: maximum recursion depth exceeded in cmp
+        # -e openshift_logging_install_eventrouter=True
         ansible-playbook -vv --become               \
                          --become-user root         \
                          --connection local         \
-                         --inventory sjb/inventory/ \
+                         --inventory $OS_A_C_J_DIR/sjb/inventory/ \
                          -e deployment_type=origin  \
                          -e debug_level=2           \
                          -e openshift_logging_install_logging=True \
                          -e openshift_logging_image_prefix="openshift/origin-" \
                          -e openshift_logging_elasticsearch_proxy_image_prefix="docker.io/openshift/" \
-                         -e openshift_hosted_logging_hostname="kibana.127.0.0.1.nip.io"           \
-                         -e openshift_logging_master_public_url="https://localhost:8443"          \
-                         -e openshift_master_logging_public_url="https://kibana.127.0.0.1.nip.io" \
+                         -e openshift_hosted_logging_hostname="kibana.${public_ip}.xip.io"            \
+                         -e openshift_logging_kibana_ops_hostname="kibana-ops.${public_ip}.xip.io"    \
+                         -e openshift_logging_master_public_url="https://${public_hostname}:8443"     \
+                         -e openshift_master_logging_public_url="https://kibana.${public_ip}.xip.io"  \
                          -e openshift_logging_use_mux=True                                        \
                          -e openshift_logging_mux_allow_external=True                             \
                          -e openshift_logging_es_allow_external=True                              \
                          -e openshift_logging_es_ops_allow_external=True                          \
-                         -e openshift_logging_install_eventrouter=True                            \
                          ${playbook} \
                          --skip-tags=update_master_config
     - type: "script"

--- a/sjb/generated/merge_pull_request_origin_aggregated_logging.xml
+++ b/sjb/generated/merge_pull_request_origin_aggregated_logging.xml
@@ -69,11 +69,6 @@
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
-          <name>ORIGIN_AGGREGATED_LOGGING_PULL_ID</name>
-          <description>The pull-request in the &lt;a href=&#34;https://github.com/openshift/origin-aggregated-logging&#34;&gt;origin-aggregated-logging&lt;/a&gt; repository to test.</description>
-          <defaultValue></defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
           <name>OPENSHIFT_ANSIBLE_TARGET_BRANCH</name>
           <description>The branch in the &lt;a href=&#34;https://github.com/openshift/openshift-ansible&#34;&gt;openshift-ansible&lt;/a&gt; repository to test against.</description>
           <defaultValue>master</defaultValue>

--- a/sjb/generated/test_branch_openshift_ansible_logging.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging.xml
@@ -394,42 +394,14 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: BUILD AN OPENSHIFT-ANSIBLE RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: BUILD AN OPENSHIFT-ANSIBLE RELEASE [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL ANSIBLE AND OTHER PACKAGES NEEDED FOR OPENSHIFT ANSIBLE TASKS ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL ANSIBLE AND OTHER PACKAGES NEEDED FOR OPENSHIFT ANSIBLE TASKS [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
-tito_tmp_dir=&#34;tito&#34;
-rm -rf &#34;\${tito_tmp_dir}&#34;
-mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog
-tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
-createrepo &#34;\${tito_tmp_dir}/noarch&#34;
-cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo
-[openshift-ansible-local-release]
-baseurl = file://\$( pwd )/\${tito_tmp_dir}/noarch
-gpgcheck = 0
-name = OpenShift Ansible Release from Local Source
-EOR
-sudo cp ./openshift-ansible-local-release.repo /etc/yum.repos.d
-SCRIPT
-chmod +x &#34;${script}&#34;
-scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 14400 ${script}\&#34;&#34; </command>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-          <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL THE OPENSHIFT-ANSIBLE RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE OPENSHIFT-ANSIBLE RELEASE [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-script=&#34;$( mktemp )&#34;
-cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
-#!/bin/bash
-set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
-last_tag=&#34;\$( git describe --tags --abbrev=0 --exact-match HEAD )&#34;
-last_commit=&#34;\$( git log -n 1 --pretty=%h )&#34;
-sudo yum install -y &#34;atomic-openshift-utils\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7&#34;
-rpm -V &#34;atomic-openshift-utils\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7&#34;
+cd &#34;\${GOPATH}/src/github.com/openshift/origin-aggregated-logging&#34;
+sudo yum install -y ansible python2 python-six tar java-1.8.0-openjdk-headless httpd-tools \
+   libselinux-python python-passlib python-pip
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -442,7 +414,7 @@ script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
+cd &#34;\${GOPATH}/src/github.com/openshift/origin-aggregated-logging&#34;
 sudo chmod o+rw /etc/environment
 echo &#34;ANSIBLE_JUNIT_DIR=\$( pwd )/_output/scripts/ansible_junit&#34; &gt;&gt; /etc/environment
 sudo mkdir -p /usr/share/ansible/plugins/callback
@@ -458,23 +430,20 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: DETERMINE THE RELEASE COMMIT FOR ORIGIN IMAGES AND VERSION FOR RPMS ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: DETERMINE THE RELEASE COMMIT FOR ORIGIN IMAGES AND VERSION FOR RPMS [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: ENSURE THE CORRECT PACKAGE REPOSITORIES ARE USED FOR THE CORRECT RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: ENSURE THE CORRECT PACKAGE REPOSITORIES ARE USED FOR THE CORRECT RELEASE [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
+cd &#34;\${GOPATH}/src/github.com/openshift/origin-aggregated-logging&#34;
 # is logging using master or a release branch?
-pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
 curbranch=\$( git rev-parse --abbrev-ref HEAD )
-popd
-jobs_repo=&#34;/data/src/github.com/openshift/aos-cd-jobs/&#34;
 if [[ &#34;\${curbranch}&#34; == master ]] ; then
-   git log -1 --pretty=%h &gt;&gt; &#34;\${jobs_repo}/ORIGIN_COMMIT&#34;
-   ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo &#34;-\${OS_RPM_VERSION}-\${OS_RPM_RELEASE}&#34; ) &gt;&gt; &#34;\${jobs_repo}/ORIGIN_PKG_VERSION&#34;
-   ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo &#34;\${OS_GIT_MAJOR}.\${OS_GIT_MINOR}&#34; | sed &#34;s/+//&#34; ) &gt;&gt; &#34;\${jobs_repo}/ORIGIN_RELEASE&#34;
+   # enable centos-openshift-origin and centos-openshift-origin-testing
+   # assume everything else has been disabled
+   sudo yum-config-manager --enable centos-openshift-origin &gt; /dev/null
+   sudo yum-config-manager --enable centos-openshift-origin-testing &gt; /dev/null
 elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
-   pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
    # get repo ver from branch name
    repover=\$( echo &#34;\${curbranch}&#34; | sed -e &#39;s/release-//&#39; -e &#39;s/[.]//&#39; )
    # get version from tag
@@ -490,19 +459,7 @@ elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
          *) sudo yum-config-manager --disable \$repo &gt; /dev/null ;;
       esac
    done
-   echo &#34;\${closest_tag}&#34; &gt; \${jobs_repo}/ORIGIN_COMMIT
-   echo &#34;\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
-   echo &#34;\${closest_tag:1}&#34; | cut -d&#39;.&#39; -f1,2 &gt; \${jobs_repo}/ORIGIN_RELEASE
-   # disable local origin repo
    sudo yum-config-manager --disable origin-local-release &gt; /dev/null
-   # hackety hackety hack hack - pre-releases use a *wack[y]* versioning scheme
-   if ( sudo yum install --assumeno origin\${pkgver} 2&gt;&amp;1 || : ) | grep -q &#39;No package .* available&#39; ; then
-      # just ask yum what the heck the version is
-      pkgver=\$( ( sudo yum install --assumeno origin 2&gt;&amp;1 || : ) | awk &#39;\$1 == &#34;x86_64&#34; {print \$2}&#39; )
-      echo &#34;-\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
-   else
-      echo package origin\${pkgver} is available
-   fi
 else
    echo Error: unknown base branch \$curbranch: please resubmit PR on master or a release-x.y branch
 fi
@@ -513,56 +470,80 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: ORIGIN PREREQUISITES ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: ORIGIN PREREQUISITES [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: CONFIGURE SYSTEM TO RUN OC CLUSTER UP AND RUN IT ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: CONFIGURE SYSTEM TO RUN OC CLUSTER UP AND RUN IT [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e containerized=true      \
-                 -e deployment_type=origin  \
-                 /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
-SCRIPT
-chmod +x &#34;${script}&#34;
-scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 14400 ${script}\&#34;&#34; </command>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-          <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL ORIGIN ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL ORIGIN [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-script=&#34;$( mktemp )&#34;
-cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
-#!/bin/bash
-set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-playbook_base=&#39;/usr/share/ansible/openshift-ansible/playbooks/&#39;
-if [[ -s &#34;\${playbook_base}/openshift-node/network_manager.yml&#34; ]]; then
-    playbook=&#34;\${playbook_base}openshift-node/network_manager.yml&#34;
-else
-    playbook=&#34;\${playbook_base}byo/openshift-node/network_manager.yml&#34;
+cd &#34;\${GOPATH}/src/github.com/openshift/origin-aggregated-logging&#34;
+# https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md#overview
+# 3.8 has a problem with fail-swap-on - not a valid flag
+sudo yum install -y origin-clients docker /usr/bin/firewall-cmd
+sudo yum info origin-clients
+sudo systemctl enable firewalld
+sudo systemctl start firewalld
+sudo sysctl -w net.ipv4.ip_forward=1
+
+# set up docker for local registry
+if ! sudo grep -q &#39;^INSECURE_REGISTRY=&#39; /etc/sysconfig/docker ; then
+  # not present - easy - just add it
+  echo &#34;INSECURE_REGISTRY=&#39;--insecure-registry=172.30.0.0/16&#39;&#34; | sudo tee -a /etc/sysconfig/docker &gt; /dev/null
+elif ! sudo grep -q &#39;^INSECURE_REGISTRY=.*--insecure-registry=172.30.0.0/16&#39; /etc/sysconfig/docker ; then
+  # already there - just add our registry - assumes 1 single line
+  sudo sed -e &#34;/^INSECURE_REGISTRY=/s,[&#39;]\$, --insecure-registry 172.30.0.0/16&#39;,&#34; -i /etc/sysconfig/docker
 fi
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
-                 \${playbook}
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e openshift_logging_install_logging=False \
-                 -e deployment_type=origin  \
-                 -e debug_level=2           \
-                 -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
-                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
-                 -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
-                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
+
+# set docker log driver correctly
+if ! sudo grep -q &#39;^OPTIONS=&#39; /etc/sysconfig/docker ; then
+  # not present - easy - just add it
+  echo &#34;OPTIONS=&#39;--log-driver=\${LOG_DRIVER:-journald}&#39;&#34; | sudo tee -a /etc/sysconfig/docker &gt; /dev/null
+elif ! sudo grep -q &#39;^OPTIONS=.*--log-driver&#39; /etc/sysconfig/docker ; then
+  # already there - just add our value - assumes 1 single line
+  sudo sed -e &#34;/^OPTIONS=/s,[&#39;]\$, --log-driver=\${LOG_DRIVER:-journald}&#39;,&#34; -i /etc/sysconfig/docker
+else
+  # already there with value - change the value
+  sudo sed -e &#34;/^OPTIONS=/s/--log-driver=[-_a-zA-Z0-9][-_a-zA-Z0-9]*/--log-driver=\${LOG_DRIVER:-journald}/&#34; -i /etc/sysconfig/docker
+fi
+
+sudo systemctl daemon-reload
+sudo systemctl restart docker
+
+subnet=\$( sudo docker network inspect -f &#34;{{range .IPAM.Config }}{{ .Subnet }}{{end}}&#34; bridge )
+sudo firewall-cmd --permanent --new-zone dockerc
+sudo firewall-cmd --permanent --zone dockerc --add-source \$subnet
+sudo firewall-cmd --permanent --zone dockerc --add-port 8443/tcp
+sudo firewall-cmd --permanent --zone dockerc --add-port 53/udp
+sudo firewall-cmd --permanent --zone dockerc --add-port 8053/udp
+sudo firewall-cmd --reload
+# this is specific to AWS - other platforms will need to get public ip and hostname elsewhere
+metadata_endpoint=&#34;http://169.254.169.254/latest/meta-data&#34;
+public_hostname=&#34;\$( curl -s &#34;\${metadata_endpoint}/public-hostname&#34; )&#34;
+public_ip=&#34;\$( curl -s &#34;\${metadata_endpoint}/public-ipv4&#34; )&#34;
+sudo oc cluster up --public-hostname=&#34;\${public_hostname}&#34; --routing-suffix=&#34;\${public_ip}.xip.io&#34;
+# change the config
+# allow externalIPs, and kibana UI access
+SERVER_CONFIG_DIR=/var/lib/origin/openshift.local.config
+# add loggingPublicURL so the OpenShift UI Console will include a link for Kibana
+# this part stolen from util.sh configure_os_server()
+sudo cp \${SERVER_CONFIG_DIR}/master/master-config.yaml \${SERVER_CONFIG_DIR}/master/master-config.orig.yaml
+ocver=\$( oc version | awk -F&#39;[ v.-]+&#39; &#39;/^oc / {print \$2 \$3 \$4}&#39; )
+patchcmd=&#34;sudo oc ex config patch&#34;
+if [ \$ocver -lt 380 ] ; then
+    patchcmd=&#34;docker exec origin openshift ex config patch&#34;
+fi
+\$patchcmd \${SERVER_CONFIG_DIR}/master/master-config.orig.yaml \
+    --patch=&#34;{\&#34;assetConfig\&#34;: {\&#34;loggingPublicURL\&#34;: \&#34;https://kibana.\${public_ip}.xip.io\&#34;}}&#34; | \
+    sudo tee \${SERVER_CONFIG_DIR}/master/master-config.yaml &gt; /dev/null
+sudo cp \${SERVER_CONFIG_DIR}/master/master-config.yaml \${SERVER_CONFIG_DIR}/master/master-config.save.yaml
+\$patchcmd \${SERVER_CONFIG_DIR}/master/master-config.save.yaml \
+    --patch=&#34;{\&#34;networkConfig\&#34;: {\&#34;externalIPNetworkCIDRs\&#34;: [\&#34;0.0.0.0/0\&#34;]}}&#34; | \
+    sudo tee \${SERVER_CONFIG_DIR}/master/master-config.yaml &gt; /dev/null
+# restart cluster so changes will take effect
+sudo oc cluster down
+# have to restart docker while oc cluster is down, after it has been initialized, or inter-pod
+# networking does not work
+sudo systemctl restart docker
+sudo oc cluster up --use-existing-config --public-hostname=&#34;\${public_hostname}&#34; --routing-suffix=&#34;\${public_ip}.xip.io&#34;
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -576,6 +557,13 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
+if [ ! -d \$HOME/.kube ] ; then
+  mkdir \$HOME/.kube
+fi
+sudo cp /var/lib/origin/openshift.local.config/master/admin.kubeconfig \$HOME/.kube/config
+sudo chown \$USER \$HOME/.kube/config
+sudo mkdir -p /etc/origin/master
+sudo cp /var/lib/origin/openshift.local.config/master/admin.kubeconfig /etc/origin/master/admin.kubeconfig
 sudo chmod a+x /etc/ /etc/origin/ /etc/origin/master/
 sudo chmod a+rw /etc/origin/master/admin.kubeconfig
 SCRIPT
@@ -585,57 +573,55 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: ENSURE BUILT VERSION OF ORIGIN IS INSTALLED ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: ENSURE BUILT VERSION OF ORIGIN IS INSTALLED [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-script=&#34;$( mktemp )&#34;
-cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
-#!/bin/bash
-set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
-curbranch=\$( git rev-parse --abbrev-ref HEAD )
-popd
-if [[ &#34;\${curbranch}&#34; == master ]] ; then
-   origin_package=&#34;\$( source hack/lib/init.sh; os::build::rpm::format_nvra )&#34;
-   rpm -V &#34;\${origin_package}&#34;
-fi
-SCRIPT
-chmod +x &#34;${script}&#34;
-scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 600 ${script}\&#34;&#34; </command>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-          <command>#!/bin/bash
 SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL ORIGIN-AGGREGATED-LOGGING ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL ORIGIN-AGGREGATED-LOGGING [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-playbook_base=&#39;/usr/share/ansible/openshift-ansible/playbooks/&#39;
+cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
+OS_A_C_J_DIR=/data/src/github.com/openshift/aos-cd-jobs
+pushd \$OS_A_C_J_DIR &gt; /dev/null
+# cannot use the networking related parameters with cluster up deployment
+if [ -f sjb/inventory/group_vars/OSEv3/general.yml ] ; then
+    sed -e &#39;/^osm_cluster_network_cidr/d&#39; \
+        -e &#39;/^openshift_portal_net/d&#39; \
+        -e &#39;/^osm_host_subnet_length/d&#39; \
+        -i sjb/inventory/group_vars/OSEv3/general.yml
+else
+    echo ERROR: no such file \$OS_A_C_J_DIR/sjb/inventory/group_vars/OSEv3/general.yml
+    exit 1
+fi
+popd &gt; /dev/null
+# this is specific to AWS - other platforms will need to get public ip and hostname elsewhere
+metadata_endpoint=&#34;http://169.254.169.254/latest/meta-data&#34;
+public_hostname=&#34;\$( curl -s &#34;\${metadata_endpoint}/public-hostname&#34; )&#34;
+public_ip=&#34;\$( curl -s &#34;\${metadata_endpoint}/public-ipv4&#34; )&#34;
+playbook_base=&#39;playbooks/&#39;
 if [[ -s &#34;\${playbook_base}openshift-logging/config.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}openshift-logging/config.yml&#34;
 else
     playbook=&#34;\${playbook_base}byo/openshift-cluster/openshift-logging.yml&#34;
 fi
+# richm 20171205 - causes this:
+# RuntimeError: maximum recursion depth exceeded in cmp
+# -e openshift_logging_install_eventrouter=True
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
-                 --inventory sjb/inventory/ \
+                 --inventory \$OS_A_C_J_DIR/sjb/inventory/ \
                  -e deployment_type=origin  \
                  -e debug_level=2           \
                  -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
                  -e openshift_logging_elasticsearch_proxy_image_prefix=&#34;docker.io/openshift/&#34; \
-                 -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
-                 -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \
-                 -e openshift_master_logging_public_url=&#34;https://kibana.127.0.0.1.nip.io&#34; \
+                 -e openshift_hosted_logging_hostname=&#34;kibana.\${public_ip}.xip.io&#34;            \
+                 -e openshift_logging_kibana_ops_hostname=&#34;kibana-ops.\${public_ip}.xip.io&#34;    \
+                 -e openshift_logging_master_public_url=&#34;https://\${public_hostname}:8443&#34;     \
+                 -e openshift_master_logging_public_url=&#34;https://kibana.\${public_ip}.xip.io&#34;  \
                  -e openshift_logging_use_mux=True                                        \
                  -e openshift_logging_mux_allow_external=True                             \
                  -e openshift_logging_es_allow_external=True                              \
                  -e openshift_logging_es_ops_allow_external=True                          \
-                 -e openshift_logging_install_eventrouter=True                            \
-                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;                 \
-                 -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                         \
                  \${playbook} \
                  --skip-tags=update_master_config
 SCRIPT

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
@@ -380,6 +380,12 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin-aggregated-logging&#34;
+if [[ &#34;\${REPO_NAME:-}&#34; == &#34;openshift-ansible&#34; ]]; then
+  if [[ -n &#34;\${PULL_REFS:-}&#34; ]]; then
+    export OPENSHIFT_ANSIBLE_TARGET_BRANCH=&#34;\${PULL_REFS%%:*}&#34;
+  fi
+  git checkout \${OPENSHIFT_ANSIBLE_TARGET_BRANCH}
+fi
 hack/build-images.sh
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -388,42 +394,14 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: BUILD AN OPENSHIFT-ANSIBLE RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: BUILD AN OPENSHIFT-ANSIBLE RELEASE [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL ANSIBLE AND OTHER PACKAGES NEEDED FOR OPENSHIFT ANSIBLE TASKS ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL ANSIBLE AND OTHER PACKAGES NEEDED FOR OPENSHIFT ANSIBLE TASKS [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
-tito_tmp_dir=&#34;tito&#34;
-rm -rf &#34;\${tito_tmp_dir}&#34;
-mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog
-tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
-createrepo &#34;\${tito_tmp_dir}/noarch&#34;
-cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo
-[openshift-ansible-local-release]
-baseurl = file://\$( pwd )/\${tito_tmp_dir}/noarch
-gpgcheck = 0
-name = OpenShift Ansible Release from Local Source
-EOR
-sudo cp ./openshift-ansible-local-release.repo /etc/yum.repos.d
-SCRIPT
-chmod +x &#34;${script}&#34;
-scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 14400 ${script}\&#34;&#34; </command>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-          <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL THE OPENSHIFT-ANSIBLE RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE OPENSHIFT-ANSIBLE RELEASE [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-script=&#34;$( mktemp )&#34;
-cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
-#!/bin/bash
-set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
-last_tag=&#34;\$( git describe --tags --abbrev=0 --exact-match HEAD )&#34;
-last_commit=&#34;\$( git log -n 1 --pretty=%h )&#34;
-sudo yum install -y &#34;atomic-openshift-utils\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7&#34;
-rpm -V &#34;atomic-openshift-utils\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7&#34;
+cd &#34;\${GOPATH}/src/github.com/openshift/origin-aggregated-logging&#34;
+sudo yum install -y ansible python2 python-six tar java-1.8.0-openjdk-headless httpd-tools \
+   libselinux-python python-passlib python-pip
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -436,7 +414,7 @@ script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
+cd &#34;\${GOPATH}/src/github.com/openshift/origin-aggregated-logging&#34;
 sudo chmod o+rw /etc/environment
 echo &#34;ANSIBLE_JUNIT_DIR=\$( pwd )/_output/scripts/ansible_junit&#34; &gt;&gt; /etc/environment
 sudo mkdir -p /usr/share/ansible/plugins/callback
@@ -452,22 +430,20 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: DETERMINE THE RELEASE COMMIT FOR ORIGIN IMAGES AND VERSION FOR RPMS ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: DETERMINE THE RELEASE COMMIT FOR ORIGIN IMAGES AND VERSION FOR RPMS [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: ENSURE THE CORRECT PACKAGE REPOSITORIES ARE USED FOR THE CORRECT RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: ENSURE THE CORRECT PACKAGE REPOSITORIES ARE USED FOR THE CORRECT RELEASE [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
+cd &#34;\${GOPATH}/src/github.com/openshift/origin-aggregated-logging&#34;
 # is logging using master or a release branch?
-pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
 curbranch=\$( git rev-parse --abbrev-ref HEAD )
-popd
-jobs_repo=&#34;/data/src/github.com/openshift/aos-cd-jobs/&#34;
 if [[ &#34;\${curbranch}&#34; == master ]] ; then
-   git log -1 --pretty=%h &gt;&gt; &#34;\${jobs_repo}/ORIGIN_COMMIT&#34;
-   ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo &#34;-\${OS_RPM_VERSION}-\${OS_RPM_RELEASE}&#34; ) &gt;&gt; &#34;\${jobs_repo}/ORIGIN_PKG_VERSION&#34;
+   # enable centos-openshift-origin and centos-openshift-origin-testing
+   # assume everything else has been disabled
+   sudo yum-config-manager --enable centos-openshift-origin &gt; /dev/null
+   sudo yum-config-manager --enable centos-openshift-origin-testing &gt; /dev/null
 elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
-   pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
    # get repo ver from branch name
    repover=\$( echo &#34;\${curbranch}&#34; | sed -e &#39;s/release-//&#39; -e &#39;s/[.]//&#39; )
    # get version from tag
@@ -483,17 +459,7 @@ elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
          *) sudo yum-config-manager --disable \$repo &gt; /dev/null ;;
       esac
    done
-   echo &#34;\${closest_tag}&#34; &gt; \${jobs_repo}/ORIGIN_COMMIT
-   echo &#34;\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
-   # disable local origin repo
    sudo yum-config-manager --disable origin-local-release &gt; /dev/null
-   if ( sudo yum install --assumeno origin\${pkgver} 2&gt;&amp;1 || : ) | grep -q &#39;No package .* available&#39; ; then
-      # just ask yum what the heck the version is
-      pkgver=\$( ( sudo yum install --assumeno origin 2&gt;&amp;1 || : ) | awk &#39;\$1 == &#34;x86_64&#34; {print \$2}&#39; )
-      echo &#34;-\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
-   else
-      echo package origin\${pkgver} is available
-   fi
 else
    echo Error: unknown base branch \$curbranch: please resubmit PR on master or a release-x.y branch
 fi
@@ -504,57 +470,80 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: ORIGIN PREREQUISITES ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: ORIGIN PREREQUISITES [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: CONFIGURE SYSTEM TO RUN OC CLUSTER UP AND RUN IT ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: CONFIGURE SYSTEM TO RUN OC CLUSTER UP AND RUN IT [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e containerized=true      \
-                 -e deployment_type=origin  \
-                 /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
-SCRIPT
-chmod +x &#34;${script}&#34;
-scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 14400 ${script}\&#34;&#34; </command>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-          <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL ORIGIN ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL ORIGIN [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-script=&#34;$( mktemp )&#34;
-cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
-#!/bin/bash
-set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-playbook_base=&#39;/usr/share/ansible/openshift-ansible/playbooks/&#39;
-if [[ -s &#34;\${playbook_base}/openshift-node/network_manager.yml&#34; ]]; then
-    playbook=&#34;\${playbook_base}openshift-node/network_manager.yml&#34;
-else
-    playbook=&#34;\${playbook_base}byo/openshift-node/network_manager.yml&#34;
+cd &#34;\${GOPATH}/src/github.com/openshift/origin-aggregated-logging&#34;
+# https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md#overview
+# 3.8 has a problem with fail-swap-on - not a valid flag
+sudo yum install -y origin-clients docker /usr/bin/firewall-cmd
+sudo yum info origin-clients
+sudo systemctl enable firewalld
+sudo systemctl start firewalld
+sudo sysctl -w net.ipv4.ip_forward=1
+
+# set up docker for local registry
+if ! sudo grep -q &#39;^INSECURE_REGISTRY=&#39; /etc/sysconfig/docker ; then
+  # not present - easy - just add it
+  echo &#34;INSECURE_REGISTRY=&#39;--insecure-registry=172.30.0.0/16&#39;&#34; | sudo tee -a /etc/sysconfig/docker &gt; /dev/null
+elif ! sudo grep -q &#39;^INSECURE_REGISTRY=.*--insecure-registry=172.30.0.0/16&#39; /etc/sysconfig/docker ; then
+  # already there - just add our registry - assumes 1 single line
+  sudo sed -e &#34;/^INSECURE_REGISTRY=/s,[&#39;]\$, --insecure-registry 172.30.0.0/16&#39;,&#34; -i /etc/sysconfig/docker
 fi
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
-                 \${playbook}
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
-                 -e debug_level=2           \
-                 -e openshift_logging_install_logging=False \
-                 -e openshift_docker_log_driver=json-file \
-                 -e openshift_docker_options=&#34;--log-driver=json-file&#34; \
-                 -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
-                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
-                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
+
+# set docker log driver correctly
+if ! sudo grep -q &#39;^OPTIONS=&#39; /etc/sysconfig/docker ; then
+  # not present - easy - just add it
+  echo &#34;OPTIONS=&#39;--log-driver=\${LOG_DRIVER:-json-file}&#39;&#34; | sudo tee -a /etc/sysconfig/docker &gt; /dev/null
+elif ! sudo grep -q &#39;^OPTIONS=.*--log-driver&#39; /etc/sysconfig/docker ; then
+  # already there - just add our value - assumes 1 single line
+  sudo sed -e &#34;/^OPTIONS=/s,[&#39;]\$, --log-driver=\${LOG_DRIVER:-json-file}&#39;,&#34; -i /etc/sysconfig/docker
+else
+  # already there with value - change the value
+  sudo sed -e &#34;/^OPTIONS=/s/--log-driver=[-_a-zA-Z0-9][-_a-zA-Z0-9]*/--log-driver=\${LOG_DRIVER:-json-file}/&#34; -i /etc/sysconfig/docker
+fi
+
+sudo systemctl daemon-reload
+sudo systemctl restart docker
+
+subnet=\$( sudo docker network inspect -f &#34;{{range .IPAM.Config }}{{ .Subnet }}{{end}}&#34; bridge )
+sudo firewall-cmd --permanent --new-zone dockerc
+sudo firewall-cmd --permanent --zone dockerc --add-source \$subnet
+sudo firewall-cmd --permanent --zone dockerc --add-port 8443/tcp
+sudo firewall-cmd --permanent --zone dockerc --add-port 53/udp
+sudo firewall-cmd --permanent --zone dockerc --add-port 8053/udp
+sudo firewall-cmd --reload
+# this is specific to AWS - other platforms will need to get public ip and hostname elsewhere
+metadata_endpoint=&#34;http://169.254.169.254/latest/meta-data&#34;
+public_hostname=&#34;\$( curl -s &#34;\${metadata_endpoint}/public-hostname&#34; )&#34;
+public_ip=&#34;\$( curl -s &#34;\${metadata_endpoint}/public-ipv4&#34; )&#34;
+sudo oc cluster up --public-hostname=&#34;\${public_hostname}&#34; --routing-suffix=&#34;\${public_ip}.xip.io&#34;
+# change the config
+# allow externalIPs, and kibana UI access
+SERVER_CONFIG_DIR=/var/lib/origin/openshift.local.config
+# add loggingPublicURL so the OpenShift UI Console will include a link for Kibana
+# this part stolen from util.sh configure_os_server()
+sudo cp \${SERVER_CONFIG_DIR}/master/master-config.yaml \${SERVER_CONFIG_DIR}/master/master-config.orig.yaml
+ocver=\$( oc version | awk -F&#39;[ v.-]+&#39; &#39;/^oc / {print \$2 \$3 \$4}&#39; )
+patchcmd=&#34;sudo oc ex config patch&#34;
+if [ \$ocver -lt 380 ] ; then
+    patchcmd=&#34;docker exec origin openshift ex config patch&#34;
+fi
+\$patchcmd \${SERVER_CONFIG_DIR}/master/master-config.orig.yaml \
+    --patch=&#34;{\&#34;assetConfig\&#34;: {\&#34;loggingPublicURL\&#34;: \&#34;https://kibana.\${public_ip}.xip.io\&#34;}}&#34; | \
+    sudo tee \${SERVER_CONFIG_DIR}/master/master-config.yaml &gt; /dev/null
+sudo cp \${SERVER_CONFIG_DIR}/master/master-config.yaml \${SERVER_CONFIG_DIR}/master/master-config.save.yaml
+\$patchcmd \${SERVER_CONFIG_DIR}/master/master-config.save.yaml \
+    --patch=&#34;{\&#34;networkConfig\&#34;: {\&#34;externalIPNetworkCIDRs\&#34;: [\&#34;0.0.0.0/0\&#34;]}}&#34; | \
+    sudo tee \${SERVER_CONFIG_DIR}/master/master-config.yaml &gt; /dev/null
+# restart cluster so changes will take effect
+sudo oc cluster down
+# have to restart docker while oc cluster is down, after it has been initialized, or inter-pod
+# networking does not work
+sudo systemctl restart docker
+sudo oc cluster up --use-existing-config --public-hostname=&#34;\${public_hostname}&#34; --routing-suffix=&#34;\${public_ip}.xip.io&#34;
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -568,6 +557,13 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
+if [ ! -d \$HOME/.kube ] ; then
+  mkdir \$HOME/.kube
+fi
+sudo cp /var/lib/origin/openshift.local.config/master/admin.kubeconfig \$HOME/.kube/config
+sudo chown \$USER \$HOME/.kube/config
+sudo mkdir -p /etc/origin/master
+sudo cp /var/lib/origin/openshift.local.config/master/admin.kubeconfig /etc/origin/master/admin.kubeconfig
 sudo chmod a+x /etc/ /etc/origin/ /etc/origin/master/
 sudo chmod a+rw /etc/origin/master/admin.kubeconfig
 SCRIPT
@@ -577,55 +573,55 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: ENSURE BUILT VERSION OF ORIGIN IS INSTALLED ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: ENSURE BUILT VERSION OF ORIGIN IS INSTALLED [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-script=&#34;$( mktemp )&#34;
-cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
-#!/bin/bash
-set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
-curbranch=\$( git rev-parse --abbrev-ref HEAD )
-popd
-if [[ &#34;\${curbranch}&#34; == master ]] ; then
-   origin_package=&#34;\$( source hack/lib/init.sh; os::build::rpm::format_nvra )&#34;
-   rpm -V &#34;\${origin_package}&#34;
-fi
-SCRIPT
-chmod +x &#34;${script}&#34;
-scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 600 ${script}\&#34;&#34; </command>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-          <command>#!/bin/bash
 SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL ORIGIN-AGGREGATED-LOGGING ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL ORIGIN-AGGREGATED-LOGGING [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-playbook_base=&#39;/usr/share/ansible/openshift-ansible/playbooks/&#39;
+cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
+OS_A_C_J_DIR=/data/src/github.com/openshift/aos-cd-jobs
+pushd \$OS_A_C_J_DIR &gt; /dev/null
+# cannot use the networking related parameters with cluster up deployment
+if [ -f sjb/inventory/group_vars/OSEv3/general.yml ] ; then
+    sed -e &#39;/^osm_cluster_network_cidr/d&#39; \
+        -e &#39;/^openshift_portal_net/d&#39; \
+        -e &#39;/^osm_host_subnet_length/d&#39; \
+        -i sjb/inventory/group_vars/OSEv3/general.yml
+else
+    echo ERROR: no such file \$OS_A_C_J_DIR/sjb/inventory/group_vars/OSEv3/general.yml
+    exit 1
+fi
+popd &gt; /dev/null
+# this is specific to AWS - other platforms will need to get public ip and hostname elsewhere
+metadata_endpoint=&#34;http://169.254.169.254/latest/meta-data&#34;
+public_hostname=&#34;\$( curl -s &#34;\${metadata_endpoint}/public-hostname&#34; )&#34;
+public_ip=&#34;\$( curl -s &#34;\${metadata_endpoint}/public-ipv4&#34; )&#34;
+playbook_base=&#39;playbooks/&#39;
 if [[ -s &#34;\${playbook_base}openshift-logging/config.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}openshift-logging/config.yml&#34;
 else
     playbook=&#34;\${playbook_base}byo/openshift-cluster/openshift-logging.yml&#34;
 fi
+# richm 20171205 - causes this:
+# RuntimeError: maximum recursion depth exceeded in cmp
+# -e openshift_logging_install_eventrouter=True
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
-                 --inventory sjb/inventory/ \
+                 --inventory \$OS_A_C_J_DIR/sjb/inventory/ \
                  -e deployment_type=origin  \
-                 -e openshift_logging_install_logging=True \
                  -e debug_level=2           \
+                 -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
                  -e openshift_logging_elasticsearch_proxy_image_prefix=&#34;docker.io/openshift/&#34; \
-                 -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
-                 -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \
-                 -e openshift_master_logging_public_url=&#34;https://kibana.127.0.0.1.nip.io&#34; \
+                 -e openshift_hosted_logging_hostname=&#34;kibana.\${public_ip}.xip.io&#34;            \
+                 -e openshift_logging_kibana_ops_hostname=&#34;kibana-ops.\${public_ip}.xip.io&#34;    \
+                 -e openshift_logging_master_public_url=&#34;https://\${public_hostname}:8443&#34;     \
+                 -e openshift_master_logging_public_url=&#34;https://kibana.\${public_ip}.xip.io&#34;  \
                  -e openshift_logging_use_mux=True                                        \
                  -e openshift_logging_mux_allow_external=True                             \
                  -e openshift_logging_es_allow_external=True                              \
                  -e openshift_logging_es_ops_allow_external=True                          \
-                 -e openshift_logging_install_eventrouter=True                            \
                  \${playbook} \
                  --skip-tags=update_master_config
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_logging.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging.xml
@@ -410,42 +410,14 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: BUILD AN OPENSHIFT-ANSIBLE RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: BUILD AN OPENSHIFT-ANSIBLE RELEASE [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL ANSIBLE AND OTHER PACKAGES NEEDED FOR OPENSHIFT ANSIBLE TASKS ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL ANSIBLE AND OTHER PACKAGES NEEDED FOR OPENSHIFT ANSIBLE TASKS [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
-tito_tmp_dir=&#34;tito&#34;
-rm -rf &#34;\${tito_tmp_dir}&#34;
-mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog
-tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
-createrepo &#34;\${tito_tmp_dir}/noarch&#34;
-cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo
-[openshift-ansible-local-release]
-baseurl = file://\$( pwd )/\${tito_tmp_dir}/noarch
-gpgcheck = 0
-name = OpenShift Ansible Release from Local Source
-EOR
-sudo cp ./openshift-ansible-local-release.repo /etc/yum.repos.d
-SCRIPT
-chmod +x &#34;${script}&#34;
-scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 14400 ${script}\&#34;&#34; </command>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-          <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL THE OPENSHIFT-ANSIBLE RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE OPENSHIFT-ANSIBLE RELEASE [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-script=&#34;$( mktemp )&#34;
-cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
-#!/bin/bash
-set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
-last_tag=&#34;\$( git describe --tags --abbrev=0 --exact-match HEAD )&#34;
-last_commit=&#34;\$( git log -n 1 --pretty=%h )&#34;
-sudo yum install -y &#34;atomic-openshift-utils\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7&#34;
-rpm -V &#34;atomic-openshift-utils\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7&#34;
+cd &#34;\${GOPATH}/src/github.com/openshift/origin-aggregated-logging&#34;
+sudo yum install -y ansible python2 python-six tar java-1.8.0-openjdk-headless httpd-tools \
+   libselinux-python python-passlib python-pip
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -458,7 +430,7 @@ script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
+cd &#34;\${GOPATH}/src/github.com/openshift/origin-aggregated-logging&#34;
 sudo chmod o+rw /etc/environment
 echo &#34;ANSIBLE_JUNIT_DIR=\$( pwd )/_output/scripts/ansible_junit&#34; &gt;&gt; /etc/environment
 sudo mkdir -p /usr/share/ansible/plugins/callback
@@ -474,23 +446,20 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: DETERMINE THE RELEASE COMMIT FOR ORIGIN IMAGES AND VERSION FOR RPMS ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: DETERMINE THE RELEASE COMMIT FOR ORIGIN IMAGES AND VERSION FOR RPMS [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: ENSURE THE CORRECT PACKAGE REPOSITORIES ARE USED FOR THE CORRECT RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: ENSURE THE CORRECT PACKAGE REPOSITORIES ARE USED FOR THE CORRECT RELEASE [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
+cd &#34;\${GOPATH}/src/github.com/openshift/origin-aggregated-logging&#34;
 # is logging using master or a release branch?
-pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
 curbranch=\$( git rev-parse --abbrev-ref HEAD )
-popd
-jobs_repo=&#34;/data/src/github.com/openshift/aos-cd-jobs/&#34;
 if [[ &#34;\${curbranch}&#34; == master ]] ; then
-   git log -1 --pretty=%h &gt;&gt; &#34;\${jobs_repo}/ORIGIN_COMMIT&#34;
-   ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo &#34;-\${OS_RPM_VERSION}-\${OS_RPM_RELEASE}&#34; ) &gt;&gt; &#34;\${jobs_repo}/ORIGIN_PKG_VERSION&#34;
-   ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo &#34;\${OS_GIT_MAJOR}.\${OS_GIT_MINOR}&#34; | sed &#34;s/+//&#34; ) &gt;&gt; &#34;\${jobs_repo}/ORIGIN_RELEASE&#34;
+   # enable centos-openshift-origin and centos-openshift-origin-testing
+   # assume everything else has been disabled
+   sudo yum-config-manager --enable centos-openshift-origin &gt; /dev/null
+   sudo yum-config-manager --enable centos-openshift-origin-testing &gt; /dev/null
 elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
-   pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
    # get repo ver from branch name
    repover=\$( echo &#34;\${curbranch}&#34; | sed -e &#39;s/release-//&#39; -e &#39;s/[.]//&#39; )
    # get version from tag
@@ -506,19 +475,7 @@ elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
          *) sudo yum-config-manager --disable \$repo &gt; /dev/null ;;
       esac
    done
-   echo &#34;\${closest_tag}&#34; &gt; \${jobs_repo}/ORIGIN_COMMIT
-   echo &#34;\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
-   echo &#34;\${closest_tag:1}&#34; | cut -d&#39;.&#39; -f1,2 &gt; \${jobs_repo}/ORIGIN_RELEASE
-   # disable local origin repo
    sudo yum-config-manager --disable origin-local-release &gt; /dev/null
-   # hackety hackety hack hack - pre-releases use a *wack[y]* versioning scheme
-   if ( sudo yum install --assumeno origin\${pkgver} 2&gt;&amp;1 || : ) | grep -q &#39;No package .* available&#39; ; then
-      # just ask yum what the heck the version is
-      pkgver=\$( ( sudo yum install --assumeno origin 2&gt;&amp;1 || : ) | awk &#39;\$1 == &#34;x86_64&#34; {print \$2}&#39; )
-      echo &#34;-\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
-   else
-      echo package origin\${pkgver} is available
-   fi
 else
    echo Error: unknown base branch \$curbranch: please resubmit PR on master or a release-x.y branch
 fi
@@ -529,56 +486,80 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: ORIGIN PREREQUISITES ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: ORIGIN PREREQUISITES [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: CONFIGURE SYSTEM TO RUN OC CLUSTER UP AND RUN IT ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: CONFIGURE SYSTEM TO RUN OC CLUSTER UP AND RUN IT [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e containerized=true      \
-                 -e deployment_type=origin  \
-                 /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
-SCRIPT
-chmod +x &#34;${script}&#34;
-scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 14400 ${script}\&#34;&#34; </command>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-          <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL ORIGIN ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL ORIGIN [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-script=&#34;$( mktemp )&#34;
-cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
-#!/bin/bash
-set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-playbook_base=&#39;/usr/share/ansible/openshift-ansible/playbooks/&#39;
-if [[ -s &#34;\${playbook_base}/openshift-node/network_manager.yml&#34; ]]; then
-    playbook=&#34;\${playbook_base}openshift-node/network_manager.yml&#34;
-else
-    playbook=&#34;\${playbook_base}byo/openshift-node/network_manager.yml&#34;
+cd &#34;\${GOPATH}/src/github.com/openshift/origin-aggregated-logging&#34;
+# https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md#overview
+# 3.8 has a problem with fail-swap-on - not a valid flag
+sudo yum install -y origin-clients docker /usr/bin/firewall-cmd
+sudo yum info origin-clients
+sudo systemctl enable firewalld
+sudo systemctl start firewalld
+sudo sysctl -w net.ipv4.ip_forward=1
+
+# set up docker for local registry
+if ! sudo grep -q &#39;^INSECURE_REGISTRY=&#39; /etc/sysconfig/docker ; then
+  # not present - easy - just add it
+  echo &#34;INSECURE_REGISTRY=&#39;--insecure-registry=172.30.0.0/16&#39;&#34; | sudo tee -a /etc/sysconfig/docker &gt; /dev/null
+elif ! sudo grep -q &#39;^INSECURE_REGISTRY=.*--insecure-registry=172.30.0.0/16&#39; /etc/sysconfig/docker ; then
+  # already there - just add our registry - assumes 1 single line
+  sudo sed -e &#34;/^INSECURE_REGISTRY=/s,[&#39;]\$, --insecure-registry 172.30.0.0/16&#39;,&#34; -i /etc/sysconfig/docker
 fi
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
-                 \${playbook}
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e openshift_logging_install_logging=False \
-                 -e deployment_type=origin  \
-                 -e debug_level=2           \
-                 -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
-                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
-                 -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
-                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
+
+# set docker log driver correctly
+if ! sudo grep -q &#39;^OPTIONS=&#39; /etc/sysconfig/docker ; then
+  # not present - easy - just add it
+  echo &#34;OPTIONS=&#39;--log-driver=\${LOG_DRIVER:-journald}&#39;&#34; | sudo tee -a /etc/sysconfig/docker &gt; /dev/null
+elif ! sudo grep -q &#39;^OPTIONS=.*--log-driver&#39; /etc/sysconfig/docker ; then
+  # already there - just add our value - assumes 1 single line
+  sudo sed -e &#34;/^OPTIONS=/s,[&#39;]\$, --log-driver=\${LOG_DRIVER:-journald}&#39;,&#34; -i /etc/sysconfig/docker
+else
+  # already there with value - change the value
+  sudo sed -e &#34;/^OPTIONS=/s/--log-driver=[-_a-zA-Z0-9][-_a-zA-Z0-9]*/--log-driver=\${LOG_DRIVER:-journald}/&#34; -i /etc/sysconfig/docker
+fi
+
+sudo systemctl daemon-reload
+sudo systemctl restart docker
+
+subnet=\$( sudo docker network inspect -f &#34;{{range .IPAM.Config }}{{ .Subnet }}{{end}}&#34; bridge )
+sudo firewall-cmd --permanent --new-zone dockerc
+sudo firewall-cmd --permanent --zone dockerc --add-source \$subnet
+sudo firewall-cmd --permanent --zone dockerc --add-port 8443/tcp
+sudo firewall-cmd --permanent --zone dockerc --add-port 53/udp
+sudo firewall-cmd --permanent --zone dockerc --add-port 8053/udp
+sudo firewall-cmd --reload
+# this is specific to AWS - other platforms will need to get public ip and hostname elsewhere
+metadata_endpoint=&#34;http://169.254.169.254/latest/meta-data&#34;
+public_hostname=&#34;\$( curl -s &#34;\${metadata_endpoint}/public-hostname&#34; )&#34;
+public_ip=&#34;\$( curl -s &#34;\${metadata_endpoint}/public-ipv4&#34; )&#34;
+sudo oc cluster up --public-hostname=&#34;\${public_hostname}&#34; --routing-suffix=&#34;\${public_ip}.xip.io&#34;
+# change the config
+# allow externalIPs, and kibana UI access
+SERVER_CONFIG_DIR=/var/lib/origin/openshift.local.config
+# add loggingPublicURL so the OpenShift UI Console will include a link for Kibana
+# this part stolen from util.sh configure_os_server()
+sudo cp \${SERVER_CONFIG_DIR}/master/master-config.yaml \${SERVER_CONFIG_DIR}/master/master-config.orig.yaml
+ocver=\$( oc version | awk -F&#39;[ v.-]+&#39; &#39;/^oc / {print \$2 \$3 \$4}&#39; )
+patchcmd=&#34;sudo oc ex config patch&#34;
+if [ \$ocver -lt 380 ] ; then
+    patchcmd=&#34;docker exec origin openshift ex config patch&#34;
+fi
+\$patchcmd \${SERVER_CONFIG_DIR}/master/master-config.orig.yaml \
+    --patch=&#34;{\&#34;assetConfig\&#34;: {\&#34;loggingPublicURL\&#34;: \&#34;https://kibana.\${public_ip}.xip.io\&#34;}}&#34; | \
+    sudo tee \${SERVER_CONFIG_DIR}/master/master-config.yaml &gt; /dev/null
+sudo cp \${SERVER_CONFIG_DIR}/master/master-config.yaml \${SERVER_CONFIG_DIR}/master/master-config.save.yaml
+\$patchcmd \${SERVER_CONFIG_DIR}/master/master-config.save.yaml \
+    --patch=&#34;{\&#34;networkConfig\&#34;: {\&#34;externalIPNetworkCIDRs\&#34;: [\&#34;0.0.0.0/0\&#34;]}}&#34; | \
+    sudo tee \${SERVER_CONFIG_DIR}/master/master-config.yaml &gt; /dev/null
+# restart cluster so changes will take effect
+sudo oc cluster down
+# have to restart docker while oc cluster is down, after it has been initialized, or inter-pod
+# networking does not work
+sudo systemctl restart docker
+sudo oc cluster up --use-existing-config --public-hostname=&#34;\${public_hostname}&#34; --routing-suffix=&#34;\${public_ip}.xip.io&#34;
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -592,6 +573,13 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
+if [ ! -d \$HOME/.kube ] ; then
+  mkdir \$HOME/.kube
+fi
+sudo cp /var/lib/origin/openshift.local.config/master/admin.kubeconfig \$HOME/.kube/config
+sudo chown \$USER \$HOME/.kube/config
+sudo mkdir -p /etc/origin/master
+sudo cp /var/lib/origin/openshift.local.config/master/admin.kubeconfig /etc/origin/master/admin.kubeconfig
 sudo chmod a+x /etc/ /etc/origin/ /etc/origin/master/
 sudo chmod a+rw /etc/origin/master/admin.kubeconfig
 SCRIPT
@@ -601,57 +589,55 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: ENSURE BUILT VERSION OF ORIGIN IS INSTALLED ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: ENSURE BUILT VERSION OF ORIGIN IS INSTALLED [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-script=&#34;$( mktemp )&#34;
-cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
-#!/bin/bash
-set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
-curbranch=\$( git rev-parse --abbrev-ref HEAD )
-popd
-if [[ &#34;\${curbranch}&#34; == master ]] ; then
-   origin_package=&#34;\$( source hack/lib/init.sh; os::build::rpm::format_nvra )&#34;
-   rpm -V &#34;\${origin_package}&#34;
-fi
-SCRIPT
-chmod +x &#34;${script}&#34;
-scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 600 ${script}\&#34;&#34; </command>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-          <command>#!/bin/bash
 SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL ORIGIN-AGGREGATED-LOGGING ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL ORIGIN-AGGREGATED-LOGGING [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-playbook_base=&#39;/usr/share/ansible/openshift-ansible/playbooks/&#39;
+cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
+OS_A_C_J_DIR=/data/src/github.com/openshift/aos-cd-jobs
+pushd \$OS_A_C_J_DIR &gt; /dev/null
+# cannot use the networking related parameters with cluster up deployment
+if [ -f sjb/inventory/group_vars/OSEv3/general.yml ] ; then
+    sed -e &#39;/^osm_cluster_network_cidr/d&#39; \
+        -e &#39;/^openshift_portal_net/d&#39; \
+        -e &#39;/^osm_host_subnet_length/d&#39; \
+        -i sjb/inventory/group_vars/OSEv3/general.yml
+else
+    echo ERROR: no such file \$OS_A_C_J_DIR/sjb/inventory/group_vars/OSEv3/general.yml
+    exit 1
+fi
+popd &gt; /dev/null
+# this is specific to AWS - other platforms will need to get public ip and hostname elsewhere
+metadata_endpoint=&#34;http://169.254.169.254/latest/meta-data&#34;
+public_hostname=&#34;\$( curl -s &#34;\${metadata_endpoint}/public-hostname&#34; )&#34;
+public_ip=&#34;\$( curl -s &#34;\${metadata_endpoint}/public-ipv4&#34; )&#34;
+playbook_base=&#39;playbooks/&#39;
 if [[ -s &#34;\${playbook_base}openshift-logging/config.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}openshift-logging/config.yml&#34;
 else
     playbook=&#34;\${playbook_base}byo/openshift-cluster/openshift-logging.yml&#34;
 fi
+# richm 20171205 - causes this:
+# RuntimeError: maximum recursion depth exceeded in cmp
+# -e openshift_logging_install_eventrouter=True
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
-                 --inventory sjb/inventory/ \
+                 --inventory \$OS_A_C_J_DIR/sjb/inventory/ \
                  -e deployment_type=origin  \
                  -e debug_level=2           \
                  -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
                  -e openshift_logging_elasticsearch_proxy_image_prefix=&#34;docker.io/openshift/&#34; \
-                 -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
-                 -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \
-                 -e openshift_master_logging_public_url=&#34;https://kibana.127.0.0.1.nip.io&#34; \
+                 -e openshift_hosted_logging_hostname=&#34;kibana.\${public_ip}.xip.io&#34;            \
+                 -e openshift_logging_kibana_ops_hostname=&#34;kibana-ops.\${public_ip}.xip.io&#34;    \
+                 -e openshift_logging_master_public_url=&#34;https://\${public_hostname}:8443&#34;     \
+                 -e openshift_master_logging_public_url=&#34;https://kibana.\${public_ip}.xip.io&#34;  \
                  -e openshift_logging_use_mux=True                                        \
                  -e openshift_logging_mux_allow_external=True                             \
                  -e openshift_logging_es_allow_external=True                              \
                  -e openshift_logging_es_ops_allow_external=True                          \
-                 -e openshift_logging_install_eventrouter=True                            \
-                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;                 \
-                 -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                         \
                  \${playbook} \
                  --skip-tags=update_master_config
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_aggregated_logging.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging.xml
@@ -69,11 +69,6 @@
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
-          <name>ORIGIN_AGGREGATED_LOGGING_PULL_ID</name>
-          <description>The pull-request in the &lt;a href=&#34;https://github.com/openshift/origin-aggregated-logging&#34;&gt;origin-aggregated-logging&lt;/a&gt; repository to test.</description>
-          <defaultValue></defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
           <name>OPENSHIFT_ANSIBLE_TARGET_BRANCH</name>
           <description>The branch in the &lt;a href=&#34;https://github.com/openshift/openshift-ansible&#34;&gt;openshift-ansible&lt;/a&gt; repository to test against.</description>
           <defaultValue>master</defaultValue>

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
@@ -89,26 +89,6 @@
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
-          <name>ORIGIN_AGGREGATED_LOGGING_PULL_ID</name>
-          <description>The pull-request in the &lt;a href=&quot;https://github.com/openshift/origin-aggregated-logging&quot;&gt;origin-aggregated-logging&lt;/a&gt; repository to test.</description>
-          <defaultValue></defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>PULL_NUMBER</name>
-          <description>The pull-request in the &lt;a href=&quot;https://github.com/openshift/origin-aggregated-logging&quot;&gt;origin-aggregated-logging&lt;/a&gt; repository to test. This is compatible with prow.</description>
-          <defaultValue></defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>PULL_REFS</name>
-          <description>The pull-request(s) in the &lt;a href=&quot;https://github.com/openshift/origin-aggregated-logging&quot;&gt;origin-aggregated-logging&lt;/a&gt; repository to test. This is compatible with prow and can be used for batch testing.</description>
-          <defaultValue></defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>buildId</name>
-          <description>The ID that prow sets on a Jenkins job in order to correlate it with a ProwJob and bubble statuses up to the correct pull request.</description>
-          <defaultValue></defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
           <name>OPENSHIFT_ANSIBLE_TARGET_BRANCH</name>
           <description>The branch in the &lt;a href=&quot;https://github.com/openshift/openshift-ansible&quot;&gt;openshift-ansible&lt;/a&gt; repository to test against.</description>
           <defaultValue>master</defaultValue>
@@ -214,8 +194,8 @@ oct provision remote all-in-one --os &#34;rhel&#34; --stage &#34;build&#34; --pr
     <hudson.plugins.descriptionsetter.DescriptionSetterBuilder plugin="description-setter@1.10">
       <regexp></regexp>
       <description>&lt;div&gt;
-Using PR &lt;a href=&#34;https://github.com/openshift/origin-aggregated-logging/pull/${ORIGIN_AGGREGATED_LOGGING_PULL_ID}&#34;&gt;${ORIGIN_AGGREGATED_LOGGING_PULL_ID}&lt;/a&gt; merged into the &lt;a href=&#34;https://github.com/openshift/origin-aggregated-logging/tree/${ORIGIN_AGGREGATED_LOGGING_TARGET_BRANCH}&#34;&gt;origin-aggregated-logging ${ORIGIN_AGGREGATED_LOGGING_TARGET_BRANCH}&lt;/a&gt; branch.&lt;br/&gt;
-Using the &lt;a href=&#34;https://github.com/openshift/openshift-ansible/tree/${ORIGIN_AGGREGATED_LOGGING_TARGET_BRANCH}&#34;&gt;openshift-ansible ${ORIGIN_AGGREGATED_LOGGING_TARGET_BRANCH}&lt;/a&gt; branch.&lt;br/&gt;
+Using the &lt;a href=&#34;https://github.com/openshift/origin-aggregated-logging/tree/${ORIGIN_AGGREGATED_LOGGING_TARGET_BRANCH}&#34;&gt;origin-aggregated-logging ${ORIGIN_AGGREGATED_LOGGING_TARGET_BRANCH}&lt;/a&gt; branch.&lt;br/&gt;
+Using the &lt;a href=&#34;https://github.com/openshift/openshift-ansible/tree/${OPENSHIFT_ANSIBLE_TARGET_BRANCH}&#34;&gt;openshift-ansible ${OPENSHIFT_ANSIBLE_TARGET_BRANCH}&lt;/a&gt; branch.&lt;br/&gt;
 Using the &lt;a href=&#34;https://github.com/openshift/aos-cd-jobs/tree/${AOS_CD_JOBS_TARGET_BRANCH}&#34;&gt;aos-cd-jobs ${AOS_CD_JOBS_TARGET_BRANCH}&lt;/a&gt; branch.
 &lt;/div&gt;</description>
     </hudson.plugins.descriptionsetter.DescriptionSetterBuilder>
@@ -226,42 +206,8 @@ oct sync remote origin-aggregated-logging --branch &#34;${ORIGIN_AGGREGATED_LOGG
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: SYNC ORIGIN-AGGREGATED-LOGGING PULL REQUEST ${PULL_NUMBER:-}${ORIGIN_AGGREGATED_LOGGING_PULL_ID:-} ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: SYNC ORIGIN-AGGREGATED-LOGGING PULL REQUEST ${PULL_NUMBER:-}${ORIGIN_AGGREGATED_LOGGING_PULL_ID:-} [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-cat &lt;&lt; SCRIPT &gt; unravel-pull-refs.py
-#!/usr/bin/env python
-from __future__ import print_function
-import sys
-
-# PULL_REFS is expected to be in the form of:
-#
-# base_branch:commit_sha_of_base_branch,pull_request_no:commit_sha_of_pull_request_no,...
-#
-# For example:
-#
-# master:97d901d,4:bcb00a1
-#
-# And for multiple pull requests that have been batched:
-#
-# master:97d901d,4:bcb00a1,6:ddk2tka
-print( &#34;\n&#34;.join([r.split(&#39;:&#39;)[0] for r in sys.argv[1].split(&#39;,&#39;)][1:]) )
-SCRIPT
-chmod +x unravel-pull-refs.py
-
-if [[ -n &#34;${PULL_REFS:-}&#34; ]]; then
-  for ref in $(./unravel-pull-refs.py $PULL_REFS); do
-      oct sync remote origin-aggregated-logging --refspec &#34;pull/$ref/head&#34; --branch &#34;pull-$ref&#34; --merge-into &#34;${PULL_REFS%%:*}&#34;
-   done
-elif [[ -n &#34;${ORIGIN_AGGREGATED_LOGGING_PULL_ID:-}&#34; ]]; then
-  oct sync remote origin-aggregated-logging --refspec &#34;pull/${ORIGIN_AGGREGATED_LOGGING_PULL_ID}/head&#34; --branch &#34;pull-${ORIGIN_AGGREGATED_LOGGING_PULL_ID}&#34; --merge-into &#34;${ORIGIN_AGGREGATED_LOGGING_TARGET_BRANCH}&#34;
-else
-  echo &#34;[ERROR] Either \$PULL_REFS or ${ORIGIN_AGGREGATED_LOGGING_PULL_ID:-} and \$ORIGIN_AGGREGATED_LOGGING_TARGET_BRANCH must be set&#34;
-  exit 1
-fi</command>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-          <command>#!/bin/bash
 SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: SYNC OPENSHIFT-ANSIBLE REPOSITORY ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: SYNC OPENSHIFT-ANSIBLE REPOSITORY [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-oct sync remote openshift-ansible --branch &#34;${ORIGIN_AGGREGATED_LOGGING_TARGET_BRANCH}&#34; </command>
+oct sync remote openshift-ansible --branch &#34;${OPENSHIFT_ANSIBLE_TARGET_BRANCH}&#34; </command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -278,10 +224,6 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &
 ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;BUILD_ID=${BUILD_ID:-}&#39; &gt;&gt; /etc/environment&#34;
 ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;REPO_OWNER=${REPO_OWNER:-}&#39; &gt;&gt; /etc/environment&#34;
 ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;REPO_NAME=${REPO_NAME:-}&#39; &gt;&gt; /etc/environment&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;ORIGIN_AGGREGATED_LOGGING_PULL_ID=${ORIGIN_AGGREGATED_LOGGING_PULL_ID:-}&#39; &gt;&gt; /etc/environment&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;PULL_NUMBER=${PULL_NUMBER:-}&#39; &gt;&gt; /etc/environment&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;PULL_REFS=${PULL_REFS:-}&#39; &gt;&gt; /etc/environment&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;buildId=${buildId:-}&#39; &gt;&gt; /etc/environment&#34;
 ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;OPENSHIFT_ANSIBLE_TARGET_BRANCH=${OPENSHIFT_ANSIBLE_TARGET_BRANCH:-}&#39; &gt;&gt; /etc/environment&#34;
 ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;PULL_REFS=${PULL_REFS:-}&#39; &gt;&gt; /etc/environment&#34;
 ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;buildId=${buildId:-}&#39; &gt;&gt; /etc/environment&#34;
@@ -446,43 +388,14 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: BUILD AN OPENSHIFT-ANSIBLE RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: BUILD AN OPENSHIFT-ANSIBLE RELEASE [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL ANSIBLE AND OTHER PACKAGES NEEDED FOR OPENSHIFT ANSIBLE TASKS ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL ANSIBLE AND OTHER PACKAGES NEEDED FOR OPENSHIFT ANSIBLE TASKS [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
-git checkout &#34;\${PULL_REFS%%:*}&#34;
-tito_tmp_dir=&#34;tito&#34;
-rm -rf &#34;\${tito_tmp_dir}&#34;
-mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog
-tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
-createrepo &#34;\${tito_tmp_dir}/noarch&#34;
-cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo
-[openshift-ansible-local-release]
-baseurl = file://\$( pwd )/\${tito_tmp_dir}/noarch
-gpgcheck = 0
-name = OpenShift Ansible Release from Local Source
-EOR
-sudo cp ./openshift-ansible-local-release.repo /etc/yum.repos.d
-SCRIPT
-chmod +x &#34;${script}&#34;
-scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 14400 ${script}\&#34;&#34; </command>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-          <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL THE OPENSHIFT-ANSIBLE RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE OPENSHIFT-ANSIBLE RELEASE [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-script=&#34;$( mktemp )&#34;
-cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
-#!/bin/bash
-set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
-last_tag=&#34;\$( git describe --tags --abbrev=0 --exact-match HEAD )&#34;
-last_commit=&#34;\$( git log -n 1 --pretty=%h )&#34;
-sudo yum install -y &#34;atomic-openshift-utils\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7&#34;
-rpm -V &#34;atomic-openshift-utils\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7&#34;
+cd &#34;\${GOPATH}/src/github.com/openshift/origin-aggregated-logging&#34;
+sudo yum install -y ansible python2 python-six tar java-1.8.0-openjdk-headless httpd-tools \
+   libselinux-python python-passlib python-pip
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -495,7 +408,7 @@ script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
+cd &#34;\${GOPATH}/src/github.com/openshift/origin-aggregated-logging&#34;
 sudo chmod o+rw /etc/environment
 echo &#34;ANSIBLE_JUNIT_DIR=\$( pwd )/_output/scripts/ansible_junit&#34; &gt;&gt; /etc/environment
 sudo mkdir -p /usr/share/ansible/plugins/callback
@@ -511,22 +424,20 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: DETERMINE THE RELEASE COMMIT FOR ORIGIN IMAGES AND VERSION FOR RPMS ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: DETERMINE THE RELEASE COMMIT FOR ORIGIN IMAGES AND VERSION FOR RPMS [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: ENSURE THE CORRECT PACKAGE REPOSITORIES ARE USED FOR THE CORRECT RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: ENSURE THE CORRECT PACKAGE REPOSITORIES ARE USED FOR THE CORRECT RELEASE [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
+cd &#34;\${GOPATH}/src/github.com/openshift/origin-aggregated-logging&#34;
 # is logging using master or a release branch?
-pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
 curbranch=\$( git rev-parse --abbrev-ref HEAD )
-popd
-jobs_repo=&#34;/data/src/github.com/openshift/aos-cd-jobs/&#34;
 if [[ &#34;\${curbranch}&#34; == master ]] ; then
-   git log -1 --pretty=%h &gt;&gt; &#34;\${jobs_repo}/ORIGIN_COMMIT&#34;
-   ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo &#34;-\${OS_RPM_VERSION}-\${OS_RPM_RELEASE}&#34; ) &gt;&gt; &#34;\${jobs_repo}/ORIGIN_PKG_VERSION&#34;
+   # enable centos-openshift-origin and centos-openshift-origin-testing
+   # assume everything else has been disabled
+   sudo yum-config-manager --enable centos-openshift-origin &gt; /dev/null
+   sudo yum-config-manager --enable centos-openshift-origin-testing &gt; /dev/null
 elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
-   pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
    # get repo ver from branch name
    repover=\$( echo &#34;\${curbranch}&#34; | sed -e &#39;s/release-//&#39; -e &#39;s/[.]//&#39; )
    # get version from tag
@@ -542,17 +453,7 @@ elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
          *) sudo yum-config-manager --disable \$repo &gt; /dev/null ;;
       esac
    done
-   echo &#34;\${closest_tag}&#34; &gt; \${jobs_repo}/ORIGIN_COMMIT
-   echo &#34;\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
-   # disable local origin repo
    sudo yum-config-manager --disable origin-local-release &gt; /dev/null
-   if ( sudo yum install --assumeno origin\${pkgver} 2&gt;&amp;1 || : ) | grep -q &#39;No package .* available&#39; ; then
-      # just ask yum what the heck the version is
-      pkgver=\$( ( sudo yum install --assumeno origin 2&gt;&amp;1 || : ) | awk &#39;\$1 == &#34;x86_64&#34; {print \$2}&#39; )
-      echo &#34;-\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
-   else
-      echo package origin\${pkgver} is available
-   fi
 else
    echo Error: unknown base branch \$curbranch: please resubmit PR on master or a release-x.y branch
 fi
@@ -563,55 +464,80 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: ORIGIN PREREQUISITES ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: ORIGIN PREREQUISITES [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: CONFIGURE SYSTEM TO RUN OC CLUSTER UP AND RUN IT ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: CONFIGURE SYSTEM TO RUN OC CLUSTER UP AND RUN IT [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e containerized=true      \
-                 -e deployment_type=origin  \
-                 /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
-SCRIPT
-chmod +x &#34;${script}&#34;
-scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 14400 ${script}\&#34;&#34; </command>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-          <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL ORIGIN ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL ORIGIN [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-script=&#34;$( mktemp )&#34;
-cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
-#!/bin/bash
-set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-playbook_base=&#39;/usr/share/ansible/openshift-ansible/playbooks/&#39;
-if [[ -s &#34;\${playbook_base}/openshift-node/network_manager.yml&#34; ]]; then
-    playbook=&#34;\${playbook_base}openshift-node/network_manager.yml&#34;
-else
-    playbook=&#34;\${playbook_base}byo/openshift-node/network_manager.yml&#34;
+cd &#34;\${GOPATH}/src/github.com/openshift/origin-aggregated-logging&#34;
+# https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md#overview
+# 3.8 has a problem with fail-swap-on - not a valid flag
+sudo yum install -y origin-clients docker /usr/bin/firewall-cmd
+sudo yum info origin-clients
+sudo systemctl enable firewalld
+sudo systemctl start firewalld
+sudo sysctl -w net.ipv4.ip_forward=1
+
+# set up docker for local registry
+if ! sudo grep -q &#39;^INSECURE_REGISTRY=&#39; /etc/sysconfig/docker ; then
+  # not present - easy - just add it
+  echo &#34;INSECURE_REGISTRY=&#39;--insecure-registry=172.30.0.0/16&#39;&#34; | sudo tee -a /etc/sysconfig/docker &gt; /dev/null
+elif ! sudo grep -q &#39;^INSECURE_REGISTRY=.*--insecure-registry=172.30.0.0/16&#39; /etc/sysconfig/docker ; then
+  # already there - just add our registry - assumes 1 single line
+  sudo sed -e &#34;/^INSECURE_REGISTRY=/s,[&#39;]\$, --insecure-registry 172.30.0.0/16&#39;,&#34; -i /etc/sysconfig/docker
 fi
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
-                 -e debug_level=2           \
-                 \${playbook}
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e openshift_logging_install_logging=False \
-                 -e deployment_type=origin  \
-                 -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
-                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
-                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
+
+# set docker log driver correctly
+if ! sudo grep -q &#39;^OPTIONS=&#39; /etc/sysconfig/docker ; then
+  # not present - easy - just add it
+  echo &#34;OPTIONS=&#39;--log-driver=\${LOG_DRIVER:-journald}&#39;&#34; | sudo tee -a /etc/sysconfig/docker &gt; /dev/null
+elif ! sudo grep -q &#39;^OPTIONS=.*--log-driver&#39; /etc/sysconfig/docker ; then
+  # already there - just add our value - assumes 1 single line
+  sudo sed -e &#34;/^OPTIONS=/s,[&#39;]\$, --log-driver=\${LOG_DRIVER:-journald}&#39;,&#34; -i /etc/sysconfig/docker
+else
+  # already there with value - change the value
+  sudo sed -e &#34;/^OPTIONS=/s/--log-driver=[-_a-zA-Z0-9][-_a-zA-Z0-9]*/--log-driver=\${LOG_DRIVER:-journald}/&#34; -i /etc/sysconfig/docker
+fi
+
+sudo systemctl daemon-reload
+sudo systemctl restart docker
+
+subnet=\$( sudo docker network inspect -f &#34;{{range .IPAM.Config }}{{ .Subnet }}{{end}}&#34; bridge )
+sudo firewall-cmd --permanent --new-zone dockerc
+sudo firewall-cmd --permanent --zone dockerc --add-source \$subnet
+sudo firewall-cmd --permanent --zone dockerc --add-port 8443/tcp
+sudo firewall-cmd --permanent --zone dockerc --add-port 53/udp
+sudo firewall-cmd --permanent --zone dockerc --add-port 8053/udp
+sudo firewall-cmd --reload
+# this is specific to AWS - other platforms will need to get public ip and hostname elsewhere
+metadata_endpoint=&#34;http://169.254.169.254/latest/meta-data&#34;
+public_hostname=&#34;\$( curl -s &#34;\${metadata_endpoint}/public-hostname&#34; )&#34;
+public_ip=&#34;\$( curl -s &#34;\${metadata_endpoint}/public-ipv4&#34; )&#34;
+sudo oc cluster up --public-hostname=&#34;\${public_hostname}&#34; --routing-suffix=&#34;\${public_ip}.xip.io&#34;
+# change the config
+# allow externalIPs, and kibana UI access
+SERVER_CONFIG_DIR=/var/lib/origin/openshift.local.config
+# add loggingPublicURL so the OpenShift UI Console will include a link for Kibana
+# this part stolen from util.sh configure_os_server()
+sudo cp \${SERVER_CONFIG_DIR}/master/master-config.yaml \${SERVER_CONFIG_DIR}/master/master-config.orig.yaml
+ocver=\$( oc version | awk -F&#39;[ v.-]+&#39; &#39;/^oc / {print \$2 \$3 \$4}&#39; )
+patchcmd=&#34;sudo oc ex config patch&#34;
+if [ \$ocver -lt 380 ] ; then
+    patchcmd=&#34;docker exec origin openshift ex config patch&#34;
+fi
+\$patchcmd \${SERVER_CONFIG_DIR}/master/master-config.orig.yaml \
+    --patch=&#34;{\&#34;assetConfig\&#34;: {\&#34;loggingPublicURL\&#34;: \&#34;https://kibana.\${public_ip}.xip.io\&#34;}}&#34; | \
+    sudo tee \${SERVER_CONFIG_DIR}/master/master-config.yaml &gt; /dev/null
+sudo cp \${SERVER_CONFIG_DIR}/master/master-config.yaml \${SERVER_CONFIG_DIR}/master/master-config.save.yaml
+\$patchcmd \${SERVER_CONFIG_DIR}/master/master-config.save.yaml \
+    --patch=&#34;{\&#34;networkConfig\&#34;: {\&#34;externalIPNetworkCIDRs\&#34;: [\&#34;0.0.0.0/0\&#34;]}}&#34; | \
+    sudo tee \${SERVER_CONFIG_DIR}/master/master-config.yaml &gt; /dev/null
+# restart cluster so changes will take effect
+sudo oc cluster down
+# have to restart docker while oc cluster is down, after it has been initialized, or inter-pod
+# networking does not work
+sudo systemctl restart docker
+sudo oc cluster up --use-existing-config --public-hostname=&#34;\${public_hostname}&#34; --routing-suffix=&#34;\${public_ip}.xip.io&#34;
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -625,6 +551,13 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
+if [ ! -d \$HOME/.kube ] ; then
+  mkdir \$HOME/.kube
+fi
+sudo cp /var/lib/origin/openshift.local.config/master/admin.kubeconfig \$HOME/.kube/config
+sudo chown \$USER \$HOME/.kube/config
+sudo mkdir -p /etc/origin/master
+sudo cp /var/lib/origin/openshift.local.config/master/admin.kubeconfig /etc/origin/master/admin.kubeconfig
 sudo chmod a+x /etc/ /etc/origin/ /etc/origin/master/
 sudo chmod a+rw /etc/origin/master/admin.kubeconfig
 SCRIPT
@@ -634,55 +567,55 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: ENSURE BUILT VERSION OF ORIGIN IS INSTALLED ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: ENSURE BUILT VERSION OF ORIGIN IS INSTALLED [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-script=&#34;$( mktemp )&#34;
-cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
-#!/bin/bash
-set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
-curbranch=\$( git rev-parse --abbrev-ref HEAD )
-popd
-if [[ &#34;\${curbranch}&#34; == master ]] ; then
-   origin_package=&#34;\$( source hack/lib/init.sh; os::build::rpm::format_nvra )&#34;
-   rpm -V &#34;\${origin_package}&#34;
-fi
-SCRIPT
-chmod +x &#34;${script}&#34;
-scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 600 ${script}\&#34;&#34; </command>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-          <command>#!/bin/bash
 SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL ORIGIN-AGGREGATED-LOGGING ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL ORIGIN-AGGREGATED-LOGGING [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-playbook_base=&#39;/usr/share/ansible/openshift-ansible/playbooks/&#39;
+cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
+OS_A_C_J_DIR=/data/src/github.com/openshift/aos-cd-jobs
+pushd \$OS_A_C_J_DIR &gt; /dev/null
+# cannot use the networking related parameters with cluster up deployment
+if [ -f sjb/inventory/group_vars/OSEv3/general.yml ] ; then
+    sed -e &#39;/^osm_cluster_network_cidr/d&#39; \
+        -e &#39;/^openshift_portal_net/d&#39; \
+        -e &#39;/^osm_host_subnet_length/d&#39; \
+        -i sjb/inventory/group_vars/OSEv3/general.yml
+else
+    echo ERROR: no such file \$OS_A_C_J_DIR/sjb/inventory/group_vars/OSEv3/general.yml
+    exit 1
+fi
+popd &gt; /dev/null
+# this is specific to AWS - other platforms will need to get public ip and hostname elsewhere
+metadata_endpoint=&#34;http://169.254.169.254/latest/meta-data&#34;
+public_hostname=&#34;\$( curl -s &#34;\${metadata_endpoint}/public-hostname&#34; )&#34;
+public_ip=&#34;\$( curl -s &#34;\${metadata_endpoint}/public-ipv4&#34; )&#34;
+playbook_base=&#39;playbooks/&#39;
 if [[ -s &#34;\${playbook_base}openshift-logging/config.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}openshift-logging/config.yml&#34;
 else
     playbook=&#34;\${playbook_base}byo/openshift-cluster/openshift-logging.yml&#34;
 fi
+# richm 20171205 - causes this:
+# RuntimeError: maximum recursion depth exceeded in cmp
+# -e openshift_logging_install_eventrouter=True
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
-                 --inventory sjb/inventory/ \
+                 --inventory \$OS_A_C_J_DIR/sjb/inventory/ \
                  -e deployment_type=origin  \
                  -e debug_level=2           \
                  -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
                  -e openshift_logging_elasticsearch_proxy_image_prefix=&#34;docker.io/openshift/&#34; \
-                 -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
-                 -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \
-                 -e openshift_master_logging_public_url=&#34;https://kibana.127.0.0.1.nip.io&#34; \
+                 -e openshift_hosted_logging_hostname=&#34;kibana.\${public_ip}.xip.io&#34;            \
+                 -e openshift_logging_kibana_ops_hostname=&#34;kibana-ops.\${public_ip}.xip.io&#34;    \
+                 -e openshift_logging_master_public_url=&#34;https://\${public_hostname}:8443&#34;     \
+                 -e openshift_master_logging_public_url=&#34;https://kibana.\${public_ip}.xip.io&#34;  \
                  -e openshift_logging_use_mux=True                                        \
                  -e openshift_logging_mux_allow_external=True                             \
                  -e openshift_logging_es_allow_external=True                              \
                  -e openshift_logging_es_ops_allow_external=True                          \
-                 -e openshift_logging_install_eventrouter=True                            \
                  \${playbook} \
                  --skip-tags=update_master_config
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
@@ -89,26 +89,6 @@
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
-          <name>ORIGIN_AGGREGATED_LOGGING_PULL_ID</name>
-          <description>The pull-request in the &lt;a href=&quot;https://github.com/openshift/origin-aggregated-logging&quot;&gt;origin-aggregated-logging&lt;/a&gt; repository to test.</description>
-          <defaultValue></defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>PULL_NUMBER</name>
-          <description>The pull-request in the &lt;a href=&quot;https://github.com/openshift/origin-aggregated-logging&quot;&gt;origin-aggregated-logging&lt;/a&gt; repository to test. This is compatible with prow.</description>
-          <defaultValue></defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>PULL_REFS</name>
-          <description>The pull-request(s) in the &lt;a href=&quot;https://github.com/openshift/origin-aggregated-logging&quot;&gt;origin-aggregated-logging&lt;/a&gt; repository to test. This is compatible with prow and can be used for batch testing.</description>
-          <defaultValue></defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>buildId</name>
-          <description>The ID that prow sets on a Jenkins job in order to correlate it with a ProwJob and bubble statuses up to the correct pull request.</description>
-          <defaultValue></defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
           <name>OPENSHIFT_ANSIBLE_TARGET_BRANCH</name>
           <description>The branch in the &lt;a href=&quot;https://github.com/openshift/openshift-ansible&quot;&gt;openshift-ansible&lt;/a&gt; repository to test against.</description>
           <defaultValue>master</defaultValue>
@@ -214,8 +194,8 @@ oct provision remote all-in-one --os &#34;rhel&#34; --stage &#34;build&#34; --pr
     <hudson.plugins.descriptionsetter.DescriptionSetterBuilder plugin="description-setter@1.10">
       <regexp></regexp>
       <description>&lt;div&gt;
-Using PR &lt;a href=&#34;https://github.com/openshift/origin-aggregated-logging/pull/${ORIGIN_AGGREGATED_LOGGING_PULL_ID}&#34;&gt;${ORIGIN_AGGREGATED_LOGGING_PULL_ID}&lt;/a&gt; merged into the &lt;a href=&#34;https://github.com/openshift/origin-aggregated-logging/tree/${ORIGIN_AGGREGATED_LOGGING_TARGET_BRANCH}&#34;&gt;origin-aggregated-logging ${ORIGIN_AGGREGATED_LOGGING_TARGET_BRANCH}&lt;/a&gt; branch.&lt;br/&gt;
-Using the &lt;a href=&#34;https://github.com/openshift/openshift-ansible/tree/${ORIGIN_AGGREGATED_LOGGING_TARGET_BRANCH}&#34;&gt;openshift-ansible ${ORIGIN_AGGREGATED_LOGGING_TARGET_BRANCH}&lt;/a&gt; branch.&lt;br/&gt;
+Using the &lt;a href=&#34;https://github.com/openshift/origin-aggregated-logging/tree/${ORIGIN_AGGREGATED_LOGGING_TARGET_BRANCH}&#34;&gt;origin-aggregated-logging ${ORIGIN_AGGREGATED_LOGGING_TARGET_BRANCH}&lt;/a&gt; branch.&lt;br/&gt;
+Using the &lt;a href=&#34;https://github.com/openshift/openshift-ansible/tree/${OPENSHIFT_ANSIBLE_TARGET_BRANCH}&#34;&gt;openshift-ansible ${OPENSHIFT_ANSIBLE_TARGET_BRANCH}&lt;/a&gt; branch.&lt;br/&gt;
 Using the &lt;a href=&#34;https://github.com/openshift/aos-cd-jobs/tree/${AOS_CD_JOBS_TARGET_BRANCH}&#34;&gt;aos-cd-jobs ${AOS_CD_JOBS_TARGET_BRANCH}&lt;/a&gt; branch.
 &lt;/div&gt;</description>
     </hudson.plugins.descriptionsetter.DescriptionSetterBuilder>
@@ -226,42 +206,8 @@ oct sync remote origin-aggregated-logging --branch &#34;${ORIGIN_AGGREGATED_LOGG
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: SYNC ORIGIN-AGGREGATED-LOGGING PULL REQUEST ${PULL_NUMBER:-}${ORIGIN_AGGREGATED_LOGGING_PULL_ID:-} ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: SYNC ORIGIN-AGGREGATED-LOGGING PULL REQUEST ${PULL_NUMBER:-}${ORIGIN_AGGREGATED_LOGGING_PULL_ID:-} [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-cat &lt;&lt; SCRIPT &gt; unravel-pull-refs.py
-#!/usr/bin/env python
-from __future__ import print_function
-import sys
-
-# PULL_REFS is expected to be in the form of:
-#
-# base_branch:commit_sha_of_base_branch,pull_request_no:commit_sha_of_pull_request_no,...
-#
-# For example:
-#
-# master:97d901d,4:bcb00a1
-#
-# And for multiple pull requests that have been batched:
-#
-# master:97d901d,4:bcb00a1,6:ddk2tka
-print( &#34;\n&#34;.join([r.split(&#39;:&#39;)[0] for r in sys.argv[1].split(&#39;,&#39;)][1:]) )
-SCRIPT
-chmod +x unravel-pull-refs.py
-
-if [[ -n &#34;${PULL_REFS:-}&#34; ]]; then
-  for ref in $(./unravel-pull-refs.py $PULL_REFS); do
-      oct sync remote origin-aggregated-logging --refspec &#34;pull/$ref/head&#34; --branch &#34;pull-$ref&#34; --merge-into &#34;${PULL_REFS%%:*}&#34;
-   done
-elif [[ -n &#34;${ORIGIN_AGGREGATED_LOGGING_PULL_ID:-}&#34; ]]; then
-  oct sync remote origin-aggregated-logging --refspec &#34;pull/${ORIGIN_AGGREGATED_LOGGING_PULL_ID}/head&#34; --branch &#34;pull-${ORIGIN_AGGREGATED_LOGGING_PULL_ID}&#34; --merge-into &#34;${ORIGIN_AGGREGATED_LOGGING_TARGET_BRANCH}&#34;
-else
-  echo &#34;[ERROR] Either \$PULL_REFS or ${ORIGIN_AGGREGATED_LOGGING_PULL_ID:-} and \$ORIGIN_AGGREGATED_LOGGING_TARGET_BRANCH must be set&#34;
-  exit 1
-fi</command>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-          <command>#!/bin/bash
 SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: SYNC OPENSHIFT-ANSIBLE REPOSITORY ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: SYNC OPENSHIFT-ANSIBLE REPOSITORY [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-oct sync remote openshift-ansible --branch &#34;${ORIGIN_AGGREGATED_LOGGING_TARGET_BRANCH}&#34; </command>
+oct sync remote openshift-ansible --branch &#34;${OPENSHIFT_ANSIBLE_TARGET_BRANCH}&#34; </command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -278,10 +224,6 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &
 ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;BUILD_ID=${BUILD_ID:-}&#39; &gt;&gt; /etc/environment&#34;
 ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;REPO_OWNER=${REPO_OWNER:-}&#39; &gt;&gt; /etc/environment&#34;
 ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;REPO_NAME=${REPO_NAME:-}&#39; &gt;&gt; /etc/environment&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;ORIGIN_AGGREGATED_LOGGING_PULL_ID=${ORIGIN_AGGREGATED_LOGGING_PULL_ID:-}&#39; &gt;&gt; /etc/environment&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;PULL_NUMBER=${PULL_NUMBER:-}&#39; &gt;&gt; /etc/environment&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;PULL_REFS=${PULL_REFS:-}&#39; &gt;&gt; /etc/environment&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;buildId=${buildId:-}&#39; &gt;&gt; /etc/environment&#34;
 ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;OPENSHIFT_ANSIBLE_TARGET_BRANCH=${OPENSHIFT_ANSIBLE_TARGET_BRANCH:-}&#39; &gt;&gt; /etc/environment&#34;
 ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;PULL_REFS=${PULL_REFS:-}&#39; &gt;&gt; /etc/environment&#34;
 ssh -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;buildId=${buildId:-}&#39; &gt;&gt; /etc/environment&#34;
@@ -446,43 +388,14 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: BUILD AN OPENSHIFT-ANSIBLE RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: BUILD AN OPENSHIFT-ANSIBLE RELEASE [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL ANSIBLE AND OTHER PACKAGES NEEDED FOR OPENSHIFT ANSIBLE TASKS ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL ANSIBLE AND OTHER PACKAGES NEEDED FOR OPENSHIFT ANSIBLE TASKS [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
-git checkout &#34;\${PULL_REFS%%:*}&#34;
-tito_tmp_dir=&#34;tito&#34;
-rm -rf &#34;\${tito_tmp_dir}&#34;
-mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog
-tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
-createrepo &#34;\${tito_tmp_dir}/noarch&#34;
-cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo
-[openshift-ansible-local-release]
-baseurl = file://\$( pwd )/\${tito_tmp_dir}/noarch
-gpgcheck = 0
-name = OpenShift Ansible Release from Local Source
-EOR
-sudo cp ./openshift-ansible-local-release.repo /etc/yum.repos.d
-SCRIPT
-chmod +x &#34;${script}&#34;
-scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 14400 ${script}\&#34;&#34; </command>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-          <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL THE OPENSHIFT-ANSIBLE RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL THE OPENSHIFT-ANSIBLE RELEASE [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-script=&#34;$( mktemp )&#34;
-cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
-#!/bin/bash
-set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
-last_tag=&#34;\$( git describe --tags --abbrev=0 --exact-match HEAD )&#34;
-last_commit=&#34;\$( git log -n 1 --pretty=%h )&#34;
-sudo yum install -y &#34;atomic-openshift-utils\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7&#34;
-rpm -V &#34;atomic-openshift-utils\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7&#34;
+cd &#34;\${GOPATH}/src/github.com/openshift/origin-aggregated-logging&#34;
+sudo yum install -y ansible python2 python-six tar java-1.8.0-openjdk-headless httpd-tools \
+   libselinux-python python-passlib python-pip
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -495,7 +408,7 @@ script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
+cd &#34;\${GOPATH}/src/github.com/openshift/origin-aggregated-logging&#34;
 sudo chmod o+rw /etc/environment
 echo &#34;ANSIBLE_JUNIT_DIR=\$( pwd )/_output/scripts/ansible_junit&#34; &gt;&gt; /etc/environment
 sudo mkdir -p /usr/share/ansible/plugins/callback
@@ -511,22 +424,20 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: DETERMINE THE RELEASE COMMIT FOR ORIGIN IMAGES AND VERSION FOR RPMS ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: DETERMINE THE RELEASE COMMIT FOR ORIGIN IMAGES AND VERSION FOR RPMS [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: ENSURE THE CORRECT PACKAGE REPOSITORIES ARE USED FOR THE CORRECT RELEASE ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: ENSURE THE CORRECT PACKAGE REPOSITORIES ARE USED FOR THE CORRECT RELEASE [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
+cd &#34;\${GOPATH}/src/github.com/openshift/origin-aggregated-logging&#34;
 # is logging using master or a release branch?
-pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
 curbranch=\$( git rev-parse --abbrev-ref HEAD )
-popd
-jobs_repo=&#34;/data/src/github.com/openshift/aos-cd-jobs/&#34;
 if [[ &#34;\${curbranch}&#34; == master ]] ; then
-   git log -1 --pretty=%h &gt;&gt; &#34;\${jobs_repo}/ORIGIN_COMMIT&#34;
-   ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo &#34;-\${OS_RPM_VERSION}-\${OS_RPM_RELEASE}&#34; ) &gt;&gt; &#34;\${jobs_repo}/ORIGIN_PKG_VERSION&#34;
+   # enable centos-openshift-origin and centos-openshift-origin-testing
+   # assume everything else has been disabled
+   sudo yum-config-manager --enable centos-openshift-origin &gt; /dev/null
+   sudo yum-config-manager --enable centos-openshift-origin-testing &gt; /dev/null
 elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
-   pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
    # get repo ver from branch name
    repover=\$( echo &#34;\${curbranch}&#34; | sed -e &#39;s/release-//&#39; -e &#39;s/[.]//&#39; )
    # get version from tag
@@ -542,17 +453,7 @@ elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
          *) sudo yum-config-manager --disable \$repo &gt; /dev/null ;;
       esac
    done
-   echo &#34;\${closest_tag}&#34; &gt; \${jobs_repo}/ORIGIN_COMMIT
-   echo &#34;\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
-   # disable local origin repo
    sudo yum-config-manager --disable origin-local-release &gt; /dev/null
-   if ( sudo yum install --assumeno origin\${pkgver} 2&gt;&amp;1 || : ) | grep -q &#39;No package .* available&#39; ; then
-      # just ask yum what the heck the version is
-      pkgver=\$( ( sudo yum install --assumeno origin 2&gt;&amp;1 || : ) | awk &#39;\$1 == &#34;x86_64&#34; {print \$2}&#39; )
-      echo &#34;-\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
-   else
-      echo package origin\${pkgver} is available
-   fi
 else
    echo Error: unknown base branch \$curbranch: please resubmit PR on master or a release-x.y branch
 fi
@@ -563,57 +464,80 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: ORIGIN PREREQUISITES ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: ORIGIN PREREQUISITES [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: CONFIGURE SYSTEM TO RUN OC CLUSTER UP AND RUN IT ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: CONFIGURE SYSTEM TO RUN OC CLUSTER UP AND RUN IT [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e containerized=true      \
-                 -e deployment_type=origin  \
-                 /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
-SCRIPT
-chmod +x &#34;${script}&#34;
-scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 14400 ${script}\&#34;&#34; </command>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-          <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL ORIGIN ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL ORIGIN [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-script=&#34;$( mktemp )&#34;
-cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
-#!/bin/bash
-set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-playbook_base=&#39;/usr/share/ansible/openshift-ansible/playbooks/&#39;
-if [[ -s &#34;\${playbook_base}/openshift-node/network_manager.yml&#34; ]]; then
-    playbook=&#34;\${playbook_base}openshift-node/network_manager.yml&#34;
-else
-    playbook=&#34;\${playbook_base}byo/openshift-node/network_manager.yml&#34;
+cd &#34;\${GOPATH}/src/github.com/openshift/origin-aggregated-logging&#34;
+# https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md#overview
+# 3.8 has a problem with fail-swap-on - not a valid flag
+sudo yum install -y origin-clients docker /usr/bin/firewall-cmd
+sudo yum info origin-clients
+sudo systemctl enable firewalld
+sudo systemctl start firewalld
+sudo sysctl -w net.ipv4.ip_forward=1
+
+# set up docker for local registry
+if ! sudo grep -q &#39;^INSECURE_REGISTRY=&#39; /etc/sysconfig/docker ; then
+  # not present - easy - just add it
+  echo &#34;INSECURE_REGISTRY=&#39;--insecure-registry=172.30.0.0/16&#39;&#34; | sudo tee -a /etc/sysconfig/docker &gt; /dev/null
+elif ! sudo grep -q &#39;^INSECURE_REGISTRY=.*--insecure-registry=172.30.0.0/16&#39; /etc/sysconfig/docker ; then
+  # already there - just add our registry - assumes 1 single line
+  sudo sed -e &#34;/^INSECURE_REGISTRY=/s,[&#39;]\$, --insecure-registry 172.30.0.0/16&#39;,&#34; -i /etc/sysconfig/docker
 fi
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
-                 \${playbook}
-ansible-playbook -vv --become               \
-                 --become-user root         \
-                 --connection local         \
-                 --inventory sjb/inventory/ \
-                 -e openshift_logging_install_logging=False \
-                 -e deployment_type=origin  \
-                 -e debug_level=2           \
-                 -e openshift_docker_log_driver=json-file \
-                 -e openshift_docker_options=&#34;--log-driver=json-file&#34; \
-                 -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
-                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
-                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
+
+# set docker log driver correctly
+if ! sudo grep -q &#39;^OPTIONS=&#39; /etc/sysconfig/docker ; then
+  # not present - easy - just add it
+  echo &#34;OPTIONS=&#39;--log-driver=\${LOG_DRIVER:-json-file}&#39;&#34; | sudo tee -a /etc/sysconfig/docker &gt; /dev/null
+elif ! sudo grep -q &#39;^OPTIONS=.*--log-driver&#39; /etc/sysconfig/docker ; then
+  # already there - just add our value - assumes 1 single line
+  sudo sed -e &#34;/^OPTIONS=/s,[&#39;]\$, --log-driver=\${LOG_DRIVER:-json-file}&#39;,&#34; -i /etc/sysconfig/docker
+else
+  # already there with value - change the value
+  sudo sed -e &#34;/^OPTIONS=/s/--log-driver=[-_a-zA-Z0-9][-_a-zA-Z0-9]*/--log-driver=\${LOG_DRIVER:-json-file}/&#34; -i /etc/sysconfig/docker
+fi
+
+sudo systemctl daemon-reload
+sudo systemctl restart docker
+
+subnet=\$( sudo docker network inspect -f &#34;{{range .IPAM.Config }}{{ .Subnet }}{{end}}&#34; bridge )
+sudo firewall-cmd --permanent --new-zone dockerc
+sudo firewall-cmd --permanent --zone dockerc --add-source \$subnet
+sudo firewall-cmd --permanent --zone dockerc --add-port 8443/tcp
+sudo firewall-cmd --permanent --zone dockerc --add-port 53/udp
+sudo firewall-cmd --permanent --zone dockerc --add-port 8053/udp
+sudo firewall-cmd --reload
+# this is specific to AWS - other platforms will need to get public ip and hostname elsewhere
+metadata_endpoint=&#34;http://169.254.169.254/latest/meta-data&#34;
+public_hostname=&#34;\$( curl -s &#34;\${metadata_endpoint}/public-hostname&#34; )&#34;
+public_ip=&#34;\$( curl -s &#34;\${metadata_endpoint}/public-ipv4&#34; )&#34;
+sudo oc cluster up --public-hostname=&#34;\${public_hostname}&#34; --routing-suffix=&#34;\${public_ip}.xip.io&#34;
+# change the config
+# allow externalIPs, and kibana UI access
+SERVER_CONFIG_DIR=/var/lib/origin/openshift.local.config
+# add loggingPublicURL so the OpenShift UI Console will include a link for Kibana
+# this part stolen from util.sh configure_os_server()
+sudo cp \${SERVER_CONFIG_DIR}/master/master-config.yaml \${SERVER_CONFIG_DIR}/master/master-config.orig.yaml
+ocver=\$( oc version | awk -F&#39;[ v.-]+&#39; &#39;/^oc / {print \$2 \$3 \$4}&#39; )
+patchcmd=&#34;sudo oc ex config patch&#34;
+if [ \$ocver -lt 380 ] ; then
+    patchcmd=&#34;docker exec origin openshift ex config patch&#34;
+fi
+\$patchcmd \${SERVER_CONFIG_DIR}/master/master-config.orig.yaml \
+    --patch=&#34;{\&#34;assetConfig\&#34;: {\&#34;loggingPublicURL\&#34;: \&#34;https://kibana.\${public_ip}.xip.io\&#34;}}&#34; | \
+    sudo tee \${SERVER_CONFIG_DIR}/master/master-config.yaml &gt; /dev/null
+sudo cp \${SERVER_CONFIG_DIR}/master/master-config.yaml \${SERVER_CONFIG_DIR}/master/master-config.save.yaml
+\$patchcmd \${SERVER_CONFIG_DIR}/master/master-config.save.yaml \
+    --patch=&#34;{\&#34;networkConfig\&#34;: {\&#34;externalIPNetworkCIDRs\&#34;: [\&#34;0.0.0.0/0\&#34;]}}&#34; | \
+    sudo tee \${SERVER_CONFIG_DIR}/master/master-config.yaml &gt; /dev/null
+# restart cluster so changes will take effect
+sudo oc cluster down
+# have to restart docker while oc cluster is down, after it has been initialized, or inter-pod
+# networking does not work
+sudo systemctl restart docker
+sudo oc cluster up --use-existing-config --public-hostname=&#34;\${public_hostname}&#34; --routing-suffix=&#34;\${public_ip}.xip.io&#34;
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -627,6 +551,13 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
+if [ ! -d \$HOME/.kube ] ; then
+  mkdir \$HOME/.kube
+fi
+sudo cp /var/lib/origin/openshift.local.config/master/admin.kubeconfig \$HOME/.kube/config
+sudo chown \$USER \$HOME/.kube/config
+sudo mkdir -p /etc/origin/master
+sudo cp /var/lib/origin/openshift.local.config/master/admin.kubeconfig /etc/origin/master/admin.kubeconfig
 sudo chmod a+x /etc/ /etc/origin/ /etc/origin/master/
 sudo chmod a+rw /etc/origin/master/admin.kubeconfig
 SCRIPT
@@ -636,55 +567,55 @@ ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bas
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: ENSURE BUILT VERSION OF ORIGIN IS INSTALLED ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: ENSURE BUILT VERSION OF ORIGIN IS INSTALLED [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-script=&#34;$( mktemp )&#34;
-cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
-#!/bin/bash
-set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
-curbranch=\$( git rev-parse --abbrev-ref HEAD )
-popd
-if [[ &#34;\${curbranch}&#34; == master ]] ; then
-   origin_package=&#34;\$( source hack/lib/init.sh; os::build::rpm::format_nvra )&#34;
-   rpm -V &#34;\${origin_package}&#34;
-fi
-SCRIPT
-chmod +x &#34;${script}&#34;
-scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 600 ${script}\&#34;&#34; </command>
-        </hudson.tasks.Shell>
-        <hudson.tasks.Shell>
-          <command>#!/bin/bash
 SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL ORIGIN-AGGREGATED-LOGGING ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL ORIGIN-AGGREGATED-LOGGING [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
-cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
-playbook_base=&#39;/usr/share/ansible/openshift-ansible/playbooks/&#39;
+cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
+OS_A_C_J_DIR=/data/src/github.com/openshift/aos-cd-jobs
+pushd \$OS_A_C_J_DIR &gt; /dev/null
+# cannot use the networking related parameters with cluster up deployment
+if [ -f sjb/inventory/group_vars/OSEv3/general.yml ] ; then
+    sed -e &#39;/^osm_cluster_network_cidr/d&#39; \
+        -e &#39;/^openshift_portal_net/d&#39; \
+        -e &#39;/^osm_host_subnet_length/d&#39; \
+        -i sjb/inventory/group_vars/OSEv3/general.yml
+else
+    echo ERROR: no such file \$OS_A_C_J_DIR/sjb/inventory/group_vars/OSEv3/general.yml
+    exit 1
+fi
+popd &gt; /dev/null
+# this is specific to AWS - other platforms will need to get public ip and hostname elsewhere
+metadata_endpoint=&#34;http://169.254.169.254/latest/meta-data&#34;
+public_hostname=&#34;\$( curl -s &#34;\${metadata_endpoint}/public-hostname&#34; )&#34;
+public_ip=&#34;\$( curl -s &#34;\${metadata_endpoint}/public-ipv4&#34; )&#34;
+playbook_base=&#39;playbooks/&#39;
 if [[ -s &#34;\${playbook_base}openshift-logging/config.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}openshift-logging/config.yml&#34;
 else
     playbook=&#34;\${playbook_base}byo/openshift-cluster/openshift-logging.yml&#34;
 fi
+# richm 20171205 - causes this:
+# RuntimeError: maximum recursion depth exceeded in cmp
+# -e openshift_logging_install_eventrouter=True
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
-                 --inventory sjb/inventory/ \
+                 --inventory \$OS_A_C_J_DIR/sjb/inventory/ \
                  -e deployment_type=origin  \
                  -e debug_level=2           \
                  -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
                  -e openshift_logging_elasticsearch_proxy_image_prefix=&#34;docker.io/openshift/&#34; \
-                 -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
-                 -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \
-                 -e openshift_master_logging_public_url=&#34;https://kibana.127.0.0.1.nip.io&#34; \
+                 -e openshift_hosted_logging_hostname=&#34;kibana.\${public_ip}.xip.io&#34;            \
+                 -e openshift_logging_kibana_ops_hostname=&#34;kibana-ops.\${public_ip}.xip.io&#34;    \
+                 -e openshift_logging_master_public_url=&#34;https://\${public_hostname}:8443&#34;     \
+                 -e openshift_master_logging_public_url=&#34;https://kibana.\${public_ip}.xip.io&#34;  \
                  -e openshift_logging_use_mux=True                                        \
                  -e openshift_logging_mux_allow_external=True                             \
                  -e openshift_logging_es_allow_external=True                              \
                  -e openshift_logging_es_ops_allow_external=True                          \
-                 -e openshift_logging_install_eventrouter=True                            \
                  \${playbook} \
                  --skip-tags=update_master_config
 SCRIPT


### PR DESCRIPTION
Use oc cluster up to deploy openshift.  Uses whatever
origin/oc is on the machine.  Assumes that origin 3.x can be used
to deploy logging images for 3.y, and run CI tests for logging 3.y.
Do not build and install openshift-ansible - this should help avoid
strange problems with tito tagging.  Instead, just use the already
cloned ansible source code in place to install logging.
Note: there is some hackery around having to restart docker and
oc cluster up, due to the fact that inter-pod networking for logging
does not work otherwise (e.g. fluentd cannot talk to elasticsearch).
@jcantrill @stevekuznetsov @ewolinetz @nhosoi PTAL