### PR TITLE
Change oc cluster up to use --tag

### DIFF
--- a/sjb/config/test_cases/test_branch_origin_service_catalog.yml
+++ b/sjb/config/test_cases/test_branch_origin_service_catalog.yml
@@ -76,7 +76,7 @@ extensions:
       repository: "origin"
       timeout: 1800
       script: |-
-        ./_output/local/bin/linux/amd64/oc cluster up --loglevel=5 --version=latest --service-catalog
+        ./_output/local/bin/linux/amd64/oc cluster up --loglevel=5 --tag=latest --service-catalog
         ./_output/local/bin/linux/amd64/oc login -u system:admin
         ./_output/local/bin/linux/amd64/oc describe po --all-namespaces
     - type: "script"

--- a/sjb/generated/test_branch_origin_service_catalog.xml
+++ b/sjb/generated/test_branch_origin_service_catalog.xml
@@ -409,7 +409,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-./_output/local/bin/linux/amd64/oc cluster up --loglevel=5 --version=latest --service-catalog
+./_output/local/bin/linux/amd64/oc cluster up --loglevel=5 --tag=latest --service-catalog
 ./_output/local/bin/linux/amd64/oc login -u system:admin
 ./_output/local/bin/linux/amd64/oc describe po --all-namespaces
 SCRIPT


### PR DESCRIPTION
This mirrors what was done in #1270. Using a bash script instead of calling cluster up directly is a good idea since we now have branch differences.