### PR TITLE
Changing variable used to checking out branch for openshift-ansible

### DIFF
--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
@@ -17,7 +17,11 @@ extensions:
       title: "build an openshift-ansible release"
       repository: "openshift-ansible"
       script: |-
-        git checkout "${PULL_REFS%%:*}"
+        if [[ "${PULL_REFS%%:*}" == es5.x ]]; then
+          git checkout "${OPENSHIFT_ANSIBLE_TARGET_BRANCH}"
+        else
+          git checkout "${PULL_REFS%%:*}"
+        fi
         tito_tmp_dir="tito"
         rm -rf "${tito_tmp_dir}"
         mkdir -p "${tito_tmp_dir}"
@@ -63,7 +67,7 @@ extensions:
         curbranch=$( git rev-parse --abbrev-ref HEAD )
         popd
         jobs_repo="/data/src/github.com/openshift/aos-cd-jobs/"
-        if [[ "${curbranch}" == master || "${curbranch}" == es5.x ]] ; then
+        if [[ "${curbranch}" == master ]] ; then
            # why is this appending?  Is there something already in the file?
            # Will it work if there is more than one line?  What will it do?
            git log -1 --pretty=%h >> "${jobs_repo}/ORIGIN_COMMIT"
@@ -173,7 +177,7 @@ extensions:
         pushd "/data/src/github.com/openshift/origin-aggregated-logging/"
         curbranch=$( git rev-parse --abbrev-ref HEAD )
         popd
-        if [[ "${curbranch}" == master || "${curbranch}" == es5.x ]] ; then
+        if [[ "${curbranch}" == master ]] ; then
            origin_package="$( source hack/lib/init.sh; os::build::rpm::format_nvra )"
            rpm -V "${origin_package}"
         fi
@@ -187,8 +191,7 @@ extensions:
         else
             playbook="${playbook_base}byo/openshift-cluster/openshift-logging.yml"
         fi
-        curbranch=$( git rev-parse --abbrev-ref HEAD )
-        if [[ "${curbranch}" == es5.x ]]; then
+        if [[ "${PULL_REFS%%:*}" == es5.x ]]; then
             logging_extras="-e openshift_logging_es5_techpreview=True \
                             -e openshift_logging_image_version=latest"
         else

--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible_json_file.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible_json_file.yml
@@ -17,7 +17,11 @@ extensions:
       title: "build an openshift-ansible release"
       repository: "openshift-ansible"
       script: |-
-        git checkout "${PULL_REFS%%:*}"
+        if [[ "${PULL_REFS%%:*}" == es5.x ]]; then
+          git checkout "${OPENSHIFT_ANSIBLE_TARGET_BRANCH}"
+        else
+          git checkout "${PULL_REFS%%:*}"
+        fi
         tito_tmp_dir="tito"
         rm -rf "${tito_tmp_dir}"
         mkdir -p "${tito_tmp_dir}"
@@ -63,7 +67,7 @@ extensions:
         curbranch=$( git rev-parse --abbrev-ref HEAD )
         popd
         jobs_repo="/data/src/github.com/openshift/aos-cd-jobs/"
-        if [[ "${curbranch}" == master || "${curbranch}" == es5.x ]] ; then
+        if [[ "${curbranch}" == master ]] ; then
            # why is this appending?  Is there something already in the file?
            # Will it work if there is more than one line?  What will it do?
            git log -1 --pretty=%h >> "${jobs_repo}/ORIGIN_COMMIT"
@@ -168,7 +172,7 @@ extensions:
         pushd "/data/src/github.com/openshift/origin-aggregated-logging/"
         curbranch=$( git rev-parse --abbrev-ref HEAD )
         popd
-        if [[ "${curbranch}" == master || "${curbranch}" == es5.x ]] ; then
+        if [[ "${curbranch}" == master ]] ; then
            origin_package="$( source hack/lib/init.sh; os::build::rpm::format_nvra )"
            rpm -V "${origin_package}"
         fi
@@ -182,8 +186,7 @@ extensions:
         else
             playbook="${playbook_base}byo/openshift-cluster/openshift-logging.yml"
         fi
-        curbranch=$( git rev-parse --abbrev-ref HEAD )
-        if [[ "${curbranch}" == es5.x ]]; then
+        if [[ "${PULL_REFS%%:*}" == es5.x ]]; then
             logging_extras="-e openshift_logging_es5_techpreview=True \
                             -e openshift_logging_image_version=latest"
         else

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
@@ -385,7 +385,11 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
-git checkout &#34;\${PULL_REFS%%:*}&#34;
+if [[ &#34;\${PULL_REFS%%:*}&#34; == es5.x ]]; then
+  git checkout &#34;\${OPENSHIFT_ANSIBLE_TARGET_BRANCH}&#34;
+else
+  git checkout &#34;\${PULL_REFS%%:*}&#34;
+fi
 tito_tmp_dir=&#34;tito&#34;
 rm -rf &#34;\${tito_tmp_dir}&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
@@ -458,7 +462,7 @@ pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
 curbranch=\$( git rev-parse --abbrev-ref HEAD )
 popd
 jobs_repo=&#34;/data/src/github.com/openshift/aos-cd-jobs/&#34;
-if [[ &#34;\${curbranch}&#34; == master || &#34;\${curbranch}&#34; == es5.x ]] ; then
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
    # why is this appending?  Is there something already in the file?
    # Will it work if there is more than one line?  What will it do?
    git log -1 --pretty=%h &gt;&gt; &#34;\${jobs_repo}/ORIGIN_COMMIT&#34;
@@ -604,7 +608,7 @@ cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
 pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
 curbranch=\$( git rev-parse --abbrev-ref HEAD )
 popd
-if [[ &#34;\${curbranch}&#34; == master || &#34;\${curbranch}&#34; == es5.x ]] ; then
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
    origin_package=&#34;\$( source hack/lib/init.sh; os::build::rpm::format_nvra )&#34;
    rpm -V &#34;\${origin_package}&#34;
 fi
@@ -627,8 +631,7 @@ if [[ -s &#34;\${playbook_base}openshift-logging/config.yml&#34; ]]; then
 else
     playbook=&#34;\${playbook_base}byo/openshift-cluster/openshift-logging.yml&#34;
 fi
-curbranch=\$( git rev-parse --abbrev-ref HEAD )
-if [[ &#34;\${curbranch}&#34; == es5.x ]]; then
+if [[ &#34;\${PULL_REFS%%:*}&#34; == es5.x ]]; then
     logging_extras=&#34;-e openshift_logging_es5_techpreview=True \
                     -e openshift_logging_image_version=latest&#34;
 else

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
@@ -385,7 +385,11 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
-git checkout &#34;\${PULL_REFS%%:*}&#34;
+if [[ &#34;\${PULL_REFS%%:*}&#34; == es5.x ]]; then
+  git checkout &#34;\${OPENSHIFT_ANSIBLE_TARGET_BRANCH}&#34;
+else
+  git checkout &#34;\${PULL_REFS%%:*}&#34;
+fi
 tito_tmp_dir=&#34;tito&#34;
 rm -rf &#34;\${tito_tmp_dir}&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
@@ -458,7 +462,7 @@ pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
 curbranch=\$( git rev-parse --abbrev-ref HEAD )
 popd
 jobs_repo=&#34;/data/src/github.com/openshift/aos-cd-jobs/&#34;
-if [[ &#34;\${curbranch}&#34; == master || &#34;\${curbranch}&#34; == es5.x ]] ; then
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
    # why is this appending?  Is there something already in the file?
    # Will it work if there is more than one line?  What will it do?
    git log -1 --pretty=%h &gt;&gt; &#34;\${jobs_repo}/ORIGIN_COMMIT&#34;
@@ -599,7 +603,7 @@ cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
 pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
 curbranch=\$( git rev-parse --abbrev-ref HEAD )
 popd
-if [[ &#34;\${curbranch}&#34; == master || &#34;\${curbranch}&#34; == es5.x ]] ; then
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
    origin_package=&#34;\$( source hack/lib/init.sh; os::build::rpm::format_nvra )&#34;
    rpm -V &#34;\${origin_package}&#34;
 fi
@@ -622,8 +626,7 @@ if [[ -s &#34;\${playbook_base}openshift-logging/config.yml&#34; ]]; then
 else
     playbook=&#34;\${playbook_base}byo/openshift-cluster/openshift-logging.yml&#34;
 fi
-curbranch=\$( git rev-parse --abbrev-ref HEAD )
-if [[ &#34;\${curbranch}&#34; == es5.x ]]; then
+if [[ &#34;\${PULL_REFS%%:*}&#34; == es5.x ]]; then
     logging_extras=&#34;-e openshift_logging_es5_techpreview=True \
                     -e openshift_logging_image_version=latest&#34;
 else


### PR DESCRIPTION
@stevekuznetsov does this do what I think it does?
For the origin-aggregated-logging ci tests `es5.x` and `master` branches we should be using openshift-ansible `master` branch but we want to use the appropriate branch if we're doing a `release-x.y` pr/test