### PR TITLE
Added new JMS filter to differentiate OCP products.

### DIFF
--- a/jobs/build/ocp/Jenkinsfile
+++ b/jobs/build/ocp/Jenkinsfile
@@ -99,6 +99,7 @@ ${OA_CHANGELOG}
                         image_registry_root=registry.reg-aws.openshift.com:443
                         brew_task_url_openshift=${OSE_BREW_URL}
                         brew_task_url_openshift_ansible=${OA_BREW_URL}
+                        product=OpenShift Container Platform
                         """,
                         messageType: 'ProductBuildDone',
                         overrides: [topic: 'VirtualTopic.qe.ci.jenkins'],


### PR DESCRIPTION
This change allows for the smoke test to filter for OCP products on the ci bus.