### PR TITLE
Run "delete-yum-repos" during stage "upgrade: misc"

### DIFF
--- a/jobs/starter/upgrade/Jenkinsfile
+++ b/jobs/starter/upgrade/Jenkinsfile
@@ -183,6 +183,7 @@ node('openshift-build-1') {
                 if ( UPGRADE_NODES.toBoolean()  ) {
                     deploylib.run( "unschedule-extra-nodes" ) // Used to scale down dedicated instance if extra node is created prior to upgrade to ensure capacity.
                 }
+                deploylib.run( "delete-yum-repos" )
             }                 
             
             stage( "config-loop" ) {


### PR DESCRIPTION
Removes the `reposdir` override in `/etc/yum.conf`.