### PR TITLE
release-3.9 playbook: set openshift_image_tag to latest to copy it to

### DIFF
--- a/sjb/config/common/test_cases/origin_built_installed_release_39.yml
+++ b/sjb/config/common/test_cases/origin_built_installed_release_39.yml
@@ -105,6 +105,7 @@ extensions:
                          -e etcd_data_dir="${ETCD_DATA_DIR}" \
                          -e openshift_master_default_subdomain="${local_ip}.nip.io"             \
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
+                         -e openshift_image_tag="latest"                                        \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                       \
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
                          -e openshift_node_port_range='30000-32000'                             \

--- a/sjb/generated/test_branch_origin_extended_conformance_install_39.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_39.xml
@@ -554,6 +554,7 @@ ansible-playbook -vv --become               \
                  -e etcd_data_dir=&#34;\${ETCD_DATA_DIR}&#34; \
                  -e openshift_master_default_subdomain=&#34;\${local_ip}.nip.io&#34;             \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
+                 -e openshift_image_tag=&#34;latest&#34;                                        \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \


### PR DESCRIPTION
This should resolve failing system-container tests for 3.9

PTAL @sdodson @michaelgugino