### PR TITLE
remove defunct openshift rhel7 mirrors from rhel_base_images and kids

### DIFF
--- a/sjb/config/common/test_cases/rhel_base_images.yml
+++ b/sjb/config/common/test_cases/rhel_base_images.yml
@@ -27,7 +27,10 @@ extensions:
         rm -rf $contextdir/repos/*chrome*.repo
 
         # remove local openshift epel mirror - we will only temporarily mount this via imagebuilder during image builds
-        rm -rf $contextdir/repos/local_epel.repo 
+        rm -rf $contextdir/repos/local_epel.repo
+
+        # remove the now defunct openshift rhel-7 mirrors
+        rm -rf $contextdir/repos/openshift-rhel7-dependencies.repo
 
         # Add the online-int repo which has the latest jenkins rpms
         cat <<EOF > $contextdir/repos/rhel-7-server-ose-onlineint-rpms.repo

--- a/sjb/generated/push_jenkins_images.xml
+++ b/sjb/generated/push_jenkins_images.xml
@@ -222,7 +222,10 @@ rm -rf \$contextdir/repos/redhat-rhui*
 rm -rf \$contextdir/repos/*chrome*.repo
 
 # remove local openshift epel mirror - we will only temporarily mount this via imagebuilder during image builds
-rm -rf \$contextdir/repos/local_epel.repo 
+rm -rf \$contextdir/repos/local_epel.repo
+
+# remove the now defunct openshift rhel-7 mirrors
+rm -rf \$contextdir/repos/openshift-rhel7-dependencies.repo
 
 # Add the online-int repo which has the latest jenkins rpms
 cat &lt;&lt;EOF &gt; \$contextdir/repos/rhel-7-server-ose-onlineint-rpms.repo

--- a/sjb/generated/test_branch_jenkins_images.xml
+++ b/sjb/generated/test_branch_jenkins_images.xml
@@ -222,7 +222,10 @@ rm -rf \$contextdir/repos/redhat-rhui*
 rm -rf \$contextdir/repos/*chrome*.repo
 
 # remove local openshift epel mirror - we will only temporarily mount this via imagebuilder during image builds
-rm -rf \$contextdir/repos/local_epel.repo 
+rm -rf \$contextdir/repos/local_epel.repo
+
+# remove the now defunct openshift rhel-7 mirrors
+rm -rf \$contextdir/repos/openshift-rhel7-dependencies.repo
 
 # Add the online-int repo which has the latest jenkins rpms
 cat &lt;&lt;EOF &gt; \$contextdir/repos/rhel-7-server-ose-onlineint-rpms.repo

--- a/sjb/generated/test_pull_request_jenkins_images.xml
+++ b/sjb/generated/test_pull_request_jenkins_images.xml
@@ -222,7 +222,10 @@ rm -rf \$contextdir/repos/redhat-rhui*
 rm -rf \$contextdir/repos/*chrome*.repo
 
 # remove local openshift epel mirror - we will only temporarily mount this via imagebuilder during image builds
-rm -rf \$contextdir/repos/local_epel.repo 
+rm -rf \$contextdir/repos/local_epel.repo
+
+# remove the now defunct openshift rhel-7 mirrors
+rm -rf \$contextdir/repos/openshift-rhel7-dependencies.repo
 
 # Add the online-int repo which has the latest jenkins rpms
 cat &lt;&lt;EOF &gt; \$contextdir/repos/rhel-7-server-ose-onlineint-rpms.repo


### PR DESCRIPTION
@openshift/sig-continuous-infrastructure @openshift/sig-continuous-delivery @bparees ptal

See https://github.com/openshift/jenkins/pull/591#issuecomment-386410678 and http://post-office.corp.redhat.com/archives/aos-cicd/2018-May/msg00028.html