### PR TITLE
Fix usage of cluster up to use --tag instead of --version

### DIFF
--- a/sjb/config/test_cases/test_pull_request_origin_service_catalog.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_service_catalog.yml
@@ -61,7 +61,7 @@ extensions:
       repository: "origin"
       timeout: 1800
       script: |-
-        ./_output/local/bin/linux/amd64/oc cluster up --loglevel=5 --version=latest --service-catalog
+        ./_output/local/bin/linux/amd64/oc cluster up --loglevel=5 --tag=latest --service-catalog
         ./_output/local/bin/linux/amd64/oc login -u system:admin
         ./_output/local/bin/linux/amd64/oc describe po --all-namespaces
     - type: "script"


### PR DESCRIPTION
We changed the flag in 3.10/master. I'm not sure if this job is being reused for <=3.9, if yes, we need to rethink this @soltysh  :-)