### PR TITLE
Use logging images with release_commit tag for security

### DIFF
--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_journald.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_journald.yml
@@ -29,6 +29,8 @@ extensions:
         fi
         pushd "/data/src/github.com/openshift/origin-aggregated-logging/"
         curbranch=$( git rev-parse --abbrev-ref HEAD )
+        # os::build::image tags with both "latest" and the release_commit
+        release_commit="$( git log -1 --pretty=%h )"
         popd
         logging_extras=""
         if [[ "${PULL_REFS%%:*}" == es5.x ]]; then
@@ -44,7 +46,7 @@ extensions:
                          -e debug_level=2           \
                          -e openshift_logging_install_logging=True \
                          -e openshift_logging_image_prefix="openshift/origin-" \
-                         -e openshift_logging_image_version="latest" \
+                         -e openshift_logging_image_version="${release_commit:-latest}" \
                          -e openshift_logging_elasticsearch_proxy_image_prefix="docker.io/openshift/" \
                          -e openshift_hosted_logging_hostname="kibana.127.0.0.1.nip.io"           \
                          -e openshift_logging_master_public_url="https://localhost:8443"          \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald.xml
@@ -642,6 +642,8 @@ else
 fi
 pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
 curbranch=\$( git rev-parse --abbrev-ref HEAD )
+# os::build::image tags with both &#34;latest&#34; and the release_commit
+release_commit=&#34;\$( git log -1 --pretty=%h )&#34;
 popd
 logging_extras=&#34;&#34;
 if [[ &#34;\${PULL_REFS%%:*}&#34; == es5.x ]]; then
@@ -657,7 +659,7 @@ ansible-playbook -vv --become               \
                  -e debug_level=2           \
                  -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
-                 -e openshift_logging_image_version=&#34;latest&#34; \
+                 -e openshift_logging_image_version=&#34;\${release_commit:-latest}&#34; \
                  -e openshift_logging_elasticsearch_proxy_image_prefix=&#34;docker.io/openshift/&#34; \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
                  -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_36.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_36.xml
@@ -642,6 +642,8 @@ else
 fi
 pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
 curbranch=\$( git rev-parse --abbrev-ref HEAD )
+# os::build::image tags with both &#34;latest&#34; and the release_commit
+release_commit=&#34;\$( git log -1 --pretty=%h )&#34;
 popd
 logging_extras=&#34;&#34;
 if [[ &#34;\${PULL_REFS%%:*}&#34; == es5.x ]]; then
@@ -657,7 +659,7 @@ ansible-playbook -vv --become               \
                  -e debug_level=2           \
                  -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
-                 -e openshift_logging_image_version=&#34;latest&#34; \
+                 -e openshift_logging_image_version=&#34;\${release_commit:-latest}&#34; \
                  -e openshift_logging_elasticsearch_proxy_image_prefix=&#34;docker.io/openshift/&#34; \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
                  -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_37.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_37.xml
@@ -642,6 +642,8 @@ else
 fi
 pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
 curbranch=\$( git rev-parse --abbrev-ref HEAD )
+# os::build::image tags with both &#34;latest&#34; and the release_commit
+release_commit=&#34;\$( git log -1 --pretty=%h )&#34;
 popd
 logging_extras=&#34;&#34;
 if [[ &#34;\${PULL_REFS%%:*}&#34; == es5.x ]]; then
@@ -657,7 +659,7 @@ ansible-playbook -vv --become               \
                  -e debug_level=2           \
                  -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
-                 -e openshift_logging_image_version=&#34;latest&#34; \
+                 -e openshift_logging_image_version=&#34;\${release_commit:-latest}&#34; \
                  -e openshift_logging_elasticsearch_proxy_image_prefix=&#34;docker.io/openshift/&#34; \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
                  -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_39.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_39.xml
@@ -642,6 +642,8 @@ else
 fi
 pushd &#34;/data/src/github.com/openshift/origin-aggregated-logging/&#34;
 curbranch=\$( git rev-parse --abbrev-ref HEAD )
+# os::build::image tags with both &#34;latest&#34; and the release_commit
+release_commit=&#34;\$( git log -1 --pretty=%h )&#34;
 popd
 logging_extras=&#34;&#34;
 if [[ &#34;\${PULL_REFS%%:*}&#34; == es5.x ]]; then
@@ -657,7 +659,7 @@ ansible-playbook -vv --become               \
                  -e debug_level=2           \
                  -e openshift_logging_install_logging=True \
                  -e openshift_logging_image_prefix=&#34;openshift/origin-&#34; \
-                 -e openshift_logging_image_version=&#34;latest&#34; \
+                 -e openshift_logging_image_version=&#34;\${release_commit:-latest}&#34; \
                  -e openshift_logging_elasticsearch_proxy_image_prefix=&#34;docker.io/openshift/&#34; \
                  -e openshift_hosted_logging_hostname=&#34;kibana.127.0.0.1.nip.io&#34;           \
                  -e openshift_logging_master_public_url=&#34;https://localhost:8443&#34;          \


### PR DESCRIPTION
The hack/build-images.sh script uses `os::build::image` which tags
each build with both `latest` and the commit hash.  When installing
the logging images, use the commit hash as the logging_image_version
to avoid any conflicts with latest or other extant image versions.