### PR TITLE
Skip cluster operator builds when deploying.

### DIFF
--- a/sjb/config/test_cases/test_branch_cluster_operator_e2e.yml
+++ b/sjb/config/test_cases/test_branch_cluster_operator_e2e.yml
@@ -53,7 +53,7 @@ extensions:
       repository: "cluster-operator"
       script: |-
         export PATH="${PATH}:/data/src/github.com/openshift/origin/_output/local/bin/linux/amd64:/data/bin"
-        sudo env "PATH=${PATH}" ansible-playbook ./contrib/ansible/deploy-devel-playbook.yml
+        sudo env "PATH=${PATH}" ansible-playbook ./contrib/ansible/deploy-devel-playbook.yml -e push_images=False
     - type: "script"
       title: "Create Cluster"
       repository: "cluster-operator"

--- a/sjb/generated/test_branch_cluster_operator_e2e.xml
+++ b/sjb/generated/test_branch_cluster_operator_e2e.xml
@@ -360,7 +360,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/cluster-operator&#34;
 export PATH=&#34;\${PATH}:/data/src/github.com/openshift/origin/_output/local/bin/linux/amd64:/data/bin&#34;
-sudo env &#34;PATH=\${PATH}&#34; ansible-playbook ./contrib/ansible/deploy-devel-playbook.yml
+sudo env &#34;PATH=\${PATH}&#34; ansible-playbook ./contrib/ansible/deploy-devel-playbook.yml -e push_images=False
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_cluster_operator_e2e.xml
+++ b/sjb/generated/test_pull_request_cluster_operator_e2e.xml
@@ -360,7 +360,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/cluster-operator&#34;
 export PATH=&#34;\${PATH}:/data/src/github.com/openshift/origin/_output/local/bin/linux/amd64:/data/bin&#34;
-sudo env &#34;PATH=\${PATH}&#34; ansible-playbook ./contrib/ansible/deploy-devel-playbook.yml
+sudo env &#34;PATH=\${PATH}&#34; ansible-playbook ./contrib/ansible/deploy-devel-playbook.yml -e push_images=False
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;


### PR DESCRIPTION
This is handled separately for the CI jobs due to path issues.

Will be needed before https://github.com/openshift/cluster-operator/pull/195 can merge. Should be a no-op in the meantime.

CC @csrwng 