### PR TITLE
use origin local if release specific repo not found

### DIFF
--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
@@ -65,6 +65,8 @@ extensions:
         popd
         jobs_repo="/data/src/github.com/openshift/aos-cd-jobs/"
         if [[ "${curbranch}" == master ]] ; then
+           # why is this appending?  Is there something already in the file?
+           # Will it work if there is more than one line?  What will it do?
            git log -1 --pretty=%h >> "${jobs_repo}/ORIGIN_COMMIT"
            ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo "-${OS_RPM_VERSION}-${OS_RPM_RELEASE}" ) >> "${jobs_repo}/ORIGIN_PKG_VERSION"
            ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo "${OS_GIT_MAJOR}.${OS_GIT_MINOR}" | sed "s/+//" ) >> "${jobs_repo}/ORIGIN_RELEASE"
@@ -79,24 +81,34 @@ extensions:
            # disable all of the centos repos except for the one for the
            # version being tested - this assumes a devenv environment where
            # all of the repos are installed
+           foundrepover=false
            for repo in $( sudo yum repolist all | awk '/^[!]?centos-paas-sig-openshift-origin/ {print gensub(/^!/,"",1,$1)}' ) ; do
               case $repo in
-                 centos-paas-sig-openshift-origin${repover}-rpms) sudo yum-config-manager --enable $repo > /dev/null ;;
-                 *) sudo yum-config-manager --disable $repo > /dev/null ;;
+                 centos-paas-sig-openshift-origin${repover}-rpms)
+                   foundrepover=true # found a repo for this version
+                   sudo yum-config-manager --enable $repo > /dev/null ;;
+                 *)
+                   sudo yum-config-manager --disable $repo > /dev/null ;;
               esac
            done
-           echo "${closest_tag}" > ${jobs_repo}/ORIGIN_COMMIT
-           echo "${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
-           echo "${closest_tag:1}" | cut -d'.' -f1,2 > ${jobs_repo}/ORIGIN_RELEASE
-           # disable local origin repo
-           sudo yum-config-manager --disable origin-local-release > /dev/null
-           # hackety hackety hack hack - pre-releases use a *wack[y]* versioning scheme
-           if ( sudo yum install --assumeno origin${pkgver} 2>&1 || : ) | grep -q 'No package .* available' ; then
-              # just ask yum what the heck the version is
-              pkgver=$( ( sudo yum install --assumeno origin 2>&1 || : ) | awk '$1 == "x86_64" {print $2}' )
-              echo "-${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
-           else
-              echo package origin${pkgver} is available
+           # disable local origin repo if foundrepover is true - else, we do not have
+           # a release specific repo, use origin-local-release
+           if [[ "${foundrepover:-false}" == true ]] ; then
+              echo "${closest_tag}" > ${jobs_repo}/ORIGIN_COMMIT
+              echo "${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
+              sudo yum-config-manager --disable origin-local-release > /dev/null
+              if ( sudo yum install --assumeno origin${pkgver} 2>&1 || : ) | grep -q 'No package .* available' ; then
+                  # just ask yum what the heck the version is
+                  pkgver=$( ( sudo yum install --assumeno origin 2>&1 || : ) | awk '$1 == "x86_64" {print $2}' )
+                  echo "-${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
+              else
+                  echo package origin${pkgver} is available
+              fi
+           else # use latest on machine
+              pushd "/data/src/github.com/openshift/origin/"
+              git log -1 --pretty=%h >> "${jobs_repo}/ORIGIN_COMMIT"
+              ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo "-${OS_RPM_VERSION}-${OS_RPM_RELEASE}" ) >> "${jobs_repo}/ORIGIN_PKG_VERSION"
+              popd
            fi
         else
            echo Error: unknown base branch $curbranch: please resubmit PR on master or a release-x.y branch

--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file.yml
@@ -59,8 +59,11 @@ extensions:
         popd
         jobs_repo="/data/src/github.com/openshift/aos-cd-jobs/"
         if [[ "${curbranch}" == master ]] ; then
+           # why is this appending?  Is there something already in the file?
+           # Will it work if there is more than one line?  What will it do?
            git log -1 --pretty=%h >> "${jobs_repo}/ORIGIN_COMMIT"
            ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo "-${OS_RPM_VERSION}-${OS_RPM_RELEASE}" ) >> "${jobs_repo}/ORIGIN_PKG_VERSION"
+           ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo "${OS_GIT_MAJOR}.${OS_GIT_MINOR}" | sed "s/+//" ) >> "${jobs_repo}/ORIGIN_RELEASE"
         elif [[ "${curbranch}" =~ ^release-* ]] ; then
            pushd "/data/src/github.com/openshift/origin-aggregated-logging/"
            # get repo ver from branch name
@@ -72,22 +75,34 @@ extensions:
            # disable all of the centos repos except for the one for the
            # version being tested - this assumes a devenv environment where
            # all of the repos are installed
+           foundrepover=false
            for repo in $( sudo yum repolist all | awk '/^[!]?centos-paas-sig-openshift-origin/ {print gensub(/^!/,"",1,$1)}' ) ; do
               case $repo in
-                 centos-paas-sig-openshift-origin${repover}-rpms) sudo yum-config-manager --enable $repo > /dev/null ;;
-                 *) sudo yum-config-manager --disable $repo > /dev/null ;;
+                 centos-paas-sig-openshift-origin${repover}-rpms)
+                   foundrepover=true # found a repo for this version
+                   sudo yum-config-manager --enable $repo > /dev/null ;;
+                 *)
+                   sudo yum-config-manager --disable $repo > /dev/null ;;
               esac
            done
-           echo "${closest_tag}" > ${jobs_repo}/ORIGIN_COMMIT
-           echo "${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
-           # disable local origin repo
-           sudo yum-config-manager --disable origin-local-release > /dev/null
-           if ( sudo yum install --assumeno origin${pkgver} 2>&1 || : ) | grep -q 'No package .* available' ; then
-              # just ask yum what the heck the version is
-              pkgver=$( ( sudo yum install --assumeno origin 2>&1 || : ) | awk '$1 == "x86_64" {print $2}' )
-              echo "-${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
-           else
-              echo package origin${pkgver} is available
+           # disable local origin repo if foundrepover is true - else, we do not have
+           # a release specific repo, use origin-local-release
+           if [[ "${foundrepover:-false}" == true ]] ; then
+              echo "${closest_tag}" > ${jobs_repo}/ORIGIN_COMMIT
+              echo "${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
+              sudo yum-config-manager --disable origin-local-release > /dev/null
+              if ( sudo yum install --assumeno origin${pkgver} 2>&1 || : ) | grep -q 'No package .* available' ; then
+                  # just ask yum what the heck the version is
+                  pkgver=$( ( sudo yum install --assumeno origin 2>&1 || : ) | awk '$1 == "x86_64" {print $2}' )
+                  echo "-${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
+              else
+                  echo package origin${pkgver} is available
+              fi
+           else # use latest on machine
+              pushd "/data/src/github.com/openshift/origin/"
+              git log -1 --pretty=%h >> "${jobs_repo}/ORIGIN_COMMIT"
+              ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo "-${OS_RPM_VERSION}-${OS_RPM_RELEASE}" ) >> "${jobs_repo}/ORIGIN_PKG_VERSION"
+              popd
            fi
         else
            echo Error: unknown base branch $curbranch: please resubmit PR on master or a release-x.y branch

--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
@@ -61,6 +61,8 @@ extensions:
         popd
         jobs_repo="/data/src/github.com/openshift/aos-cd-jobs/"
         if [[ "${curbranch}" == master ]] ; then
+           # why is this appending?  Is there something already in the file?
+           # Will it work if there is more than one line?  What will it do?
            git log -1 --pretty=%h >> "${jobs_repo}/ORIGIN_COMMIT"
            ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo "-${OS_RPM_VERSION}-${OS_RPM_RELEASE}" ) >> "${jobs_repo}/ORIGIN_PKG_VERSION"
         elif [[ "${curbranch}" =~ ^release-* ]] ; then
@@ -74,22 +76,34 @@ extensions:
            # disable all of the centos repos except for the one for the
            # version being tested - this assumes a devenv environment where
            # all of the repos are installed
+           foundrepover=false
            for repo in $( sudo yum repolist all | awk '/^[!]?centos-paas-sig-openshift-origin/ {print gensub(/^!/,"",1,$1)}' ) ; do
               case $repo in
-                 centos-paas-sig-openshift-origin${repover}-rpms) sudo yum-config-manager --enable $repo > /dev/null ;;
-                 *) sudo yum-config-manager --disable $repo > /dev/null ;;
+                 centos-paas-sig-openshift-origin${repover}-rpms)
+                   foundrepover=true # found a repo for this version
+                   sudo yum-config-manager --enable $repo > /dev/null ;;
+                 *)
+                   sudo yum-config-manager --disable $repo > /dev/null ;;
               esac
            done
-           echo "${closest_tag}" > ${jobs_repo}/ORIGIN_COMMIT
-           echo "${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
-           # disable local origin repo
-           sudo yum-config-manager --disable origin-local-release > /dev/null
-           if ( sudo yum install --assumeno origin${pkgver} 2>&1 || : ) | grep -q 'No package .* available' ; then
-              # just ask yum what the heck the version is
-              pkgver=$( ( sudo yum install --assumeno origin 2>&1 || : ) | awk '$1 == "x86_64" {print $2}' )
-              echo "-${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
-           else
-              echo package origin${pkgver} is available
+           # disable local origin repo if foundrepover is true - else, we do not have
+           # a release specific repo, use origin-local-release
+           if [[ "${foundrepover:-false}" == true ]] ; then
+              echo "${closest_tag}" > ${jobs_repo}/ORIGIN_COMMIT
+              echo "${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
+              sudo yum-config-manager --disable origin-local-release > /dev/null
+              if ( sudo yum install --assumeno origin${pkgver} 2>&1 || : ) | grep -q 'No package .* available' ; then
+                  # just ask yum what the heck the version is
+                  pkgver=$( ( sudo yum install --assumeno origin 2>&1 || : ) | awk '$1 == "x86_64" {print $2}' )
+                  echo "-${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
+              else
+                  echo package origin${pkgver} is available
+              fi
+           else # use latest on machine
+              pushd "/data/src/github.com/openshift/origin/"
+              git log -1 --pretty=%h >> "${jobs_repo}/ORIGIN_COMMIT"
+              ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo "-${OS_RPM_VERSION}-${OS_RPM_RELEASE}" ) >> "${jobs_repo}/ORIGIN_PKG_VERSION"
+              popd
            fi
         else
            echo Error: unknown base branch $curbranch: please resubmit PR on master or a release-x.y branch

--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible_json_file.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible_json_file.yml
@@ -61,6 +61,8 @@ extensions:
         popd
         jobs_repo="/data/src/github.com/openshift/aos-cd-jobs/"
         if [[ "${curbranch}" == master ]] ; then
+           # why is this appending?  Is there something already in the file?
+           # Will it work if there is more than one line?  What will it do?
            git log -1 --pretty=%h >> "${jobs_repo}/ORIGIN_COMMIT"
            ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo "-${OS_RPM_VERSION}-${OS_RPM_RELEASE}" ) >> "${jobs_repo}/ORIGIN_PKG_VERSION"
         elif [[ "${curbranch}" =~ ^release-* ]] ; then
@@ -74,22 +76,34 @@ extensions:
            # disable all of the centos repos except for the one for the
            # version being tested - this assumes a devenv environment where
            # all of the repos are installed
+           foundrepover=false
            for repo in $( sudo yum repolist all | awk '/^[!]?centos-paas-sig-openshift-origin/ {print gensub(/^!/,"",1,$1)}' ) ; do
               case $repo in
-                 centos-paas-sig-openshift-origin${repover}-rpms) sudo yum-config-manager --enable $repo > /dev/null ;;
-                 *) sudo yum-config-manager --disable $repo > /dev/null ;;
+                 centos-paas-sig-openshift-origin${repover}-rpms)
+                   foundrepover=true # found a repo for this version
+                   sudo yum-config-manager --enable $repo > /dev/null ;;
+                 *)
+                   sudo yum-config-manager --disable $repo > /dev/null ;;
               esac
            done
-           echo "${closest_tag}" > ${jobs_repo}/ORIGIN_COMMIT
-           echo "${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
-           # disable local origin repo
-           sudo yum-config-manager --disable origin-local-release > /dev/null
-           if ( sudo yum install --assumeno origin${pkgver} 2>&1 || : ) | grep -q 'No package .* available' ; then
-              # just ask yum what the heck the version is
-              pkgver=$( ( sudo yum install --assumeno origin 2>&1 || : ) | awk '$1 == "x86_64" {print $2}' )
-              echo "-${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
-           else
-              echo package origin${pkgver} is available
+           # disable local origin repo if foundrepover is true - else, we do not have
+           # a release specific repo, use origin-local-release
+           if [[ "${foundrepover:-false}" == true ]] ; then
+              echo "${closest_tag}" > ${jobs_repo}/ORIGIN_COMMIT
+              echo "${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
+              sudo yum-config-manager --disable origin-local-release > /dev/null
+              if ( sudo yum install --assumeno origin${pkgver} 2>&1 || : ) | grep -q 'No package .* available' ; then
+                  # just ask yum what the heck the version is
+                  pkgver=$( ( sudo yum install --assumeno origin 2>&1 || : ) | awk '$1 == "x86_64" {print $2}' )
+                  echo "-${pkgver}" > ${jobs_repo}/ORIGIN_PKG_VERSION
+              else
+                  echo package origin${pkgver} is available
+              fi
+           else # use latest on machine
+              pushd "/data/src/github.com/openshift/origin/"
+              git log -1 --pretty=%h >> "${jobs_repo}/ORIGIN_COMMIT"
+              ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo "-${OS_RPM_VERSION}-${OS_RPM_RELEASE}" ) >> "${jobs_repo}/ORIGIN_PKG_VERSION"
+              popd
            fi
         else
            echo Error: unknown base branch $curbranch: please resubmit PR on master or a release-x.y branch

--- a/sjb/generated/test_branch_openshift_ansible_logging.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging.xml
@@ -470,6 +470,8 @@ curbranch=\$( git rev-parse --abbrev-ref HEAD )
 popd
 jobs_repo=&#34;/data/src/github.com/openshift/aos-cd-jobs/&#34;
 if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   # why is this appending?  Is there something already in the file?
+   # Will it work if there is more than one line?  What will it do?
    git log -1 --pretty=%h &gt;&gt; &#34;\${jobs_repo}/ORIGIN_COMMIT&#34;
    ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo &#34;-\${OS_RPM_VERSION}-\${OS_RPM_RELEASE}&#34; ) &gt;&gt; &#34;\${jobs_repo}/ORIGIN_PKG_VERSION&#34;
    ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo &#34;\${OS_GIT_MAJOR}.\${OS_GIT_MINOR}&#34; | sed &#34;s/+//&#34; ) &gt;&gt; &#34;\${jobs_repo}/ORIGIN_RELEASE&#34;
@@ -484,24 +486,34 @@ elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
    # disable all of the centos repos except for the one for the
    # version being tested - this assumes a devenv environment where
    # all of the repos are installed
+   foundrepover=false
    for repo in \$( sudo yum repolist all | awk &#39;/^[!]?centos-paas-sig-openshift-origin/ {print gensub(/^!/,&#34;&#34;,1,\$1)}&#39; ) ; do
       case \$repo in
-         centos-paas-sig-openshift-origin\${repover}-rpms) sudo yum-config-manager --enable \$repo &gt; /dev/null ;;
-         *) sudo yum-config-manager --disable \$repo &gt; /dev/null ;;
+         centos-paas-sig-openshift-origin\${repover}-rpms)
+           foundrepover=true # found a repo for this version
+           sudo yum-config-manager --enable \$repo &gt; /dev/null ;;
+         *)
+           sudo yum-config-manager --disable \$repo &gt; /dev/null ;;
       esac
    done
-   echo &#34;\${closest_tag}&#34; &gt; \${jobs_repo}/ORIGIN_COMMIT
-   echo &#34;\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
-   echo &#34;\${closest_tag:1}&#34; | cut -d&#39;.&#39; -f1,2 &gt; \${jobs_repo}/ORIGIN_RELEASE
-   # disable local origin repo
-   sudo yum-config-manager --disable origin-local-release &gt; /dev/null
-   # hackety hackety hack hack - pre-releases use a *wack[y]* versioning scheme
-   if ( sudo yum install --assumeno origin\${pkgver} 2&gt;&amp;1 || : ) | grep -q &#39;No package .* available&#39; ; then
-      # just ask yum what the heck the version is
-      pkgver=\$( ( sudo yum install --assumeno origin 2&gt;&amp;1 || : ) | awk &#39;\$1 == &#34;x86_64&#34; {print \$2}&#39; )
-      echo &#34;-\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
-   else
-      echo package origin\${pkgver} is available
+   # disable local origin repo if foundrepover is true - else, we do not have
+   # a release specific repo, use origin-local-release
+   if [[ &#34;\${foundrepover:-false}&#34; == true ]] ; then
+      echo &#34;\${closest_tag}&#34; &gt; \${jobs_repo}/ORIGIN_COMMIT
+      echo &#34;\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
+      sudo yum-config-manager --disable origin-local-release &gt; /dev/null
+      if ( sudo yum install --assumeno origin\${pkgver} 2&gt;&amp;1 || : ) | grep -q &#39;No package .* available&#39; ; then
+          # just ask yum what the heck the version is
+          pkgver=\$( ( sudo yum install --assumeno origin 2&gt;&amp;1 || : ) | awk &#39;\$1 == &#34;x86_64&#34; {print \$2}&#39; )
+          echo &#34;-\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
+      else
+          echo package origin\${pkgver} is available
+      fi
+   else # use latest on machine
+      pushd &#34;/data/src/github.com/openshift/origin/&#34;
+      git log -1 --pretty=%h &gt;&gt; &#34;\${jobs_repo}/ORIGIN_COMMIT&#34;
+      ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo &#34;-\${OS_RPM_VERSION}-\${OS_RPM_RELEASE}&#34; ) &gt;&gt; &#34;\${jobs_repo}/ORIGIN_PKG_VERSION&#34;
+      popd
    fi
 else
    echo Error: unknown base branch \$curbranch: please resubmit PR on master or a release-x.y branch

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
@@ -464,8 +464,11 @@ curbranch=\$( git rev-parse --abbrev-ref HEAD )
 popd
 jobs_repo=&#34;/data/src/github.com/openshift/aos-cd-jobs/&#34;
 if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   # why is this appending?  Is there something already in the file?
+   # Will it work if there is more than one line?  What will it do?
    git log -1 --pretty=%h &gt;&gt; &#34;\${jobs_repo}/ORIGIN_COMMIT&#34;
    ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo &#34;-\${OS_RPM_VERSION}-\${OS_RPM_RELEASE}&#34; ) &gt;&gt; &#34;\${jobs_repo}/ORIGIN_PKG_VERSION&#34;
+   ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo &#34;\${OS_GIT_MAJOR}.\${OS_GIT_MINOR}&#34; | sed &#34;s/+//&#34; ) &gt;&gt; &#34;\${jobs_repo}/ORIGIN_RELEASE&#34;
 elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
    pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
    # get repo ver from branch name
@@ -477,22 +480,34 @@ elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
    # disable all of the centos repos except for the one for the
    # version being tested - this assumes a devenv environment where
    # all of the repos are installed
+   foundrepover=false
    for repo in \$( sudo yum repolist all | awk &#39;/^[!]?centos-paas-sig-openshift-origin/ {print gensub(/^!/,&#34;&#34;,1,\$1)}&#39; ) ; do
       case \$repo in
-         centos-paas-sig-openshift-origin\${repover}-rpms) sudo yum-config-manager --enable \$repo &gt; /dev/null ;;
-         *) sudo yum-config-manager --disable \$repo &gt; /dev/null ;;
+         centos-paas-sig-openshift-origin\${repover}-rpms)
+           foundrepover=true # found a repo for this version
+           sudo yum-config-manager --enable \$repo &gt; /dev/null ;;
+         *)
+           sudo yum-config-manager --disable \$repo &gt; /dev/null ;;
       esac
    done
-   echo &#34;\${closest_tag}&#34; &gt; \${jobs_repo}/ORIGIN_COMMIT
-   echo &#34;\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
-   # disable local origin repo
-   sudo yum-config-manager --disable origin-local-release &gt; /dev/null
-   if ( sudo yum install --assumeno origin\${pkgver} 2&gt;&amp;1 || : ) | grep -q &#39;No package .* available&#39; ; then
-      # just ask yum what the heck the version is
-      pkgver=\$( ( sudo yum install --assumeno origin 2&gt;&amp;1 || : ) | awk &#39;\$1 == &#34;x86_64&#34; {print \$2}&#39; )
-      echo &#34;-\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
-   else
-      echo package origin\${pkgver} is available
+   # disable local origin repo if foundrepover is true - else, we do not have
+   # a release specific repo, use origin-local-release
+   if [[ &#34;\${foundrepover:-false}&#34; == true ]] ; then
+      echo &#34;\${closest_tag}&#34; &gt; \${jobs_repo}/ORIGIN_COMMIT
+      echo &#34;\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
+      sudo yum-config-manager --disable origin-local-release &gt; /dev/null
+      if ( sudo yum install --assumeno origin\${pkgver} 2&gt;&amp;1 || : ) | grep -q &#39;No package .* available&#39; ; then
+          # just ask yum what the heck the version is
+          pkgver=\$( ( sudo yum install --assumeno origin 2&gt;&amp;1 || : ) | awk &#39;\$1 == &#34;x86_64&#34; {print \$2}&#39; )
+          echo &#34;-\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
+      else
+          echo package origin\${pkgver} is available
+      fi
+   else # use latest on machine
+      pushd &#34;/data/src/github.com/openshift/origin/&#34;
+      git log -1 --pretty=%h &gt;&gt; &#34;\${jobs_repo}/ORIGIN_COMMIT&#34;
+      ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo &#34;-\${OS_RPM_VERSION}-\${OS_RPM_RELEASE}&#34; ) &gt;&gt; &#34;\${jobs_repo}/ORIGIN_PKG_VERSION&#34;
+      popd
    fi
 else
    echo Error: unknown base branch \$curbranch: please resubmit PR on master or a release-x.y branch

--- a/sjb/generated/test_pull_request_openshift_ansible_logging.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging.xml
@@ -486,6 +486,8 @@ curbranch=\$( git rev-parse --abbrev-ref HEAD )
 popd
 jobs_repo=&#34;/data/src/github.com/openshift/aos-cd-jobs/&#34;
 if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   # why is this appending?  Is there something already in the file?
+   # Will it work if there is more than one line?  What will it do?
    git log -1 --pretty=%h &gt;&gt; &#34;\${jobs_repo}/ORIGIN_COMMIT&#34;
    ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo &#34;-\${OS_RPM_VERSION}-\${OS_RPM_RELEASE}&#34; ) &gt;&gt; &#34;\${jobs_repo}/ORIGIN_PKG_VERSION&#34;
    ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo &#34;\${OS_GIT_MAJOR}.\${OS_GIT_MINOR}&#34; | sed &#34;s/+//&#34; ) &gt;&gt; &#34;\${jobs_repo}/ORIGIN_RELEASE&#34;
@@ -500,24 +502,34 @@ elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
    # disable all of the centos repos except for the one for the
    # version being tested - this assumes a devenv environment where
    # all of the repos are installed
+   foundrepover=false
    for repo in \$( sudo yum repolist all | awk &#39;/^[!]?centos-paas-sig-openshift-origin/ {print gensub(/^!/,&#34;&#34;,1,\$1)}&#39; ) ; do
       case \$repo in
-         centos-paas-sig-openshift-origin\${repover}-rpms) sudo yum-config-manager --enable \$repo &gt; /dev/null ;;
-         *) sudo yum-config-manager --disable \$repo &gt; /dev/null ;;
+         centos-paas-sig-openshift-origin\${repover}-rpms)
+           foundrepover=true # found a repo for this version
+           sudo yum-config-manager --enable \$repo &gt; /dev/null ;;
+         *)
+           sudo yum-config-manager --disable \$repo &gt; /dev/null ;;
       esac
    done
-   echo &#34;\${closest_tag}&#34; &gt; \${jobs_repo}/ORIGIN_COMMIT
-   echo &#34;\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
-   echo &#34;\${closest_tag:1}&#34; | cut -d&#39;.&#39; -f1,2 &gt; \${jobs_repo}/ORIGIN_RELEASE
-   # disable local origin repo
-   sudo yum-config-manager --disable origin-local-release &gt; /dev/null
-   # hackety hackety hack hack - pre-releases use a *wack[y]* versioning scheme
-   if ( sudo yum install --assumeno origin\${pkgver} 2&gt;&amp;1 || : ) | grep -q &#39;No package .* available&#39; ; then
-      # just ask yum what the heck the version is
-      pkgver=\$( ( sudo yum install --assumeno origin 2&gt;&amp;1 || : ) | awk &#39;\$1 == &#34;x86_64&#34; {print \$2}&#39; )
-      echo &#34;-\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
-   else
-      echo package origin\${pkgver} is available
+   # disable local origin repo if foundrepover is true - else, we do not have
+   # a release specific repo, use origin-local-release
+   if [[ &#34;\${foundrepover:-false}&#34; == true ]] ; then
+      echo &#34;\${closest_tag}&#34; &gt; \${jobs_repo}/ORIGIN_COMMIT
+      echo &#34;\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
+      sudo yum-config-manager --disable origin-local-release &gt; /dev/null
+      if ( sudo yum install --assumeno origin\${pkgver} 2&gt;&amp;1 || : ) | grep -q &#39;No package .* available&#39; ; then
+          # just ask yum what the heck the version is
+          pkgver=\$( ( sudo yum install --assumeno origin 2&gt;&amp;1 || : ) | awk &#39;\$1 == &#34;x86_64&#34; {print \$2}&#39; )
+          echo &#34;-\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
+      else
+          echo package origin\${pkgver} is available
+      fi
+   else # use latest on machine
+      pushd &#34;/data/src/github.com/openshift/origin/&#34;
+      git log -1 --pretty=%h &gt;&gt; &#34;\${jobs_repo}/ORIGIN_COMMIT&#34;
+      ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo &#34;-\${OS_RPM_VERSION}-\${OS_RPM_RELEASE}&#34; ) &gt;&gt; &#34;\${jobs_repo}/ORIGIN_PKG_VERSION&#34;
+      popd
    fi
 else
    echo Error: unknown base branch \$curbranch: please resubmit PR on master or a release-x.y branch

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
@@ -523,6 +523,8 @@ curbranch=\$( git rev-parse --abbrev-ref HEAD )
 popd
 jobs_repo=&#34;/data/src/github.com/openshift/aos-cd-jobs/&#34;
 if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   # why is this appending?  Is there something already in the file?
+   # Will it work if there is more than one line?  What will it do?
    git log -1 --pretty=%h &gt;&gt; &#34;\${jobs_repo}/ORIGIN_COMMIT&#34;
    ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo &#34;-\${OS_RPM_VERSION}-\${OS_RPM_RELEASE}&#34; ) &gt;&gt; &#34;\${jobs_repo}/ORIGIN_PKG_VERSION&#34;
 elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
@@ -536,22 +538,34 @@ elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
    # disable all of the centos repos except for the one for the
    # version being tested - this assumes a devenv environment where
    # all of the repos are installed
+   foundrepover=false
    for repo in \$( sudo yum repolist all | awk &#39;/^[!]?centos-paas-sig-openshift-origin/ {print gensub(/^!/,&#34;&#34;,1,\$1)}&#39; ) ; do
       case \$repo in
-         centos-paas-sig-openshift-origin\${repover}-rpms) sudo yum-config-manager --enable \$repo &gt; /dev/null ;;
-         *) sudo yum-config-manager --disable \$repo &gt; /dev/null ;;
+         centos-paas-sig-openshift-origin\${repover}-rpms)
+           foundrepover=true # found a repo for this version
+           sudo yum-config-manager --enable \$repo &gt; /dev/null ;;
+         *)
+           sudo yum-config-manager --disable \$repo &gt; /dev/null ;;
       esac
    done
-   echo &#34;\${closest_tag}&#34; &gt; \${jobs_repo}/ORIGIN_COMMIT
-   echo &#34;\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
-   # disable local origin repo
-   sudo yum-config-manager --disable origin-local-release &gt; /dev/null
-   if ( sudo yum install --assumeno origin\${pkgver} 2&gt;&amp;1 || : ) | grep -q &#39;No package .* available&#39; ; then
-      # just ask yum what the heck the version is
-      pkgver=\$( ( sudo yum install --assumeno origin 2&gt;&amp;1 || : ) | awk &#39;\$1 == &#34;x86_64&#34; {print \$2}&#39; )
-      echo &#34;-\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
-   else
-      echo package origin\${pkgver} is available
+   # disable local origin repo if foundrepover is true - else, we do not have
+   # a release specific repo, use origin-local-release
+   if [[ &#34;\${foundrepover:-false}&#34; == true ]] ; then
+      echo &#34;\${closest_tag}&#34; &gt; \${jobs_repo}/ORIGIN_COMMIT
+      echo &#34;\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
+      sudo yum-config-manager --disable origin-local-release &gt; /dev/null
+      if ( sudo yum install --assumeno origin\${pkgver} 2&gt;&amp;1 || : ) | grep -q &#39;No package .* available&#39; ; then
+          # just ask yum what the heck the version is
+          pkgver=\$( ( sudo yum install --assumeno origin 2&gt;&amp;1 || : ) | awk &#39;\$1 == &#34;x86_64&#34; {print \$2}&#39; )
+          echo &#34;-\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
+      else
+          echo package origin\${pkgver} is available
+      fi
+   else # use latest on machine
+      pushd &#34;/data/src/github.com/openshift/origin/&#34;
+      git log -1 --pretty=%h &gt;&gt; &#34;\${jobs_repo}/ORIGIN_COMMIT&#34;
+      ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo &#34;-\${OS_RPM_VERSION}-\${OS_RPM_RELEASE}&#34; ) &gt;&gt; &#34;\${jobs_repo}/ORIGIN_PKG_VERSION&#34;
+      popd
    fi
 else
    echo Error: unknown base branch \$curbranch: please resubmit PR on master or a release-x.y branch

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
@@ -523,6 +523,8 @@ curbranch=\$( git rev-parse --abbrev-ref HEAD )
 popd
 jobs_repo=&#34;/data/src/github.com/openshift/aos-cd-jobs/&#34;
 if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   # why is this appending?  Is there something already in the file?
+   # Will it work if there is more than one line?  What will it do?
    git log -1 --pretty=%h &gt;&gt; &#34;\${jobs_repo}/ORIGIN_COMMIT&#34;
    ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo &#34;-\${OS_RPM_VERSION}-\${OS_RPM_RELEASE}&#34; ) &gt;&gt; &#34;\${jobs_repo}/ORIGIN_PKG_VERSION&#34;
 elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
@@ -536,22 +538,34 @@ elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
    # disable all of the centos repos except for the one for the
    # version being tested - this assumes a devenv environment where
    # all of the repos are installed
+   foundrepover=false
    for repo in \$( sudo yum repolist all | awk &#39;/^[!]?centos-paas-sig-openshift-origin/ {print gensub(/^!/,&#34;&#34;,1,\$1)}&#39; ) ; do
       case \$repo in
-         centos-paas-sig-openshift-origin\${repover}-rpms) sudo yum-config-manager --enable \$repo &gt; /dev/null ;;
-         *) sudo yum-config-manager --disable \$repo &gt; /dev/null ;;
+         centos-paas-sig-openshift-origin\${repover}-rpms)
+           foundrepover=true # found a repo for this version
+           sudo yum-config-manager --enable \$repo &gt; /dev/null ;;
+         *)
+           sudo yum-config-manager --disable \$repo &gt; /dev/null ;;
       esac
    done
-   echo &#34;\${closest_tag}&#34; &gt; \${jobs_repo}/ORIGIN_COMMIT
-   echo &#34;\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
-   # disable local origin repo
-   sudo yum-config-manager --disable origin-local-release &gt; /dev/null
-   if ( sudo yum install --assumeno origin\${pkgver} 2&gt;&amp;1 || : ) | grep -q &#39;No package .* available&#39; ; then
-      # just ask yum what the heck the version is
-      pkgver=\$( ( sudo yum install --assumeno origin 2&gt;&amp;1 || : ) | awk &#39;\$1 == &#34;x86_64&#34; {print \$2}&#39; )
-      echo &#34;-\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
-   else
-      echo package origin\${pkgver} is available
+   # disable local origin repo if foundrepover is true - else, we do not have
+   # a release specific repo, use origin-local-release
+   if [[ &#34;\${foundrepover:-false}&#34; == true ]] ; then
+      echo &#34;\${closest_tag}&#34; &gt; \${jobs_repo}/ORIGIN_COMMIT
+      echo &#34;\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
+      sudo yum-config-manager --disable origin-local-release &gt; /dev/null
+      if ( sudo yum install --assumeno origin\${pkgver} 2&gt;&amp;1 || : ) | grep -q &#39;No package .* available&#39; ; then
+          # just ask yum what the heck the version is
+          pkgver=\$( ( sudo yum install --assumeno origin 2&gt;&amp;1 || : ) | awk &#39;\$1 == &#34;x86_64&#34; {print \$2}&#39; )
+          echo &#34;-\${pkgver}&#34; &gt; \${jobs_repo}/ORIGIN_PKG_VERSION
+      else
+          echo package origin\${pkgver} is available
+      fi
+   else # use latest on machine
+      pushd &#34;/data/src/github.com/openshift/origin/&#34;
+      git log -1 --pretty=%h &gt;&gt; &#34;\${jobs_repo}/ORIGIN_COMMIT&#34;
+      ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo &#34;-\${OS_RPM_VERSION}-\${OS_RPM_RELEASE}&#34; ) &gt;&gt; &#34;\${jobs_repo}/ORIGIN_PKG_VERSION&#34;
+      popd
    fi
 else
    echo Error: unknown base branch \$curbranch: please resubmit PR on master or a release-x.y branch


### PR DESCRIPTION
If there is no release specific repo e.g. currently the repo
centos-paas-sig-openshift-origin38-rpms does not exist, then
just use the latest origin built on the devenv machine.