### PR TITLE
Adding authentication to quay.io

### DIFF
--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -46,6 +46,11 @@ def registry_login() {
         sh 'chmod +x docker_login.sh'
         sh './docker_login.sh'
     }
+    // Login to quay.io
+    withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'creds_registry.quay.io',
+                      usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD']]) {
+        sh 'docker login -u $USERNAME -p $PASSWORD quay.io'
+    }
 }
 
 def print_tags(image_name) {


### PR DESCRIPTION
Pipelines will now authenticate with quay.io so that oit can push during a build. Right now, only a single image pushes to quay.io (3.10 openshift-enterprise-node-docker pushes as openshift/ocp-node). Clayton wants us to check with him as each image is added to quay. Note that he wanted the name of ose-node changed to ocp-node for the current image. I think that will be the general naming convention (ocp vs ose).