### PR TITLE
default to use auto-version unless caller provides version and releas…

### DIFF
--- a/jobs/build/refresh-images/Jenkinsfile
+++ b/jobs/build/refresh-images/Jenkinsfile
@@ -35,8 +35,8 @@ node('openshift-build-1') {
                       [
                               [$class: 'hudson.model.ChoiceParameterDefinition', choices: "3", defaultValue: '3', description: 'OSE Major Version', name: 'OSE_MAJOR'],
                               [$class: 'hudson.model.ChoiceParameterDefinition', choices: "1\n2\n3\n4\n5\n6\n7", defaultValue: '4', description: 'OSE Minor Version', name: 'OSE_MINOR'],
-                              [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'auto', description: 'Optional version to use. (i.e. v3.6.173); leave blank to bump', name: 'VERSION_OVERRIDE'],
-                              [$class: 'hudson.model.StringParameterDefinition', defaultValue: '', description: 'Specific release to use. Must be > 1 (i.e. 2)', name: 'RELEASE_OVERRIDE'],
+                              [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'auto', description: 'Optional version to use. (i.e. v3.6.17). Defaults to "auto"', name: 'VERSION_OVERRIDE'],
+                              [$class: 'hudson.model.StringParameterDefinition', defaultValue: '', description: 'Optional release to use. Must be > 1 (i.e. 2)', name: 'RELEASE_OVERRIDE'],
                               [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'jupierce@redhat.com,ahaile@redhat.com,smunilla@redhat.com', description: 'Success Mailing List', name: 'MAIL_LIST_SUCCESS'],
                               [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'jupierce@redhat.com,ahaile@redhat.com,smunilla@redhat.com', description: 'Failure Mailing List', name: 'MAIL_LIST_FAILURE'],
                               [$class: 'BooleanParameterDefinition', defaultValue: false, description: 'Mock run to pickup new Jenkins parameters?.', name: 'MOCK'],

--- a/jobs/build/refresh-images/Jenkinsfile
+++ b/jobs/build/refresh-images/Jenkinsfile
@@ -80,7 +80,7 @@ node('openshift-build-1') {
             sshagent(['openshift-bot']) {
 
                 // default to using the atomic-openshift package version
-                // unless the calller provides a version and release
+                // unless the caller provides a version and release
                 if ( VERSION_OVERRIDE == "" ) {
                     oit_update_docker_args = "--version auto --repo-type signed"
                 } else {

--- a/jobs/build/refresh-images/Jenkinsfile
+++ b/jobs/build/refresh-images/Jenkinsfile
@@ -35,7 +35,8 @@ node('openshift-build-1') {
                       [
                               [$class: 'hudson.model.ChoiceParameterDefinition', choices: "3", defaultValue: '3', description: 'OSE Major Version', name: 'OSE_MAJOR'],
                               [$class: 'hudson.model.ChoiceParameterDefinition', choices: "1\n2\n3\n4\n5\n6\n7", defaultValue: '4', description: 'OSE Minor Version', name: 'OSE_MINOR'],
-                              [$class: 'hudson.model.StringParameterDefinition', defaultValue: '', description: 'Optiontal version to use. (i.e. v3.6.173); leave blank to bump', name: 'VERSION_OVERRIDE'],
+                              [$class: 'hudson.model.ChoiceParameterDefinition', choices: "base\nall", defaultValue: 'base', description: 'Which group to refresh', name: 'OSE_GROUP'],
+                              [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'auto', description: 'Optional version to use. (i.e. v3.6.173); leave blank to bump', name: 'VERSION_OVERRIDE'],
                               [$class: 'hudson.model.StringParameterDefinition', defaultValue: '', description: 'Specific release to use. Must be > 1 (i.e. 2)', name: 'RELEASE_OVERRIDE'],
                               [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'jupierce@redhat.com,ahaile@redhat.com,smunilla@redhat.com', description: 'Success Mailing List', name: 'MAIL_LIST_SUCCESS'],
                               [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'jupierce@redhat.com,ahaile@redhat.com,smunilla@redhat.com', description: 'Failure Mailing List', name: 'MAIL_LIST_FAILURE'],
@@ -79,17 +80,18 @@ node('openshift-build-1') {
             
             sshagent(['openshift-bot']) {
 
-                update_docker_args = "--bump_release"
-                oit_update_docker_args = ""
-                if ( VERSION_OVERRIDE != "" ) {
+                // default to using the atomic-openshift package version
+                // unless the calller provides a version and release
+                if ( VERSION_OVERRIDE == "" ) {
+                    oit_update_docker_args = "--version auto --bumprelease"
+                } else {
                     if ( ! VERSION_OVERRIDE.startsWith("v") ) {
                         error("Version overrides must start with 'v'")
                     }
                     if ( RELEASE_OVERRIDE == "" ) {
                         error( "RELEASE_OVERRIDE must be specified if VERSION_OVERRIDE is" )
                     }
-                    update_docker_args = "--version ${VERSION_OVERRIDE} --release ${RELEASE_OVERRIDE}"
-                    oit_update_docker_args = update_docker_args
+                    oit_update_docker_args = "--version ${VERSION_OVERRIDE} --release ${RELEASE_OVERRIDE}"
                 }
 
                 sh "kinit -k -t /home/jenkins/ocp-build-buildvm.openshift.eng.bos.redhat.com.keytab ocp-build/buildvm.openshift.eng.bos.redhat.com@REDHAT.COM"

--- a/jobs/build/refresh-images/Jenkinsfile
+++ b/jobs/build/refresh-images/Jenkinsfile
@@ -35,7 +35,6 @@ node('openshift-build-1') {
                       [
                               [$class: 'hudson.model.ChoiceParameterDefinition', choices: "3", defaultValue: '3', description: 'OSE Major Version', name: 'OSE_MAJOR'],
                               [$class: 'hudson.model.ChoiceParameterDefinition', choices: "1\n2\n3\n4\n5\n6\n7", defaultValue: '4', description: 'OSE Minor Version', name: 'OSE_MINOR'],
-                              [$class: 'hudson.model.ChoiceParameterDefinition', choices: "base\nall", defaultValue: 'base', description: 'Which group to refresh', name: 'OSE_GROUP'],
                               [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'auto', description: 'Optional version to use. (i.e. v3.6.173); leave blank to bump', name: 'VERSION_OVERRIDE'],
                               [$class: 'hudson.model.StringParameterDefinition', defaultValue: '', description: 'Specific release to use. Must be > 1 (i.e. 2)', name: 'RELEASE_OVERRIDE'],
                               [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'jupierce@redhat.com,ahaile@redhat.com,smunilla@redhat.com', description: 'Success Mailing List', name: 'MAIL_LIST_SUCCESS'],

--- a/jobs/build/refresh-images/Jenkinsfile
+++ b/jobs/build/refresh-images/Jenkinsfile
@@ -82,15 +82,16 @@ node('openshift-build-1') {
                 // default to using the atomic-openshift package version
                 // unless the calller provides a version and release
                 if ( VERSION_OVERRIDE == "" ) {
-                    oit_update_docker_args = "--version auto --bumprelease"
+                    oit_update_docker_args = "--version auto --repo-type signed"
                 } else {
                     if ( ! VERSION_OVERRIDE.startsWith("v") ) {
                         error("Version overrides must start with 'v'")
                     }
-                    if ( RELEASE_OVERRIDE == "" ) {
-                        error( "RELEASE_OVERRIDE must be specified if VERSION_OVERRIDE is" )
-                    }
-                    oit_update_docker_args = "--version ${VERSION_OVERRIDE} --release ${RELEASE_OVERRIDE}"
+                    oit_update_docker_args = "--version ${VERSION_OVERRIDE}"
+                }
+
+                if ( RELEASE_OVERRIDE != "" ) {
+                    oit_update_docker_args = "${oit_update_docker_args} --release ${RELEASE_OVERRIDE}"
                 }
 
                 sh "kinit -k -t /home/jenkins/ocp-build-buildvm.openshift.eng.bos.redhat.com.keytab ocp-build/buildvm.openshift.eng.bos.redhat.com@REDHAT.COM"

--- a/jobs/build/refresh-images/Jenkinsfile
+++ b/jobs/build/refresh-images/Jenkinsfile
@@ -81,7 +81,7 @@ node('openshift-build-1') {
 
                 // default to using the atomic-openshift package version
                 // unless the caller provides a version and release
-                if ( VERSION_OVERRIDE == "" ) {
+                if ( VERSION_OVERRIDE == "auto" ) {
                     oit_update_docker_args = "--version auto --repo-type signed"
                 } else {
                     if ( ! VERSION_OVERRIDE.startsWith("v") ) {


### PR DESCRIPTION
This change introduces the `--version auto` optiion to the oit.py `images:update-dockerfiles` task.

The new default is to retrieve the image version number from the `atomic-openshift` package in the RPM repo, and to increase the release number by 1.  The caller can override the default by providing a version and release string.

This depends on the merge of  [PR 137](https://github.com/openshift/enterprise-images/pull/137)