### PR TITLE
Set openshift_image_tag explicitely

### DIFF
--- a/jobs/package-dockertested/install-origin-release.sh
+++ b/jobs/package-dockertested/install-origin-release.sh
@@ -21,6 +21,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e deployment_type=origin  \
+                 -e openshift_image_tag="$( cat ./ORIGIN_RELEASE )" \
                  -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
                  -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
                  -e openshift_disable_check=docker_image_availability,package_update,package_availability    \
@@ -47,6 +48,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e deployment_type=origin  \
+                 -e openshift_image_tag="$( cat ./ORIGIN_RELEASE )" \
                  -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
                  -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
                  -e openshift_disable_check=docker_image_availability,package_update,package_availability    \

--- a/sjb/config/common/test_cases/origin_built_installed_release_39.yml
+++ b/sjb/config/common/test_cases/origin_built_installed_release_39.yml
@@ -58,6 +58,7 @@ extensions:
                          --connection local         \
                          --inventory sjb/inventory/ \
                          -e openshift_deployment_type=origin  \
+                         -e openshift_image_tag="$( cat ./ORIGIN_RELEASE )" \
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                       \
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \

--- a/sjb/generated/test_branch_origin_extended_conformance_install_39.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_39.xml
@@ -498,6 +498,7 @@ ansible-playbook -vv --become               \
                  --connection local         \
                  --inventory sjb/inventory/ \
                  -e openshift_deployment_type=origin  \
+                 -e openshift_image_tag=&#34;\$( cat ./ORIGIN_RELEASE )&#34; \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \


### PR DESCRIPTION
openshift-ansible uses `version` output to detect the image tag if its
not set. It can be 3.x.0, while CI tags only 3.x. CI should pass
openshift_image_tag to avoid this.

This should resolve https://github.com/openshift/openshift-ansible/pull/7919#issuecomment-380572925

PTAL @sdodson @stevekuznetsov