### PR TITLE
Fail jobs with correct message

### DIFF
--- a/sjb/config/common/test_cases/origin.yml
+++ b/sjb/config/common/test_cases/origin.yml
@@ -55,7 +55,7 @@ actions:
       function gcs_path() {
         bucket="gs://origin-ci-test/"
 
-        if [[ -z "${buildId}" ]]; then
+        if [[ -z "${buildId:-}" ]]; then
           echo "Not a Prow job!" 1>&2
           return 1
         fi

--- a/sjb/generated/merge_pull_request_jenkins_client_plugin.xml
+++ b/sjb/generated/merge_pull_request_jenkins_client_plugin.xml
@@ -262,7 +262,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/merge_pull_request_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/merge_pull_request_jenkins_openshift_login_plugin.xml
@@ -262,7 +262,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/merge_pull_request_jenkins_plugin.xml
+++ b/sjb/generated/merge_pull_request_jenkins_plugin.xml
@@ -262,7 +262,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/merge_pull_request_jenkins_sync_plugin.xml
+++ b/sjb/generated/merge_pull_request_jenkins_sync_plugin.xml
@@ -262,7 +262,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/merge_pull_request_origin_web_console.xml
+++ b/sjb/generated/merge_pull_request_origin_web_console.xml
@@ -262,7 +262,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/push_origin_release.xml
+++ b/sjb/generated/push_origin_release.xml
@@ -324,7 +324,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_cluster_operator_unit.xml
+++ b/sjb/generated/test_branch_cluster_operator_unit.xml
@@ -277,7 +277,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_image_registry_extended.xml
+++ b/sjb/generated/test_branch_image_registry_extended.xml
@@ -193,7 +193,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_image_registry_integration.xml
+++ b/sjb/generated/test_branch_image_registry_integration.xml
@@ -193,7 +193,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_image_registry_unit.xml
+++ b/sjb/generated/test_branch_image_registry_unit.xml
@@ -277,7 +277,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_jenkins_client_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_client_plugin.xml
@@ -193,7 +193,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_openshift_login_plugin.xml
@@ -193,7 +193,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_jenkins_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_plugin.xml
@@ -193,7 +193,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_jenkins_sync_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_sync_plugin.xml
@@ -193,7 +193,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_kubernetes_metrics_server_unit.xml
+++ b/sjb/generated/test_branch_kubernetes_metrics_server_unit.xml
@@ -277,7 +277,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_online_hibernation_unit.xml
+++ b/sjb/generated/test_branch_online_hibernation_unit.xml
@@ -193,7 +193,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_openshift_ansible_logging.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging.xml
@@ -277,7 +277,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
@@ -277,7 +277,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_aggregated_logging_prior.xml
+++ b/sjb/generated/test_branch_origin_aggregated_logging_prior.xml
@@ -193,7 +193,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_check.xml
+++ b/sjb/generated/test_branch_origin_check.xml
@@ -277,7 +277,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_cmd.xml
+++ b/sjb/generated/test_branch_origin_cmd.xml
@@ -277,7 +277,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_cross.xml
+++ b/sjb/generated/test_branch_origin_cross.xml
@@ -277,7 +277,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_end_to_end.xml
+++ b/sjb/generated/test_branch_origin_end_to_end.xml
@@ -277,7 +277,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_extended.xml
+++ b/sjb/generated/test_branch_origin_extended.xml
@@ -287,7 +287,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_extended_builds.xml
+++ b/sjb/generated/test_branch_origin_extended_builds.xml
@@ -144,7 +144,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_extended_clusterup.xml
+++ b/sjb/generated/test_branch_origin_extended_clusterup.xml
@@ -144,7 +144,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_extended_conformance.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance.xml
@@ -277,7 +277,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_crio.xml
@@ -323,7 +323,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce.xml
@@ -357,7 +357,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install.xml
@@ -361,7 +361,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install_containerized.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_containerized.xml
@@ -361,7 +361,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install_in_tree.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_in_tree.xml
@@ -361,7 +361,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
@@ -361,7 +361,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
@@ -361,7 +361,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized.xml
@@ -361,7 +361,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers.xml
@@ -361,7 +361,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_extended_conformance_k8s.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_k8s.xml
@@ -357,7 +357,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_extended_gssapi.xml
+++ b/sjb/generated/test_branch_origin_extended_gssapi.xml
@@ -144,7 +144,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_extended_image_ecosystem.xml
+++ b/sjb/generated/test_branch_origin_extended_image_ecosystem.xml
@@ -144,7 +144,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_extended_image_registry.xml
+++ b/sjb/generated/test_branch_origin_extended_image_registry.xml
@@ -144,7 +144,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_extended_ldap_groups.xml
+++ b/sjb/generated/test_branch_origin_extended_ldap_groups.xml
@@ -144,7 +144,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_extended_networking.xml
+++ b/sjb/generated/test_branch_origin_extended_networking.xml
@@ -281,7 +281,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_extended_networking_minimal.xml
+++ b/sjb/generated/test_branch_origin_extended_networking_minimal.xml
@@ -277,7 +277,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_integration.xml
+++ b/sjb/generated/test_branch_origin_integration.xml
@@ -277,7 +277,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_service_catalog.xml
+++ b/sjb/generated/test_branch_origin_service_catalog.xml
@@ -144,7 +144,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_unit.xml
+++ b/sjb/generated/test_branch_origin_unit.xml
@@ -277,7 +277,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_verify.xml
+++ b/sjb/generated/test_branch_origin_verify.xml
@@ -277,7 +277,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_web_console.xml
+++ b/sjb/generated/test_branch_origin_web_console.xml
@@ -193,7 +193,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_web_console_server_check.xml
+++ b/sjb/generated/test_branch_origin_web_console_server_check.xml
@@ -193,7 +193,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_branch_origin_web_console_server_e2e.xml
+++ b/sjb/generated/test_branch_origin_web_console_server_e2e.xml
@@ -319,7 +319,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_cluster_operator_unit.xml
+++ b/sjb/generated/test_pull_request_cluster_operator_unit.xml
@@ -251,7 +251,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_image_registry_extended.xml
+++ b/sjb/generated/test_pull_request_image_registry_extended.xml
@@ -251,7 +251,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_image_registry_integration.xml
+++ b/sjb/generated/test_pull_request_image_registry_integration.xml
@@ -251,7 +251,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_image_registry_unit.xml
+++ b/sjb/generated/test_pull_request_image_registry_unit.xml
@@ -251,7 +251,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_jenkins_client_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_client_plugin.xml
@@ -251,7 +251,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_openshift_login_plugin.xml
@@ -251,7 +251,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_jenkins_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_plugin.xml
@@ -251,7 +251,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_jenkins_sync_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_sync_plugin.xml
@@ -251,7 +251,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_kubernetes_metrics_server_unit.xml
+++ b/sjb/generated/test_pull_request_kubernetes_metrics_server_unit.xml
@@ -251,7 +251,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_online_hibernation_unit.xml
+++ b/sjb/generated/test_pull_request_online_hibernation_unit.xml
@@ -251,7 +251,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
@@ -419,7 +419,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized.xml
@@ -419,7 +419,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio.xml
@@ -423,7 +423,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_in_tree.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_in_tree.xml
@@ -419,7 +419,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
@@ -419,7 +419,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
@@ -419,7 +419,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized.xml
@@ -419,7 +419,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers.xml
@@ -419,7 +419,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
@@ -419,7 +419,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_openshift_ansible_logging.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging.xml
@@ -293,7 +293,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_openshift_ansible_tox.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_tox.xml
@@ -251,7 +251,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
@@ -335,7 +335,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
@@ -335,7 +335,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_check.xml
+++ b/sjb/generated/test_pull_request_origin_check.xml
@@ -251,7 +251,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_cmd.xml
+++ b/sjb/generated/test_pull_request_origin_cmd.xml
@@ -251,7 +251,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_cross.xml
+++ b/sjb/generated/test_pull_request_origin_cross.xml
@@ -251,7 +251,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_end_to_end.xml
+++ b/sjb/generated/test_pull_request_origin_end_to_end.xml
@@ -335,7 +335,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_extended.xml
+++ b/sjb/generated/test_pull_request_origin_extended.xml
@@ -345,7 +345,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_extended_builds.xml
+++ b/sjb/generated/test_pull_request_origin_extended_builds.xml
@@ -419,7 +419,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_extended_clusterup.xml
+++ b/sjb/generated/test_pull_request_origin_extended_clusterup.xml
@@ -251,7 +251,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_extended_conformance.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance.xml
@@ -335,7 +335,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
@@ -423,7 +423,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
@@ -331,7 +331,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
@@ -419,7 +419,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
@@ -419,7 +419,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_extended_conformance_k8s.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_k8s.xml
@@ -336,7 +336,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_extended_gssapi.xml
+++ b/sjb/generated/test_pull_request_origin_extended_gssapi.xml
@@ -419,7 +419,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_extended_image_ecosystem.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_ecosystem.xml
@@ -419,7 +419,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_extended_image_registry.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_registry.xml
@@ -419,7 +419,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_extended_ldap_groups.xml
+++ b/sjb/generated/test_pull_request_origin_extended_ldap_groups.xml
@@ -335,7 +335,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_extended_networking.xml
+++ b/sjb/generated/test_pull_request_origin_extended_networking.xml
@@ -335,7 +335,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_extended_networking_minimal.xml
+++ b/sjb/generated/test_pull_request_origin_extended_networking_minimal.xml
@@ -335,7 +335,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_integration.xml
+++ b/sjb/generated/test_pull_request_origin_integration.xml
@@ -251,7 +251,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_launch_gce.xml
+++ b/sjb/generated/test_pull_request_origin_launch_gce.xml
@@ -331,7 +331,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_service_catalog.xml
+++ b/sjb/generated/test_pull_request_origin_service_catalog.xml
@@ -251,7 +251,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_unit.xml
+++ b/sjb/generated/test_pull_request_origin_unit.xml
@@ -251,7 +251,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_verify.xml
+++ b/sjb/generated/test_pull_request_origin_verify.xml
@@ -251,7 +251,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_web_console.xml
+++ b/sjb/generated/test_pull_request_origin_web_console.xml
@@ -251,7 +251,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_web_console_server_check.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_server_check.xml
@@ -251,7 +251,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi

--- a/sjb/generated/test_pull_request_origin_web_console_server_e2e.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_server_e2e.xml
@@ -251,7 +251,7 @@ scp -F ./.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/data/start
 function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
-  if [[ -z &#34;${buildId}&#34; ]]; then
+  if [[ -z &#34;${buildId:-}&#34; ]]; then
     echo &#34;Not a Prow job!&#34; 1&gt;&amp;2
     return 1
   fi


### PR DESCRIPTION
conformance_k8s ran directly failed with "undefined buildId", not the
appropriate error.

Also, branch jobs are sometimes invoked directly.  Having this check is annoying, not sure it's correct in all cases.

@stevekuznetsov