### PR TITLE
Azure: resource group name too long

### DIFF
--- a/sjb/config/common/test_cases/origin_release_install_azure.yml
+++ b/sjb/config/common/test_cases/origin_release_install_azure.yml
@@ -170,7 +170,7 @@ extensions:
           -e "debug_level=5" \
           -e "openshift_azure_base_image_ns=magentaciimages" \
           -e "openshift_azure_image=openshift-gi-$(date +%Y%m%d%H%M%S)" \
-          -e "openshift_azure_clusterid=magentaci${INSTANCE_PREFIX//-}" \
+          -e "openshift_azure_clusterid=ci${INSTANCE_PREFIX//-}" \
           playbooks/${CLUSTER_PROFILE}/openshift-cluster/build_image.yml
         popd
 
@@ -186,7 +186,7 @@ extensions:
         TYPE=$CLUSTER_PROFILE ../../bin/ansible.sh ansible-playbook \
           -e "openshift_test_repo=${location_url}" \
           -e "debug_level=5" \
-          -e "openshift_azure_clusterid=magentaci${INSTANCE_PREFIX//-}" \
+          -e "openshift_azure_clusterid=ci${INSTANCE_PREFIX//-}" \
           playbooks/${CLUSTER_PROFILE}/openshift-cluster/launch.yml
         popd
   post_actions:
@@ -197,6 +197,6 @@ extensions:
         trap 'exit 0' EXIT
         pushd release/cluster/test-deploy/${CLUSTER_PROFILE}
         TYPE=$CLUSTER_PROFILE ../../bin/ansible.sh ansible-playbook \
-          -e "openshift_azure_clusterid=magentaci${INSTANCE_PREFIX//-}" \
+          -e "openshift_azure_clusterid=ci${INSTANCE_PREFIX//-}" \
           playbooks/${CLUSTER_PROFILE}/openshift-cluster/deprovision.yml
         popd

--- a/sjb/config/common/test_cases/origin_release_install_azure_39.yml
+++ b/sjb/config/common/test_cases/origin_release_install_azure_39.yml
@@ -170,7 +170,7 @@ extensions:
           -e "debug_level=5" \
           -e "openshift_azure_base_image_ns=magentaciimages" \
           -e "openshift_azure_image=openshift-gi-$(date +%Y%m%d%H%M%S)" \
-          -e "openshift_azure_clusterid=magentaci${INSTANCE_PREFIX//-}" \
+          -e "openshift_azure_clusterid=ci${INSTANCE_PREFIX//-}" \
           playbooks/${CLUSTER_PROFILE}/openshift-cluster/build_image.yml
         popd
 
@@ -186,7 +186,7 @@ extensions:
         TYPE=$CLUSTER_PROFILE ../../bin/ansible.sh ansible-playbook \
           -e "openshift_test_repo=${location_url}" \
           -e "debug_level=5" \
-          -e "openshift_azure_clusterid=magentaci${INSTANCE_PREFIX//-}" \
+          -e "openshift_azure_clusterid=ci${INSTANCE_PREFIX//-}" \
           playbooks/${CLUSTER_PROFILE}/openshift-cluster/launch.yml
         popd
   post_actions:
@@ -197,6 +197,6 @@ extensions:
         trap 'exit 0' EXIT
         pushd release/cluster/test-deploy/${CLUSTER_PROFILE}
         TYPE=$CLUSTER_PROFILE ../../bin/ansible.sh ansible-playbook \
-          -e "openshift_azure_clusterid=magentaci${INSTANCE_PREFIX//-}" \
+          -e "openshift_azure_clusterid=ci${INSTANCE_PREFIX//-}" \
           playbooks/${CLUSTER_PROFILE}/openshift-cluster/deprovision.yml
         popd

--- a/sjb/config/test_cases/azure_build_node_image_rhel.yml
+++ b/sjb/config/test_cases/azure_build_node_image_rhel.yml
@@ -59,8 +59,6 @@ actions:
     script: |-
       pushd release/cluster/test-deploy/${CLUSTER_PROFILE}
       TYPE=$CLUSTER_PROFILE ../../bin/ansible.sh ansible-playbook \
-        -e "openshift_test_repo=https://storage.googleapis.com/origin-ci-test/releases/openshift/origin/release-3.9/origin.repo" \
-        -e "debug_level=5" \
         -e "openshift_azure_base_image_ns=magentaciimages" \
         -e "openshift_azure_image=openshift-gi-${INSTANCE_PREFIX}" \
         -e "openshift_azure_clusterid=magentaciimages" \

--- a/sjb/generated/azure_build_node_image_rhel.xml
+++ b/sjb/generated/azure_build_node_image_rhel.xml
@@ -254,8 +254,6 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 pushd release/cluster/test-deploy/\${CLUSTER_PROFILE}
 TYPE=\$CLUSTER_PROFILE ../../bin/ansible.sh ansible-playbook \
-  -e &#34;openshift_test_repo=https://storage.googleapis.com/origin-ci-test/releases/openshift/origin/release-3.9/origin.repo&#34; \
-  -e &#34;debug_level=5&#34; \
   -e &#34;openshift_azure_base_image_ns=magentaciimages&#34; \
   -e &#34;openshift_azure_image=openshift-gi-\${INSTANCE_PREFIX}&#34; \
   -e &#34;openshift_azure_clusterid=magentaciimages&#34; \

--- a/sjb/generated/test_branch_origin_extended_conformance_azure.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_azure.xml
@@ -669,7 +669,7 @@ TYPE=\$CLUSTER_PROFILE ../../bin/ansible.sh ansible-playbook \
   -e &#34;debug_level=5&#34; \
   -e &#34;openshift_azure_base_image_ns=magentaciimages&#34; \
   -e &#34;openshift_azure_image=openshift-gi-\$(date +%Y%m%d%H%M%S)&#34; \
-  -e &#34;openshift_azure_clusterid=magentaci\${INSTANCE_PREFIX//-}&#34; \
+  -e &#34;openshift_azure_clusterid=ci\${INSTANCE_PREFIX//-}&#34; \
   playbooks/\${CLUSTER_PROFILE}/openshift-cluster/build_image.yml
 popd
 SCRIPT
@@ -693,7 +693,7 @@ pushd release/cluster/test-deploy/\${CLUSTER_PROFILE}
 TYPE=\$CLUSTER_PROFILE ../../bin/ansible.sh ansible-playbook \
   -e &#34;openshift_test_repo=\${location_url}&#34; \
   -e &#34;debug_level=5&#34; \
-  -e &#34;openshift_azure_clusterid=magentaci\${INSTANCE_PREFIX//-}&#34; \
+  -e &#34;openshift_azure_clusterid=ci\${INSTANCE_PREFIX//-}&#34; \
   playbooks/\${CLUSTER_PROFILE}/openshift-cluster/launch.yml
 popd
 SCRIPT
@@ -817,7 +817,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 pushd release/cluster/test-deploy/\${CLUSTER_PROFILE}
 TYPE=\$CLUSTER_PROFILE ../../bin/ansible.sh ansible-playbook \
-  -e &#34;openshift_azure_clusterid=magentaci\${INSTANCE_PREFIX//-}&#34; \
+  -e &#34;openshift_azure_clusterid=ci\${INSTANCE_PREFIX//-}&#34; \
   playbooks/\${CLUSTER_PROFILE}/openshift-cluster/deprovision.yml
 popd
 SCRIPT

--- a/sjb/generated/test_branch_origin_extended_conformance_azure_39.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_azure_39.xml
@@ -669,7 +669,7 @@ TYPE=\$CLUSTER_PROFILE ../../bin/ansible.sh ansible-playbook \
   -e &#34;debug_level=5&#34; \
   -e &#34;openshift_azure_base_image_ns=magentaciimages&#34; \
   -e &#34;openshift_azure_image=openshift-gi-\$(date +%Y%m%d%H%M%S)&#34; \
-  -e &#34;openshift_azure_clusterid=magentaci\${INSTANCE_PREFIX//-}&#34; \
+  -e &#34;openshift_azure_clusterid=ci\${INSTANCE_PREFIX//-}&#34; \
   playbooks/\${CLUSTER_PROFILE}/openshift-cluster/build_image.yml
 popd
 SCRIPT
@@ -693,7 +693,7 @@ pushd release/cluster/test-deploy/\${CLUSTER_PROFILE}
 TYPE=\$CLUSTER_PROFILE ../../bin/ansible.sh ansible-playbook \
   -e &#34;openshift_test_repo=\${location_url}&#34; \
   -e &#34;debug_level=5&#34; \
-  -e &#34;openshift_azure_clusterid=magentaci\${INSTANCE_PREFIX//-}&#34; \
+  -e &#34;openshift_azure_clusterid=ci\${INSTANCE_PREFIX//-}&#34; \
   playbooks/\${CLUSTER_PROFILE}/openshift-cluster/launch.yml
 popd
 SCRIPT
@@ -817,7 +817,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 pushd release/cluster/test-deploy/\${CLUSTER_PROFILE}
 TYPE=\$CLUSTER_PROFILE ../../bin/ansible.sh ansible-playbook \
-  -e &#34;openshift_azure_clusterid=magentaci\${INSTANCE_PREFIX//-}&#34; \
+  -e &#34;openshift_azure_clusterid=ci\${INSTANCE_PREFIX//-}&#34; \
   playbooks/\${CLUSTER_PROFILE}/openshift-cluster/deprovision.yml
 popd
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_extended_conformance_azure.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_azure.xml
@@ -669,7 +669,7 @@ TYPE=\$CLUSTER_PROFILE ../../bin/ansible.sh ansible-playbook \
   -e &#34;debug_level=5&#34; \
   -e &#34;openshift_azure_base_image_ns=magentaciimages&#34; \
   -e &#34;openshift_azure_image=openshift-gi-\$(date +%Y%m%d%H%M%S)&#34; \
-  -e &#34;openshift_azure_clusterid=magentaci\${INSTANCE_PREFIX//-}&#34; \
+  -e &#34;openshift_azure_clusterid=ci\${INSTANCE_PREFIX//-}&#34; \
   playbooks/\${CLUSTER_PROFILE}/openshift-cluster/build_image.yml
 popd
 SCRIPT
@@ -693,7 +693,7 @@ pushd release/cluster/test-deploy/\${CLUSTER_PROFILE}
 TYPE=\$CLUSTER_PROFILE ../../bin/ansible.sh ansible-playbook \
   -e &#34;openshift_test_repo=\${location_url}&#34; \
   -e &#34;debug_level=5&#34; \
-  -e &#34;openshift_azure_clusterid=magentaci\${INSTANCE_PREFIX//-}&#34; \
+  -e &#34;openshift_azure_clusterid=ci\${INSTANCE_PREFIX//-}&#34; \
   playbooks/\${CLUSTER_PROFILE}/openshift-cluster/launch.yml
 popd
 SCRIPT
@@ -817,7 +817,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 pushd release/cluster/test-deploy/\${CLUSTER_PROFILE}
 TYPE=\$CLUSTER_PROFILE ../../bin/ansible.sh ansible-playbook \
-  -e &#34;openshift_azure_clusterid=magentaci\${INSTANCE_PREFIX//-}&#34; \
+  -e &#34;openshift_azure_clusterid=ci\${INSTANCE_PREFIX//-}&#34; \
   playbooks/\${CLUSTER_PROFILE}/openshift-cluster/deprovision.yml
 popd
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_extended_conformance_azure_39.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_azure_39.xml
@@ -669,7 +669,7 @@ TYPE=\$CLUSTER_PROFILE ../../bin/ansible.sh ansible-playbook \
   -e &#34;debug_level=5&#34; \
   -e &#34;openshift_azure_base_image_ns=magentaciimages&#34; \
   -e &#34;openshift_azure_image=openshift-gi-\$(date +%Y%m%d%H%M%S)&#34; \
-  -e &#34;openshift_azure_clusterid=magentaci\${INSTANCE_PREFIX//-}&#34; \
+  -e &#34;openshift_azure_clusterid=ci\${INSTANCE_PREFIX//-}&#34; \
   playbooks/\${CLUSTER_PROFILE}/openshift-cluster/build_image.yml
 popd
 SCRIPT
@@ -693,7 +693,7 @@ pushd release/cluster/test-deploy/\${CLUSTER_PROFILE}
 TYPE=\$CLUSTER_PROFILE ../../bin/ansible.sh ansible-playbook \
   -e &#34;openshift_test_repo=\${location_url}&#34; \
   -e &#34;debug_level=5&#34; \
-  -e &#34;openshift_azure_clusterid=magentaci\${INSTANCE_PREFIX//-}&#34; \
+  -e &#34;openshift_azure_clusterid=ci\${INSTANCE_PREFIX//-}&#34; \
   playbooks/\${CLUSTER_PROFILE}/openshift-cluster/launch.yml
 popd
 SCRIPT
@@ -817,7 +817,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 pushd release/cluster/test-deploy/\${CLUSTER_PROFILE}
 TYPE=\$CLUSTER_PROFILE ../../bin/ansible.sh ansible-playbook \
-  -e &#34;openshift_azure_clusterid=magentaci\${INSTANCE_PREFIX//-}&#34; \
+  -e &#34;openshift_azure_clusterid=ci\${INSTANCE_PREFIX//-}&#34; \
   playbooks/\${CLUSTER_PROFILE}/openshift-cluster/deprovision.yml
 popd
 SCRIPT


### PR DESCRIPTION
Fix issue when resource group name is too long for Azure, remove repo and debug level when building the node image for publishing.