### PR TITLE
Redirect redundant gcs_path output to stderr

### DIFF
--- a/sjb/config/common/test_cases/origin.yml
+++ b/sjb/config/common/test_cases/origin.yml
@@ -62,10 +62,10 @@ actions:
         bucket="gs://origin-ci-test/"
 
         if [[ "$( jq --compact-output ".buildid" <<<"${JOB_SPEC}" )" =~ ^\"[0-9]+\"$ ]]; then
-          echo "Keeping BUILD_ID"
+          echo "Keeping BUILD_ID" >&2
           BUILD="${BUILD_ID}"
         else
-          echo "Using BUILD_NUMBER"
+          echo "Using BUILD_NUMBER" >&2
           BUILD="${BUILD_NUMBER}"
         fi
         suffix="${JOB_NAME}/${BUILD}/"

--- a/sjb/generated/merge_pull_request_jenkins_client_plugin.xml
+++ b/sjb/generated/merge_pull_request_jenkins_client_plugin.xml
@@ -239,10 +239,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/merge_pull_request_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/merge_pull_request_jenkins_openshift_login_plugin.xml
@@ -239,10 +239,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/merge_pull_request_jenkins_plugin.xml
+++ b/sjb/generated/merge_pull_request_jenkins_plugin.xml
@@ -239,10 +239,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/merge_pull_request_jenkins_sync_plugin.xml
+++ b/sjb/generated/merge_pull_request_jenkins_sync_plugin.xml
@@ -239,10 +239,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/merge_pull_request_origin_web_console.xml
+++ b/sjb/generated/merge_pull_request_origin_web_console.xml
@@ -239,10 +239,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_cluster_operator_unit.xml
+++ b/sjb/generated/test_branch_cluster_operator_unit.xml
@@ -211,10 +211,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_image_registry_extended.xml
+++ b/sjb/generated/test_branch_image_registry_extended.xml
@@ -187,10 +187,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_image_registry_integration.xml
+++ b/sjb/generated/test_branch_image_registry_integration.xml
@@ -187,10 +187,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_image_registry_unit.xml
+++ b/sjb/generated/test_branch_image_registry_unit.xml
@@ -211,10 +211,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_jenkins_client_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_client_plugin.xml
@@ -187,10 +187,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_openshift_login_plugin.xml
@@ -187,10 +187,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_jenkins_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_plugin.xml
@@ -187,10 +187,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_jenkins_sync_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_sync_plugin.xml
@@ -187,10 +187,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_kubernetes_metrics_server_unit.xml
+++ b/sjb/generated/test_branch_kubernetes_metrics_server_unit.xml
@@ -211,10 +211,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_online_console_extensions.xml
+++ b/sjb/generated/test_branch_online_console_extensions.xml
@@ -187,10 +187,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_online_hibernation_unit.xml
+++ b/sjb/generated/test_branch_online_hibernation_unit.xml
@@ -187,10 +187,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce.xml
@@ -269,10 +269,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_openshift_ansible_logging.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging.xml
@@ -211,10 +211,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
@@ -211,10 +211,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_origin_aggregated_logging_prior.xml
+++ b/sjb/generated/test_branch_origin_aggregated_logging_prior.xml
@@ -187,10 +187,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_origin_check.xml
+++ b/sjb/generated/test_branch_origin_check.xml
@@ -211,10 +211,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_origin_cross.xml
+++ b/sjb/generated/test_branch_origin_cross.xml
@@ -211,10 +211,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_origin_extended_builds.xml
+++ b/sjb/generated/test_branch_origin_extended_builds.xml
@@ -152,10 +152,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_origin_extended_clusterup.xml
+++ b/sjb/generated/test_branch_origin_extended_clusterup.xml
@@ -152,10 +152,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_crio.xml
@@ -227,10 +227,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce.xml
@@ -264,10 +264,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install.xml
@@ -235,10 +235,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_containerized.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_containerized.xml
@@ -235,10 +235,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_in_tree.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_in_tree.xml
@@ -235,10 +235,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
@@ -235,10 +235,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
@@ -235,10 +235,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized.xml
@@ -235,10 +235,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers.xml
@@ -235,10 +235,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_k8s.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_k8s.xml
@@ -269,10 +269,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_origin_extended_gssapi.xml
+++ b/sjb/generated/test_branch_origin_extended_gssapi.xml
@@ -152,10 +152,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_origin_extended_image_ecosystem.xml
+++ b/sjb/generated/test_branch_origin_extended_image_ecosystem.xml
@@ -152,10 +152,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_origin_extended_image_registry.xml
+++ b/sjb/generated/test_branch_origin_extended_image_registry.xml
@@ -152,10 +152,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_origin_extended_ldap_groups.xml
+++ b/sjb/generated/test_branch_origin_extended_ldap_groups.xml
@@ -152,10 +152,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_origin_integration.xml
+++ b/sjb/generated/test_branch_origin_integration.xml
@@ -211,10 +211,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_origin_service_catalog.xml
+++ b/sjb/generated/test_branch_origin_service_catalog.xml
@@ -152,10 +152,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_origin_verify.xml
+++ b/sjb/generated/test_branch_origin_verify.xml
@@ -211,10 +211,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_origin_web_console.xml
+++ b/sjb/generated/test_branch_origin_web_console.xml
@@ -187,10 +187,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_origin_web_console_server_check.xml
+++ b/sjb/generated/test_branch_origin_web_console_server_check.xml
@@ -187,10 +187,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_branch_origin_web_console_server_e2e.xml
+++ b/sjb/generated/test_branch_origin_web_console_server_e2e.xml
@@ -187,10 +187,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_cluster_operator_unit.xml
+++ b/sjb/generated/test_pull_request_cluster_operator_unit.xml
@@ -228,10 +228,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_image_registry_extended.xml
+++ b/sjb/generated/test_pull_request_image_registry_extended.xml
@@ -228,10 +228,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_image_registry_integration.xml
+++ b/sjb/generated/test_pull_request_image_registry_integration.xml
@@ -228,10 +228,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_image_registry_unit.xml
+++ b/sjb/generated/test_pull_request_image_registry_unit.xml
@@ -228,10 +228,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_jenkins_client_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_client_plugin.xml
@@ -228,10 +228,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_openshift_login_plugin.xml
@@ -228,10 +228,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_jenkins_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_plugin.xml
@@ -228,10 +228,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_jenkins_sync_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_sync_plugin.xml
@@ -228,10 +228,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_kubernetes_metrics_server_unit.xml
+++ b/sjb/generated/test_pull_request_kubernetes_metrics_server_unit.xml
@@ -228,10 +228,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_online_console_extensions.xml
+++ b/sjb/generated/test_pull_request_online_console_extensions.xml
@@ -228,10 +228,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_online_hibernation_unit.xml
+++ b/sjb/generated/test_pull_request_online_hibernation_unit.xml
@@ -228,10 +228,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce.xml
@@ -305,10 +305,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha.xml
@@ -305,10 +305,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
@@ -276,10 +276,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized.xml
@@ -276,10 +276,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio.xml
@@ -280,10 +280,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_in_tree.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_in_tree.xml
@@ -276,10 +276,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
@@ -276,10 +276,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
@@ -276,10 +276,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized.xml
@@ -276,10 +276,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers.xml
@@ -276,10 +276,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
@@ -276,10 +276,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_launch_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_launch_gce.xml
@@ -300,10 +300,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_logging.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging.xml
@@ -240,10 +240,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_36.xml
@@ -203,10 +203,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_37.xml
@@ -203,10 +203,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_tox.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_tox.xml
@@ -228,10 +228,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
@@ -252,10 +252,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_36.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_36.xml
@@ -203,10 +203,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_37.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_37.xml
@@ -203,10 +203,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
@@ -252,10 +252,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file_36.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file_36.xml
@@ -203,10 +203,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file_37.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file_37.xml
@@ -203,10 +203,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_origin_check.xml
+++ b/sjb/generated/test_pull_request_origin_check.xml
@@ -228,10 +228,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_origin_cross.xml
+++ b/sjb/generated/test_pull_request_origin_cross.xml
@@ -228,10 +228,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
@@ -292,10 +292,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
@@ -317,10 +317,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
@@ -288,10 +288,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
@@ -288,10 +288,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_k8s.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_k8s.xml
@@ -317,10 +317,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_origin_extended_gssapi.xml
+++ b/sjb/generated/test_pull_request_origin_extended_gssapi.xml
@@ -276,10 +276,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_origin_integration.xml
+++ b/sjb/generated/test_pull_request_origin_integration.xml
@@ -228,10 +228,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_origin_launch_gce.xml
+++ b/sjb/generated/test_pull_request_origin_launch_gce.xml
@@ -300,10 +300,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_origin_service_catalog.xml
+++ b/sjb/generated/test_pull_request_origin_service_catalog.xml
@@ -228,10 +228,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_origin_verify.xml
+++ b/sjb/generated/test_pull_request_origin_verify.xml
@@ -228,10 +228,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_origin_web_console.xml
+++ b/sjb/generated/test_pull_request_origin_web_console.xml
@@ -228,10 +228,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_origin_web_console_server_check.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_server_check.xml
@@ -228,10 +228,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;

--- a/sjb/generated/test_pull_request_origin_web_console_server_e2e.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_server_e2e.xml
@@ -228,10 +228,10 @@ function gcs_path() {
   bucket=&#34;gs://origin-ci-test/&#34;
 
   if [[ &#34;$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;$ ]]; then
-    echo &#34;Keeping BUILD_ID&#34;
+    echo &#34;Keeping BUILD_ID&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_ID}&#34;
   else
-    echo &#34;Using BUILD_NUMBER&#34;
+    echo &#34;Using BUILD_NUMBER&#34; &gt;&amp;2
     BUILD=&#34;${BUILD_NUMBER}&#34;
   fi
   suffix=&#34;${JOB_NAME}/${BUILD}/&#34;


### PR DESCRIPTION
@stevekuznetsov we are failing to upload starting metadata because
```
+ gsutil cp gcs/started.json 'Using BUILD_NUMBER
gs://origin-ci-test/pr-logs/pull/18767/test_pull_request_origin_extended_conformance_crio/4964/started.json'
InvalidUrlError: Unrecognized scheme "using build_number
gs".
```