### PR TITLE
Fix image registry jobs

### DIFF
--- a/sjb/config/test_cases/test_branch_image_registry_extended.yml
+++ b/sjb/config/test_cases/test_branch_image_registry_extended.yml
@@ -1,5 +1,11 @@
 ---
 parent: 'common/test_cases/origin_built_installed_release.yml'
+overrides:
+  sync:
+    - "openshift,openshift-ansible=master"
+    - "openshift,kubernetes-metrics-server=master"
+    - "openshift,origin-web-console-server=master"
+    - "openshift,aos-cd-jobs=master"
 extensions:
   actions:
     - type: "script"

--- a/sjb/generated/test_branch_image_registry_extended.xml
+++ b/sjb/generated/test_branch_image_registry_extended.xml
@@ -161,7 +161,7 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
         fi
     done
 done
-clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,image-registry=master --repo=openshift,openshift-ansible=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master --repo=openshift,aos-cd-jobs=master }
+clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master --repo=openshift,aos-cd-jobs=master }
 docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${clonerefs_args}
 docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-bucket=origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 sudo chmod -R a+rwX /data

--- a/sjb/generated/test_pull_request_image_registry_extended.xml
+++ b/sjb/generated/test_pull_request_image_registry_extended.xml
@@ -161,7 +161,7 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
         fi
     done
 done
-clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,image-registry=master --repo=openshift,openshift-ansible=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master --repo=openshift,aos-cd-jobs=master }
+clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master --repo=openshift,aos-cd-jobs=master }
 docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${clonerefs_args}
 docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-bucket=origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 sudo chmod -R a+rwX /data


### PR DESCRIPTION
This may not be the best solution to the problem, but this issue is blocking
the image registry team:

https://github.com/kubernetes/test-infra/pull/7151#pullrequestreview-103766727

The problem here is that a parent job of `test_branch_image_registry_extended`,
`origin_release_with_ecosystem.yml`, adds `openshift,image-registry=master` to
`sync`.  But this is the repository that triggers the job, so it causes the
validation added on the PR mentioned above to fail.

This PR works around the issue by overriding `sync` and removing
`openshift,image-registry=master` from it.  Not the ideal solution, but it
unblocks the folks from image registry while we work on a better one.

@kargakis, @stevekuznetsov: can you verify this?