### PR TITLE
always use latest logging image version

### DIFF
--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_journald.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_journald.yml
@@ -44,6 +44,7 @@ extensions:
                          -e debug_level=2           \
                          -e openshift_logging_install_logging=True \
                          -e openshift_logging_image_prefix="openshift/origin-" \
+                         -e openshift_logging_image_version="latest" \
                          -e openshift_logging_elasticsearch_proxy_image_prefix="docker.io/openshift/" \
                          -e openshift_hosted_logging_hostname="kibana.127.0.0.1.nip.io"           \
                          -e openshift_logging_master_public_url="https://localhost:8443"          \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald.xml
@@ -657,6 +657,7 @@ ansible-playbook -vv --become               \
                  -e debug_level=2           \
                  -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
+                 -e openshift_logging_image_version=&#34;latest&#34; \
                  -e openshift_logging_elasticsearch_proxy_image_prefix=&#34;docker.io/openshift/&#34; \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
                  -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_36.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_36.xml
@@ -657,6 +657,7 @@ ansible-playbook -vv --become               \
                  -e debug_level=2           \
                  -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
+                 -e openshift_logging_image_version=&#34;latest&#34; \
                  -e openshift_logging_elasticsearch_proxy_image_prefix=&#34;docker.io/openshift/&#34; \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
                  -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_37.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_37.xml
@@ -657,6 +657,7 @@ ansible-playbook -vv --become               \
                  -e debug_level=2           \
                  -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
+                 -e openshift_logging_image_version=&#34;latest&#34; \
                  -e openshift_logging_elasticsearch_proxy_image_prefix=&#34;docker.io/openshift/&#34; \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
                  -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_39.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_39.xml
@@ -657,6 +657,7 @@ ansible-playbook -vv --become               \
                  -e debug_level=2           \
                  -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
+                 -e openshift_logging_image_version=&#34;latest&#34; \
                  -e openshift_logging_elasticsearch_proxy_image_prefix=&#34;docker.io/openshift/&#34; \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
                  -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \


### PR DESCRIPTION
The images are always built and tagged with `latest` before running
logging install and CI, so just hard code the use of `latest` for
all of the logging images.