### PR TITLE
Remove extraneous containerize=true, specify imagetags when needed

### DIFF
--- a/sjb/config/common/test_cases/origin_built_installed_release.yml
+++ b/sjb/config/common/test_cases/origin_built_installed_release.yml
@@ -74,7 +74,6 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e containerized=true      \
                          -e openshift_deployment_type=origin  \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
     - type: "script"

--- a/sjb/config/common/test_cases/origin_installed_release.yml
+++ b/sjb/config/common/test_cases/origin_installed_release.yml
@@ -40,7 +40,6 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e containerized=true      \
                          -e openshift_deployment_type=origin  \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
     - type: "script"

--- a/sjb/config/test_cases/ami_build_origin_int_rhel_install.yml
+++ b/sjb/config/test_cases/ami_build_origin_int_rhel_install.yml
@@ -55,7 +55,6 @@ actions:
                        --become-user root         \
                        --connection local         \
                        --inventory sjb/inventory/ \
-                       -e containerized=true      \
                        -e openshift_deployment_type=origin  \
                        /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
   - type: "script"

--- a/sjb/config/test_cases/test_branch_image_registry_extended.yml
+++ b/sjb/config/test_cases/test_branch_image_registry_extended.yml
@@ -51,7 +51,6 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e containerized=true      \
                          -e openshift_deployment_type=origin  \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
     - type: "script"

--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file.yml
@@ -115,7 +115,6 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e containerized=true      \
                          -e openshift_deployment_type=origin  \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
     - type: "script"

--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update.yml
@@ -115,7 +115,6 @@ extensions:
                            --become-user root         \
                            --connection local         \
                            --inventory sjb/inventory/ \
-                           -e containerized=true      \
                            -e openshift_deployment_type=origin  \
                            /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
         fi

--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update_containerized.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update_containerized.yml
@@ -98,6 +98,9 @@ extensions:
                          --inventory sjb/inventory/ \
                          -e containerized=true      \
                          -e openshift_deployment_type=origin  \
+                         -e openshift_image_tag="$( cat ./ORIGIN_TAG )"                      \
+                         -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"            \
+                         -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
     - type: "script"
       title: "install origin"
@@ -115,6 +118,9 @@ extensions:
                          --inventory sjb/inventory/ \
                          -e containerized=true      \
                          -e openshift_deployment_type=origin  \
+                         -e openshift_image_tag="$( cat ./ORIGIN_TAG )"                      \
+                         -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"            \
+                         -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \
                          ${playbook}
         if [[ -s "${playbook_base}deploy_cluster.yml" ]]; then
             playbook="${playbook_base}deploy_cluster.yml"

--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update_system_containers.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update_system_containers.yml
@@ -132,6 +132,9 @@ extensions:
                          --inventory sjb/inventory/ \
                          -e containerized=true      \
                          -e openshift_deployment_type=origin  \
+                         -e openshift_image_tag="$( cat ./ORIGIN_TAG )"                      \
+                         -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"            \
+                         -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
     - type: "script"
       title: "install origin"
@@ -157,6 +160,9 @@ extensions:
                          --inventory sjb/inventory/ \
                          -e containerized=true      \
                          -e openshift_deployment_type=origin  \
+                         -e openshift_image_tag="$( cat ./ORIGIN_TAG )"                      \
+                         -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"            \
+                         -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \
                          ${playbook}
         # install atomic rpm
         sudo yum install atomic -y

--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
@@ -116,7 +116,6 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e containerized=true      \
                          -e openshift_deployment_type=origin  \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
     - type: "script"

--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible_json_file.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible_json_file.yml
@@ -116,7 +116,6 @@ extensions:
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
-                         -e containerized=true      \
                          -e openshift_deployment_type=origin  \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
     - type: "script"

--- a/sjb/generated/ami_build_origin_int_rhel_install.xml
+++ b/sjb/generated/ami_build_origin_int_rhel_install.xml
@@ -148,7 +148,6 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e containerized=true      \
                  -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/merge_pull_request_jenkins_client_plugin.xml
+++ b/sjb/generated/merge_pull_request_jenkins_client_plugin.xml
@@ -423,7 +423,6 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e containerized=true      \
                  -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/merge_pull_request_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/merge_pull_request_jenkins_openshift_login_plugin.xml
@@ -423,7 +423,6 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e containerized=true      \
                  -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/merge_pull_request_jenkins_plugin.xml
+++ b/sjb/generated/merge_pull_request_jenkins_plugin.xml
@@ -423,7 +423,6 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e containerized=true      \
                  -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/merge_pull_request_jenkins_sync_plugin.xml
+++ b/sjb/generated/merge_pull_request_jenkins_sync_plugin.xml
@@ -423,7 +423,6 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e containerized=true      \
                  -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_branch_image_registry_extended.xml
+++ b/sjb/generated/test_branch_image_registry_extended.xml
@@ -371,7 +371,6 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e containerized=true      \
                  -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_branch_jenkins_client_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_client_plugin.xml
@@ -354,7 +354,6 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e containerized=true      \
                  -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_branch_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_openshift_login_plugin.xml
@@ -354,7 +354,6 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e containerized=true      \
                  -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_branch_jenkins_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_plugin.xml
@@ -354,7 +354,6 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e containerized=true      \
                  -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_branch_jenkins_sync_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_sync_plugin.xml
@@ -354,7 +354,6 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e containerized=true      \
                  -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
@@ -529,7 +529,6 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e containerized=true      \
                  -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_branch_origin_extended_builds.xml
+++ b/sjb/generated/test_branch_origin_extended_builds.xml
@@ -305,7 +305,6 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e containerized=true      \
                  -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
@@ -631,7 +631,6 @@ if [ -f /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml ]; then
                    --become-user root         \
                    --connection local         \
                    --inventory sjb/inventory/ \
-                   -e containerized=true      \
                    -e openshift_deployment_type=origin  \
                    /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized.xml
@@ -611,6 +611,9 @@ ansible-playbook -vv --become               \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
                  -e openshift_deployment_type=origin  \
+                 -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
+                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
+                 -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -637,6 +640,9 @@ ansible-playbook -vv --become               \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
                  -e openshift_deployment_type=origin  \
+                 -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
+                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
+                 -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers.xml
@@ -647,6 +647,9 @@ ansible-playbook -vv --become               \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
                  -e openshift_deployment_type=origin  \
+                 -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
+                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
+                 -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -681,6 +684,9 @@ ansible-playbook -vv --become               \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
                  -e openshift_deployment_type=origin  \
+                 -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
+                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
+                 -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  \${playbook}
 # install atomic rpm
 sudo yum install atomic -y

--- a/sjb/generated/test_branch_origin_extended_image_ecosystem.xml
+++ b/sjb/generated/test_branch_origin_extended_image_ecosystem.xml
@@ -305,7 +305,6 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e containerized=true      \
                  -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_branch_origin_extended_image_registry.xml
+++ b/sjb/generated/test_branch_origin_extended_image_registry.xml
@@ -305,7 +305,6 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e containerized=true      \
                  -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_image_registry_extended.xml
+++ b/sjb/generated/test_pull_request_image_registry_extended.xml
@@ -429,7 +429,6 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e containerized=true      \
                  -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_jenkins_client_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_client_plugin.xml
@@ -412,7 +412,6 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e containerized=true      \
                  -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_openshift_login_plugin.xml
@@ -412,7 +412,6 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e containerized=true      \
                  -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_jenkins_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_plugin.xml
@@ -412,7 +412,6 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e containerized=true      \
                  -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_jenkins_sync_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_sync_plugin.xml
@@ -412,7 +412,6 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e containerized=true      \
                  -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
@@ -689,7 +689,6 @@ if [ -f /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml ]; then
                    --become-user root         \
                    --connection local         \
                    --inventory sjb/inventory/ \
-                   -e containerized=true      \
                    -e openshift_deployment_type=origin  \
                    /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized.xml
@@ -669,6 +669,9 @@ ansible-playbook -vv --become               \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
                  -e openshift_deployment_type=origin  \
+                 -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
+                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
+                 -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -695,6 +698,9 @@ ansible-playbook -vv --become               \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
                  -e openshift_deployment_type=origin  \
+                 -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
+                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
+                 -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers.xml
@@ -705,6 +705,9 @@ ansible-playbook -vv --become               \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
                  -e openshift_deployment_type=origin  \
+                 -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
+                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
+                 -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -739,6 +742,9 @@ ansible-playbook -vv --become               \
                  --inventory sjb/inventory/ \
                  -e containerized=true      \
                  -e openshift_deployment_type=origin  \
+                 -e openshift_image_tag=&#34;\$( cat ./ORIGIN_TAG )&#34;                      \
+                 -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
+                 -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  \${playbook}
 # install atomic rpm
 sudo yum install atomic -y

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
@@ -587,7 +587,6 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e containerized=true      \
                  -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
@@ -587,7 +587,6 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e containerized=true      \
                  -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_extended_builds.xml
+++ b/sjb/generated/test_pull_request_origin_extended_builds.xml
@@ -671,7 +671,6 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e containerized=true      \
                  -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
@@ -689,7 +689,6 @@ if [ -f /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml ]; then
                    --become-user root         \
                    --connection local         \
                    --inventory sjb/inventory/ \
-                   -e containerized=true      \
                    -e openshift_deployment_type=origin  \
                    /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 fi

--- a/sjb/generated/test_pull_request_origin_extended_image_ecosystem.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_ecosystem.xml
@@ -671,7 +671,6 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e containerized=true      \
                  -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_extended_image_registry.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_registry.xml
@@ -671,7 +671,6 @@ ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
-                 -e containerized=true      \
                  -e openshift_deployment_type=origin  \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT


### PR DESCRIPTION
A change was merged to openshift-ansible that requires openshift_release or openshift_image_tag be specified when containerized=true. This should remove a bunch of cases where containerized=true was not necessary and add required variables where we are running containerized installs.