### PR TITLE
conformance_crio: Force prereq and install to use same options

### DIFF
--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_crio.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_crio.yml
@@ -97,8 +97,15 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e containerized=true      \
                          -e deployment_type=origin  \
+                         -e openshift_use_crio=True   \
+                         -e openshift_crio_systemcontainer_image_override=docker.io/gscrivano/cri-o-centos \
+                         -e etcd_data_dir="${ETCD_DATA_DIR}" \
+                         -e openshift_master_default_subdomain="${local_ip}.nip.io"             \
+                         -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
+                         -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
+                         -e openshift_node_port_range='30000-32000'                             \
+                         -e 'osm_controller_args={"enable-hostpath-provisioner":["true"]}'      \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
     - type: "script"
       title: "install origin"


### PR DESCRIPTION
It was noted that the prereq and install playbook calls require the same
set of options. This change copies the options from the install up to
the prereq call.

/cc @giuseppe @runcom @sdodson @michaelgugino 