### PR TITLE
Allow publishing RPMs to tagged releases

### DIFF
--- a/sjb/config/common/test_cases/origin_release_install_gce.yml
+++ b/sjb/config/common/test_cases/origin_release_install_gce.yml
@@ -70,6 +70,10 @@ extensions:
           exit 0
         fi
         
+        # Allows us to publish artifacts for tags, since we have no tag mechanism
+        if [[ -z "${JOB_SPEC}" ]]; then
+          JOB_SPEC='{"type":"postsubmit","refs":{"base_ref":"${OPENSHIFT_TARGET_BRANCH}"}}'
+        fi
         type="$( echo "${JOB_SPEC}" | jq  -r '.type' )"
         if   [[ "${type}" == "postsubmit" ]]; then
           location_base="origin-ci-test/logs/${JOB_NAME}/${BUILD_NUMBER}"
@@ -104,11 +108,11 @@ extensions:
         rsync --archive --omit-dir-times --rsh "ssh -F ./.config/origin-ci-tool/inventory/.ssh_config" --rsync-path='sudo rsync' openshiftdevel:/data/src/github.com/openshift/origin/_output/local/releases/rpms ./artifacts/ || true
         gsutil -m cp -r artifacts/rpms "gs://${location}"
         if [[ "${type}" == "postsubmit" ]]; then
-          # update the pointer to this location to either ORIGIN_TARGET_BRANCH or the base ref branch
+          # update the pointer to this location to the base ref branch
           echo "${location_url}" > .latest-rpms
           ref="$( echo "${JOB_SPEC}" | jq  -r '.refs.base_ref' )"
-          gsutil cp .latest-rpms "gs://origin-ci-test/releases/openshift/origin/${ORIGIN_TARGET_BRANCH:-${ref}}/.latest-rpms"
-          gsutil cp /tmp/local.repo "gs://origin-ci-test/releases/openshift/origin/${ORIGIN_TARGET_BRANCH:-${ref}}/origin.repo"
+          gsutil cp .latest-rpms "gs://origin-ci-test/releases/openshift/origin/${ref}/.latest-rpms"
+          gsutil cp /tmp/local.repo "gs://origin-ci-test/releases/openshift/origin/${ref}/origin.repo"
         fi
 
         # hack around forwarding this to the other machine

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce.xml
@@ -446,6 +446,10 @@ if [[ &#34;${REPO_OWNER-}&#34; != &#34;openshift&#34; || &#34;${REPO_NAME-}&#34;
   exit 0
 fi
 
+# Allows us to publish artifacts for tags, since we have no tag mechanism
+if [[ -z &#34;${JOB_SPEC}&#34; ]]; then
+  JOB_SPEC=&#39;{&#34;type&#34;:&#34;postsubmit&#34;,&#34;refs&#34;:{&#34;base_ref&#34;:&#34;${OPENSHIFT_TARGET_BRANCH}&#34;}}&#39;
+fi
 type=&#34;$( echo &#34;${JOB_SPEC}&#34; | jq  -r &#39;.type&#39; )&#34;
 if   [[ &#34;${type}&#34; == &#34;postsubmit&#34; ]]; then
   location_base=&#34;origin-ci-test/logs/${JOB_NAME}/${BUILD_NUMBER}&#34;
@@ -480,11 +484,11 @@ mkdir -p artifacts/rpms
 rsync --archive --omit-dir-times --rsh &#34;ssh -F ./.config/origin-ci-tool/inventory/.ssh_config&#34; --rsync-path=&#39;sudo rsync&#39; openshiftdevel:/data/src/github.com/openshift/origin/_output/local/releases/rpms ./artifacts/ || true
 gsutil -m cp -r artifacts/rpms &#34;gs://${location}&#34;
 if [[ &#34;${type}&#34; == &#34;postsubmit&#34; ]]; then
-  # update the pointer to this location to either ORIGIN_TARGET_BRANCH or the base ref branch
+  # update the pointer to this location to the base ref branch
   echo &#34;${location_url}&#34; &gt; .latest-rpms
   ref=&#34;$( echo &#34;${JOB_SPEC}&#34; | jq  -r &#39;.refs.base_ref&#39; )&#34;
-  gsutil cp .latest-rpms &#34;gs://origin-ci-test/releases/openshift/origin/${ORIGIN_TARGET_BRANCH:-${ref}}/.latest-rpms&#34;
-  gsutil cp /tmp/local.repo &#34;gs://origin-ci-test/releases/openshift/origin/${ORIGIN_TARGET_BRANCH:-${ref}}/origin.repo&#34;
+  gsutil cp .latest-rpms &#34;gs://origin-ci-test/releases/openshift/origin/${ref}/.latest-rpms&#34;
+  gsutil cp /tmp/local.repo &#34;gs://origin-ci-test/releases/openshift/origin/${ref}/origin.repo&#34;
 fi
 
 # hack around forwarding this to the other machine

--- a/sjb/generated/test_branch_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce.xml
@@ -441,6 +441,10 @@ if [[ &#34;${REPO_OWNER-}&#34; != &#34;openshift&#34; || &#34;${REPO_NAME-}&#34;
   exit 0
 fi
 
+# Allows us to publish artifacts for tags, since we have no tag mechanism
+if [[ -z &#34;${JOB_SPEC}&#34; ]]; then
+  JOB_SPEC=&#39;{&#34;type&#34;:&#34;postsubmit&#34;,&#34;refs&#34;:{&#34;base_ref&#34;:&#34;${OPENSHIFT_TARGET_BRANCH}&#34;}}&#39;
+fi
 type=&#34;$( echo &#34;${JOB_SPEC}&#34; | jq  -r &#39;.type&#39; )&#34;
 if   [[ &#34;${type}&#34; == &#34;postsubmit&#34; ]]; then
   location_base=&#34;origin-ci-test/logs/${JOB_NAME}/${BUILD_NUMBER}&#34;
@@ -475,11 +479,11 @@ mkdir -p artifacts/rpms
 rsync --archive --omit-dir-times --rsh &#34;ssh -F ./.config/origin-ci-tool/inventory/.ssh_config&#34; --rsync-path=&#39;sudo rsync&#39; openshiftdevel:/data/src/github.com/openshift/origin/_output/local/releases/rpms ./artifacts/ || true
 gsutil -m cp -r artifacts/rpms &#34;gs://${location}&#34;
 if [[ &#34;${type}&#34; == &#34;postsubmit&#34; ]]; then
-  # update the pointer to this location to either ORIGIN_TARGET_BRANCH or the base ref branch
+  # update the pointer to this location to the base ref branch
   echo &#34;${location_url}&#34; &gt; .latest-rpms
   ref=&#34;$( echo &#34;${JOB_SPEC}&#34; | jq  -r &#39;.refs.base_ref&#39; )&#34;
-  gsutil cp .latest-rpms &#34;gs://origin-ci-test/releases/openshift/origin/${ORIGIN_TARGET_BRANCH:-${ref}}/.latest-rpms&#34;
-  gsutil cp /tmp/local.repo &#34;gs://origin-ci-test/releases/openshift/origin/${ORIGIN_TARGET_BRANCH:-${ref}}/origin.repo&#34;
+  gsutil cp .latest-rpms &#34;gs://origin-ci-test/releases/openshift/origin/${ref}/.latest-rpms&#34;
+  gsutil cp /tmp/local.repo &#34;gs://origin-ci-test/releases/openshift/origin/${ref}/origin.repo&#34;
 fi
 
 # hack around forwarding this to the other machine

--- a/sjb/generated/test_branch_origin_extended_conformance_k8s.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_k8s.xml
@@ -446,6 +446,10 @@ if [[ &#34;${REPO_OWNER-}&#34; != &#34;openshift&#34; || &#34;${REPO_NAME-}&#34;
   exit 0
 fi
 
+# Allows us to publish artifacts for tags, since we have no tag mechanism
+if [[ -z &#34;${JOB_SPEC}&#34; ]]; then
+  JOB_SPEC=&#39;{&#34;type&#34;:&#34;postsubmit&#34;,&#34;refs&#34;:{&#34;base_ref&#34;:&#34;${OPENSHIFT_TARGET_BRANCH}&#34;}}&#39;
+fi
 type=&#34;$( echo &#34;${JOB_SPEC}&#34; | jq  -r &#39;.type&#39; )&#34;
 if   [[ &#34;${type}&#34; == &#34;postsubmit&#34; ]]; then
   location_base=&#34;origin-ci-test/logs/${JOB_NAME}/${BUILD_NUMBER}&#34;
@@ -480,11 +484,11 @@ mkdir -p artifacts/rpms
 rsync --archive --omit-dir-times --rsh &#34;ssh -F ./.config/origin-ci-tool/inventory/.ssh_config&#34; --rsync-path=&#39;sudo rsync&#39; openshiftdevel:/data/src/github.com/openshift/origin/_output/local/releases/rpms ./artifacts/ || true
 gsutil -m cp -r artifacts/rpms &#34;gs://${location}&#34;
 if [[ &#34;${type}&#34; == &#34;postsubmit&#34; ]]; then
-  # update the pointer to this location to either ORIGIN_TARGET_BRANCH or the base ref branch
+  # update the pointer to this location to the base ref branch
   echo &#34;${location_url}&#34; &gt; .latest-rpms
   ref=&#34;$( echo &#34;${JOB_SPEC}&#34; | jq  -r &#39;.refs.base_ref&#39; )&#34;
-  gsutil cp .latest-rpms &#34;gs://origin-ci-test/releases/openshift/origin/${ORIGIN_TARGET_BRANCH:-${ref}}/.latest-rpms&#34;
-  gsutil cp /tmp/local.repo &#34;gs://origin-ci-test/releases/openshift/origin/${ORIGIN_TARGET_BRANCH:-${ref}}/origin.repo&#34;
+  gsutil cp .latest-rpms &#34;gs://origin-ci-test/releases/openshift/origin/${ref}/.latest-rpms&#34;
+  gsutil cp /tmp/local.repo &#34;gs://origin-ci-test/releases/openshift/origin/${ref}/origin.repo&#34;
 fi
 
 # hack around forwarding this to the other machine

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce.xml
@@ -482,6 +482,10 @@ if [[ &#34;${REPO_OWNER-}&#34; != &#34;openshift&#34; || &#34;${REPO_NAME-}&#34;
   exit 0
 fi
 
+# Allows us to publish artifacts for tags, since we have no tag mechanism
+if [[ -z &#34;${JOB_SPEC}&#34; ]]; then
+  JOB_SPEC=&#39;{&#34;type&#34;:&#34;postsubmit&#34;,&#34;refs&#34;:{&#34;base_ref&#34;:&#34;${OPENSHIFT_TARGET_BRANCH}&#34;}}&#39;
+fi
 type=&#34;$( echo &#34;${JOB_SPEC}&#34; | jq  -r &#39;.type&#39; )&#34;
 if   [[ &#34;${type}&#34; == &#34;postsubmit&#34; ]]; then
   location_base=&#34;origin-ci-test/logs/${JOB_NAME}/${BUILD_NUMBER}&#34;
@@ -516,11 +520,11 @@ mkdir -p artifacts/rpms
 rsync --archive --omit-dir-times --rsh &#34;ssh -F ./.config/origin-ci-tool/inventory/.ssh_config&#34; --rsync-path=&#39;sudo rsync&#39; openshiftdevel:/data/src/github.com/openshift/origin/_output/local/releases/rpms ./artifacts/ || true
 gsutil -m cp -r artifacts/rpms &#34;gs://${location}&#34;
 if [[ &#34;${type}&#34; == &#34;postsubmit&#34; ]]; then
-  # update the pointer to this location to either ORIGIN_TARGET_BRANCH or the base ref branch
+  # update the pointer to this location to the base ref branch
   echo &#34;${location_url}&#34; &gt; .latest-rpms
   ref=&#34;$( echo &#34;${JOB_SPEC}&#34; | jq  -r &#39;.refs.base_ref&#39; )&#34;
-  gsutil cp .latest-rpms &#34;gs://origin-ci-test/releases/openshift/origin/${ORIGIN_TARGET_BRANCH:-${ref}}/.latest-rpms&#34;
-  gsutil cp /tmp/local.repo &#34;gs://origin-ci-test/releases/openshift/origin/${ORIGIN_TARGET_BRANCH:-${ref}}/origin.repo&#34;
+  gsutil cp .latest-rpms &#34;gs://origin-ci-test/releases/openshift/origin/${ref}/.latest-rpms&#34;
+  gsutil cp /tmp/local.repo &#34;gs://origin-ci-test/releases/openshift/origin/${ref}/origin.repo&#34;
 fi
 
 # hack around forwarding this to the other machine

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha.xml
@@ -482,6 +482,10 @@ if [[ &#34;${REPO_OWNER-}&#34; != &#34;openshift&#34; || &#34;${REPO_NAME-}&#34;
   exit 0
 fi
 
+# Allows us to publish artifacts for tags, since we have no tag mechanism
+if [[ -z &#34;${JOB_SPEC}&#34; ]]; then
+  JOB_SPEC=&#39;{&#34;type&#34;:&#34;postsubmit&#34;,&#34;refs&#34;:{&#34;base_ref&#34;:&#34;${OPENSHIFT_TARGET_BRANCH}&#34;}}&#39;
+fi
 type=&#34;$( echo &#34;${JOB_SPEC}&#34; | jq  -r &#39;.type&#39; )&#34;
 if   [[ &#34;${type}&#34; == &#34;postsubmit&#34; ]]; then
   location_base=&#34;origin-ci-test/logs/${JOB_NAME}/${BUILD_NUMBER}&#34;
@@ -516,11 +520,11 @@ mkdir -p artifacts/rpms
 rsync --archive --omit-dir-times --rsh &#34;ssh -F ./.config/origin-ci-tool/inventory/.ssh_config&#34; --rsync-path=&#39;sudo rsync&#39; openshiftdevel:/data/src/github.com/openshift/origin/_output/local/releases/rpms ./artifacts/ || true
 gsutil -m cp -r artifacts/rpms &#34;gs://${location}&#34;
 if [[ &#34;${type}&#34; == &#34;postsubmit&#34; ]]; then
-  # update the pointer to this location to either ORIGIN_TARGET_BRANCH or the base ref branch
+  # update the pointer to this location to the base ref branch
   echo &#34;${location_url}&#34; &gt; .latest-rpms
   ref=&#34;$( echo &#34;${JOB_SPEC}&#34; | jq  -r &#39;.refs.base_ref&#39; )&#34;
-  gsutil cp .latest-rpms &#34;gs://origin-ci-test/releases/openshift/origin/${ORIGIN_TARGET_BRANCH:-${ref}}/.latest-rpms&#34;
-  gsutil cp /tmp/local.repo &#34;gs://origin-ci-test/releases/openshift/origin/${ORIGIN_TARGET_BRANCH:-${ref}}/origin.repo&#34;
+  gsutil cp .latest-rpms &#34;gs://origin-ci-test/releases/openshift/origin/${ref}/.latest-rpms&#34;
+  gsutil cp /tmp/local.repo &#34;gs://origin-ci-test/releases/openshift/origin/${ref}/origin.repo&#34;
 fi
 
 # hack around forwarding this to the other machine

--- a/sjb/generated/test_pull_request_openshift_ansible_launch_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_launch_gce.xml
@@ -477,6 +477,10 @@ if [[ &#34;${REPO_OWNER-}&#34; != &#34;openshift&#34; || &#34;${REPO_NAME-}&#34;
   exit 0
 fi
 
+# Allows us to publish artifacts for tags, since we have no tag mechanism
+if [[ -z &#34;${JOB_SPEC}&#34; ]]; then
+  JOB_SPEC=&#39;{&#34;type&#34;:&#34;postsubmit&#34;,&#34;refs&#34;:{&#34;base_ref&#34;:&#34;${OPENSHIFT_TARGET_BRANCH}&#34;}}&#39;
+fi
 type=&#34;$( echo &#34;${JOB_SPEC}&#34; | jq  -r &#39;.type&#39; )&#34;
 if   [[ &#34;${type}&#34; == &#34;postsubmit&#34; ]]; then
   location_base=&#34;origin-ci-test/logs/${JOB_NAME}/${BUILD_NUMBER}&#34;
@@ -511,11 +515,11 @@ mkdir -p artifacts/rpms
 rsync --archive --omit-dir-times --rsh &#34;ssh -F ./.config/origin-ci-tool/inventory/.ssh_config&#34; --rsync-path=&#39;sudo rsync&#39; openshiftdevel:/data/src/github.com/openshift/origin/_output/local/releases/rpms ./artifacts/ || true
 gsutil -m cp -r artifacts/rpms &#34;gs://${location}&#34;
 if [[ &#34;${type}&#34; == &#34;postsubmit&#34; ]]; then
-  # update the pointer to this location to either ORIGIN_TARGET_BRANCH or the base ref branch
+  # update the pointer to this location to the base ref branch
   echo &#34;${location_url}&#34; &gt; .latest-rpms
   ref=&#34;$( echo &#34;${JOB_SPEC}&#34; | jq  -r &#39;.refs.base_ref&#39; )&#34;
-  gsutil cp .latest-rpms &#34;gs://origin-ci-test/releases/openshift/origin/${ORIGIN_TARGET_BRANCH:-${ref}}/.latest-rpms&#34;
-  gsutil cp /tmp/local.repo &#34;gs://origin-ci-test/releases/openshift/origin/${ORIGIN_TARGET_BRANCH:-${ref}}/origin.repo&#34;
+  gsutil cp .latest-rpms &#34;gs://origin-ci-test/releases/openshift/origin/${ref}/.latest-rpms&#34;
+  gsutil cp /tmp/local.repo &#34;gs://origin-ci-test/releases/openshift/origin/${ref}/origin.repo&#34;
 fi
 
 # hack around forwarding this to the other machine

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
@@ -494,6 +494,10 @@ if [[ &#34;${REPO_OWNER-}&#34; != &#34;openshift&#34; || &#34;${REPO_NAME-}&#34;
   exit 0
 fi
 
+# Allows us to publish artifacts for tags, since we have no tag mechanism
+if [[ -z &#34;${JOB_SPEC}&#34; ]]; then
+  JOB_SPEC=&#39;{&#34;type&#34;:&#34;postsubmit&#34;,&#34;refs&#34;:{&#34;base_ref&#34;:&#34;${OPENSHIFT_TARGET_BRANCH}&#34;}}&#39;
+fi
 type=&#34;$( echo &#34;${JOB_SPEC}&#34; | jq  -r &#39;.type&#39; )&#34;
 if   [[ &#34;${type}&#34; == &#34;postsubmit&#34; ]]; then
   location_base=&#34;origin-ci-test/logs/${JOB_NAME}/${BUILD_NUMBER}&#34;
@@ -528,11 +532,11 @@ mkdir -p artifacts/rpms
 rsync --archive --omit-dir-times --rsh &#34;ssh -F ./.config/origin-ci-tool/inventory/.ssh_config&#34; --rsync-path=&#39;sudo rsync&#39; openshiftdevel:/data/src/github.com/openshift/origin/_output/local/releases/rpms ./artifacts/ || true
 gsutil -m cp -r artifacts/rpms &#34;gs://${location}&#34;
 if [[ &#34;${type}&#34; == &#34;postsubmit&#34; ]]; then
-  # update the pointer to this location to either ORIGIN_TARGET_BRANCH or the base ref branch
+  # update the pointer to this location to the base ref branch
   echo &#34;${location_url}&#34; &gt; .latest-rpms
   ref=&#34;$( echo &#34;${JOB_SPEC}&#34; | jq  -r &#39;.refs.base_ref&#39; )&#34;
-  gsutil cp .latest-rpms &#34;gs://origin-ci-test/releases/openshift/origin/${ORIGIN_TARGET_BRANCH:-${ref}}/.latest-rpms&#34;
-  gsutil cp /tmp/local.repo &#34;gs://origin-ci-test/releases/openshift/origin/${ORIGIN_TARGET_BRANCH:-${ref}}/origin.repo&#34;
+  gsutil cp .latest-rpms &#34;gs://origin-ci-test/releases/openshift/origin/${ref}/.latest-rpms&#34;
+  gsutil cp /tmp/local.repo &#34;gs://origin-ci-test/releases/openshift/origin/${ref}/origin.repo&#34;
 fi
 
 # hack around forwarding this to the other machine

--- a/sjb/generated/test_pull_request_origin_extended_conformance_k8s.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_k8s.xml
@@ -494,6 +494,10 @@ if [[ &#34;${REPO_OWNER-}&#34; != &#34;openshift&#34; || &#34;${REPO_NAME-}&#34;
   exit 0
 fi
 
+# Allows us to publish artifacts for tags, since we have no tag mechanism
+if [[ -z &#34;${JOB_SPEC}&#34; ]]; then
+  JOB_SPEC=&#39;{&#34;type&#34;:&#34;postsubmit&#34;,&#34;refs&#34;:{&#34;base_ref&#34;:&#34;${OPENSHIFT_TARGET_BRANCH}&#34;}}&#39;
+fi
 type=&#34;$( echo &#34;${JOB_SPEC}&#34; | jq  -r &#39;.type&#39; )&#34;
 if   [[ &#34;${type}&#34; == &#34;postsubmit&#34; ]]; then
   location_base=&#34;origin-ci-test/logs/${JOB_NAME}/${BUILD_NUMBER}&#34;
@@ -528,11 +532,11 @@ mkdir -p artifacts/rpms
 rsync --archive --omit-dir-times --rsh &#34;ssh -F ./.config/origin-ci-tool/inventory/.ssh_config&#34; --rsync-path=&#39;sudo rsync&#39; openshiftdevel:/data/src/github.com/openshift/origin/_output/local/releases/rpms ./artifacts/ || true
 gsutil -m cp -r artifacts/rpms &#34;gs://${location}&#34;
 if [[ &#34;${type}&#34; == &#34;postsubmit&#34; ]]; then
-  # update the pointer to this location to either ORIGIN_TARGET_BRANCH or the base ref branch
+  # update the pointer to this location to the base ref branch
   echo &#34;${location_url}&#34; &gt; .latest-rpms
   ref=&#34;$( echo &#34;${JOB_SPEC}&#34; | jq  -r &#39;.refs.base_ref&#39; )&#34;
-  gsutil cp .latest-rpms &#34;gs://origin-ci-test/releases/openshift/origin/${ORIGIN_TARGET_BRANCH:-${ref}}/.latest-rpms&#34;
-  gsutil cp /tmp/local.repo &#34;gs://origin-ci-test/releases/openshift/origin/${ORIGIN_TARGET_BRANCH:-${ref}}/origin.repo&#34;
+  gsutil cp .latest-rpms &#34;gs://origin-ci-test/releases/openshift/origin/${ref}/.latest-rpms&#34;
+  gsutil cp /tmp/local.repo &#34;gs://origin-ci-test/releases/openshift/origin/${ref}/origin.repo&#34;
 fi
 
 # hack around forwarding this to the other machine

--- a/sjb/generated/test_pull_request_origin_launch_gce.xml
+++ b/sjb/generated/test_pull_request_origin_launch_gce.xml
@@ -477,6 +477,10 @@ if [[ &#34;${REPO_OWNER-}&#34; != &#34;openshift&#34; || &#34;${REPO_NAME-}&#34;
   exit 0
 fi
 
+# Allows us to publish artifacts for tags, since we have no tag mechanism
+if [[ -z &#34;${JOB_SPEC}&#34; ]]; then
+  JOB_SPEC=&#39;{&#34;type&#34;:&#34;postsubmit&#34;,&#34;refs&#34;:{&#34;base_ref&#34;:&#34;${OPENSHIFT_TARGET_BRANCH}&#34;}}&#39;
+fi
 type=&#34;$( echo &#34;${JOB_SPEC}&#34; | jq  -r &#39;.type&#39; )&#34;
 if   [[ &#34;${type}&#34; == &#34;postsubmit&#34; ]]; then
   location_base=&#34;origin-ci-test/logs/${JOB_NAME}/${BUILD_NUMBER}&#34;
@@ -511,11 +515,11 @@ mkdir -p artifacts/rpms
 rsync --archive --omit-dir-times --rsh &#34;ssh -F ./.config/origin-ci-tool/inventory/.ssh_config&#34; --rsync-path=&#39;sudo rsync&#39; openshiftdevel:/data/src/github.com/openshift/origin/_output/local/releases/rpms ./artifacts/ || true
 gsutil -m cp -r artifacts/rpms &#34;gs://${location}&#34;
 if [[ &#34;${type}&#34; == &#34;postsubmit&#34; ]]; then
-  # update the pointer to this location to either ORIGIN_TARGET_BRANCH or the base ref branch
+  # update the pointer to this location to the base ref branch
   echo &#34;${location_url}&#34; &gt; .latest-rpms
   ref=&#34;$( echo &#34;${JOB_SPEC}&#34; | jq  -r &#39;.refs.base_ref&#39; )&#34;
-  gsutil cp .latest-rpms &#34;gs://origin-ci-test/releases/openshift/origin/${ORIGIN_TARGET_BRANCH:-${ref}}/.latest-rpms&#34;
-  gsutil cp /tmp/local.repo &#34;gs://origin-ci-test/releases/openshift/origin/${ORIGIN_TARGET_BRANCH:-${ref}}/origin.repo&#34;
+  gsutil cp .latest-rpms &#34;gs://origin-ci-test/releases/openshift/origin/${ref}/.latest-rpms&#34;
+  gsutil cp /tmp/local.repo &#34;gs://origin-ci-test/releases/openshift/origin/${ref}/origin.repo&#34;
 fi
 
 # hack around forwarding this to the other machine


### PR DESCRIPTION
We need to be able to publish RPMs to v3.9.0-alpha.4, which won't have a
JOB_SPEC. Create a synthetic JOB_SPEC instead.

@kargakis @stevekuznetsov I found this today when i tried to cut v3.9.0-alpha.4