### PR TITLE
Adding es5.x inventory for o-a-l es5.x branch

### DIFF
--- a/sjb/inventory/es5.x.cfg
+++ b/sjb/inventory/es5.x.cfg
@@ -1,0 +1,7 @@
+---
+ansible_service_broker_image_tag: latest
+openshift_logging_image_version: latest
+openshift_metrics_image_version: latest
+openshift_prometheus_image_version: latest
+openshift_service_catalog_image_version: latest
+openshift_web_console_version: latest


### PR DESCRIPTION
This is to fix which inventory gets used when running tests against the openshift-aggregated-logging es5.x branch. ES5.x should install the same as `master`, but currently seeing the following in CI output:
```
+ [[ -f sjb/inventory/es5.x.cfg ]]
+ evars='-e @sjb/inventory/base.cfg'
```

@stevekuznetsov @richm 