### PR TITLE
logging - workaround ansible eventrouter recursion bug

### DIFF
--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
@@ -167,6 +167,8 @@ extensions:
         else
             playbook="${playbook_base}byo/openshift-cluster/openshift-logging.yml"
         fi
+        #                          -e openshift_logging_install_eventrouter=True                            \
+        # richm 20171205 - ansible "too much recursion" bug
         ansible-playbook -vv --become               \
                          --become-user root         \
                          --connection local         \
@@ -183,7 +185,6 @@ extensions:
                          -e openshift_logging_mux_allow_external=True                             \
                          -e openshift_logging_es_allow_external=True                              \
                          -e openshift_logging_es_ops_allow_external=True                          \
-                         -e openshift_logging_install_eventrouter=True                            \
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"                 \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                         \
                          ${playbook} \

--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file.yml
@@ -159,6 +159,8 @@ extensions:
         else
             playbook="${playbook_base}byo/openshift-cluster/openshift-logging.yml"
         fi
+        #                          -e openshift_logging_install_eventrouter=True                            \
+        # richm 20171205 - ansible "too much recursion" bug
         ansible-playbook -vv --become               \
                          --become-user root         \
                          --connection local         \
@@ -175,7 +177,6 @@ extensions:
                          -e openshift_logging_mux_allow_external=True                             \
                          -e openshift_logging_es_allow_external=True                              \
                          -e openshift_logging_es_ops_allow_external=True                          \
-                         -e openshift_logging_install_eventrouter=True                            \
                          ${playbook} \
                          --skip-tags=update_master_config
     - type: "script"

--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
@@ -159,6 +159,8 @@ extensions:
         else
             playbook="${playbook_base}byo/openshift-cluster/openshift-logging.yml"
         fi
+        #                          -e openshift_logging_install_eventrouter=True                            \
+        # richm 20171205 - ansible "too much recursion" bug
         ansible-playbook -vv --become               \
                          --become-user root         \
                          --connection local         \
@@ -175,7 +177,6 @@ extensions:
                          -e openshift_logging_mux_allow_external=True                             \
                          -e openshift_logging_es_allow_external=True                              \
                          -e openshift_logging_es_ops_allow_external=True                          \
-                         -e openshift_logging_install_eventrouter=True                            \
                          ${playbook} \
                          --skip-tags=update_master_config
     - type: "script"

--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible_json_file.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible_json_file.yml
@@ -161,6 +161,8 @@ extensions:
         else
             playbook="${playbook_base}byo/openshift-cluster/openshift-logging.yml"
         fi
+        #                          -e openshift_logging_install_eventrouter=True                            \
+        # richm 20171205 - ansible "too much recursion" bug
         ansible-playbook -vv --become               \
                          --become-user root         \
                          --connection local         \
@@ -177,7 +179,6 @@ extensions:
                          -e openshift_logging_mux_allow_external=True                             \
                          -e openshift_logging_es_allow_external=True                              \
                          -e openshift_logging_es_ops_allow_external=True                          \
-                         -e openshift_logging_install_eventrouter=True                            \
                          ${playbook} \
                          --skip-tags=update_master_config
     - type: "script"

--- a/sjb/generated/test_branch_openshift_ansible_logging.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging.xml
@@ -617,6 +617,8 @@ if [[ -s &#34;\${playbook_base}openshift-logging/config.yml&#34; ]]; then
 else
     playbook=&#34;\${playbook_base}byo/openshift-cluster/openshift-logging.yml&#34;
 fi
+#                          -e openshift_logging_install_eventrouter=True                            \
+# richm 20171205 - ansible &#34;too much recursion&#34; bug
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
@@ -633,7 +635,6 @@ ansible-playbook -vv --become               \
                  -e openshift_logging_mux_allow_external=True                             \
                  -e openshift_logging_es_allow_external=True                              \
                  -e openshift_logging_es_ops_allow_external=True                          \
-                 -e openshift_logging_install_eventrouter=True                            \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;                 \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                         \
                  \${playbook} \

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
@@ -609,6 +609,8 @@ if [[ -s &#34;\${playbook_base}openshift-logging/config.yml&#34; ]]; then
 else
     playbook=&#34;\${playbook_base}byo/openshift-cluster/openshift-logging.yml&#34;
 fi
+#                          -e openshift_logging_install_eventrouter=True                            \
+# richm 20171205 - ansible &#34;too much recursion&#34; bug
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
@@ -625,7 +627,6 @@ ansible-playbook -vv --become               \
                  -e openshift_logging_mux_allow_external=True                             \
                  -e openshift_logging_es_allow_external=True                              \
                  -e openshift_logging_es_ops_allow_external=True                          \
-                 -e openshift_logging_install_eventrouter=True                            \
                  \${playbook} \
                  --skip-tags=update_master_config
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_logging.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging.xml
@@ -633,6 +633,8 @@ if [[ -s &#34;\${playbook_base}openshift-logging/config.yml&#34; ]]; then
 else
     playbook=&#34;\${playbook_base}byo/openshift-cluster/openshift-logging.yml&#34;
 fi
+#                          -e openshift_logging_install_eventrouter=True                            \
+# richm 20171205 - ansible &#34;too much recursion&#34; bug
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
@@ -649,7 +651,6 @@ ansible-playbook -vv --become               \
                  -e openshift_logging_mux_allow_external=True                             \
                  -e openshift_logging_es_allow_external=True                              \
                  -e openshift_logging_es_ops_allow_external=True                          \
-                 -e openshift_logging_install_eventrouter=True                            \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;                 \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                         \
                  \${playbook} \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
@@ -666,6 +666,8 @@ if [[ -s &#34;\${playbook_base}openshift-logging/config.yml&#34; ]]; then
 else
     playbook=&#34;\${playbook_base}byo/openshift-cluster/openshift-logging.yml&#34;
 fi
+#                          -e openshift_logging_install_eventrouter=True                            \
+# richm 20171205 - ansible &#34;too much recursion&#34; bug
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
@@ -682,7 +684,6 @@ ansible-playbook -vv --become               \
                  -e openshift_logging_mux_allow_external=True                             \
                  -e openshift_logging_es_allow_external=True                              \
                  -e openshift_logging_es_ops_allow_external=True                          \
-                 -e openshift_logging_install_eventrouter=True                            \
                  \${playbook} \
                  --skip-tags=update_master_config
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
@@ -668,6 +668,8 @@ if [[ -s &#34;\${playbook_base}openshift-logging/config.yml&#34; ]]; then
 else
     playbook=&#34;\${playbook_base}byo/openshift-cluster/openshift-logging.yml&#34;
 fi
+#                          -e openshift_logging_install_eventrouter=True                            \
+# richm 20171205 - ansible &#34;too much recursion&#34; bug
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
@@ -684,7 +686,6 @@ ansible-playbook -vv --become               \
                  -e openshift_logging_mux_allow_external=True                             \
                  -e openshift_logging_es_allow_external=True                              \
                  -e openshift_logging_es_ops_allow_external=True                          \
-                 -e openshift_logging_install_eventrouter=True                            \
                  \${playbook} \
                  --skip-tags=update_master_config
 SCRIPT


### PR DESCRIPTION
Enabling eventrouter causes ansible to crash with a
recursion bug - disable to unblock CI until we can fix it