### PR TITLE
Fix puddle issue

### DIFF
--- a/build-scripts/rcm-guest/push-to-mirrors.sh
+++ b/build-scripts/rcm-guest/push-to-mirrors.sh
@@ -76,7 +76,7 @@ LASTDIR=$(readlink --verbose "${PUDDLEDIR}/latest")
 # we can't simply rename the directory, because the directory contains
 # puddle.repo contains a URL referring to the puddle directory name
 # that was created by the puddle command.
-VERSIONED_DIR="${LASTDIR}_v${FULL_VERSION}"  # e.g. 2017-06-09.4_v3.7.0-0.173.0
+VERSIONED_DIR="v${FULL_VERSION}_${LASTDIR}"  # e.g. v3.7.0-0.173.0_2017-06-09.4
 ln -sfn "${LASTDIR}" "${PUDDLEDIR}/${VERSIONED_DIR}"
 
 echo "Pushing puddle: $LASTDIR"

--- a/jobs/build/ocp/Jenkinsfile
+++ b/jobs/build/ocp/Jenkinsfile
@@ -615,7 +615,7 @@ distgits:build-image
         buildlib.invoke_on_rcm_guest( "push-to-mirrors.sh", "simple", NEW_FULL_VERSION, BUILD_MODE )
 
         // push-to-mirrors.sh sets up a different puddle name on rcm-guest and the mirrors
-        OCP_PUDDLE = "${OCP_PUDDLE}_v${NEW_FULL_VERSION}"
+        OCP_PUDDLE = "v${NEW_FULL_VERSION}_${OCP_PUDDLE}"
 
         if ( NEW_RELEASE != "1" ) {
             // If this is not a release candidate, push binary in a directory qualified with release field information

--- a/jobs/build/ose/scripts/merge-and-build.sh
+++ b/jobs/build/ose/scripts/merge-and-build.sh
@@ -457,7 +457,7 @@ ssh ocp-build@rcm-guest.app.eng.bos.redhat.com \
 
 # push-to-mirrors.sh creates a symlink on rcm-guest with this new name and makes the
 # directory on the mirrors match this name.
-echo -n "${PUDDLE_NAME}_v${VERSION}" > "${RESULTS}/ose-puddle.name"
+echo -n "v${VERSION}_${PUDDLE_NAME}" > "${RESULTS}/ose-puddle.name"
 
 echo
 echo "=========="


### PR DESCRIPTION
Puddle tries to determine a new directory name for each puddle by looking for $(date)_* . If it fines something of this form, it tries to increment an integer value is expects to find after the _ . In our symlink's case, this was not an integer value and was crashing puddle.