### PR TITLE
Remove cron schedules from AMI jobs

### DIFF
--- a/sjb/config/test_cases/ami_build_origin_int_rhel_base.yml
+++ b/sjb/config/test_cases/ami_build_origin_int_rhel_base.yml
@@ -1,5 +1,4 @@
 ---
-timer: 'H H * * *'
 parameters: []
 provision:
   os: "rhel"

--- a/sjb/config/test_cases/ami_build_origin_int_rhel_crio.yml
+++ b/sjb/config/test_cases/ami_build_origin_int_rhel_crio.yml
@@ -1,7 +1,6 @@
 ---
 parent: 'common/test_cases/crio.yml'
 overrides:
-  timer: 'H H * * *'
   provision:
     os: "rhel"
     stage: "bare"

--- a/sjb/config/test_cases/ami_build_origin_int_rhel_install.yml
+++ b/sjb/config/test_cases/ami_build_origin_int_rhel_install.yml
@@ -1,5 +1,4 @@
 ---
-timer: 'H H * * *'
 parameters: []
 provision:
   os: "rhel"

--- a/sjb/generated/ami_build_origin_int_fedora_crio.xml
+++ b/sjb/generated/ami_build_origin_int_fedora_crio.xml
@@ -81,11 +81,7 @@
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
   <authToken>origin1</authToken>
-  <triggers>
-    <hudson.triggers.TimerTrigger>
-      <spec>H H * * *</spec>
-    </hudson.triggers.TimerTrigger>
-  </triggers>
+  <triggers/>
   <concurrentBuild>true</concurrentBuild>
   <builders>
         <hudson.tasks.Shell>

--- a/sjb/generated/ami_build_origin_int_rhel_base.xml
+++ b/sjb/generated/ami_build_origin_int_rhel_base.xml
@@ -32,11 +32,7 @@
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
   <authToken>origin1</authToken>
-  <triggers>
-    <hudson.triggers.TimerTrigger>
-      <spec>H H * * *</spec>
-    </hudson.triggers.TimerTrigger>
-  </triggers>
+  <triggers/>
   <concurrentBuild>true</concurrentBuild>
   <builders>
         <hudson.tasks.Shell>

--- a/sjb/generated/ami_build_origin_int_rhel_crio.xml
+++ b/sjb/generated/ami_build_origin_int_rhel_crio.xml
@@ -81,11 +81,7 @@
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
   <authToken>origin1</authToken>
-  <triggers>
-    <hudson.triggers.TimerTrigger>
-      <spec>H H * * *</spec>
-    </hudson.triggers.TimerTrigger>
-  </triggers>
+  <triggers/>
   <concurrentBuild>true</concurrentBuild>
   <builders>
         <hudson.tasks.Shell>

--- a/sjb/generated/ami_build_origin_int_rhel_install.xml
+++ b/sjb/generated/ami_build_origin_int_rhel_install.xml
@@ -32,11 +32,7 @@
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
   <authToken>origin1</authToken>
-  <triggers>
-    <hudson.triggers.TimerTrigger>
-      <spec>H H * * *</spec>
-    </hudson.triggers.TimerTrigger>
-  </triggers>
+  <triggers/>
   <concurrentBuild>true</concurrentBuild>
   <builders>
         <hudson.tasks.Shell>


### PR DESCRIPTION
Prow will run these as periodics and we don't need them to internalize a
cron schedule any longer.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>