### PR TITLE
adding extra commit to bring back auto-gen spec changelog

### DIFF
--- a/jobs/build/ocp/Jenkinsfile
+++ b/jobs/build/ocp/Jenkinsfile
@@ -469,7 +469,8 @@ node(TARGET_NODE) {
                     commit_msg = "${commit_msg} ; bump origin-web-console ${VC_COMMIT}"
                 }
 
-                sh "tito tag --accept-auto-changelog --keep-version --debug --changelog='${commit_msg}'"
+                sh "git commit --allow-empty -m '${commit_msg}'" // add commit to capture our change message
+                sh "tito tag --accept-auto-changelog --keep-version --debug"
                 if ( ! IS_TEST_MODE ) {
                     sh "git push"
                     sh "git push --tags"


### PR DESCRIPTION
@jupierce @smunilla 

In ose, it does a different message if online:stg (https://github.com/openshift/aos-cd-jobs/blob/master/jobs/build/ose/scripts/merge-and-build.sh#L252), but nothing in OCP did that, so I did not include that as well. I just used the same message that was getting put into the spec file. Let me know if that's not what was desired. 