### PR TITLE
Uncommented the CI message capabilities for OSO starter upgrades.

### DIFF
--- a/jobs/starter/upgrade/Jenkinsfile
+++ b/jobs/starter/upgrade/Jenkinsfile
@@ -278,14 +278,11 @@ Jenkins job: ${env.BUILD_URL}
     if ( MODE != "silent" && "${env.BRANCH_NAME}".contains( "starter" )  ) {
         try {
             // Send out a CI message for QE
-            // Disbaling until our Jenkins instance is working with the UMB
-            /*
             build job: 'starter%2Fsend-ci-msg',
                     propagate: false,
                     parameters: [
                             [$class: 'hudson.model.StringParameterValue', name: 'CLUSTER_SPEC', value: CLUSTER_SPEC],
                     ]
-                    */
         } catch ( err2 ) {
             mail(to: "${MAIL_LIST_FAILURE}",
                     from: "aos-cd@redhat.com",


### PR DESCRIPTION
This PR will allow the OSO starter upgrade job to send out CI bus messages over the new Jenkins UMB.