### PR TITLE
remove additional defunct rhel/centos repos for jenkins image build

### DIFF
--- a/sjb/config/common/test_cases/rhel_base_images.yml
+++ b/sjb/config/common/test_cases/rhel_base_images.yml
@@ -31,6 +31,9 @@ extensions:
 
         # remove the now defunct openshift rhel-7 mirrors
         rm -rf $contextdir/repos/openshift-rhel7-dependencies.repo
+        rm -rf $contextdir/repos/centos-paas-sig-openshift*
+        rm -rf $contextdir/repos/rhel-7-server-ose-*
+
 
         # Add the online-int repo which has the latest jenkins rpms
         cat <<EOF > $contextdir/repos/rhel-7-server-ose-onlineint-rpms.repo

--- a/sjb/generated/push_jenkins_images.xml
+++ b/sjb/generated/push_jenkins_images.xml
@@ -226,6 +226,9 @@ rm -rf \$contextdir/repos/local_epel.repo
 
 # remove the now defunct openshift rhel-7 mirrors
 rm -rf \$contextdir/repos/openshift-rhel7-dependencies.repo
+rm -rf \$contextdir/repos/centos-paas-sig-openshift*
+rm -rf \$contextdir/repos/rhel-7-server-ose-*
+
 
 # Add the online-int repo which has the latest jenkins rpms
 cat &lt;&lt;EOF &gt; \$contextdir/repos/rhel-7-server-ose-onlineint-rpms.repo

--- a/sjb/generated/test_branch_jenkins_images.xml
+++ b/sjb/generated/test_branch_jenkins_images.xml
@@ -226,6 +226,9 @@ rm -rf \$contextdir/repos/local_epel.repo
 
 # remove the now defunct openshift rhel-7 mirrors
 rm -rf \$contextdir/repos/openshift-rhel7-dependencies.repo
+rm -rf \$contextdir/repos/centos-paas-sig-openshift*
+rm -rf \$contextdir/repos/rhel-7-server-ose-*
+
 
 # Add the online-int repo which has the latest jenkins rpms
 cat &lt;&lt;EOF &gt; \$contextdir/repos/rhel-7-server-ose-onlineint-rpms.repo

--- a/sjb/generated/test_pull_request_jenkins_images.xml
+++ b/sjb/generated/test_pull_request_jenkins_images.xml
@@ -226,6 +226,9 @@ rm -rf \$contextdir/repos/local_epel.repo
 
 # remove the now defunct openshift rhel-7 mirrors
 rm -rf \$contextdir/repos/openshift-rhel7-dependencies.repo
+rm -rf \$contextdir/repos/centos-paas-sig-openshift*
+rm -rf \$contextdir/repos/rhel-7-server-ose-*
+
 
 # Add the online-int repo which has the latest jenkins rpms
 cat &lt;&lt;EOF &gt; \$contextdir/repos/rhel-7-server-ose-onlineint-rpms.repo


### PR DESCRIPTION
@bparees @openshift/sig-continuous-infrastructure fyi

see https://github.com/openshift/jenkins/pull/591