### PR TITLE
sources.yml write needed to happen sooner

### DIFF
--- a/jobs/build/ocp/Jenkinsfile
+++ b/jobs/build/ocp/Jenkinsfile
@@ -559,6 +559,8 @@ node(TARGET_NODE) {
             }
         }
         
+        buildlib.write_sources_file()
+
         stage( "build OIT rpms" ) {
           buildlib.oit """
 --working-dir ${OIT_WORKING} --group 'openshift-${BUILD_VERSION}'
@@ -589,7 +591,6 @@ rpms:build --version v${NEW_VERSION}
         }
 
         stage( "update dist-git" ) {
-          buildlib.write_sources_file()
           buildlib.oit """
 --working-dir ${OIT_WORKING} --group 'openshift-${BUILD_VERSION}'
 --sources ${env.WORKSPACE}/sources.yml


### PR DESCRIPTION
@jupierce - Found a timing bug while trying to fix the 3.9 build this morning. It was masked by the fact that we don't cleanup everything in the workspace between runs and sources.yml basically never changes. But I had a clean slate this time, so it was causing an issue.