### PR TITLE
move oit path to tools/bin

### DIFF
--- a/jobs/build/buildvm-maint/Jenkinsfile
+++ b/jobs/build/buildvm-maint/Jenkinsfile
@@ -38,10 +38,10 @@ node('openshift-build-1') {
 
                 stage("push images") {
                     dir ( "enterprise-images" ) {
-                        sh './oit/oit.py --user=ocp-build --group sync-misc images:push --to-defaults'
-                        sh './oit/oit.py --user=ocp-build --group sync-3.7 images:push --to-defaults'
+                        sh './tools/bin/oit --user=ocp-build --group sync-misc images:push --to-defaults'
+                        sh './tools/bin/oit --user=ocp-build --group sync-3.7 images:push --to-defaults'
                         try {
-                            sh './oit/oit.py --user=ocp-build --group sync-3.8 images:push --to-defaults'
+                            sh './tools/bin/oit --user=ocp-build --group sync-3.8 images:push --to-defaults'
                         } catch ( e38 ) {
                             // need dist-git branches before this will work without exceptions; swallow for now
                         }

--- a/jobs/build/openshift-online/scripts/merge-and-build-openshift-scripts.sh
+++ b/jobs/build/openshift-online/scripts/merge-and-build-openshift-scripts.sh
@@ -96,7 +96,7 @@ echo "=========="
 OIT_DIR="${BUILDPATH}/enterprise-images/"
 rm -rf ${OIT_DIR}
 mkdir -p ${OIT_DIR}
-OIT_PATH="${OIT_DIR}/oit/oit.py"
+OIT_PATH="${OIT_DIR}/tools/bin/oit"
 git clone git@github.com:openshift/enterprise-images.git ${OIT_DIR}
 
 # Check to see if there have been any changes since the last tag

--- a/jobs/build/ose/scripts/merge-and-build.sh
+++ b/jobs/build/ose/scripts/merge-and-build.sh
@@ -127,7 +127,7 @@ pushd ${BUILDPATH}
 OIT_DIR="${BUILDPATH}/enterprise-images/"
 rm -rf ${OIT_DIR}
 mkdir -p ${OIT_DIR}
-OIT_PATH="${OIT_DIR}/oit/oit.py"
+OIT_PATH="${OIT_DIR}/tools/bin/oit"
 git clone git@github.com:openshift/enterprise-images.git ${OIT_DIR}
 popd
 

--- a/jobs/build/scan-images/Jenkinsfile
+++ b/jobs/build/scan-images/Jenkinsfile
@@ -47,7 +47,7 @@ node('openshift-build-1') {
       buildlib.with_virtualenv("${pwd()}/env") {
         sh """\
 set -o pipefail
-sudo python oit/oit/oit.py \
+sudo python oit/tools/bin/oit \
   --metadata-dir oit/ \
   --group 'openshift-${BUILD_VERSION}' \
   images:scan-for-cves \

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -68,7 +68,7 @@ def initialize_enterprise_images_dir() {
     ENTERPRISE_IMAGES_DIR = "${env.WORKSPACE}/enterprise-images"
     sh "rm -rf ${ENTERPRISE_IMAGES_DIR}"  // Remove any cruft
     sh "mkdir -p ${ENTERPRISE_IMAGES_DIR}"
-    OIT_PATH = "${ENTERPRISE_IMAGES_DIR}/oit/oit.py"
+    OIT_PATH = "${ENTERPRISE_IMAGES_DIR}/tools/bin/oit"
     sh "git clone ${GITHUB_BASE}/enterprise-images.git ${ENTERPRISE_IMAGES_DIR}"
     env.ENTERPRISE_IMAGES_DIR = ENTERPRISE_IMAGES_DIR
     env.OIT_PATH = OIT_PATH
@@ -80,7 +80,7 @@ def oit(cmd, opts=[:]){
     cmd = cmd.replaceAll( ' \\ ', ' ' ) // If caller included line continuation characters, remove them
     return sh(
         returnStdout: opts.capture ?: false,
-        script: "${env.ENTERPRISE_IMAGES_DIR}/oit/oit.py --user=ocp-build --metadata-dir ${env.ENTERPRISE_IMAGES_DIR} ${cmd.trim()}")
+        script: "${env.ENTERPRISE_IMAGES_DIR}/tools/bin/oit --user=ocp-build --metadata-dir ${env.ENTERPRISE_IMAGES_DIR} ${cmd.trim()}")
 }
 
 def initialize_ose_dir() {


### PR DESCRIPTION
After refactoring the directory layout of `enterprise-images` the OIT script and any new ones will reside in `tools/bin`.  This change reflects the new location of the `oit.py` script in the directory structure.

This change must not commit until the `buildvm:/home/jenkins` copy of `enterprise-images` is up to date. 