### PR TITLE
Add new catalog repo to release push script

### DIFF
--- a/sjb/config/test_cases/push_origin_release.yml
+++ b/sjb/config/test_cases/push_origin_release.yml
@@ -8,6 +8,7 @@ overrides:
     - "openshift,origin-web-console-server=master"
     - "openshift,aos-cd-jobs=master"
     - "openshift,release=master"
+    - "openshift,service-catalog=master"
 extensions:
   parameters:
     - name: "OS_PUSH_TAG"
@@ -46,4 +47,10 @@ extensions:
       repository: "origin-web-console-server"
       script: |-
         DOCKER_CONFIG=/tmp/.docker OS_PUSH_LOCAL=1 OS_PUSH_ALWAYS=1 OS_PUSH_BASE_REGISTRY="docker.io/" hack/push-release.sh
+    - type: "script"
+      title: "push the image service-catalog release"
+      repository: "service-catalog"
+      script: |-
+        DOCKER_CONFIG=/tmp/.docker OS_PUSH_LOCAL=1 OS_PUSH_ALWAYS=1 OS_PUSH_BASE_REGISTRY="docker.io/" hack/push-release.sh
+        # (!)Note: the following command always needs to be LAST in the file, so move if additional scripts are added
         sudo rm -rf /tmp/.docker


### PR DESCRIPTION
This adds images to be pushed based on openshift/service-catalog. Note that this should be merged only if https://github.com/openshift/origin/pull/19221 is. (Edit: 19221 was merged.)