### PR TITLE
deprecate deployment_type for openshift_deployment_type

### DIFF
--- a/sjb/config/common/test_cases/origin_built_installed_release.yml
+++ b/sjb/config/common/test_cases/origin_built_installed_release.yml
@@ -75,7 +75,7 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e containerized=true      \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
     - type: "script"
       title: "install origin"
@@ -93,7 +93,7 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          ${playbook}
         if [[ -s "${playbook_base}deploy_cluster.yml" ]]; then
             playbook="${playbook_base}deploy_cluster.yml"
@@ -104,7 +104,7 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          -e etcd_data_dir="${ETCD_DATA_DIR}" \
                          -e openshift_master_default_subdomain="${local_ip}.nip.io"             \
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \

--- a/sjb/config/common/test_cases/origin_installed_release.yml
+++ b/sjb/config/common/test_cases/origin_installed_release.yml
@@ -41,7 +41,7 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e containerized=true      \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
     - type: "script"
       title: "install origin"
@@ -59,7 +59,7 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          ${playbook}
         if [[ -s "${playbook_base}deploy_cluster.yml" ]]; then
             playbook="${playbook_base}deploy_cluster.yml"
@@ -70,7 +70,7 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          -e etcd_data_dir="${ETCD_DATA_DIR}" \
                          -e openshift_master_default_subdomain="${local_ip}.nip.io"             \
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \

--- a/sjb/config/test_cases/ami_build_origin_int_rhel_install.yml
+++ b/sjb/config/test_cases/ami_build_origin_int_rhel_install.yml
@@ -56,7 +56,7 @@ actions:
                        --connection local         \
                        --inventory sjb/inventory/ \
                        -e containerized=true      \
-                       -e deployment_type=origin  \
+                       -e openshift_deployment_type=origin  \
                        /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
   - type: "script"
     title: "install origin"
@@ -74,7 +74,7 @@ actions:
                        --become-user root         \
                        --connection local         \
                        --inventory sjb/inventory/ \
-                       -e deployment_type=origin  \
+                       -e openshift_deployment_type=origin  \
                        ${playbook}
       if [[ -s "${playbook_base}deploy_cluster.yml" ]]; then
           playbook="${playbook_base}deploy_cluster.yml"
@@ -85,7 +85,7 @@ actions:
                        --become-user root         \
                        --connection local         \
                        --inventory sjb/inventory/ \
-                       -e deployment_type=origin  \
+                       -e openshift_deployment_type=origin  \
                        -e etcd_data_dir="${ETCD_DATA_DIR}" \
                        -e openshift_master_default_subdomain="${local_ip}.nip.io"             \
                        -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \

--- a/sjb/config/test_cases/test_branch_image_registry_extended.yml
+++ b/sjb/config/test_cases/test_branch_image_registry_extended.yml
@@ -52,7 +52,7 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e containerized=true      \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
     - type: "script"
       title: "install origin"
@@ -70,7 +70,7 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          ${playbook}
         if [[ -s "${playbook_base}deploy_cluster.yml" ]]; then
             playbook="${playbook_base}deploy_cluster.yml"
@@ -81,7 +81,7 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          -e etcd_data_dir="${ETCD_DATA_DIR}" \
                          -e openshift_master_default_subdomain="${local_ip}.nip.io"             \
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \

--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file.yml
@@ -116,7 +116,7 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e containerized=true      \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
     - type: "script"
       title: "install origin"
@@ -132,7 +132,7 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          ${playbook}
         if [[ -s "${playbook_base}deploy_cluster.yml" ]]; then
             playbook="${playbook_base}deploy_cluster.yml"
@@ -143,7 +143,7 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          -e debug_level=2           \
                          -e openshift_logging_install_logging=False \
                          -e openshift_docker_log_driver=json-file \
@@ -185,7 +185,7 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          -e openshift_logging_install_logging=True \
                          -e debug_level=2           \
                          -e openshift_logging_image_prefix="openshift/origin-" \

--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_crio.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_crio.yml
@@ -122,7 +122,7 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          -e openshift_use_crio=True   \
                          -e openshift_crio_systemcontainer_image_override="${crio_image}" \
                          -e etcd_data_dir="${ETCD_DATA_DIR}" \
@@ -163,7 +163,7 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          ${playbook}
         if [[ -s "${playbook_base}deploy_cluster.yml" ]]; then
             playbook="${playbook_base}deploy_cluster.yml"
@@ -174,7 +174,7 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          -e openshift_use_crio=True   \
                          -e openshift_crio_systemcontainer_image_override="${crio_image}" \
                          -e etcd_data_dir="${ETCD_DATA_DIR}" \

--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_install.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_install.yml
@@ -92,7 +92,7 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
     - type: "script"
       title: "install origin"
@@ -108,7 +108,7 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          ${playbook}
         if [[ -s "${playbook_base}deploy_cluster.yml" ]]; then
             playbook="${playbook_base}deploy_cluster.yml"
@@ -119,7 +119,7 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          -e etcd_data_dir="${ETCD_DATA_DIR}" \
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                       \

--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update.yml
@@ -116,7 +116,7 @@ extensions:
                            --connection local         \
                            --inventory sjb/inventory/ \
                            -e containerized=true      \
-                           -e deployment_type=origin  \
+                           -e openshift_deployment_type=origin  \
                            /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
         fi
     - type: "script"
@@ -129,14 +129,14 @@ extensions:
         fi
         pkg_name=$( cat ./PKG_NAME )
         if [[ "${pkg_name}" == "origin" ]]; then
-            deployment_type="origin"
+            openshift_deployment_type="origin"
         elif [[ "${pkg_name}" == "atomic-openshift" ]]; then
-            deployment_type="openshift-enterprise"
+            openshift_deployment_type="openshift-enterprise"
         else
             echo "Can't determine deployment type"
             exit 1
         fi
-        echo "${deployment_type}" > DEPLOYMENT_TYPE
+        echo "${openshift_deployment_type}" > DEPLOYMENT_TYPE
         sudo python sjb/hack/determine_install_upgrade_version.py $( cat ORIGIN_BUILT_VERSION ) --dependency_branch ${OPENSHIFT_ANSIBLE_TARGET_BRANCH} > ORIGIN_VARS
         source ORIGIN_VARS
         source OPENSHIFT_ANSIBLE_VARS
@@ -152,7 +152,7 @@ extensions:
                           --become-user root \
                           --connection local \
                           --inventory sjb/inventory/ \
-                          -e deployment_type=$( cat ./DEPLOYMENT_TYPE) \
+                          -e openshift_deployment_type=$( cat ./DEPLOYMENT_TYPE) \
                           ${playbook}
         if [[ -s "${playbook_base}deploy_cluster.yml" ]]; then
             playbook="${playbook_base}deploy_cluster.yml"
@@ -167,7 +167,7 @@ extensions:
                           -e openshift_pkg_version="-${ORIGIN_INSTALL_VERSION}"         \
                           -e openshift_release="3.${ORIGIN_INSTALL_MINOR_VERSION}"      \
                           -e etcd_data_dir="${ETCD_DATA_DIR}"                           \
-                          -e deployment_type=$( cat ./DEPLOYMENT_TYPE)                  \
+                          -e openshift_deployment_type=$( cat ./DEPLOYMENT_TYPE)                  \
                           -e openshift_node_port_range='30000-32000'                    \
                           -e 'osm_controller_args={"enable-hostpath-provisioner":["true"]}' \
                           ${playbook}
@@ -209,7 +209,7 @@ extensions:
                           -e etcd_data_dir="${ETCD_DATA_DIR}" \
                           -e openshift_pkg_version="-${ORIGIN_UPGRADE_RELEASE_VERSION}" \
                           -e openshift_release="3.${ORIGIN_UPGRADE_RELEASE_MINOR_VERSION}" \
-                          -e deployment_type=$( cat ./DEPLOYMENT_TYPE)                  \
+                          -e openshift_deployment_type=$( cat ./DEPLOYMENT_TYPE)                  \
                           -e openshift_node_port_range='30000-32000'                    \
                           -e 'osm_controller_args={"enable-hostpath-provisioner":["true"]}' \
                           -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )"

--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update_containerized.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update_containerized.yml
@@ -97,7 +97,7 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e containerized=true      \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
     - type: "script"
       title: "install origin"
@@ -114,7 +114,7 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e containerized=true      \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          ${playbook}
         if [[ -s "${playbook_base}deploy_cluster.yml" ]]; then
             playbook="${playbook_base}deploy_cluster.yml"
@@ -126,7 +126,7 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e containerized=true      \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          -e openshift_image_tag="$( cat ./ORIGIN_TAG )"                      \
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"            \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \
@@ -153,7 +153,7 @@ extensions:
                          --connection local     \
                          --inventory sjb/inventory/ \
                          -e containerized=true      \
-                         -e deployment_type=origin                  \
+                         -e openshift_deployment_type=origin                  \
                          -e openshift_image_tag="$( cat ./ORIGIN_TAG )"                      \
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )" \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \

--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update_system_containers.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update_system_containers.yml
@@ -131,7 +131,7 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e containerized=true      \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
     - type: "script"
       title: "install origin"
@@ -156,7 +156,7 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e containerized=true      \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          ${playbook}
         # install atomic rpm
         sudo yum install atomic -y
@@ -177,7 +177,7 @@ extensions:
                          -e openshift_docker_systemcontainer_image_override=brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/rhel7 \
                          -e system_images_registry=docker \
                          -e containerized=true      \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          -e openshift_image_tag="$( cat ./ORIGIN_TAG )"                      \
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"            \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \
@@ -218,7 +218,7 @@ extensions:
                          -e openshift_docker_systemcontainer_image_override=brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/rhel7 \
                          -e system_images_registry=docker \
                          -e containerized=true      \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          -e openshift_image_tag="$( cat ./ORIGIN_TAG )"                      \
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"            \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \

--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
@@ -117,7 +117,7 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e containerized=true      \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
     - type: "script"
       title: "install origin"
@@ -133,7 +133,7 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          -e debug_level=2           \
                          ${playbook}
         if [[ -s "${playbook_base}deploy_cluster.yml" ]]; then
@@ -146,7 +146,7 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e openshift_logging_install_logging=False \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          -e debug_level=2           \
                          -e openshift_docker_log_driver=journald \
                          -e openshift_docker_options="--log-driver=journald" \
@@ -187,7 +187,7 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          -e debug_level=2           \
                          -e openshift_logging_install_logging=True \
                          -e openshift_logging_image_prefix="openshift/origin-" \

--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible_json_file.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible_json_file.yml
@@ -117,7 +117,7 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e containerized=true      \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
     - type: "script"
       title: "install origin"
@@ -133,7 +133,7 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          ${playbook}
         if [[ -s "${playbook_base}deploy_cluster.yml" ]]; then
             playbook="${playbook_base}deploy_cluster.yml"
@@ -145,7 +145,7 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e openshift_logging_install_logging=False \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          -e debug_level=2           \
                          -e openshift_docker_log_driver=json-file \
                          -e openshift_docker_options="--log-driver=json-file" \
@@ -186,7 +186,7 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e deployment_type=origin  \
+                         -e openshift_deployment_type=origin  \
                          -e debug_level=2           \
                          -e openshift_logging_install_logging=True \
                          -e openshift_logging_image_prefix="openshift/origin-" \

--- a/sjb/generated/ami_build_origin_int_rhel_install.xml
+++ b/sjb/generated/ami_build_origin_int_rhel_install.xml
@@ -149,7 +149,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -175,7 +175,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -186,7 +186,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \

--- a/sjb/generated/merge_pull_request_jenkins_client_plugin.xml
+++ b/sjb/generated/merge_pull_request_jenkins_client_plugin.xml
@@ -424,7 +424,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -450,7 +450,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -461,7 +461,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \

--- a/sjb/generated/merge_pull_request_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/merge_pull_request_jenkins_openshift_login_plugin.xml
@@ -424,7 +424,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -450,7 +450,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -461,7 +461,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \

--- a/sjb/generated/merge_pull_request_jenkins_plugin.xml
+++ b/sjb/generated/merge_pull_request_jenkins_plugin.xml
@@ -424,7 +424,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -450,7 +450,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -461,7 +461,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \

--- a/sjb/generated/merge_pull_request_jenkins_sync_plugin.xml
+++ b/sjb/generated/merge_pull_request_jenkins_sync_plugin.xml
@@ -424,7 +424,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -450,7 +450,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -461,7 +461,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \

--- a/sjb/generated/test_branch_image_registry_extended.xml
+++ b/sjb/generated/test_branch_image_registry_extended.xml
@@ -372,7 +372,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -398,7 +398,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -409,7 +409,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \

--- a/sjb/generated/test_branch_jenkins_client_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_client_plugin.xml
@@ -355,7 +355,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -381,7 +381,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -392,7 +392,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \

--- a/sjb/generated/test_branch_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_openshift_login_plugin.xml
@@ -355,7 +355,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -381,7 +381,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -392,7 +392,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \

--- a/sjb/generated/test_branch_jenkins_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_plugin.xml
@@ -355,7 +355,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -381,7 +381,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -392,7 +392,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \

--- a/sjb/generated/test_branch_jenkins_sync_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_sync_plugin.xml
@@ -355,7 +355,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -381,7 +381,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -392,7 +392,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
@@ -530,7 +530,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -555,7 +555,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -566,7 +566,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e debug_level=2           \
                  -e openshift_logging_install_logging=False \
                  -e openshift_docker_log_driver=json-file \
@@ -635,7 +635,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e openshift_logging_install_logging=True \
                  -e debug_level=2           \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \

--- a/sjb/generated/test_branch_origin_extended_builds.xml
+++ b/sjb/generated/test_branch_origin_extended_builds.xml
@@ -306,7 +306,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -332,7 +332,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -343,7 +343,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \

--- a/sjb/generated/test_branch_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_crio.xml
@@ -608,7 +608,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e openshift_use_crio=True   \
                  -e openshift_crio_systemcontainer_image_override=&#34;\${crio_image}&#34; \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
@@ -657,7 +657,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -668,7 +668,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e openshift_use_crio=True   \
                  -e openshift_crio_systemcontainer_image_override=&#34;\${crio_image}&#34; \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \

--- a/sjb/generated/test_branch_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install.xml
@@ -605,7 +605,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -630,7 +630,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -641,7 +641,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
@@ -632,7 +632,7 @@ if [ -f /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml ]; then
                    --connection local         \
                    --inventory sjb/inventory/ \
                    -e containerized=true      \
-                   -e deployment_type=origin  \
+                   -e openshift_deployment_type=origin  \
                    /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 fi
 SCRIPT
@@ -653,14 +653,14 @@ if [[ -n &#34;\${PULL_REFS:-}&#34; ]]; then
 fi
 pkg_name=\$( cat ./PKG_NAME )
 if [[ &#34;\${pkg_name}&#34; == &#34;origin&#34; ]]; then
-    deployment_type=&#34;origin&#34;
+    openshift_deployment_type=&#34;origin&#34;
 elif [[ &#34;\${pkg_name}&#34; == &#34;atomic-openshift&#34; ]]; then
-    deployment_type=&#34;openshift-enterprise&#34;
+    openshift_deployment_type=&#34;openshift-enterprise&#34;
 else
     echo &#34;Can&#39;t determine deployment type&#34;
     exit 1
 fi
-echo &#34;\${deployment_type}&#34; &gt; DEPLOYMENT_TYPE
+echo &#34;\${openshift_deployment_type}&#34; &gt; DEPLOYMENT_TYPE
 sudo python sjb/hack/determine_install_upgrade_version.py \$( cat ORIGIN_BUILT_VERSION ) --dependency_branch \${OPENSHIFT_ANSIBLE_TARGET_BRANCH} &gt; ORIGIN_VARS
 source ORIGIN_VARS
 source OPENSHIFT_ANSIBLE_VARS
@@ -676,7 +676,7 @@ ansible-playbook  -vv                \
                   --become-user root \
                   --connection local \
                   --inventory sjb/inventory/ \
-                  -e deployment_type=\$( cat ./DEPLOYMENT_TYPE) \
+                  -e openshift_deployment_type=\$( cat ./DEPLOYMENT_TYPE) \
                   \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -691,7 +691,7 @@ ansible-playbook  -vv                \
                   -e openshift_pkg_version=&#34;-\${ORIGIN_INSTALL_VERSION}&#34;         \
                   -e openshift_release=&#34;3.\${ORIGIN_INSTALL_MINOR_VERSION}&#34;      \
                   -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34;                           \
-                  -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)                  \
+                  -e openshift_deployment_type=\$( cat ./DEPLOYMENT_TYPE)                  \
                   -e openshift_node_port_range=&#39;30000-32000&#39;                    \
                   -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39; \
                   \${playbook}
@@ -758,7 +758,7 @@ ansible-playbook  -vv                    \
                   -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                   -e openshift_pkg_version=&#34;-\${ORIGIN_UPGRADE_RELEASE_VERSION}&#34; \
                   -e openshift_release=&#34;3.\${ORIGIN_UPGRADE_RELEASE_MINOR_VERSION}&#34; \
-                  -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)                  \
+                  -e openshift_deployment_type=\$( cat ./DEPLOYMENT_TYPE)                  \
                   -e openshift_node_port_range=&#39;30000-32000&#39;                    \
                   -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39; \
                   -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized.xml
@@ -610,7 +610,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -636,7 +636,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -648,7 +648,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
@@ -691,7 +691,7 @@ ansible-playbook -vv                    \
                  --connection local     \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin                  \
+                 -e openshift_deployment_type=origin                  \
                  -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34; \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers.xml
@@ -646,7 +646,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -680,7 +680,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 # install atomic rpm
 sudo yum install atomic -y
@@ -701,7 +701,7 @@ ansible-playbook -vv --become               \
                  -e openshift_docker_systemcontainer_image_override=brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/rhel7 \
                  -e system_images_registry=docker \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
@@ -758,7 +758,7 @@ ansible-playbook -vv --become               \
                  -e openshift_docker_systemcontainer_image_override=brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/rhel7 \
                  -e system_images_registry=docker \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \

--- a/sjb/generated/test_branch_origin_extended_image_ecosystem.xml
+++ b/sjb/generated/test_branch_origin_extended_image_ecosystem.xml
@@ -306,7 +306,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -332,7 +332,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -343,7 +343,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \

--- a/sjb/generated/test_branch_origin_extended_image_registry.xml
+++ b/sjb/generated/test_branch_origin_extended_image_registry.xml
@@ -306,7 +306,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -332,7 +332,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -343,7 +343,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \

--- a/sjb/generated/test_pull_request_image_registry_extended.xml
+++ b/sjb/generated/test_pull_request_image_registry_extended.xml
@@ -430,7 +430,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -456,7 +456,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -467,7 +467,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \

--- a/sjb/generated/test_pull_request_jenkins_client_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_client_plugin.xml
@@ -413,7 +413,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -439,7 +439,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -450,7 +450,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \

--- a/sjb/generated/test_pull_request_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_openshift_login_plugin.xml
@@ -413,7 +413,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -439,7 +439,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -450,7 +450,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \

--- a/sjb/generated/test_pull_request_jenkins_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_plugin.xml
@@ -413,7 +413,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -439,7 +439,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -450,7 +450,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \

--- a/sjb/generated/test_pull_request_jenkins_sync_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_sync_plugin.xml
@@ -413,7 +413,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -439,7 +439,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -450,7 +450,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
@@ -663,7 +663,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -688,7 +688,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -699,7 +699,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio.xml
@@ -708,7 +708,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e openshift_use_crio=True   \
                  -e openshift_crio_systemcontainer_image_override=&#34;\${crio_image}&#34; \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
@@ -757,7 +757,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -768,7 +768,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e openshift_use_crio=True   \
                  -e openshift_crio_systemcontainer_image_override=&#34;\${crio_image}&#34; \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
@@ -690,7 +690,7 @@ if [ -f /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml ]; then
                    --connection local         \
                    --inventory sjb/inventory/ \
                    -e containerized=true      \
-                   -e deployment_type=origin  \
+                   -e openshift_deployment_type=origin  \
                    /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 fi
 SCRIPT
@@ -711,14 +711,14 @@ if [[ -n &#34;\${PULL_REFS:-}&#34; ]]; then
 fi
 pkg_name=\$( cat ./PKG_NAME )
 if [[ &#34;\${pkg_name}&#34; == &#34;origin&#34; ]]; then
-    deployment_type=&#34;origin&#34;
+    openshift_deployment_type=&#34;origin&#34;
 elif [[ &#34;\${pkg_name}&#34; == &#34;atomic-openshift&#34; ]]; then
-    deployment_type=&#34;openshift-enterprise&#34;
+    openshift_deployment_type=&#34;openshift-enterprise&#34;
 else
     echo &#34;Can&#39;t determine deployment type&#34;
     exit 1
 fi
-echo &#34;\${deployment_type}&#34; &gt; DEPLOYMENT_TYPE
+echo &#34;\${openshift_deployment_type}&#34; &gt; DEPLOYMENT_TYPE
 sudo python sjb/hack/determine_install_upgrade_version.py \$( cat ORIGIN_BUILT_VERSION ) --dependency_branch \${OPENSHIFT_ANSIBLE_TARGET_BRANCH} &gt; ORIGIN_VARS
 source ORIGIN_VARS
 source OPENSHIFT_ANSIBLE_VARS
@@ -734,7 +734,7 @@ ansible-playbook  -vv                \
                   --become-user root \
                   --connection local \
                   --inventory sjb/inventory/ \
-                  -e deployment_type=\$( cat ./DEPLOYMENT_TYPE) \
+                  -e openshift_deployment_type=\$( cat ./DEPLOYMENT_TYPE) \
                   \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -749,7 +749,7 @@ ansible-playbook  -vv                \
                   -e openshift_pkg_version=&#34;-\${ORIGIN_INSTALL_VERSION}&#34;         \
                   -e openshift_release=&#34;3.\${ORIGIN_INSTALL_MINOR_VERSION}&#34;      \
                   -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34;                           \
-                  -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)                  \
+                  -e openshift_deployment_type=\$( cat ./DEPLOYMENT_TYPE)                  \
                   -e openshift_node_port_range=&#39;30000-32000&#39;                    \
                   -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39; \
                   \${playbook}
@@ -816,7 +816,7 @@ ansible-playbook  -vv                    \
                   -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                   -e openshift_pkg_version=&#34;-\${ORIGIN_UPGRADE_RELEASE_VERSION}&#34; \
                   -e openshift_release=&#34;3.\${ORIGIN_UPGRADE_RELEASE_MINOR_VERSION}&#34; \
-                  -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)                  \
+                  -e openshift_deployment_type=\$( cat ./DEPLOYMENT_TYPE)                  \
                   -e openshift_node_port_range=&#39;30000-32000&#39;                    \
                   -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39; \
                   -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized.xml
@@ -668,7 +668,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -694,7 +694,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -706,7 +706,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
@@ -749,7 +749,7 @@ ansible-playbook -vv                    \
                  --connection local     \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin                  \
+                 -e openshift_deployment_type=origin                  \
                  -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34; \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers.xml
@@ -704,7 +704,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -738,7 +738,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 # install atomic rpm
 sudo yum install atomic -y
@@ -759,7 +759,7 @@ ansible-playbook -vv --become               \
                  -e openshift_docker_systemcontainer_image_override=brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/rhel7 \
                  -e system_images_registry=docker \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
@@ -816,7 +816,7 @@ ansible-playbook -vv --become               \
                  -e openshift_docker_systemcontainer_image_override=brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/rhel7 \
                  -e system_images_registry=docker \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
@@ -663,7 +663,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -688,7 +688,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -699,7 +699,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
@@ -588,7 +588,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -613,7 +613,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e debug_level=2           \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -626,7 +626,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e openshift_logging_install_logging=False \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e debug_level=2           \
                  -e openshift_docker_log_driver=journald \
                  -e openshift_docker_options=&#34;--log-driver=journald&#34; \
@@ -694,7 +694,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e debug_level=2           \
                  -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
@@ -588,7 +588,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -613,7 +613,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -625,7 +625,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e openshift_logging_install_logging=False \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e debug_level=2           \
                  -e openshift_docker_log_driver=json-file \
                  -e openshift_docker_options=&#34;--log-driver=json-file&#34; \
@@ -693,7 +693,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e debug_level=2           \
                  -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \

--- a/sjb/generated/test_pull_request_origin_extended_builds.xml
+++ b/sjb/generated/test_pull_request_origin_extended_builds.xml
@@ -672,7 +672,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -698,7 +698,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -709,7 +709,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \

--- a/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
@@ -708,7 +708,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e openshift_use_crio=True   \
                  -e openshift_crio_systemcontainer_image_override=&#34;\${crio_image}&#34; \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
@@ -757,7 +757,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -768,7 +768,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e openshift_use_crio=True   \
                  -e openshift_crio_systemcontainer_image_override=&#34;\${crio_image}&#34; \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
@@ -663,7 +663,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -688,7 +688,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -699,7 +699,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
@@ -690,7 +690,7 @@ if [ -f /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml ]; then
                    --connection local         \
                    --inventory sjb/inventory/ \
                    -e containerized=true      \
-                   -e deployment_type=origin  \
+                   -e openshift_deployment_type=origin  \
                    /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 fi
 SCRIPT
@@ -711,14 +711,14 @@ if [[ -n &#34;\${PULL_REFS:-}&#34; ]]; then
 fi
 pkg_name=\$( cat ./PKG_NAME )
 if [[ &#34;\${pkg_name}&#34; == &#34;origin&#34; ]]; then
-    deployment_type=&#34;origin&#34;
+    openshift_deployment_type=&#34;origin&#34;
 elif [[ &#34;\${pkg_name}&#34; == &#34;atomic-openshift&#34; ]]; then
-    deployment_type=&#34;openshift-enterprise&#34;
+    openshift_deployment_type=&#34;openshift-enterprise&#34;
 else
     echo &#34;Can&#39;t determine deployment type&#34;
     exit 1
 fi
-echo &#34;\${deployment_type}&#34; &gt; DEPLOYMENT_TYPE
+echo &#34;\${openshift_deployment_type}&#34; &gt; DEPLOYMENT_TYPE
 sudo python sjb/hack/determine_install_upgrade_version.py \$( cat ORIGIN_BUILT_VERSION ) --dependency_branch \${OPENSHIFT_ANSIBLE_TARGET_BRANCH} &gt; ORIGIN_VARS
 source ORIGIN_VARS
 source OPENSHIFT_ANSIBLE_VARS
@@ -734,7 +734,7 @@ ansible-playbook  -vv                \
                   --become-user root \
                   --connection local \
                   --inventory sjb/inventory/ \
-                  -e deployment_type=\$( cat ./DEPLOYMENT_TYPE) \
+                  -e openshift_deployment_type=\$( cat ./DEPLOYMENT_TYPE) \
                   \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -749,7 +749,7 @@ ansible-playbook  -vv                \
                   -e openshift_pkg_version=&#34;-\${ORIGIN_INSTALL_VERSION}&#34;         \
                   -e openshift_release=&#34;3.\${ORIGIN_INSTALL_MINOR_VERSION}&#34;      \
                   -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34;                           \
-                  -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)                  \
+                  -e openshift_deployment_type=\$( cat ./DEPLOYMENT_TYPE)                  \
                   -e openshift_node_port_range=&#39;30000-32000&#39;                    \
                   -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39; \
                   \${playbook}
@@ -816,7 +816,7 @@ ansible-playbook  -vv                    \
                   -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                   -e openshift_pkg_version=&#34;-\${ORIGIN_UPGRADE_RELEASE_VERSION}&#34; \
                   -e openshift_release=&#34;3.\${ORIGIN_UPGRADE_RELEASE_MINOR_VERSION}&#34; \
-                  -e deployment_type=\$( cat ./DEPLOYMENT_TYPE)                  \
+                  -e openshift_deployment_type=\$( cat ./DEPLOYMENT_TYPE)                  \
                   -e openshift_node_port_range=&#39;30000-32000&#39;                    \
                   -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39; \
                   -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34;

--- a/sjb/generated/test_pull_request_origin_extended_image_ecosystem.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_ecosystem.xml
@@ -672,7 +672,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -698,7 +698,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -709,7 +709,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \

--- a/sjb/generated/test_pull_request_origin_extended_image_registry.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_registry.xml
@@ -672,7 +672,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -698,7 +698,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;
@@ -709,7 +709,7 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e deployment_type=origin  \
+                 -e openshift_deployment_type=origin  \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \


### PR DESCRIPTION
deployment_type is deprecated.  Switch jobs to use
openshift_deployment_type instead.  openshift_deployment_type
should work on all recent releases.