### PR TITLE
make sure docker is using journald for journald tests

### DIFF
--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
@@ -120,6 +120,8 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e openshift_deployment_type=origin  \
+                         -e openshift_docker_log_driver=journald \
+                         -e openshift_docker_options="--log-driver=journald" \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
     - type: "script"
       title: "install origin"
@@ -137,6 +139,8 @@ extensions:
                          --inventory sjb/inventory/ \
                          -e openshift_deployment_type=origin  \
                          -e debug_level=2           \
+                         -e openshift_docker_log_driver=journald \
+                         -e openshift_docker_options="--log-driver=journald" \
                          ${playbook}
         if [[ -s "${playbook_base}deploy_cluster.yml" ]]; then
             playbook="${playbook_base}deploy_cluster.yml"

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
@@ -524,6 +524,8 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e openshift_deployment_type=origin  \
+                 -e openshift_docker_log_driver=journald \
+                 -e openshift_docker_options=&#34;--log-driver=journald&#34; \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -550,6 +552,8 @@ ansible-playbook -vv --become               \
                  --inventory sjb/inventory/ \
                  -e openshift_deployment_type=origin  \
                  -e debug_level=2           \
+                 -e openshift_docker_log_driver=journald \
+                 -e openshift_docker_options=&#34;--log-driver=journald&#34; \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
     playbook=&#34;\${playbook_base}deploy_cluster.yml&#34;


### PR DESCRIPTION
Not sure which playbook enables docker log-driver, so just use
all of them.
With this, I can confirm:

    $ sudo docker info |grep -i log
    Logging Driver: journald