### PR TITLE
have to explicitly set log-driver=journald now

### DIFF
--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
@@ -135,6 +135,8 @@ extensions:
                          -e openshift_logging_install_logging=False \
                          -e deployment_type=origin  \
                          -e debug_level=2           \
+                         -e openshift_docker_log_driver=journald \
+                         -e openshift_docker_options="--log-driver=journald" \
                          -e etcd_data_dir="${ETCD_DATA_DIR}" \
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                       \

--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
@@ -128,6 +128,9 @@ extensions:
                          --inventory sjb/inventory/ \
                          -e openshift_logging_install_logging=False \
                          -e deployment_type=origin  \
+                         -e debug_level=2           \
+                         -e openshift_docker_log_driver=journald \
+                         -e openshift_docker_options="--log-driver=journald" \
                          -e etcd_data_dir="${ETCD_DATA_DIR}" \
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \

--- a/sjb/generated/test_branch_openshift_ansible_logging.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging.xml
@@ -558,6 +558,8 @@ ansible-playbook -vv --become               \
                  -e openshift_logging_install_logging=False \
                  -e deployment_type=origin  \
                  -e debug_level=2           \
+                 -e openshift_docker_log_driver=journald \
+                 -e openshift_docker_options=&#34;--log-driver=journald&#34; \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \

--- a/sjb/generated/test_pull_request_openshift_ansible_logging.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging.xml
@@ -574,6 +574,8 @@ ansible-playbook -vv --become               \
                  -e openshift_logging_install_logging=False \
                  -e deployment_type=origin  \
                  -e debug_level=2           \
+                 -e openshift_docker_log_driver=journald \
+                 -e openshift_docker_options=&#34;--log-driver=journald&#34; \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
@@ -608,6 +608,9 @@ ansible-playbook -vv --become               \
                  --inventory sjb/inventory/ \
                  -e openshift_logging_install_logging=False \
                  -e deployment_type=origin  \
+                 -e debug_level=2           \
+                 -e openshift_docker_log_driver=journald \
+                 -e openshift_docker_options=&#34;--log-driver=journald&#34; \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \


### PR DESCRIPTION
Looks like the default install for origin is to omit the docker
log-driver setting, which by default means docker will use json-file
That means we need to explicitly tell origin to configure docker
to use the journald log driver (which we probably should have done
anyway . . .)