### PR TITLE
Use '--tag' flag in UI tests

### DIFF
--- a/sjb/config/test_cases/test_branch_origin_web_console.yml
+++ b/sjb/config/test_cases/test_branch_origin_web_console.yml
@@ -35,11 +35,8 @@ extensions:
         sudo yum install ./google-chrome-stable_current_*.rpm -y
         source IMAGE_VERSION_VAR
         oc version
-        # If the version is not specified for the 3.9 and 3.10(latest) images, the oc binary will use download will fail to start the cluster,
-        # since both of those image versions currently contain bug, so we have to specify the version. Once the bug is fixed and the image is
-        # rebuilt, we can remove this statement.
-        if [ "${IMAGE_VERSION}" == "v3.9" ] || [ "${IMAGE_VERSION}" == "latest" ]; then
-          oc cluster up --version="${IMAGE_VERSION}" --public-hostname=localhost --loglevel=5 --server-loglevel=5
+        if [ "${IMAGE_VERSION}" == "latest" ]; then
+          oc cluster up --tag="${IMAGE_VERSION}" --public-hostname=localhost --loglevel=5 --server-loglevel=5
         else
           oc cluster up --public-hostname=localhost --loglevel=5 --server-loglevel=5
         fi

--- a/sjb/config/test_cases/test_branch_origin_web_console_server_e2e.yml
+++ b/sjb/config/test_cases/test_branch_origin_web_console_server_e2e.yml
@@ -16,6 +16,6 @@ extensions:
       # TODO For now, run cluster up to verify the console starts, but
       # eventually we will want to do more interesting e2e tests.
       script: |-
-        oc cluster up --version=latest --public-hostname=localhost --loglevel=5
+        oc cluster up --tag=latest --public-hostname=localhost --loglevel=5
   system_journals:
     - systemd-journald.service

--- a/sjb/generated/test_branch_origin_web_console.xml
+++ b/sjb/generated/test_branch_origin_web_console.xml
@@ -309,11 +309,8 @@ wget https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm
 sudo yum install ./google-chrome-stable_current_*.rpm -y
 source IMAGE_VERSION_VAR
 oc version
-# If the version is not specified for the 3.9 and 3.10(latest) images, the oc binary will use download will fail to start the cluster,
-# since both of those image versions currently contain bug, so we have to specify the version. Once the bug is fixed and the image is
-# rebuilt, we can remove this statement.
-if [ &#34;\${IMAGE_VERSION}&#34; == &#34;v3.9&#34; ] || [ &#34;\${IMAGE_VERSION}&#34; == &#34;latest&#34; ]; then
-  oc cluster up --version=&#34;\${IMAGE_VERSION}&#34; --public-hostname=localhost --loglevel=5 --server-loglevel=5
+if [ &#34;\${IMAGE_VERSION}&#34; == &#34;latest&#34; ]; then
+  oc cluster up --tag=&#34;\${IMAGE_VERSION}&#34; --public-hostname=localhost --loglevel=5 --server-loglevel=5
 else
   oc cluster up --public-hostname=localhost --loglevel=5 --server-loglevel=5
 fi

--- a/sjb/generated/test_branch_origin_web_console_server_e2e.xml
+++ b/sjb/generated/test_branch_origin_web_console_server_e2e.xml
@@ -286,7 +286,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin-web-console-server&#34;
-oc cluster up --version=latest --public-hostname=localhost --loglevel=5
+oc cluster up --tag=latest --public-hostname=localhost --loglevel=5
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_web_console.xml
+++ b/sjb/generated/test_pull_request_origin_web_console.xml
@@ -309,11 +309,8 @@ wget https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm
 sudo yum install ./google-chrome-stable_current_*.rpm -y
 source IMAGE_VERSION_VAR
 oc version
-# If the version is not specified for the 3.9 and 3.10(latest) images, the oc binary will use download will fail to start the cluster,
-# since both of those image versions currently contain bug, so we have to specify the version. Once the bug is fixed and the image is
-# rebuilt, we can remove this statement.
-if [ &#34;\${IMAGE_VERSION}&#34; == &#34;v3.9&#34; ] || [ &#34;\${IMAGE_VERSION}&#34; == &#34;latest&#34; ]; then
-  oc cluster up --version=&#34;\${IMAGE_VERSION}&#34; --public-hostname=localhost --loglevel=5 --server-loglevel=5
+if [ &#34;\${IMAGE_VERSION}&#34; == &#34;latest&#34; ]; then
+  oc cluster up --tag=&#34;\${IMAGE_VERSION}&#34; --public-hostname=localhost --loglevel=5 --server-loglevel=5
 else
   oc cluster up --public-hostname=localhost --loglevel=5 --server-loglevel=5
 fi

--- a/sjb/generated/test_pull_request_origin_web_console_server_e2e.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_server_e2e.xml
@@ -286,7 +286,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin-web-console-server&#34;
-oc cluster up --version=latest --public-hostname=localhost --loglevel=5
+oc cluster up --tag=latest --public-hostname=localhost --loglevel=5
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;


### PR DESCRIPTION
Updating web console tests cases to the `latest` tag is used for the latest oc binary, which should be now 3.10 and up. Otherwise let the `oc` determine the image tag.

Ran couple of test in https://ci.openshift.redhat.com/jenkins/job/test_pull_request_origin_web_console_jakub/ they succeeded if not a flake.

@spadgett @stevekuznetsov 