### PR TITLE
Prevent push of signed images to reg-aws

### DIFF
--- a/jobs/build/refresh-images/Jenkinsfile
+++ b/jobs/build/refresh-images/Jenkinsfile
@@ -115,7 +115,7 @@ images:update-dockerfile
 		buildlib.oit """
 --working-dir ${OIT_WORKING} --group openshift-${OSE_MAJOR}.${OSE_MINOR}
 images:build
---push-to-defaults --repo-type signed
+--repo-type signed
 """
 
 		try {


### PR DESCRIPTION
Erroneous refresh-images jobs are overwriting manually pushed / patched images. Since no one depends on signed images from this registry, disabling this behavior. 