### PR TITLE
Adding oso 3.7.0 jobs

### DIFF
--- a/jobs/build/openshift-online/Jenkinsfile
+++ b/jobs/build/openshift-online/Jenkinsfile
@@ -26,7 +26,7 @@ properties(
                                                     release         online/online-X.Y.Z -> https://mirror.openshift.com/enterprise/online-openshift-scripts/X.Y <br>
                                                     ''',
                                     name: 'BUILD_MODE'],
-                                [$class: 'hudson.model.ChoiceParameterDefinition', choices: "3.6.0", defaultValue: '3.6.0', description: 'Release version (matches version in branch name for release builds)', name: 'RELEASE_VERSION'],
+                                [$class: 'hudson.model.ChoiceParameterDefinition', choices: "3.6.0\n3.7.0", defaultValue: '3.6.0', description: 'Release version (matches version in branch name for release builds)', name: 'RELEASE_VERSION'],
                                 [$class: 'BooleanParameterDefinition', defaultValue: false, description: 'Mock run to pickup new Jenkins parameters?.', name: 'MOCK'],
                          ]
                 ],

--- a/scheduled-jobs/build/online/Jenkinsfile
+++ b/scheduled-jobs/build/online/Jenkinsfile
@@ -16,6 +16,14 @@ b = build       job: '../aos-cd-builds/build%2Fopenshift-online', propagate: fal
 description += "${b.displayName} - ${b.result}\n"
 failed |= (b.result != "SUCCESS")
 
+b = build       job: '../aos-cd-builds/build%2Fopenshift-online', propagate: false,
+                        parameters: [
+                                        [$class: 'StringParameterValue', name: 'BUILD_MODE', value: 'online:int'],
+                                        [$class: 'StringParameterValue', name: 'RELEASE_VERSION', value: '3.7.0'],
+                        ]
+description += "${b.displayName} - ${b.result}\n"
+failed |= (b.result != "SUCCESS")
+
 
 currentBuild.description = description.trim()
 currentBuild.result = failed?"FAILURE":"SUCCESS"


### PR DESCRIPTION
@jupierce 
Note @dak1n1 needs to add an online-3.6.0 branch for the older 3.6.0 job to work as intended.
But online master is 3.7.0 now so the new job should work as desired.