### PR TITLE
Removed qualification to send CI bus message only for starter.

### DIFF
--- a/jobs/starter/upgrade/Jenkinsfile
+++ b/jobs/starter/upgrade/Jenkinsfile
@@ -273,7 +273,7 @@ Jenkins job: ${env.BUILD_URL}
     }
 
 
-    if ( MODE != "silent" && "${env.BRANCH_NAME}".contains( "starter" )  ) {
+    if ( MODE != "silent" ) {
         try {
             // Send out a CI message for QE
             build job: 'starter%2Fsend-ci-msg',


### PR DESCRIPTION
This will allow QE to monitor for all CI bus upgrade messages relating to OSO Starter, OSO Ded, and OSO Pro.