### PR TITLE
just pass in the data needed

### DIFF
--- a/jobs/build/ocp/Jenkinsfile
+++ b/jobs/build/ocp/Jenkinsfile
@@ -55,7 +55,7 @@ def get_mirror_url(build_mode, version) {
     return "https://mirror.openshift.com/enterprise/enterprise-${version}"
 }
 
-def mail_success(version, mirrorURL, buildlib) {
+def mail_success(version, mirrorURL, record_log) {
 
     def target = "(Release Candidate)"
 
@@ -72,8 +72,8 @@ def mail_success(version, mirrorURL, buildlib) {
         inject_notes = "\n***Special notes associated with this build****\n${SPECIAL_NOTES.trim()}\n***********************************************\n"
     }
 
-    def timing_report = get_build_timing_report(buildlib)
-    def image_list = get_image_build_report(buildlib)
+    def timing_report = get_build_timing_report(record_log)
+    def image_list = get_image_build_report(record_log)
 
     PARTIAL = " "
     exclude_subject = ""
@@ -154,12 +154,11 @@ ${OA_CHANGELOG}
 // extract timing information from the record_log and write a report string
 // the timing record log entry has this form:
 // image_build_metrics|elapsed_total_minutes={d}|task_count={d}|elapsed_wait_minutes={d}|
-def get_build_timing_report(buildlib) {
-
-    record_log = buildlib.parse_record_log(OIT_WORKING)
+def get_build_timing_report(record_log) {
     metrics = record_log['image_build_metrics']
+
     if (metrics == null || metrics.size == 0) {
-	return ""
+        return ""
     }
 
     return """
@@ -170,9 +169,7 @@ Time spent waiting for OSBS capacity: ${metrics[0]['elapsed_wait_minutes']} minu
 }
 
 // get the list of images built
-def get_image_build_report(buildlib) {
-
-    record_log = buildlib.parse_record_log(OIT_WORKING)
+def get_image_build_report(record_log) {
     builds = record_log['build']
 
     Set image_set = []
@@ -836,7 +833,8 @@ Please direct any questsions to the Continuous Delivery team (#aos-cd-team on IR
             echo "Finished building OCP ${NEW_FULL_VERSION}"
             PREV_BUILD = null  // We are done. Don't untag even if there is an error sending the email.
 
-            mail_success(NEW_FULL_VERSION, mirror_url, buildlib)
+            record_log = buildlib.parse_record_log(OIT_WORKING)
+            mail_success(NEW_FULL_VERSION, mirror_url, record_log)
         }
     } catch (err) {
 


### PR DESCRIPTION
With this change, only the data actually needed by the report functions is passed in.  The data used inside is clearly noted for the reader so that they can understand just by reading the function signature why the data is being passed in.

This reduces exposure to unexpected fails if the format or behavior of the buildlib functions changes.