### PR TITLE
Don't explicitly list `skopeo-containers`

### DIFF
--- a/jobs/package-dockertested/Jenkinsfile
+++ b/jobs/package-dockertested/Jenkinsfile
@@ -21,7 +21,7 @@ node('openshift-build-1') {
 	]])
 	// https://issues.jenkins-ci.org/browse/JENKINS-33511
 	env.WORKSPACE = pwd()
-	def packages = ['docker', 'container-selinux', 'container-storage-setup', 'skopeo', 'skopeo-containers', 'atomic', 'python-pytoml']
+	def packages = ['docker', 'container-selinux', 'container-storage-setup', 'skopeo', 'atomic', 'python-pytoml', 'oci-register-machine']
 	def installed_packages = []
 
 	stage ('Check to see if we need to run') {


### PR DESCRIPTION
It's a sub-package of `skopeo` and apparently brew handles all this fine
now.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>