### PR TITLE
logging: docker 'Thin Pool' issue

### DIFF
--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging.yml
@@ -17,6 +17,7 @@ extensions:
           fi
           git checkout ${OPENSHIFT_ANSIBLE_TARGET_BRANCH}
         fi
+        docker images | awk '/logging/{print($3)}' | xargs docker rmi -f || :
         hack/build-images.sh
     - type: "script"
       title: "build an openshift-ansible release"

--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file.yml
@@ -11,6 +11,7 @@ extensions:
       title: "build an origin-aggregated-logging release"
       repository: "origin-aggregated-logging"
       script: |-
+        docker images | awk '/logging/{print($3)}' | xargs docker rmi -f || :
         hack/build-images.sh
     - type: "script"
       title: "build an openshift-ansible release"

--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
@@ -12,6 +12,7 @@ extensions:
       title: "build an origin-aggregated-logging release"
       repository: "origin-aggregated-logging"
       script: |-
+        docker images | awk '/logging/{print($3)}' | xargs docker rmi -f || :
         hack/build-images.sh
     - type: "script"
       title: "build an openshift-ansible release"

--- a/sjb/generated/test_branch_openshift_ansible_logging.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging.xml
@@ -386,6 +386,7 @@ if [[ &#34;\${REPO_NAME:-}&#34; == &#34;openshift-ansible&#34; ]]; then
   fi
   git checkout \${OPENSHIFT_ANSIBLE_TARGET_BRANCH}
 fi
+docker images | awk &#39;/logging/{print(\$3)}&#39; | xargs docker rmi -f || :
 hack/build-images.sh
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
@@ -380,6 +380,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin-aggregated-logging&#34;
+docker images | awk &#39;/logging/{print(\$3)}&#39; | xargs docker rmi -f || :
 hack/build-images.sh
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_logging.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging.xml
@@ -402,6 +402,7 @@ if [[ &#34;\${REPO_NAME:-}&#34; == &#34;openshift-ansible&#34; ]]; then
   fi
   git checkout \${OPENSHIFT_ANSIBLE_TARGET_BRANCH}
 fi
+docker images | awk &#39;/logging/{print(\$3)}&#39; | xargs docker rmi -f || :
 hack/build-images.sh
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
@@ -438,6 +438,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin-aggregated-logging&#34;
+docker images | awk &#39;/logging/{print(\$3)}&#39; | xargs docker rmi -f || :
 hack/build-images.sh
 SCRIPT
 chmod +x &#34;${script}&#34;


### PR DESCRIPTION
building logging images have been recently failing for tests with

```
[openshift/origin-logging-kibana] --> Committing changes to openshift/origin-logging-kibana:f677e1d ...
[openshift/origin-logging-kibana] unable to commit build container: API error (500):
{"message":"devmapper: Thin Pool has 2017 free data blocks which is less than minimum required 2128 free
 data blocks. Create more free space in thin pool or use dm.min_free_space option to change behavior"}
```

https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_origin-aggregated-logging/883/test_pull_request_origin_aggregated_logging_ansible/1392/
https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_origin-aggregated-logging/889/test_pull_request_origin_aggregated_logging_ansible/1391/

This PR works around by first deleting logging images because they
are going to be build as one of the initial steps anyways

https://stackoverflow.com/questions/36918387/space-issue-on-docker-devmapper-and-centos7
https://ci.openshift.redhat.com/jenkins/job/test_pull_request_origin_aggregated_logging_ansible_json_file_debugging/9