### PR TITLE
Fix output_format when evars is set

### DIFF
--- a/sjb/actions/clonerefs.py
+++ b/sjb/actions/clonerefs.py
@@ -90,9 +90,9 @@ class ClonerefsAction(Action):
             repository=None,
             title="SYNC REPOSITORIES",
             script=_CLONEREFS_ACTION_TEMPLATE.render(repos=self.repos, upload_to_gcs_step=upload_to_gcs_step),
-            timeout=None
+            timeout=None,
+            output_format=self.output_format
         )
-        script_action.output_format = self.output_format
         steps += script_action.generate_build_steps()
 
         return steps

--- a/sjb/actions/evars.py
+++ b/sjb/actions/evars.py
@@ -15,8 +15,9 @@ class EvarsAction(Action):
     records extra -e vars for the Ansible install
     """
 
-    def __init__(self, evars):
+    def __init__(self, evars, output_format):
         self.evars = evars
+        self.output_format = output_format
 
     def generate_parameters(self):
         return []
@@ -26,5 +27,6 @@ class EvarsAction(Action):
             repository=None,
             title="RECORD EXTRA EVARS",
             script=_EVARS_ACTION_TEMPLATE.render(evars=self.evars),
-            timeout=None
+            timeout=None,
+            output_format = self.output_format
         ).generate_build_steps()

--- a/sjb/actions/script.py
+++ b/sjb/actions/script.py
@@ -30,7 +30,7 @@ class ScriptAction(Action):
     the repository as the working directory.
     """
 
-    def __init__(self, repository, script, title, timeout):
+    def __init__(self, repository, script, title, timeout, output_format):
         self.repository = repository
         self.script = script
         if title == None:
@@ -39,6 +39,7 @@ class ScriptAction(Action):
             timeout = 14400
         self.title = title
         self.timeout = timeout
+        self.output_format = output_format
 
     def generate_build_steps(self):
         return [render_task(

--- a/sjb/generate.py
+++ b/sjb/generate.py
@@ -162,13 +162,13 @@ if job_type == "test":
 
     # we need to expose the extra -e vars to the steps
     if "evars" in job_config:
-        actions.append(EvarsAction(job_config["evars"]))
+        actions.append(EvarsAction(job_config["evars"], output_format))
 
     def parse_action(action):
         if action["type"] == "script":
             debug("[INFO] Adding script action " + action.get("title", ""))
             return ScriptAction(action.get("repository", None), action["script"], action.get("title", None),
-                                action.get("timeout", None))
+                                action.get("timeout", None), output_format)
         elif action["type"] == "host_script":
             debug("[INFO] Adding host script action " + action.get("title", ""))
             return HostScriptAction(action["script"], action.get("title", None))


### PR DESCRIPTION
This fixes generated shell scripts when evars are set. Doesn't affect xml 
formatter so no changes to xmls are required