### PR TITLE
For non-master (read - backporting) prs disable all health checks for origin logging tests

### DIFF
--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible.yml
@@ -119,6 +119,13 @@ extensions:
       title: "origin prerequisites"
       repository: "aos-cd-jobs"
       script: |-
+        curbranch=$( git rev-parse --abbrev-ref HEAD )
+        logging_extras=""
+        if [[ "${curbranch}" == master ]] ; then
+           logging_extras="${logging_extras} -e openshift_install_examples=false"
+        elif [[ "${curbranch}" =~ ^release-* ]] ; then
+           logging_extras="${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false"
+        fi
         ansible-playbook -vv --become               \
                          --become-user root         \
                          --connection local         \
@@ -126,6 +133,7 @@ extensions:
                          -e openshift_deployment_type=origin  \
                          -e openshift_docker_log_driver=journald \
                          -e openshift_docker_options="--log-driver=journald" \
+                         ${logging_extras}          \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
     - type: "script"
       title: "install origin"
@@ -151,6 +159,13 @@ extensions:
         else
             playbook="${playbook_base}byo/config.yml"
         fi
+        curbranch=$( git rev-parse --abbrev-ref HEAD )
+        logging_extras=""
+        if [[ "${curbranch}" == master ]] ; then
+           logging_extras="${logging_extras} -e openshift_install_examples=false"
+        elif [[ "${curbranch}" =~ ^release-* ]] ; then
+           logging_extras="${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false"
+        fi
         ansible-playbook -vv --become               \
                          --become-user root         \
                          --connection local         \
@@ -163,6 +178,7 @@ extensions:
                          -e etcd_data_dir="${ETCD_DATA_DIR}" \
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
+                         ${logging_extras}          \
                          ${playbook}
     - type: "script"
       title: "expose the kubeconfig"
@@ -195,6 +211,11 @@ extensions:
         curbranch=$( git rev-parse --abbrev-ref HEAD )
         popd
         logging_extras=""
+        if [[ "${curbranch}" == master ]] ; then
+           logging_extras="${logging_extras} -e openshift_install_examples=false"
+        elif [[ "${curbranch}" =~ ^release-* ]] ; then
+           logging_extras="${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false"
+        fi
         if [[ "${PULL_REFS%%:*}" == es5.x ]]; then
             logging_extras="${logging_extras} -e openshift_logging_es5_techpreview=True \
                             -e openshift_logging_image_version=latest"

--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible_json_file.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_ansible_json_file.yml
@@ -119,11 +119,19 @@ extensions:
       title: "origin prerequisites"
       repository: "aos-cd-jobs"
       script: |-
+        curbranch=$( git rev-parse --abbrev-ref HEAD )
+        logging_extras=""
+        if [[ "${curbranch}" == master ]] ; then
+           logging_extras="${logging_extras} -e openshift_install_examples=false"
+        elif [[ "${curbranch}" =~ ^release-* ]] ; then
+           logging_extras="${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false"
+        fi
         ansible-playbook -vv --become               \
                          --become-user root         \
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e openshift_deployment_type=origin  \
+                         ${logging_extras}          \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
     - type: "script"
       title: "install origin"
@@ -146,6 +154,13 @@ extensions:
         else
             playbook="${playbook_base}byo/config.yml"
         fi
+        curbranch=$( git rev-parse --abbrev-ref HEAD )
+        logging_extras=""
+        if [[ "${curbranch}" == master ]] ; then
+           logging_extras="${logging_extras} -e openshift_install_examples=false"
+        elif [[ "${curbranch}" =~ ^release-* ]] ; then
+           logging_extras="${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false"
+        fi
         ansible-playbook -vv --become               \
                          --become-user root         \
                          --connection local         \
@@ -158,6 +173,7 @@ extensions:
                          -e etcd_data_dir="${ETCD_DATA_DIR}" \
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
+                         ${logging_extras}          \
                          ${playbook}
     - type: "script"
       title: "expose the kubeconfig"
@@ -190,6 +206,11 @@ extensions:
         curbranch=$( git rev-parse --abbrev-ref HEAD )
         popd
         logging_extras=""
+        if [[ "${curbranch}" == master ]] ; then
+           logging_extras="${logging_extras} -e openshift_install_examples=false"
+        elif [[ "${curbranch}" =~ ^release-* ]] ; then
+           logging_extras="${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false"
+        fi
         if [[ "${PULL_REFS%%:*}" == es5.x ]]; then
             logging_extras="${logging_extras} -e openshift_logging_es5_techpreview=True \
                             -e openshift_logging_image_version=latest"

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible.xml
@@ -546,6 +546,13 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
+curbranch=\$( git rev-parse --abbrev-ref HEAD )
+logging_extras=&#34;&#34;
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_install_examples=false&#34;
+elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false&#34;
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
@@ -553,6 +560,7 @@ ansible-playbook -vv --become               \
                  -e openshift_deployment_type=origin  \
                  -e openshift_docker_log_driver=journald \
                  -e openshift_docker_options=&#34;--log-driver=journald&#34; \
+                 \${logging_extras}          \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -587,6 +595,13 @@ if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
 else
     playbook=&#34;\${playbook_base}byo/config.yml&#34;
 fi
+curbranch=\$( git rev-parse --abbrev-ref HEAD )
+logging_extras=&#34;&#34;
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_install_examples=false&#34;
+elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false&#34;
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
@@ -599,6 +614,7 @@ ansible-playbook -vv --become               \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 \${logging_extras}          \
                  \${playbook}
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -658,6 +674,11 @@ pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
 curbranch=\$( git rev-parse --abbrev-ref HEAD )
 popd
 logging_extras=&#34;&#34;
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_install_examples=false&#34;
+elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false&#34;
+fi
 if [[ &#34;\${PULL_REFS%%:*}&#34; == es5.x ]]; then
     logging_extras=&#34;\${logging_extras} -e openshift_logging_es5_techpreview=True \
                     -e openshift_logging_image_version=latest&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_36.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_36.xml
@@ -499,6 +499,13 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
+curbranch=\$( git rev-parse --abbrev-ref HEAD )
+logging_extras=&#34;&#34;
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_install_examples=false&#34;
+elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false&#34;
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
@@ -506,6 +513,7 @@ ansible-playbook -vv --become               \
                  -e openshift_deployment_type=origin  \
                  -e openshift_docker_log_driver=journald \
                  -e openshift_docker_options=&#34;--log-driver=journald&#34; \
+                 \${logging_extras}          \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -540,6 +548,13 @@ if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
 else
     playbook=&#34;\${playbook_base}byo/config.yml&#34;
 fi
+curbranch=\$( git rev-parse --abbrev-ref HEAD )
+logging_extras=&#34;&#34;
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_install_examples=false&#34;
+elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false&#34;
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
@@ -552,6 +567,7 @@ ansible-playbook -vv --become               \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 \${logging_extras}          \
                  \${playbook}
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -611,6 +627,11 @@ pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
 curbranch=\$( git rev-parse --abbrev-ref HEAD )
 popd
 logging_extras=&#34;&#34;
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_install_examples=false&#34;
+elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false&#34;
+fi
 if [[ &#34;\${PULL_REFS%%:*}&#34; == es5.x ]]; then
     logging_extras=&#34;\${logging_extras} -e openshift_logging_es5_techpreview=True \
                     -e openshift_logging_image_version=latest&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_37.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_37.xml
@@ -499,6 +499,13 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
+curbranch=\$( git rev-parse --abbrev-ref HEAD )
+logging_extras=&#34;&#34;
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_install_examples=false&#34;
+elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false&#34;
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
@@ -506,6 +513,7 @@ ansible-playbook -vv --become               \
                  -e openshift_deployment_type=origin  \
                  -e openshift_docker_log_driver=journald \
                  -e openshift_docker_options=&#34;--log-driver=journald&#34; \
+                 \${logging_extras}          \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -540,6 +548,13 @@ if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
 else
     playbook=&#34;\${playbook_base}byo/config.yml&#34;
 fi
+curbranch=\$( git rev-parse --abbrev-ref HEAD )
+logging_extras=&#34;&#34;
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_install_examples=false&#34;
+elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false&#34;
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
@@ -552,6 +567,7 @@ ansible-playbook -vv --become               \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 \${logging_extras}          \
                  \${playbook}
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -611,6 +627,11 @@ pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
 curbranch=\$( git rev-parse --abbrev-ref HEAD )
 popd
 logging_extras=&#34;&#34;
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_install_examples=false&#34;
+elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false&#34;
+fi
 if [[ &#34;\${PULL_REFS%%:*}&#34; == es5.x ]]; then
     logging_extras=&#34;\${logging_extras} -e openshift_logging_es5_techpreview=True \
                     -e openshift_logging_image_version=latest&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_39.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_39.xml
@@ -499,6 +499,13 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
+curbranch=\$( git rev-parse --abbrev-ref HEAD )
+logging_extras=&#34;&#34;
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_install_examples=false&#34;
+elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false&#34;
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
@@ -506,6 +513,7 @@ ansible-playbook -vv --become               \
                  -e openshift_deployment_type=origin  \
                  -e openshift_docker_log_driver=journald \
                  -e openshift_docker_options=&#34;--log-driver=journald&#34; \
+                 \${logging_extras}          \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -540,6 +548,13 @@ if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
 else
     playbook=&#34;\${playbook_base}byo/config.yml&#34;
 fi
+curbranch=\$( git rev-parse --abbrev-ref HEAD )
+logging_extras=&#34;&#34;
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_install_examples=false&#34;
+elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false&#34;
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
@@ -552,6 +567,7 @@ ansible-playbook -vv --become               \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 \${logging_extras}          \
                  \${playbook}
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -611,6 +627,11 @@ pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
 curbranch=\$( git rev-parse --abbrev-ref HEAD )
 popd
 logging_extras=&#34;&#34;
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_install_examples=false&#34;
+elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false&#34;
+fi
 if [[ &#34;\${PULL_REFS%%:*}&#34; == es5.x ]]; then
     logging_extras=&#34;\${logging_extras} -e openshift_logging_es5_techpreview=True \
                     -e openshift_logging_image_version=latest&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file.xml
@@ -546,11 +546,19 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
+curbranch=\$( git rev-parse --abbrev-ref HEAD )
+logging_extras=&#34;&#34;
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_install_examples=false&#34;
+elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false&#34;
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e openshift_deployment_type=origin  \
+                 \${logging_extras}          \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -582,6 +590,13 @@ if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
 else
     playbook=&#34;\${playbook_base}byo/config.yml&#34;
 fi
+curbranch=\$( git rev-parse --abbrev-ref HEAD )
+logging_extras=&#34;&#34;
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_install_examples=false&#34;
+elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false&#34;
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
@@ -594,6 +609,7 @@ ansible-playbook -vv --become               \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 \${logging_extras}          \
                  \${playbook}
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -653,6 +669,11 @@ pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
 curbranch=\$( git rev-parse --abbrev-ref HEAD )
 popd
 logging_extras=&#34;&#34;
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_install_examples=false&#34;
+elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false&#34;
+fi
 if [[ &#34;\${PULL_REFS%%:*}&#34; == es5.x ]]; then
     logging_extras=&#34;\${logging_extras} -e openshift_logging_es5_techpreview=True \
                     -e openshift_logging_image_version=latest&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file_36.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file_36.xml
@@ -499,11 +499,19 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
+curbranch=\$( git rev-parse --abbrev-ref HEAD )
+logging_extras=&#34;&#34;
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_install_examples=false&#34;
+elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false&#34;
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e openshift_deployment_type=origin  \
+                 \${logging_extras}          \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -535,6 +543,13 @@ if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
 else
     playbook=&#34;\${playbook_base}byo/config.yml&#34;
 fi
+curbranch=\$( git rev-parse --abbrev-ref HEAD )
+logging_extras=&#34;&#34;
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_install_examples=false&#34;
+elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false&#34;
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
@@ -547,6 +562,7 @@ ansible-playbook -vv --become               \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 \${logging_extras}          \
                  \${playbook}
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -606,6 +622,11 @@ pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
 curbranch=\$( git rev-parse --abbrev-ref HEAD )
 popd
 logging_extras=&#34;&#34;
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_install_examples=false&#34;
+elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false&#34;
+fi
 if [[ &#34;\${PULL_REFS%%:*}&#34; == es5.x ]]; then
     logging_extras=&#34;\${logging_extras} -e openshift_logging_es5_techpreview=True \
                     -e openshift_logging_image_version=latest&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file_37.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file_37.xml
@@ -499,11 +499,19 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
+curbranch=\$( git rev-parse --abbrev-ref HEAD )
+logging_extras=&#34;&#34;
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_install_examples=false&#34;
+elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false&#34;
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e openshift_deployment_type=origin  \
+                 \${logging_extras}          \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -535,6 +543,13 @@ if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
 else
     playbook=&#34;\${playbook_base}byo/config.yml&#34;
 fi
+curbranch=\$( git rev-parse --abbrev-ref HEAD )
+logging_extras=&#34;&#34;
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_install_examples=false&#34;
+elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false&#34;
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
@@ -547,6 +562,7 @@ ansible-playbook -vv --become               \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 \${logging_extras}          \
                  \${playbook}
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -606,6 +622,11 @@ pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
 curbranch=\$( git rev-parse --abbrev-ref HEAD )
 popd
 logging_extras=&#34;&#34;
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_install_examples=false&#34;
+elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false&#34;
+fi
 if [[ &#34;\${PULL_REFS%%:*}&#34; == es5.x ]]; then
     logging_extras=&#34;\${logging_extras} -e openshift_logging_es5_techpreview=True \
                     -e openshift_logging_image_version=latest&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file_39.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_ansible_json_file_39.xml
@@ -499,11 +499,19 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/aos-cd-jobs&#34;
+curbranch=\$( git rev-parse --abbrev-ref HEAD )
+logging_extras=&#34;&#34;
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_install_examples=false&#34;
+elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false&#34;
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e openshift_deployment_type=origin  \
+                 \${logging_extras}          \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -535,6 +543,13 @@ if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
 else
     playbook=&#34;\${playbook_base}byo/config.yml&#34;
 fi
+curbranch=\$( git rev-parse --abbrev-ref HEAD )
+logging_extras=&#34;&#34;
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_install_examples=false&#34;
+elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false&#34;
+fi
 ansible-playbook -vv --become               \
                  --become-user root         \
                  --connection local         \
@@ -547,6 +562,7 @@ ansible-playbook -vv --become               \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 \${logging_extras}          \
                  \${playbook}
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -606,6 +622,11 @@ pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
 curbranch=\$( git rev-parse --abbrev-ref HEAD )
 popd
 logging_extras=&#34;&#34;
+if [[ &#34;\${curbranch}&#34; == master ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_install_examples=false&#34;
+elif [[ &#34;\${curbranch}&#34; =~ ^release-* ]] ; then
+   logging_extras=&#34;\${logging_extras} -e openshift_disable_check=* -e openshift_install_examples=false&#34;
+fi
 if [[ &#34;\${PULL_REFS%%:*}&#34; == es5.x ]]; then
     logging_extras=&#34;\${logging_extras} -e openshift_logging_es5_techpreview=True \
                     -e openshift_logging_image_version=latest&#34;


### PR DESCRIPTION
We only want to disable them for the origin aggregated logging repo and only if they are `release-*` branches.

PTAL @sosiouxme @richm @stevekuznetsov 