### PR TITLE
Fix ansible jobs to include all vars in each step

### DIFF
--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
@@ -121,8 +121,15 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e containerized=true      \
-                         -e deployment_type=origin  \
+                         -e openshift_logging_install_logging=False \
+                         -e openshift_deployment_type=origin  \
+                         -e debug_level=2           \
+                         -e openshift_docker_log_driver=journald \
+                         -e openshift_docker_options="--log-driver=journald" \
+                         -e etcd_data_dir="${ETCD_DATA_DIR}" \
+                         -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
+                         -e openshift_release="$( cat ./ORIGIN_RELEASE )"                       \
+                         -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
     - type: "script"
       title: "install origin"
@@ -138,7 +145,15 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
+                         -e openshift_logging_install_logging=False \
+                         -e openshift_deployment_type=origin  \
+                         -e debug_level=2           \
+                         -e openshift_docker_log_driver=journald \
+                         -e openshift_docker_options="--log-driver=journald" \
+                         -e etcd_data_dir="${ETCD_DATA_DIR}" \
+                         -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
+                         -e openshift_release="$( cat ./ORIGIN_RELEASE )"                       \
+                         -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
                          ${playbook}
         if [[ -s "${playbook_base}deploy_cluster.yml" ]]; then
             playbook="${playbook_base}deploy_cluster.yml"
@@ -150,7 +165,7 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e openshift_logging_install_logging=False \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          -e debug_level=2           \
                          -e openshift_docker_log_driver=journald \
                          -e openshift_docker_options="--log-driver=journald" \
@@ -192,7 +207,7 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          -e debug_level=2           \
                          -e openshift_logging_install_logging=True \
                          -e openshift_logging_image_prefix="openshift/origin-" \

--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_install_containerized.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_install_containerized.yml
@@ -96,7 +96,13 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e containerized=true      \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
+                         -e openshift_image_tag="$( cat ./ORIGIN_TAG )"                      \
+                         -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"            \
+                         -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \
+                         -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_TAG )" \
+                         -e openshift_node_port_range='30000-32000'                          \
+                         -e 'osm_controller_args={"enable-hostpath-provisioner":["true"]}'   \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
     - type: "script"
       title: "install origin"
@@ -113,7 +119,13 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e containerized=true      \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
+                         -e openshift_image_tag="$( cat ./ORIGIN_TAG )"                      \
+                         -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"            \
+                         -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \
+                         -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_TAG )" \
+                         -e openshift_node_port_range='30000-32000'                          \
+                         -e 'osm_controller_args={"enable-hostpath-provisioner":["true"]}'   \
                          ${playbook}
         if [[ -s "${playbook_base}deploy_cluster.yml" ]]; then
             playbook="${playbook_base}deploy_cluster.yml"
@@ -125,7 +137,7 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e containerized=true      \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          -e openshift_image_tag="$( cat ./ORIGIN_TAG )"                      \
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"            \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \

--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_install_system_containers.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_install_system_containers.yml
@@ -129,8 +129,17 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
+                         -e openshift_use_system_containers=true \
+                         -e openshift_docker_systemcontainer_image_registry_override=brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/rhel7 \
+                         -e system_images_registry=docker \
                          -e containerized=true      \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
+                         -e openshift_image_tag="$( cat ./ORIGIN_TAG )"                      \
+                         -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"            \
+                         -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \
+                         -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_TAG )" \
+                         -e openshift_node_port_range='30000-32000'                          \
+                         -e 'osm_controller_args={"enable-hostpath-provisioner":["true"]}'   \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
     - type: "script"
       title: "install origin"
@@ -154,8 +163,17 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
+                         -e openshift_use_system_containers=true \
+                         -e openshift_docker_systemcontainer_image_registry_override=brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/rhel7 \
+                         -e system_images_registry=docker \
                          -e containerized=true      \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
+                         -e openshift_image_tag="$( cat ./ORIGIN_TAG )"                      \
+                         -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"            \
+                         -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \
+                         -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_TAG )" \
+                         -e openshift_node_port_range='30000-32000'                          \
+                         -e 'osm_controller_args={"enable-hostpath-provisioner":["true"]}'   \
                          ${playbook}
         # install atomic rpm
         sudo yum install atomic -y
@@ -176,7 +194,7 @@ extensions:
                          -e openshift_docker_systemcontainer_image_registry_override=brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/rhel7 \
                          -e system_images_registry=docker \
                          -e containerized=true      \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          -e openshift_image_tag="$( cat ./ORIGIN_TAG )"                      \
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"            \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \

--- a/sjb/generated/test_branch_openshift_ansible_logging.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging.xml
@@ -535,8 +535,15 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_logging_install_logging=False \
+                 -e openshift_deployment_type=origin  \
+                 -e debug_level=2           \
+                 -e openshift_docker_log_driver=journald \
+                 -e openshift_docker_options=&#34;--log-driver=journald&#34; \
+                 -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
+                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
+                 -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
+                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -561,7 +568,15 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_logging_install_logging=False \
+                 -e openshift_deployment_type=origin  \
+                 -e debug_level=2           \
+                 -e openshift_docker_log_driver=journald \
+                 -e openshift_docker_options=&#34;--log-driver=journald&#34; \
+                 -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
+                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
+                 -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
+                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -573,7 +588,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e openshift_logging_install_logging=False \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e debug_level=2           \
                  -e openshift_docker_log_driver=journald \
                  -e openshift_docker_options=&#34;--log-driver=journald&#34; \
@@ -642,7 +657,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e debug_level=2           \
                  -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \

--- a/sjb/generated/test_branch_origin_extended_conformance_install_containerized.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_containerized.xml
@@ -609,7 +609,13 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
+                 -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
+                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
+                 -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
+                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_TAG )&#34; \
+                 -e openshift_node_port_range=&#39;30000-32000&#39;                          \
+                 -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;   \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -635,7 +641,13 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
+                 -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
+                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
+                 -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
+                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_TAG )&#34; \
+                 -e openshift_node_port_range=&#39;30000-32000&#39;                          \
+                 -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;   \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -647,7 +659,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \

--- a/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
@@ -644,8 +644,17 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
+                 -e openshift_use_system_containers=true \
+                 -e openshift_docker_systemcontainer_image_registry_override=brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/rhel7 \
+                 -e system_images_registry=docker \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
+                 -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
+                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
+                 -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
+                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_TAG )&#34; \
+                 -e openshift_node_port_range=&#39;30000-32000&#39;                          \
+                 -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;   \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -678,8 +687,17 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
+                 -e openshift_use_system_containers=true \
+                 -e openshift_docker_systemcontainer_image_registry_override=brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/rhel7 \
+                 -e system_images_registry=docker \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
+                 -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
+                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
+                 -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
+                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_TAG )&#34; \
+                 -e openshift_node_port_range=&#39;30000-32000&#39;                          \
+                 -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;   \
                  \${playbook}
 # install atomic rpm
 sudo yum install atomic -y
@@ -700,7 +718,7 @@ ansible-playbook -vv --become               \
                  -e openshift_docker_systemcontainer_image_registry_override=brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/rhel7 \
                  -e system_images_registry=docker \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized.xml
@@ -667,7 +667,13 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
+                 -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
+                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
+                 -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
+                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_TAG )&#34; \
+                 -e openshift_node_port_range=&#39;30000-32000&#39;                          \
+                 -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;   \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -693,7 +699,13 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
+                 -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
+                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
+                 -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
+                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_TAG )&#34; \
+                 -e openshift_node_port_range=&#39;30000-32000&#39;                          \
+                 -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;   \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -705,7 +717,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
@@ -702,8 +702,17 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
+                 -e openshift_use_system_containers=true \
+                 -e openshift_docker_systemcontainer_image_registry_override=brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/rhel7 \
+                 -e system_images_registry=docker \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
+                 -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
+                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
+                 -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
+                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_TAG )&#34; \
+                 -e openshift_node_port_range=&#39;30000-32000&#39;                          \
+                 -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;   \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -736,8 +745,17 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
+                 -e openshift_use_system_containers=true \
+                 -e openshift_docker_systemcontainer_image_registry_override=brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/rhel7 \
+                 -e system_images_registry=docker \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
+                 -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
+                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
+                 -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
+                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_TAG )&#34; \
+                 -e openshift_node_port_range=&#39;30000-32000&#39;                          \
+                 -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;   \
                  \${playbook}
 # install atomic rpm
 sudo yum install atomic -y
@@ -758,7 +776,7 @@ ansible-playbook -vv --become               \
                  -e openshift_docker_systemcontainer_image_registry_override=brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/rhel7 \
                  -e system_images_registry=docker \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \

--- a/sjb/generated/test_pull_request_openshift_ansible_logging.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging.xml
@@ -551,8 +551,15 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_logging_install_logging=False \
+                 -e openshift_deployment_type=origin  \
+                 -e debug_level=2           \
+                 -e openshift_docker_log_driver=journald \
+                 -e openshift_docker_options=&#34;--log-driver=journald&#34; \
+                 -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
+                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
+                 -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
+                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -577,7 +584,15 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_logging_install_logging=False \
+                 -e openshift_deployment_type=origin  \
+                 -e debug_level=2           \
+                 -e openshift_docker_log_driver=journald \
+                 -e openshift_docker_options=&#34;--log-driver=journald&#34; \
+                 -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
+                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
+                 -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
+                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -589,7 +604,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e openshift_logging_install_logging=False \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e debug_level=2           \
                  -e openshift_docker_log_driver=journald \
                  -e openshift_docker_options=&#34;--log-driver=journald&#34; \
@@ -658,7 +673,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e debug_level=2           \
                  -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \


### PR DESCRIPTION
Currently, there are variables defined in the
'install origin' step that are not included
in the 'origin prerequisites' step.

This commit adds those vars to each step.

This commit also changes deployment_type to
openshift_deployment_type