### PR TITLE
Bump k8s CI jobs to go1.10.2

### DIFF
--- a/sjb/config/test_cases/ci-kubernetes-conformance-node-e2e-containerized-rhel.yml
+++ b/sjb/config/test_cases/ci-kubernetes-conformance-node-e2e-containerized-rhel.yml
@@ -5,16 +5,16 @@ overrides:
 extensions:
   actions:
     - type: "script"
-      title: "Install go 1.10.1"
+      title: "Install go 1.10.2"
       script: |-
         mkdir -p ~/bin
         curl -sL -o ~/bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
         chmod +x ~/bin/gimme
-        gimme 1.10.1
+        gimme 1.10.2
     - type: "script"
       title: "Build hyperkube image"
       script: |-
-        source ~/.gimme/envs/go1.10.1.env
+        source ~/.gimme/envs/go1.10.2.env
         # The docker run command run by the systemd-run can get longer than 2048 characters,
         # causing the systemd-run command to fail. Thus, in order to minimize the
         # length of all arguments, we need to replace /home/origin with /go prefix path.
@@ -36,7 +36,7 @@ extensions:
     - type: "script"
       title: "Run node e2e tests over containerized Kubelet"
       script: |-
-        source ~/.gimme/envs/go1.10.1.env
+        source ~/.gimme/envs/go1.10.2.env
         export GOPATH=/go
         cd /go/src/k8s.io/kubernetes
         IMAGE_TAG=$(git describe --abbrev=0)

--- a/sjb/config/test_cases/ci-kubernetes-conformance-node-e2e-rhel.yml
+++ b/sjb/config/test_cases/ci-kubernetes-conformance-node-e2e-rhel.yml
@@ -5,16 +5,16 @@ overrides:
 extensions:
   actions:
     - type: "script"
-      title: "Install go 1.10.1"
+      title: "Install go 1.10.2"
       script: |-
         mkdir -p ~/bin
         curl -sL -o ~/bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
         chmod +x ~/bin/gimme
-        gimme 1.10.1
+        gimme 1.10.2
     - type: "script"
       title: "Run node e2e tests"
       script: |-
-        source ~/.gimme/envs/go1.10.1.env
+        source ~/.gimme/envs/go1.10.2.env
         export GOPATH=$(pwd)
         env
         cd src/k8s.io/kubernetes

--- a/sjb/generated/ci-kubernetes-conformance-node-e2e-containerized-rhel.xml
+++ b/sjb/generated/ci-kubernetes-conformance-node-e2e-containerized-rhel.xml
@@ -247,7 +247,7 @@ fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL GO 1.10.1 ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL GO 1.10.1 [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL GO 1.10.2 ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL GO 1.10.2 [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
@@ -256,7 +256,7 @@ cd &#34;\${HOME}&#34;
 mkdir -p ~/bin
 curl -sL -o ~/bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
 chmod +x ~/bin/gimme
-gimme 1.10.1
+gimme 1.10.2
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -270,7 +270,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
-source ~/.gimme/envs/go1.10.1.env
+source ~/.gimme/envs/go1.10.2.env
 # The docker run command run by the systemd-run can get longer than 2048 characters,
 # causing the systemd-run command to fail. Thus, in order to minimize the
 # length of all arguments, we need to replace /home/origin with /go prefix path.
@@ -302,7 +302,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
-source ~/.gimme/envs/go1.10.1.env
+source ~/.gimme/envs/go1.10.2.env
 export GOPATH=/go
 cd /go/src/k8s.io/kubernetes
 IMAGE_TAG=\$(git describe --abbrev=0)

--- a/sjb/generated/ci-kubernetes-conformance-node-e2e-rhel.xml
+++ b/sjb/generated/ci-kubernetes-conformance-node-e2e-rhel.xml
@@ -247,7 +247,7 @@ fi</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
-SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL GO 1.10.1 ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL GO 1.10.1 [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: INSTALL GO 1.10.2 ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: INSTALL GO 1.10.2 [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
 script=&#34;$( mktemp )&#34;
 cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
@@ -256,7 +256,7 @@ cd &#34;\${HOME}&#34;
 mkdir -p ~/bin
 curl -sL -o ~/bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
 chmod +x ~/bin/gimme
-gimme 1.10.1
+gimme 1.10.2
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -270,7 +270,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
-source ~/.gimme/envs/go1.10.1.env
+source ~/.gimme/envs/go1.10.2.env
 export GOPATH=\$(pwd)
 env
 cd src/k8s.io/kubernetes


### PR DESCRIPTION
Because https://github.com/kubernetes/kubernetes/pull/63412

Wondering if it would be better to detect the version automatically, e.g. by running `grep "minimum_go_version=go" hack/lib/golang.sh | cut -d'=' -f2`. Still, even the `hack/lib/golang.sh` and the `minimum_go_version` variable can change over time so it's not bulletproof.