### PR TITLE
CRI-O: move junit results to gcs artifacts root

### DIFF
--- a/sjb/config/common/test_cases/crio.yml
+++ b/sjb/config/common/test_cases/crio.yml
@@ -81,6 +81,7 @@ post_actions:
       FINISHED
       cat "/var/lib/jenkins/jobs/${JOB_NAME}/builds/${BUILD_NUMBER}/log" > gcs/build-log.txt
       cp -r artifacts/gathered/* gcs/artifacts/ || true
+      cp artifacts/gathered/artifacts/junit_01.xml gcs/artifacts || true
       cp artifacts/generated/* gcs/artifacts/generated/ || true
       cp artifacts/journals/* gcs/artifacts/journals/ || true
 


### PR DESCRIPTION
Needed by the k8s testgrid as per
https://github.com/kubernetes/test-infra/pull/5943#issuecomment-351584590

@stevekuznetsov PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>