### PR TITLE
Handle syntax differences for "oc cluster up"

### DIFF
--- a/sjb/config/test_cases/test_branch_origin_service_catalog.yml
+++ b/sjb/config/test_cases/test_branch_origin_service_catalog.yml
@@ -43,7 +43,7 @@ extensions:
     - type: "script"
       title: "run Service Catalog integration tests"
       repository: "origin"
-      timeout: 1800
+      timeout: 2700
       script: |-
         sudo yum -y install etcd
         # switch to wget since curl is using NSS - https://github.com/kubernetes/kubernetes/pull/59966 (can be removed once 0.1.9+ vendored)
@@ -76,7 +76,11 @@ extensions:
       repository: "origin"
       timeout: 1800
       script: |-
-        ./_output/local/bin/linux/amd64/oc cluster up --loglevel=5 --tag=latest --service-catalog
+        if [[ "${PULL_BASE_REF:-master}" == "release-3.9" ]]; then
+          ./_output/local/bin/linux/amd64/oc cluster up --loglevel=5 --version=latest --service-catalog
+        else
+          ./_output/local/bin/linux/amd64/oc cluster up --loglevel=5 --tag=latest --service-catalog
+        fi
         ./_output/local/bin/linux/amd64/oc login -u system:admin
         ./_output/local/bin/linux/amd64/oc describe po --all-namespaces
     - type: "script"

--- a/sjb/config/test_cases/test_pull_request_origin_service_catalog.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_service_catalog.yml
@@ -61,7 +61,11 @@ extensions:
       repository: "origin"
       timeout: 1800
       script: |-
-        ./_output/local/bin/linux/amd64/oc cluster up --loglevel=5 --tag=latest --service-catalog
+        if [[ "${PULL_BASE_REF:-master}" == "release-3.9" ]]; then
+          ./_output/local/bin/linux/amd64/oc cluster up --loglevel=5 --version=latest --service-catalog
+        else
+          ./_output/local/bin/linux/amd64/oc cluster up --loglevel=5 --tag=latest --service-catalog
+        fi
         ./_output/local/bin/linux/amd64/oc login -u system:admin
         ./_output/local/bin/linux/amd64/oc describe po --all-namespaces
     - type: "script"

--- a/sjb/generated/test_branch_origin_service_catalog.xml
+++ b/sjb/generated/test_branch_origin_service_catalog.xml
@@ -357,7 +357,7 @@ NO_DOCKER=1 make -C cmd/service-catalog/go/src/github.com/kubernetes-incubator/s
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ./.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
-ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 1800 ${script}\&#34;&#34; </command>
+ssh -F ./.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 2700 ${script}\&#34;&#34; </command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -409,7 +409,11 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-./_output/local/bin/linux/amd64/oc cluster up --loglevel=5 --tag=latest --service-catalog
+if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;release-3.9&#34; ]]; then
+  ./_output/local/bin/linux/amd64/oc cluster up --loglevel=5 --version=latest --service-catalog
+else
+  ./_output/local/bin/linux/amd64/oc cluster up --loglevel=5 --tag=latest --service-catalog
+fi
 ./_output/local/bin/linux/amd64/oc login -u system:admin
 ./_output/local/bin/linux/amd64/oc describe po --all-namespaces
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_service_catalog.xml
+++ b/sjb/generated/test_pull_request_origin_service_catalog.xml
@@ -388,7 +388,11 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-./_output/local/bin/linux/amd64/oc cluster up --loglevel=5 --tag=latest --service-catalog
+if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;release-3.9&#34; ]]; then
+  ./_output/local/bin/linux/amd64/oc cluster up --loglevel=5 --version=latest --service-catalog
+else
+  ./_output/local/bin/linux/amd64/oc cluster up --loglevel=5 --tag=latest --service-catalog
+fi
 ./_output/local/bin/linux/amd64/oc login -u system:admin
 ./_output/local/bin/linux/amd64/oc describe po --all-namespaces
 SCRIPT


### PR DESCRIPTION
Used the PULL_BASE_REF environment variable to select a different syntax
based on the branch being tested.