### PR TITLE
CRI-O: fix TSB installation

### DIFF
--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_crio.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_crio.yml
@@ -137,7 +137,6 @@ extensions:
                          -e openshift_crio_systemcontainer_image_override="${crio_image}" \
                          -e etcd_data_dir="${ETCD_DATA_DIR}" \
                          -e openshift_master_default_subdomain="${local_ip}.nip.io"             \
-                         -e openshift_image_tag="$( cat ./ORIGIN_TAG )"                      \
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"            \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
@@ -191,7 +190,6 @@ extensions:
                          -e openshift_crio_systemcontainer_image_override="${crio_image}" \
                          -e etcd_data_dir="${ETCD_DATA_DIR}" \
                          -e openshift_master_default_subdomain="${local_ip}.nip.io"             \
-                         -e openshift_image_tag="$( cat ./ORIGIN_TAG )"                      \
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"            \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \


### PR DESCRIPTION
This fixes
https://github.com/openshift/origin/issues/18732

Basically, by not setting openshift_image_tag we default to
openshift_pkg_version which is in the form of "v3.9" (???)

You can see Prow failng here https://deck-ci.svc.ci.openshift.org/?job=test_pull_request_origin_extended_conformance_crio

@michaelgugino could you please take a look at this since you added that line in the crio jobs? Thanks a lot

/cc @mrunalp @stevekuznetsov 

Signed-off-by: Antonio Murdaca <runcom@redhat.com>