### PR TITLE
build_ami: add a return statement to waitUntil

### DIFF
--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -373,6 +373,7 @@ def build_ami(major, minor, version, release, mail_list) {
                     'String', 'CRIO_SYSTEM_CONTAINER_IMAGE_OVERRIDE',
                     'registry.reg-aws.openshift.com:443/openshift3/cri-o:v'
                         + full_version)])
+            return true
         } catch(err) {
             mail(
                 to: "${mail_list}",


### PR DESCRIPTION
The `waitUntil` step requires a `true` return value, even if the end of
the block is reached without any errors.

> Job: I was successful.
> Jenkins: SUCCESS IS NOT ENOUGH!