### PR TITLE
Fix crio moar space

### DIFF
--- a/sjb/actions/oct_install.py
+++ b/sjb/actions/oct_install.py
@@ -4,6 +4,7 @@ from actions.named_shell_task import render_task
 from .interface import Action
 
 _OCT_INSTALL_TITLE = "INSTALL THE ORIGIN-CI-TOOL"
+# N/B: Running inside bash with 'set -u'!
 _OCT_INSTALL_ACTION = """latest="$( readlink "${HOME}/origin-ci-tool/latest" )"
 touch "${latest}"
 cp "${latest}/bin/activate" "${WORKSPACE}/activate"
@@ -16,7 +17,10 @@ mkdir -p "${OCT_CONFIG_HOME}"
 rm -rf "${OCT_CONFIG_HOME}/origin-ci-tool"
 oct configure ansible-client verbosity 2
 oct configure aws-client 'keypair_name' 'libra'
-oct configure aws-client 'private_key_path' '/var/lib/jenkins/.ssh/devenv.pem'"""
+oct configure aws-client 'private_key_path' '/var/lib/jenkins/.ssh/devenv.pem'
+if [[ -n "${ROOT_VOLUME_SIZE:-}" ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi"""
 
 
 class OCTInstallAction(Action):

--- a/sjb/config/common/test_cases/crio.yml
+++ b/sjb/config/common/test_cases/crio.yml
@@ -16,6 +16,9 @@ parameters:
     description: "Pull request number."
   - name: PULL_PULL_SHA
     description: "Pull request head SHA."
+  - name: ROOT_VOLUME_SIZE
+    description: "Size of the root volume in gigabytes"
+    default_value: "50"
 actions:
   - type: "host_script"
     title: "upload GCS starting metadata"

--- a/sjb/generated/ami_build_origin_int_fedora_crio.xml
+++ b/sjb/generated/ami_build_origin_int_fedora_crio.xml
@@ -58,6 +58,11 @@
           <description>Pull request head SHA.</description>
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>ROOT_VOLUME_SIZE</name>
+          <description>Size of the root volume in gigabytes</description>
+          <defaultValue>50</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@1.9.0">
@@ -98,7 +103,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/ami_build_origin_int_rhel_base.xml
+++ b/sjb/generated/ami_build_origin_int_rhel_base.xml
@@ -54,7 +54,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/ami_build_origin_int_rhel_build.xml
+++ b/sjb/generated/ami_build_origin_int_rhel_build.xml
@@ -59,7 +59,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/ami_build_origin_int_rhel_crio.xml
+++ b/sjb/generated/ami_build_origin_int_rhel_crio.xml
@@ -58,6 +58,11 @@
           <description>Pull request head SHA.</description>
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>ROOT_VOLUME_SIZE</name>
+          <description>Size of the root volume in gigabytes</description>
+          <defaultValue>50</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@1.9.0">
@@ -98,7 +103,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/ami_build_origin_int_rhel_fork.xml
+++ b/sjb/generated/ami_build_origin_int_rhel_fork.xml
@@ -84,7 +84,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/ami_build_origin_int_rhel_install.xml
+++ b/sjb/generated/ami_build_origin_int_rhel_install.xml
@@ -54,7 +54,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/ci-kubernetes-conformance-node-e2e-containerized-rhel.xml
+++ b/sjb/generated/ci-kubernetes-conformance-node-e2e-containerized-rhel.xml
@@ -108,7 +108,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/ci-kubernetes-conformance-node-e2e-rhel.xml
+++ b/sjb/generated/ci-kubernetes-conformance-node-e2e-rhel.xml
@@ -108,7 +108,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/merge_pull_request_jenkins_client_plugin.xml
+++ b/sjb/generated/merge_pull_request_jenkins_client_plugin.xml
@@ -125,7 +125,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/merge_pull_request_jenkins_images.xml
+++ b/sjb/generated/merge_pull_request_jenkins_images.xml
@@ -105,7 +105,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/merge_pull_request_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/merge_pull_request_jenkins_openshift_login_plugin.xml
@@ -125,7 +125,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/merge_pull_request_jenkins_plugin.xml
+++ b/sjb/generated/merge_pull_request_jenkins_plugin.xml
@@ -125,7 +125,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/merge_pull_request_jenkins_sync_plugin.xml
+++ b/sjb/generated/merge_pull_request_jenkins_sync_plugin.xml
@@ -125,7 +125,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/merge_pull_request_origin_web_console.xml
+++ b/sjb/generated/merge_pull_request_origin_web_console.xml
@@ -125,7 +125,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/merge_pull_request_wildfly_images.xml
+++ b/sjb/generated/merge_pull_request_wildfly_images.xml
@@ -107,7 +107,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/push_jenkins_images.xml
+++ b/sjb/generated/push_jenkins_images.xml
@@ -84,7 +84,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/push_origin_aggregated_logging_release.xml
+++ b/sjb/generated/push_origin_aggregated_logging_release.xml
@@ -108,7 +108,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/push_origin_metrics_release.xml
+++ b/sjb/generated/push_origin_metrics_release.xml
@@ -108,7 +108,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/push_origin_release.xml
+++ b/sjb/generated/push_origin_release.xml
@@ -129,7 +129,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/push_wildfly_images.xml
+++ b/sjb/generated/push_wildfly_images.xml
@@ -86,7 +86,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_cluster_operator_unit.xml
+++ b/sjb/generated/test_branch_cluster_operator_unit.xml
@@ -119,7 +119,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_crio_e2e_fedora.xml
+++ b/sjb/generated/test_branch_crio_e2e_fedora.xml
@@ -58,6 +58,11 @@
           <description>Pull request head SHA.</description>
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>ROOT_VOLUME_SIZE</name>
+          <description>Size of the root volume in gigabytes</description>
+          <defaultValue>50</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@1.9.0">
@@ -94,7 +99,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_crio_e2e_rhel.xml
+++ b/sjb/generated/test_branch_crio_e2e_rhel.xml
@@ -58,6 +58,11 @@
           <description>Pull request head SHA.</description>
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>ROOT_VOLUME_SIZE</name>
+          <description>Size of the root volume in gigabytes</description>
+          <defaultValue>50</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@1.9.0">
@@ -94,7 +99,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_image_registry_extended.xml
+++ b/sjb/generated/test_branch_image_registry_extended.xml
@@ -109,7 +109,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_image_registry_integration.xml
+++ b/sjb/generated/test_branch_image_registry_integration.xml
@@ -109,7 +109,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_image_registry_unit.xml
+++ b/sjb/generated/test_branch_image_registry_unit.xml
@@ -119,7 +119,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_jenkins_client_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_client_plugin.xml
@@ -109,7 +109,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_jenkins_images.xml
+++ b/sjb/generated/test_branch_jenkins_images.xml
@@ -89,7 +89,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_openshift_login_plugin.xml
@@ -109,7 +109,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_jenkins_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_plugin.xml
@@ -109,7 +109,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_jenkins_sync_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_sync_plugin.xml
@@ -109,7 +109,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_kubernetes_metrics_server_unit.xml
+++ b/sjb/generated/test_branch_kubernetes_metrics_server_unit.xml
@@ -119,7 +119,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_online_console_extensions.xml
+++ b/sjb/generated/test_branch_online_console_extensions.xml
@@ -109,7 +109,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_online_hibernation_unit.xml
+++ b/sjb/generated/test_branch_online_hibernation_unit.xml
@@ -109,7 +109,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce.xml
@@ -163,7 +163,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_openshift_ansible_logging.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging.xml
@@ -119,7 +119,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
@@ -119,7 +119,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_aggregated_logging_prior.xml
+++ b/sjb/generated/test_branch_origin_aggregated_logging_prior.xml
@@ -109,7 +109,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_check.xml
+++ b/sjb/generated/test_branch_origin_check.xml
@@ -119,7 +119,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_cmd.xml
+++ b/sjb/generated/test_branch_origin_cmd.xml
@@ -119,7 +119,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_cross.xml
+++ b/sjb/generated/test_branch_origin_cross.xml
@@ -119,7 +119,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_end_to_end.xml
+++ b/sjb/generated/test_branch_origin_end_to_end.xml
@@ -119,7 +119,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_extended.xml
+++ b/sjb/generated/test_branch_origin_extended.xml
@@ -129,7 +129,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_extended_builds.xml
+++ b/sjb/generated/test_branch_origin_extended_builds.xml
@@ -103,7 +103,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_extended_clusterup.xml
+++ b/sjb/generated/test_branch_origin_extended_clusterup.xml
@@ -103,7 +103,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_extended_conformance.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance.xml
@@ -119,7 +119,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_crio.xml
@@ -128,7 +128,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce.xml
@@ -158,7 +158,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install.xml
@@ -129,7 +129,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_extended_conformance_install_containerized.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_containerized.xml
@@ -129,7 +129,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_extended_conformance_install_in_tree.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_in_tree.xml
@@ -129,7 +129,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
@@ -129,7 +129,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
@@ -129,7 +129,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized.xml
@@ -129,7 +129,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers.xml
@@ -129,7 +129,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_extended_conformance_k8s.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_k8s.xml
@@ -163,7 +163,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_extended_gssapi.xml
+++ b/sjb/generated/test_branch_origin_extended_gssapi.xml
@@ -103,7 +103,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_extended_image_ecosystem.xml
+++ b/sjb/generated/test_branch_origin_extended_image_ecosystem.xml
@@ -103,7 +103,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_extended_image_registry.xml
+++ b/sjb/generated/test_branch_origin_extended_image_registry.xml
@@ -103,7 +103,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_extended_ldap_groups.xml
+++ b/sjb/generated/test_branch_origin_extended_ldap_groups.xml
@@ -103,7 +103,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_extended_networking.xml
+++ b/sjb/generated/test_branch_origin_extended_networking.xml
@@ -123,7 +123,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_extended_networking_minimal.xml
+++ b/sjb/generated/test_branch_origin_extended_networking_minimal.xml
@@ -119,7 +119,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_integration.xml
+++ b/sjb/generated/test_branch_origin_integration.xml
@@ -119,7 +119,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_service_catalog.xml
+++ b/sjb/generated/test_branch_origin_service_catalog.xml
@@ -103,7 +103,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_unit.xml
+++ b/sjb/generated/test_branch_origin_unit.xml
@@ -119,7 +119,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_verify.xml
+++ b/sjb/generated/test_branch_origin_verify.xml
@@ -119,7 +119,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_web_console.xml
+++ b/sjb/generated/test_branch_origin_web_console.xml
@@ -109,7 +109,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_web_console_server_check.xml
+++ b/sjb/generated/test_branch_origin_web_console_server_check.xml
@@ -109,7 +109,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_origin_web_console_server_e2e.xml
+++ b/sjb/generated/test_branch_origin_web_console_server_e2e.xml
@@ -109,7 +109,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_wildfly_images.xml
+++ b/sjb/generated/test_branch_wildfly_images.xml
@@ -91,7 +91,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_cluster_operator_unit.xml
+++ b/sjb/generated/test_pull_request_cluster_operator_unit.xml
@@ -114,7 +114,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_crio_ami_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_ami_fedora.xml
@@ -58,6 +58,11 @@
           <description>Pull request head SHA.</description>
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>ROOT_VOLUME_SIZE</name>
+          <description>Size of the root volume in gigabytes</description>
+          <defaultValue>50</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@1.9.0">
@@ -98,7 +103,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_crio_ami_rhel.xml
+++ b/sjb/generated/test_pull_request_crio_ami_rhel.xml
@@ -58,6 +58,11 @@
           <description>Pull request head SHA.</description>
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>ROOT_VOLUME_SIZE</name>
+          <description>Size of the root volume in gigabytes</description>
+          <defaultValue>50</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@1.9.0">
@@ -98,7 +103,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_crio_critest_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_critest_fedora.xml
@@ -58,6 +58,11 @@
           <description>Pull request head SHA.</description>
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>ROOT_VOLUME_SIZE</name>
+          <description>Size of the root volume in gigabytes</description>
+          <defaultValue>50</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@1.9.0">
@@ -94,7 +99,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_crio_critest_rhel.xml
+++ b/sjb/generated/test_pull_request_crio_critest_rhel.xml
@@ -58,6 +58,11 @@
           <description>Pull request head SHA.</description>
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>ROOT_VOLUME_SIZE</name>
+          <description>Size of the root volume in gigabytes</description>
+          <defaultValue>50</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@1.9.0">
@@ -94,7 +99,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_crio_e2e_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_e2e_fedora.xml
@@ -58,6 +58,11 @@
           <description>Pull request head SHA.</description>
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>ROOT_VOLUME_SIZE</name>
+          <description>Size of the root volume in gigabytes</description>
+          <defaultValue>50</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@1.9.0">
@@ -94,7 +99,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_crio_e2e_rhel.xml
+++ b/sjb/generated/test_pull_request_crio_e2e_rhel.xml
@@ -58,6 +58,11 @@
           <description>Pull request head SHA.</description>
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>ROOT_VOLUME_SIZE</name>
+          <description>Size of the root volume in gigabytes</description>
+          <defaultValue>50</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@1.9.0">
@@ -94,7 +99,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_crio_integration_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_integration_fedora.xml
@@ -58,6 +58,11 @@
           <description>Pull request head SHA.</description>
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>ROOT_VOLUME_SIZE</name>
+          <description>Size of the root volume in gigabytes</description>
+          <defaultValue>50</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@1.9.0">
@@ -94,7 +99,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_crio_integration_rhel.xml
+++ b/sjb/generated/test_pull_request_crio_integration_rhel.xml
@@ -58,6 +58,11 @@
           <description>Pull request head SHA.</description>
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>ROOT_VOLUME_SIZE</name>
+          <description>Size of the root volume in gigabytes</description>
+          <defaultValue>50</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@1.9.0">
@@ -94,7 +99,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_image_registry_extended.xml
+++ b/sjb/generated/test_pull_request_image_registry_extended.xml
@@ -114,7 +114,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_image_registry_integration.xml
+++ b/sjb/generated/test_pull_request_image_registry_integration.xml
@@ -114,7 +114,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_image_registry_unit.xml
+++ b/sjb/generated/test_pull_request_image_registry_unit.xml
@@ -114,7 +114,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_jenkins_client_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_client_plugin.xml
@@ -114,7 +114,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_jenkins_images.xml
+++ b/sjb/generated/test_pull_request_jenkins_images.xml
@@ -94,7 +94,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_openshift_login_plugin.xml
@@ -114,7 +114,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_jenkins_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_plugin.xml
@@ -114,7 +114,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_jenkins_sync_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_sync_plugin.xml
@@ -114,7 +114,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_kubernetes_metrics_server_unit.xml
+++ b/sjb/generated/test_pull_request_kubernetes_metrics_server_unit.xml
@@ -114,7 +114,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_online_console_extensions.xml
+++ b/sjb/generated/test_pull_request_online_console_extensions.xml
@@ -114,7 +114,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_online_hibernation_unit.xml
+++ b/sjb/generated/test_pull_request_online_hibernation_unit.xml
@@ -114,7 +114,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce.xml
@@ -163,7 +163,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha.xml
@@ -163,7 +163,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
@@ -134,7 +134,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized.xml
@@ -134,7 +134,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio.xml
@@ -138,7 +138,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_in_tree.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_in_tree.xml
@@ -134,7 +134,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
@@ -134,7 +134,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
@@ -134,7 +134,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized.xml
@@ -134,7 +134,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers.xml
@@ -134,7 +134,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
@@ -134,7 +134,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_openshift_ansible_launch_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_launch_gce.xml
@@ -158,7 +158,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_openshift_ansible_logging.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging.xml
@@ -119,7 +119,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_openshift_ansible_tox.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_tox.xml
@@ -114,7 +114,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
@@ -124,7 +124,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
@@ -124,7 +124,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_check.xml
+++ b/sjb/generated/test_pull_request_origin_check.xml
@@ -114,7 +114,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_cmd.xml
+++ b/sjb/generated/test_pull_request_origin_cmd.xml
@@ -114,7 +114,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_cross.xml
+++ b/sjb/generated/test_pull_request_origin_cross.xml
@@ -114,7 +114,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_end_to_end.xml
+++ b/sjb/generated/test_pull_request_origin_end_to_end.xml
@@ -124,7 +124,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_extended.xml
+++ b/sjb/generated/test_pull_request_origin_extended.xml
@@ -134,7 +134,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_extended_builds.xml
+++ b/sjb/generated/test_pull_request_origin_extended_builds.xml
@@ -134,7 +134,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_extended_clusterup.xml
+++ b/sjb/generated/test_pull_request_origin_extended_clusterup.xml
@@ -114,7 +114,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_extended_conformance.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance.xml
@@ -124,7 +124,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
@@ -143,7 +143,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
@@ -168,7 +168,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
@@ -139,7 +139,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
@@ -139,7 +139,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_extended_conformance_k8s.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_k8s.xml
@@ -168,7 +168,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_extended_gssapi.xml
+++ b/sjb/generated/test_pull_request_origin_extended_gssapi.xml
@@ -134,7 +134,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_extended_image_ecosystem.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_ecosystem.xml
@@ -134,7 +134,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_extended_image_registry.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_registry.xml
@@ -134,7 +134,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_extended_ldap_groups.xml
+++ b/sjb/generated/test_pull_request_origin_extended_ldap_groups.xml
@@ -124,7 +124,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_extended_networking.xml
+++ b/sjb/generated/test_pull_request_origin_extended_networking.xml
@@ -124,7 +124,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_extended_networking_minimal.xml
+++ b/sjb/generated/test_pull_request_origin_extended_networking_minimal.xml
@@ -124,7 +124,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_integration.xml
+++ b/sjb/generated/test_pull_request_origin_integration.xml
@@ -114,7 +114,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_launch_gce.xml
+++ b/sjb/generated/test_pull_request_origin_launch_gce.xml
@@ -158,7 +158,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_service_catalog.xml
+++ b/sjb/generated/test_pull_request_origin_service_catalog.xml
@@ -114,7 +114,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_unit.xml
+++ b/sjb/generated/test_pull_request_origin_unit.xml
@@ -114,7 +114,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_verify.xml
+++ b/sjb/generated/test_pull_request_origin_verify.xml
@@ -114,7 +114,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_web_console.xml
+++ b/sjb/generated/test_pull_request_origin_web_console.xml
@@ -114,7 +114,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_web_console_server_check.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_server_check.xml
@@ -114,7 +114,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_origin_web_console_server_e2e.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_server_e2e.xml
@@ -114,7 +114,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_wildfly_images.xml
+++ b/sjb/generated/test_pull_request_wildfly_images.xml
@@ -96,7 +96,10 @@ mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;libra&#39;
-oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;</command>
+oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/devenv.pem&#39;
+if [[ -n &#34;${ROOT_VOLUME_SIZE:-}&#34; ]] ; then
+    oct configure aws-defaults master_root_volume_size $ROOT_VOLUME_SIZE
+fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash


### PR DESCRIPTION
Because these commands operate inside a shell with ``set -u`` on it, any
undefined variable will throw an error instead of being treated as if it
were empty (default behavior).  Fix generation of the oct commands
WRT ``$ROOT_VOLUME_SIZE`` such that it's explicitly treated as empty
when undefined.

Also wrap the oct configure command in a complete 'if' statement, using
the bash conditional syntax (double-bracket) rather than shelling out to
"test" (single bracket).