### PR TITLE
Always fall back to the default GCE service account and project

### DIFF
--- a/sjb/config/common/test_cases/origin_minimal.yml
+++ b/sjb/config/common/test_cases/origin_minimal.yml
@@ -94,6 +94,11 @@ post_actions:
     script: |-
       trap 'exit 0' EXIT
       if [[ -n "${JOB_SPEC:-}" ]]; then
+        # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+        # in case different SA was used to provision/teardown GCE cluster
+        gcloud auth activate-service-account --key-file /data/credentials.json
+        gcloud config set project openshift-gce-devel
+
         if [[ "$( jq --compact-output ".buildid" <<<"${JOB_SPEC}" )" =~ ^\"[0-9]+\"$ ]]; then
           echo "Keeping BUILD_ID"
         else

--- a/sjb/generated/push_origin_release.xml
+++ b/sjb/generated/push_origin_release.xml
@@ -575,6 +575,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/push_origin_release_36.xml
+++ b/sjb/generated/push_origin_release_36.xml
@@ -469,6 +469,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/push_origin_release_37.xml
+++ b/sjb/generated/push_origin_release_37.xml
@@ -469,6 +469,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/push_origin_release_38.xml
+++ b/sjb/generated/push_origin_release_38.xml
@@ -544,6 +544,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/push_origin_release_39.xml
+++ b/sjb/generated/push_origin_release_39.xml
@@ -575,6 +575,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_cluster_operator_unit.xml
+++ b/sjb/generated/test_branch_cluster_operator_unit.xml
@@ -369,6 +369,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_image_registry_extended.xml
+++ b/sjb/generated/test_branch_image_registry_extended.xml
@@ -698,6 +698,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_image_registry_integration.xml
+++ b/sjb/generated/test_branch_image_registry_integration.xml
@@ -363,6 +363,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_image_registry_unit.xml
+++ b/sjb/generated/test_branch_image_registry_unit.xml
@@ -355,6 +355,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_jenkins_client_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_client_plugin.xml
@@ -554,6 +554,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_openshift_login_plugin.xml
@@ -554,6 +554,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_jenkins_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_plugin.xml
@@ -554,6 +554,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_jenkins_sync_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_sync_plugin.xml
@@ -554,6 +554,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_kubernetes_metrics_server_unit.xml
+++ b/sjb/generated/test_branch_kubernetes_metrics_server_unit.xml
@@ -355,6 +355,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_online_console_extensions.xml
+++ b/sjb/generated/test_branch_online_console_extensions.xml
@@ -355,6 +355,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_online_hibernation_unit.xml
+++ b/sjb/generated/test_branch_online_hibernation_unit.xml
@@ -355,6 +355,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce.xml
@@ -859,6 +859,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_37.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_37.xml
@@ -753,6 +753,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_39.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_39.xml
@@ -859,6 +859,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_openshift_ansible_logging.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging.xml
@@ -790,6 +790,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
@@ -800,6 +800,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_aggregated_logging_json_file.xml
+++ b/sjb/generated/test_branch_origin_aggregated_logging_json_file.xml
@@ -800,6 +800,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_aggregated_logging_prior.xml
+++ b/sjb/generated/test_branch_origin_aggregated_logging_prior.xml
@@ -401,6 +401,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_check.xml
+++ b/sjb/generated/test_branch_origin_check.xml
@@ -374,6 +374,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_cmd.xml
+++ b/sjb/generated/test_branch_origin_cmd.xml
@@ -355,6 +355,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_cross.xml
+++ b/sjb/generated/test_branch_origin_cross.xml
@@ -372,6 +372,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_end_to_end.xml
+++ b/sjb/generated/test_branch_origin_end_to_end.xml
@@ -501,6 +501,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_extended_builds.xml
+++ b/sjb/generated/test_branch_origin_extended_builds.xml
@@ -538,6 +538,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_extended_clusterup.xml
+++ b/sjb/generated/test_branch_origin_extended_clusterup.xml
@@ -356,6 +356,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_crio.xml
@@ -707,6 +707,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce.xml
@@ -821,6 +821,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_extended_conformance_gce_37.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce_37.xml
@@ -697,6 +697,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_extended_conformance_gce_38.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce_38.xml
@@ -772,6 +772,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_extended_conformance_gce_39.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce_39.xml
@@ -803,6 +803,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install.xml
@@ -698,6 +698,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_extended_conformance_install_36.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_36.xml
@@ -634,6 +634,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_extended_conformance_install_37.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_37.xml
@@ -634,6 +634,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_extended_conformance_install_38.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_38.xml
@@ -681,6 +681,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_extended_conformance_install_39.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_39.xml
@@ -698,6 +698,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_extended_conformance_install_containerized.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_containerized.xml
@@ -627,6 +627,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_extended_conformance_install_in_tree.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_in_tree.xml
@@ -559,6 +559,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
@@ -727,6 +727,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
@@ -707,6 +707,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized.xml
@@ -665,6 +665,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers.xml
@@ -756,6 +756,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_extended_conformance_k8s.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_k8s.xml
@@ -821,6 +821,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_extended_conformance_k8s_39.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_k8s_39.xml
@@ -821,6 +821,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_extended_gssapi.xml
+++ b/sjb/generated/test_branch_origin_extended_gssapi.xml
@@ -356,6 +356,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_extended_image_ecosystem.xml
+++ b/sjb/generated/test_branch_origin_extended_image_ecosystem.xml
@@ -538,6 +538,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_extended_image_registry.xml
+++ b/sjb/generated/test_branch_origin_extended_image_registry.xml
@@ -538,6 +538,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_extended_ldap_groups.xml
+++ b/sjb/generated/test_branch_origin_extended_ldap_groups.xml
@@ -356,6 +356,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_extended_networking.xml
+++ b/sjb/generated/test_branch_origin_extended_networking.xml
@@ -411,6 +411,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_integration.xml
+++ b/sjb/generated/test_branch_origin_integration.xml
@@ -355,6 +355,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_service_catalog.xml
+++ b/sjb/generated/test_branch_origin_service_catalog.xml
@@ -524,6 +524,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_unit.xml
+++ b/sjb/generated/test_branch_origin_unit.xml
@@ -355,6 +355,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_verify.xml
+++ b/sjb/generated/test_branch_origin_verify.xml
@@ -375,6 +375,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_web_console.xml
+++ b/sjb/generated/test_branch_origin_web_console.xml
@@ -428,6 +428,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_web_console_server_check.xml
+++ b/sjb/generated/test_branch_origin_web_console_server_check.xml
@@ -355,6 +355,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_branch_origin_web_console_server_e2e.xml
+++ b/sjb/generated/test_branch_origin_web_console_server_e2e.xml
@@ -371,6 +371,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_cluster_operator_unit.xml
+++ b/sjb/generated/test_pull_request_cluster_operator_unit.xml
@@ -369,6 +369,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_image_registry_extended.xml
+++ b/sjb/generated/test_pull_request_image_registry_extended.xml
@@ -698,6 +698,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_image_registry_integration.xml
+++ b/sjb/generated/test_pull_request_image_registry_integration.xml
@@ -363,6 +363,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_image_registry_unit.xml
+++ b/sjb/generated/test_pull_request_image_registry_unit.xml
@@ -355,6 +355,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_jenkins_client_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_client_plugin.xml
@@ -554,6 +554,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_openshift_login_plugin.xml
@@ -554,6 +554,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_jenkins_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_plugin.xml
@@ -554,6 +554,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_jenkins_sync_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_sync_plugin.xml
@@ -554,6 +554,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_kubernetes_metrics_server_unit.xml
+++ b/sjb/generated/test_pull_request_kubernetes_metrics_server_unit.xml
@@ -355,6 +355,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_online_console_extensions.xml
+++ b/sjb/generated/test_pull_request_online_console_extensions.xml
@@ -355,6 +355,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_online_hibernation_unit.xml
+++ b/sjb/generated/test_pull_request_online_hibernation_unit.xml
@@ -355,6 +355,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce.xml
@@ -802,6 +802,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_37.xml
@@ -696,6 +696,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_39.xml
@@ -802,6 +802,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha.xml
@@ -802,6 +802,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha_39.xml
@@ -802,6 +802,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
@@ -698,6 +698,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized.xml
@@ -627,6 +627,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio.xml
@@ -707,6 +707,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_in_tree.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_in_tree.xml
@@ -559,6 +559,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_36.xml
@@ -698,6 +698,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_37.xml
@@ -698,6 +698,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_39.xml
@@ -698,6 +698,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
@@ -727,6 +727,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_36.xml
@@ -727,6 +727,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_37.xml
@@ -727,6 +727,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_39.xml
@@ -727,6 +727,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
@@ -707,6 +707,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized.xml
@@ -665,6 +665,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers.xml
@@ -756,6 +756,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
@@ -708,6 +708,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_openshift_ansible_launch_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_launch_gce.xml
@@ -814,6 +814,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_openshift_ansible_logging.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging.xml
@@ -790,6 +790,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_36.xml
@@ -790,6 +790,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_37.xml
@@ -790,6 +790,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_39.xml
@@ -790,6 +790,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_openshift_ansible_tox.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_tox.xml
@@ -402,6 +402,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald.xml
@@ -792,6 +792,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_36.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_36.xml
@@ -792,6 +792,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_37.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_37.xml
@@ -792,6 +792,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_39.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_39.xml
@@ -792,6 +792,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file.xml
@@ -800,6 +800,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_36.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_36.xml
@@ -800,6 +800,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_37.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_37.xml
@@ -800,6 +800,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_39.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_39.xml
@@ -800,6 +800,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_cmd.xml
+++ b/sjb/generated/test_pull_request_origin_cmd.xml
@@ -355,6 +355,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_cross.xml
+++ b/sjb/generated/test_pull_request_origin_cross.xml
@@ -355,6 +355,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_end_to_end.xml
+++ b/sjb/generated/test_pull_request_origin_end_to_end.xml
@@ -501,6 +501,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_extended_builds.xml
+++ b/sjb/generated/test_pull_request_origin_extended_builds.xml
@@ -698,6 +698,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_extended_clusterup.xml
+++ b/sjb/generated/test_pull_request_origin_extended_clusterup.xml
@@ -411,6 +411,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
@@ -707,6 +707,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
@@ -802,6 +802,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce_37.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce_37.xml
@@ -696,6 +696,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce_39.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce_39.xml
@@ -802,6 +802,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
@@ -698,6 +698,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_36.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_36.xml
@@ -634,6 +634,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_37.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_37.xml
@@ -634,6 +634,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_38.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_38.xml
@@ -681,6 +681,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_39.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_39.xml
@@ -698,6 +698,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
@@ -707,6 +707,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_extended_conformance_k8s.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_k8s.xml
@@ -803,6 +803,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_extended_gssapi.xml
+++ b/sjb/generated/test_pull_request_origin_extended_gssapi.xml
@@ -356,6 +356,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_extended_image_ecosystem.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_ecosystem.xml
@@ -698,6 +698,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_extended_image_registry.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_registry.xml
@@ -698,6 +698,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_extended_ldap_groups.xml
+++ b/sjb/generated/test_pull_request_origin_extended_ldap_groups.xml
@@ -411,6 +411,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_extended_networking.xml
+++ b/sjb/generated/test_pull_request_origin_extended_networking.xml
@@ -411,6 +411,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_integration.xml
+++ b/sjb/generated/test_pull_request_origin_integration.xml
@@ -355,6 +355,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_launch_gce.xml
+++ b/sjb/generated/test_pull_request_origin_launch_gce.xml
@@ -814,6 +814,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_service_catalog.xml
+++ b/sjb/generated/test_pull_request_origin_service_catalog.xml
@@ -503,6 +503,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_unit.xml
+++ b/sjb/generated/test_pull_request_origin_unit.xml
@@ -355,6 +355,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_verify.xml
+++ b/sjb/generated/test_pull_request_origin_verify.xml
@@ -375,6 +375,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_web_console.xml
+++ b/sjb/generated/test_pull_request_origin_web_console.xml
@@ -428,6 +428,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_web_console_server_check.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_server_check.xml
@@ -355,6 +355,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else

--- a/sjb/generated/test_pull_request_origin_web_console_server_e2e.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_server_e2e.xml
@@ -371,6 +371,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
+  # Set the original GCE SA and project to openshift-gce-devel that can upload results to GCS bucket
+  # in case different SA was used to provision/teardown GCE cluster
+  gcloud auth activate-service-account --key-file /data/credentials.json
+  gcloud config set project openshift-gce-devel
+
   if [[ &#34;\$( jq --compact-output &#34;.buildid&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34; =~ ^\&#34;[0-9]+\&#34;\$ ]]; then
     echo &#34;Keeping BUILD_ID&#34;
   else


### PR DESCRIPTION
Some jobs change the GCE credentials. However, given all artefacts are uploaded to the same GCS bucket, we need to flip back to the default credentials in case the job fails or the JJ creator forget to switch back.