### PR TITLE
The oc binary must be built for extended tests to run

### DIFF
--- a/sjb/config/common/test_cases/origin_release_install_gce.yml
+++ b/sjb/config/common/test_cases/origin_release_install_gce.yml
@@ -171,9 +171,12 @@ extensions:
         export GOOGLE_APPLICATION_CREDENTIALS="/data/src/github.com/openshift/release/cluster/test-deploy/data/gce.json"
         export TEST_EXTENDED_ARGS='-provider=gce -gce-zone=us-central1-a -gce-project=openshift-gce-devel-ci'
 
+        # test suites need oc and extended.test
+        OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/oc hack/env make build WHAT=cmd/oc
+        OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/extended.test hack/env make build-extended-test
+
         function gather() {
           set +e
-          OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/oc hack/env make build WHAT=cmd/oc
           export PATH=$(pwd)/_output/local/bin/linux/amd64:$PATH
           oc get nodes --template '{{ range .items }}{{ .metadata.name }}{{ "\n" }}{{ end }}' | xargs -L 1 -I X bash -c 'oc get --raw /api/v1/nodes/X/proxy/metrics > /tmp/artifacts/X.metrics' ''
           oc get --raw /metrics > /tmp/artifacts/master.metrics
@@ -188,7 +191,6 @@ extensions:
           SUITE="${BASH_REMATCH[1]}"
           FOCUS="${BASH_REMATCH[2]}"
         fi
-        OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/extended.test hack/env make build-extended-test
         OPENSHIFT_SKIP_BUILD='true' make test-extended SUITE="${SUITE}" FOCUS="${FOCUS:-}"
   post_actions:
     - type: "host_script"

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce.xml
@@ -554,9 +554,12 @@ TEST_EXTENDED_SKIP+=&#34;\${ADDITIONAL_SKIP-}&#34;
 export GOOGLE_APPLICATION_CREDENTIALS=&#34;/data/src/github.com/openshift/release/cluster/test-deploy/data/gce.json&#34;
 export TEST_EXTENDED_ARGS=&#39;-provider=gce -gce-zone=us-central1-a -gce-project=openshift-gce-devel-ci&#39;
 
+# test suites need oc and extended.test
+OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/oc hack/env make build WHAT=cmd/oc
+OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/extended.test hack/env make build-extended-test
+
 function gather() {
   set +e
-  OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/oc hack/env make build WHAT=cmd/oc
   export PATH=\$(pwd)/_output/local/bin/linux/amd64:\$PATH
   oc get nodes --template &#39;{{ range .items }}{{ .metadata.name }}{{ &#34;\n&#34; }}{{ end }}&#39; | xargs -L 1 -I X bash -c &#39;oc get --raw /api/v1/nodes/X/proxy/metrics &gt; /tmp/artifacts/X.metrics&#39; &#39;&#39;
   oc get --raw /metrics &gt; /tmp/artifacts/master.metrics
@@ -571,7 +574,6 @@ if [[ -z &#34;\${FOCUS:-}&#34; &amp;&amp; &#34;\${SUITE}&#34; =~ ^(.*)\((.*)\)\$
   SUITE=&#34;\${BASH_REMATCH[1]}&#34;
   FOCUS=&#34;\${BASH_REMATCH[2]}&#34;
 fi
-OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/extended.test hack/env make build-extended-test
 OPENSHIFT_SKIP_BUILD=&#39;true&#39; make test-extended SUITE=&#34;\${SUITE}&#34; FOCUS=&#34;\${FOCUS:-}&#34;
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce.xml
@@ -549,9 +549,12 @@ TEST_EXTENDED_SKIP+=&#34;\${ADDITIONAL_SKIP-}&#34;
 export GOOGLE_APPLICATION_CREDENTIALS=&#34;/data/src/github.com/openshift/release/cluster/test-deploy/data/gce.json&#34;
 export TEST_EXTENDED_ARGS=&#39;-provider=gce -gce-zone=us-central1-a -gce-project=openshift-gce-devel-ci&#39;
 
+# test suites need oc and extended.test
+OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/oc hack/env make build WHAT=cmd/oc
+OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/extended.test hack/env make build-extended-test
+
 function gather() {
   set +e
-  OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/oc hack/env make build WHAT=cmd/oc
   export PATH=\$(pwd)/_output/local/bin/linux/amd64:\$PATH
   oc get nodes --template &#39;{{ range .items }}{{ .metadata.name }}{{ &#34;\n&#34; }}{{ end }}&#39; | xargs -L 1 -I X bash -c &#39;oc get --raw /api/v1/nodes/X/proxy/metrics &gt; /tmp/artifacts/X.metrics&#39; &#39;&#39;
   oc get --raw /metrics &gt; /tmp/artifacts/master.metrics
@@ -566,7 +569,6 @@ if [[ -z &#34;\${FOCUS:-}&#34; &amp;&amp; &#34;\${SUITE}&#34; =~ ^(.*)\((.*)\)\$
   SUITE=&#34;\${BASH_REMATCH[1]}&#34;
   FOCUS=&#34;\${BASH_REMATCH[2]}&#34;
 fi
-OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/extended.test hack/env make build-extended-test
 OPENSHIFT_SKIP_BUILD=&#39;true&#39; make test-extended SUITE=&#34;\${SUITE}&#34; FOCUS=&#34;\${FOCUS:-}&#34;
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_k8s.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_k8s.xml
@@ -554,9 +554,12 @@ TEST_EXTENDED_SKIP+=&#34;\${ADDITIONAL_SKIP-}&#34;
 export GOOGLE_APPLICATION_CREDENTIALS=&#34;/data/src/github.com/openshift/release/cluster/test-deploy/data/gce.json&#34;
 export TEST_EXTENDED_ARGS=&#39;-provider=gce -gce-zone=us-central1-a -gce-project=openshift-gce-devel-ci&#39;
 
+# test suites need oc and extended.test
+OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/oc hack/env make build WHAT=cmd/oc
+OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/extended.test hack/env make build-extended-test
+
 function gather() {
   set +e
-  OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/oc hack/env make build WHAT=cmd/oc
   export PATH=\$(pwd)/_output/local/bin/linux/amd64:\$PATH
   oc get nodes --template &#39;{{ range .items }}{{ .metadata.name }}{{ &#34;\n&#34; }}{{ end }}&#39; | xargs -L 1 -I X bash -c &#39;oc get --raw /api/v1/nodes/X/proxy/metrics &gt; /tmp/artifacts/X.metrics&#39; &#39;&#39;
   oc get --raw /metrics &gt; /tmp/artifacts/master.metrics
@@ -571,7 +574,6 @@ if [[ -z &#34;\${FOCUS:-}&#34; &amp;&amp; &#34;\${SUITE}&#34; =~ ^(.*)\((.*)\)\$
   SUITE=&#34;\${BASH_REMATCH[1]}&#34;
   FOCUS=&#34;\${BASH_REMATCH[2]}&#34;
 fi
-OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/extended.test hack/env make build-extended-test
 OPENSHIFT_SKIP_BUILD=&#39;true&#39; make test-extended SUITE=&#34;\${SUITE}&#34; FOCUS=&#34;\${FOCUS:-}&#34;
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce.xml
@@ -592,9 +592,12 @@ TEST_EXTENDED_SKIP+=&#34;\${ADDITIONAL_SKIP-}&#34;
 export GOOGLE_APPLICATION_CREDENTIALS=&#34;/data/src/github.com/openshift/release/cluster/test-deploy/data/gce.json&#34;
 export TEST_EXTENDED_ARGS=&#39;-provider=gce -gce-zone=us-central1-a -gce-project=openshift-gce-devel-ci&#39;
 
+# test suites need oc and extended.test
+OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/oc hack/env make build WHAT=cmd/oc
+OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/extended.test hack/env make build-extended-test
+
 function gather() {
   set +e
-  OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/oc hack/env make build WHAT=cmd/oc
   export PATH=\$(pwd)/_output/local/bin/linux/amd64:\$PATH
   oc get nodes --template &#39;{{ range .items }}{{ .metadata.name }}{{ &#34;\n&#34; }}{{ end }}&#39; | xargs -L 1 -I X bash -c &#39;oc get --raw /api/v1/nodes/X/proxy/metrics &gt; /tmp/artifacts/X.metrics&#39; &#39;&#39;
   oc get --raw /metrics &gt; /tmp/artifacts/master.metrics
@@ -609,7 +612,6 @@ if [[ -z &#34;\${FOCUS:-}&#34; &amp;&amp; &#34;\${SUITE}&#34; =~ ^(.*)\((.*)\)\$
   SUITE=&#34;\${BASH_REMATCH[1]}&#34;
   FOCUS=&#34;\${BASH_REMATCH[2]}&#34;
 fi
-OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/extended.test hack/env make build-extended-test
 OPENSHIFT_SKIP_BUILD=&#39;true&#39; make test-extended SUITE=&#34;\${SUITE}&#34; FOCUS=&#34;\${FOCUS:-}&#34;
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_launch_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_launch_gce.xml
@@ -587,9 +587,12 @@ TEST_EXTENDED_SKIP+=&#34;\${ADDITIONAL_SKIP-}&#34;
 export GOOGLE_APPLICATION_CREDENTIALS=&#34;/data/src/github.com/openshift/release/cluster/test-deploy/data/gce.json&#34;
 export TEST_EXTENDED_ARGS=&#39;-provider=gce -gce-zone=us-central1-a -gce-project=openshift-gce-devel-ci&#39;
 
+# test suites need oc and extended.test
+OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/oc hack/env make build WHAT=cmd/oc
+OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/extended.test hack/env make build-extended-test
+
 function gather() {
   set +e
-  OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/oc hack/env make build WHAT=cmd/oc
   export PATH=\$(pwd)/_output/local/bin/linux/amd64:\$PATH
   oc get nodes --template &#39;{{ range .items }}{{ .metadata.name }}{{ &#34;\n&#34; }}{{ end }}&#39; | xargs -L 1 -I X bash -c &#39;oc get --raw /api/v1/nodes/X/proxy/metrics &gt; /tmp/artifacts/X.metrics&#39; &#39;&#39;
   oc get --raw /metrics &gt; /tmp/artifacts/master.metrics
@@ -604,7 +607,6 @@ if [[ -z &#34;\${FOCUS:-}&#34; &amp;&amp; &#34;\${SUITE}&#34; =~ ^(.*)\((.*)\)\$
   SUITE=&#34;\${BASH_REMATCH[1]}&#34;
   FOCUS=&#34;\${BASH_REMATCH[2]}&#34;
 fi
-OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/extended.test hack/env make build-extended-test
 OPENSHIFT_SKIP_BUILD=&#39;true&#39; make test-extended SUITE=&#34;\${SUITE}&#34; FOCUS=&#34;\${FOCUS:-}&#34;
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
@@ -541,9 +541,12 @@ TEST_EXTENDED_SKIP+=&#34;\${ADDITIONAL_SKIP-}&#34;
 export GOOGLE_APPLICATION_CREDENTIALS=&#34;/data/src/github.com/openshift/release/cluster/test-deploy/data/gce.json&#34;
 export TEST_EXTENDED_ARGS=&#39;-provider=gce -gce-zone=us-central1-a -gce-project=openshift-gce-devel-ci&#39;
 
+# test suites need oc and extended.test
+OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/oc hack/env make build WHAT=cmd/oc
+OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/extended.test hack/env make build-extended-test
+
 function gather() {
   set +e
-  OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/oc hack/env make build WHAT=cmd/oc
   export PATH=\$(pwd)/_output/local/bin/linux/amd64:\$PATH
   oc get nodes --template &#39;{{ range .items }}{{ .metadata.name }}{{ &#34;\n&#34; }}{{ end }}&#39; | xargs -L 1 -I X bash -c &#39;oc get --raw /api/v1/nodes/X/proxy/metrics &gt; /tmp/artifacts/X.metrics&#39; &#39;&#39;
   oc get --raw /metrics &gt; /tmp/artifacts/master.metrics
@@ -558,7 +561,6 @@ if [[ -z &#34;\${FOCUS:-}&#34; &amp;&amp; &#34;\${SUITE}&#34; =~ ^(.*)\((.*)\)\$
   SUITE=&#34;\${BASH_REMATCH[1]}&#34;
   FOCUS=&#34;\${BASH_REMATCH[2]}&#34;
 fi
-OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/extended.test hack/env make build-extended-test
 OPENSHIFT_SKIP_BUILD=&#39;true&#39; make test-extended SUITE=&#34;\${SUITE}&#34; FOCUS=&#34;\${FOCUS:-}&#34;
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_k8s.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_k8s.xml
@@ -541,9 +541,12 @@ TEST_EXTENDED_SKIP+=&#34;\${ADDITIONAL_SKIP-}&#34;
 export GOOGLE_APPLICATION_CREDENTIALS=&#34;/data/src/github.com/openshift/release/cluster/test-deploy/data/gce.json&#34;
 export TEST_EXTENDED_ARGS=&#39;-provider=gce -gce-zone=us-central1-a -gce-project=openshift-gce-devel-ci&#39;
 
+# test suites need oc and extended.test
+OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/oc hack/env make build WHAT=cmd/oc
+OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/extended.test hack/env make build-extended-test
+
 function gather() {
   set +e
-  OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/oc hack/env make build WHAT=cmd/oc
   export PATH=\$(pwd)/_output/local/bin/linux/amd64:\$PATH
   oc get nodes --template &#39;{{ range .items }}{{ .metadata.name }}{{ &#34;\n&#34; }}{{ end }}&#39; | xargs -L 1 -I X bash -c &#39;oc get --raw /api/v1/nodes/X/proxy/metrics &gt; /tmp/artifacts/X.metrics&#39; &#39;&#39;
   oc get --raw /metrics &gt; /tmp/artifacts/master.metrics
@@ -558,7 +561,6 @@ if [[ -z &#34;\${FOCUS:-}&#34; &amp;&amp; &#34;\${SUITE}&#34; =~ ^(.*)\((.*)\)\$
   SUITE=&#34;\${BASH_REMATCH[1]}&#34;
   FOCUS=&#34;\${BASH_REMATCH[2]}&#34;
 fi
-OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/extended.test hack/env make build-extended-test
 OPENSHIFT_SKIP_BUILD=&#39;true&#39; make test-extended SUITE=&#34;\${SUITE}&#34; FOCUS=&#34;\${FOCUS:-}&#34;
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_launch_gce.xml
+++ b/sjb/generated/test_pull_request_origin_launch_gce.xml
@@ -587,9 +587,12 @@ TEST_EXTENDED_SKIP+=&#34;\${ADDITIONAL_SKIP-}&#34;
 export GOOGLE_APPLICATION_CREDENTIALS=&#34;/data/src/github.com/openshift/release/cluster/test-deploy/data/gce.json&#34;
 export TEST_EXTENDED_ARGS=&#39;-provider=gce -gce-zone=us-central1-a -gce-project=openshift-gce-devel-ci&#39;
 
+# test suites need oc and extended.test
+OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/oc hack/env make build WHAT=cmd/oc
+OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/extended.test hack/env make build-extended-test
+
 function gather() {
   set +e
-  OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/oc hack/env make build WHAT=cmd/oc
   export PATH=\$(pwd)/_output/local/bin/linux/amd64:\$PATH
   oc get nodes --template &#39;{{ range .items }}{{ .metadata.name }}{{ &#34;\n&#34; }}{{ end }}&#39; | xargs -L 1 -I X bash -c &#39;oc get --raw /api/v1/nodes/X/proxy/metrics &gt; /tmp/artifacts/X.metrics&#39; &#39;&#39;
   oc get --raw /metrics &gt; /tmp/artifacts/master.metrics
@@ -604,7 +607,6 @@ if [[ -z &#34;\${FOCUS:-}&#34; &amp;&amp; &#34;\${SUITE}&#34; =~ ^(.*)\((.*)\)\$
   SUITE=&#34;\${BASH_REMATCH[1]}&#34;
   FOCUS=&#34;\${BASH_REMATCH[2]}&#34;
 fi
-OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/local/bin/linux/amd64/extended.test hack/env make build-extended-test
 OPENSHIFT_SKIP_BUILD=&#39;true&#39; make test-extended SUITE=&#34;\${SUITE}&#34; FOCUS=&#34;\${FOCUS:-}&#34;
 SCRIPT
 chmod +x &#34;${script}&#34;


### PR DESCRIPTION
Future jobs will be less hacky, but this is necessary for k8s to run.