### PR TITLE
add retry to rebuild-images

### DIFF
--- a/jobs/build/ocp/Jenkinsfile
+++ b/jobs/build/ocp/Jenkinsfile
@@ -891,7 +891,7 @@ Please direct any questsions to the Continuous Delivery team (#aos-cd-team on IR
                                             "RETRY",
                                             "CONTINUE",
                                             "ABORT"
-                                        ],join("\n")
+                                        ].join("\n")
                                     ]
                                 ]
                             )

--- a/jobs/build/ocp/Jenkinsfile
+++ b/jobs/build/ocp/Jenkinsfile
@@ -2,35 +2,141 @@
 
 // Expose properties for a parameterized build
 properties(
+    [
+        buildDiscarder(
+	    logRotator(
+		artifactDaysToKeepStr: '',
+		artifactNumToKeepStr: '',
+		daysToKeepStr: '',
+		numToKeepStr: '1000'
+	    )
+	),
         [
-                buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '1000')),
-                [$class              : 'ParametersDefinitionProperty',
-                 parameterDefinitions:
-                         [
-                                 [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'openshift-build-1', description: 'Jenkins agent node', name: 'TARGET_NODE'],
-                                 [$class: 'hudson.model.ChoiceParameterDefinition', choices: "git@github.com:openshift\ngit@github.com:jupierce\ngit@github.com:jupierce-aos-cd-bot\ngit@github.com:adammhaile-aos-cd-bot", defaultValue: 'git@github.com:openshift', description: 'Github base for repos', name: 'GITHUB_BASE'],
-                                 [$class: 'hudson.model.ChoiceParameterDefinition', choices: "openshift-bot\naos-cd-test\njupierce-aos-cd-bot\nadammhaile-aos-cd-bot", defaultValue: 'aos-cd-test', description: 'SSH credential id to use', name: 'SSH_KEY_ID'],
-                                 [$class: 'hudson.model.ChoiceParameterDefinition', choices: "3.10\n3.9\n3.8\n3.7\n3.6\n3.5\n3.4\n3.3", defaultValue: '3.10', description: 'OCP Version to build', name: 'BUILD_VERSION'],
-                                 [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'aos-cicd@redhat.com, aos-qe@redhat.com,jupierce@redhat.com,smunilla@redhat.com,ahaile@redhat.com', description: 'Success Mailing List', name: 'MAIL_LIST_SUCCESS'],
-                                 [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'jupierce@redhat.com,smunilla@redhat.com,ahaile@redhat.com,bbarcaro@redhat.com', description: 'Failure Mailing List', name: 'MAIL_LIST_FAILURE'],
-                                 [$class             : 'hudson.model.ChoiceParameterDefinition', choices: "release\npre-release\nonline:int\nonline:stg", description:
-                                         '''
+	    $class: 'ParametersDefinitionProperty',
+            parameterDefinitions: [
+                [	
+		    name: 'TARGET_NODE',
+		    description: 'Jenkins agent node',
+		    $class: 'hudson.model.StringParameterDefinition',
+		    defaultValue: 'openshift-build-1'
+		],
+                [
+		    name: 'GITHUB_BASE',
+		    description: 'Github base for repos',
+		    $class: 'hudson.model.ChoiceParameterDefinition',
+		    choices: [
+			"git@github.com:openshift",
+			"git@github.com:jupierce",
+			"git@github.com:jupierce-aos-cd-bot",
+			"git@github.com:adammhaile-aos-cd-bot"
+		    ].join("\n"),
+		    defaultValue: 'git@github.com:openshift'
+		],
+                [
+		    name: 'SSH_KEY_ID',
+		    description: 'SSH credential id to use',
+		    $class: 'hudson.model.ChoiceParameterDefinition',
+		    choices: [
+			"openshift-bot",
+			"aos-cd-test",
+			"jupierce-aos-cd-bot",
+			"adammhaile-aos-cd-bot"
+		    ].join("\n"),
+		    defaultValue: 'aos-cd-test'
+		],
+                [
+		    name: 'BUILD_VERSION',
+		    description: 'OCP Version to build',
+		    $class: 'hudson.model.ChoiceParameterDefinition',
+		    choices: "3.10\n3.9\n3.8\n3.7\n3.6\n3.5\n3.4\n3.3",
+		    defaultValue: '3.10'
+		],
+                [
+		    name: 'MAIL_LIST_SUCCESS',
+		    description: 'Success Mailing List',
+		    $class: 'hudson.model.StringParameterDefinition',
+		    defaultValue: [
+			'aos-cicd@redhat.com',
+			'aos-qe@redhat.com',
+			'jupierce@redhat.com',
+			'smunilla@redhat.com',
+			'ahaile@redhat.com'
+		    ].join(',')
+		],
+                [
+		    name: 'MAIL_LIST_FAILURE',
+		    description: 'Failure Mailing List',
+		    $class: 'hudson.model.StringParameterDefinition',
+		    defaultValue: [
+			'jupierce@redhat.com',
+			'smunilla@redhat.com',
+			'ahaile@redhat.com',
+			'bbarcaro@redhat.com'
+		    ].join(',')
+		],
+                [
+		    name: 'BUILD_MODE',
+		    description:
+                        '''
 release                   {ose,origin-web-console,openshift-ansible}/release-X.Y ->  https://mirror.openshift.com/enterprise/enterprise-X.Y/<br>
 pre-release               {origin,origin-web-console,openshift-ansible}/release-X.Y ->  https://mirror.openshift.com/enterprise/enterprise-X.Y/<br>
 online:int                {origin,origin-web-console,openshift-ansible}/master -> online-int yum repo<br>
 online:stg                {origin,origin-web-console,openshift-ansible}/stage -> online-stg yum repo<br>
-''', name: 'BUILD_MODE'],
-                                 [$class: 'hudson.model.BooleanParameterDefinition', defaultValue: false, description: 'Sign RPMs with openshifthosted?', name: 'SIGN'],
-                                 [$class: 'hudson.model.BooleanParameterDefinition', defaultValue: false, description: 'Mock run to pickup new Jenkins parameters?', name: 'MOCK'],
-                                 [$class: 'hudson.model.BooleanParameterDefinition', defaultValue: false, description: 'Run as much code as possible without pushing / building?', name: 'TEST'],
-                                 [$class: 'hudson.model.TextParameterDefinition', defaultValue: "", description: 'Include special notes in the build email?', name: 'SPECIAL_NOTES'],
-                                 [$class: 'hudson.model.StringParameterDefinition', defaultValue: "", description: 'Exclude these images from builds. Comma or space separated list. (i.e cri-o-docker,aos3-installation-docker)', name: 'BUILD_EXCLUSIONS'],
-                                 [$class: 'hudson.model.BooleanParameterDefinition', defaultValue: true, description: 'Build container images?', name: 'BUILD_CONTAINER_IMAGES'],
-                                 [$class: 'hudson.model.BooleanParameterDefinition', defaultValue: true, description: 'Build golden image after building images?', name: 'BUILD_AMI'],
-                         ]
-                ],
-                disableConcurrentBuilds()
-        ]
+''',
+		    $class: 'hudson.model.ChoiceParameterDefinition',
+		    choices: [
+			"release",
+			"pre-release",
+			"online:int",
+			"online:stg"
+		    ].join("\n")
+		],
+                [
+		    name: 'SIGN',
+		    description: 'Sign RPMs with openshifthosted?',
+		    $class: 'hudson.model.BooleanParameterDefinition',
+		    defaultValue: false
+		],
+                [
+		    name: 'MOCK',
+		    description: 'Mock run to pickup new Jenkins parameters?',
+		    $class: 'hudson.model.BooleanParameterDefinition',
+		    defaultValue: false
+		],
+                [
+		    name: 'TEST',
+		    description: 'Run as much code as possible without pushing / building?',
+		    $class: 'hudson.model.BooleanParameterDefinition',
+		    defaultValue: false
+		],
+                [
+		    name: 'SPECIAL_NOTES',
+		    $class: 'hudson.model.TextParameterDefinition',
+		    defaultValue: "",
+		    description: 'Include special notes in the build email?'
+		],
+                [
+		    name: 'BUILD_EXCLUSIONS',
+		    description: 'Exclude these images from builds. Comma or space separated list. (i.e cri-o-docker,aos3-installation-docker)',
+		    $class: 'hudson.model.StringParameterDefinition',
+		    defaultValue: ""
+		],
+                [
+		    name: 'BUILD_CONTAINER_IMAGES',
+		    description: 'Build container images?',
+		    $class: 'hudson.model.BooleanParameterDefinition',
+		    defaultValue: true
+		],
+                [
+		    name: 'BUILD_AMI',
+		    description: 'Build golden image after building images?',
+		    $class: 'hudson.model.BooleanParameterDefinition',
+		    defaultValue: true
+		],
+            ]
+        ],
+        disableConcurrentBuilds()
+    ]
 )
 
 IS_TEST_MODE = TEST.toBoolean()
@@ -730,12 +836,16 @@ Please direct any questsions to the Continuous Delivery team (#aos-cd-team on IR
                             if (BUILD_EXCLUSIONS != "") {
                                 exclude = "-x ${BUILD_EXCLUSIONS} --ignore-missing-base"
                             }
-                            buildlib.oit """
-    --working-dir ${OIT_WORKING} --group openshift-${BUILD_VERSION}
-    ${exclude}
-    images:build
-    --push-to-defaults --repo-type unsigned
-    """
+                            buildlib.oit(
+                                [
+                                    "--working-dir ${OIT_WORKING}",
+                                    "--group openshift-${BUILD_VERSION}",
+                                    exclude,
+                                    "images:build",
+                                    "--push-to-defaults",
+                                    "--repo-type unsigned"
+                                ].join(' ')
+                            )
                             return true // finish waitUntil
                         }
                         catch (err) {
@@ -755,10 +865,13 @@ Please direct any questsions to the Continuous Delivery team (#aos-cd-team on IR
                                 }
                             }
 
-                            mail(to: "${MAIL_LIST_FAILURE}",
-                                    from: "aos-cicd@redhat.com",
-                                    subject: "RESUMABLE Error during Image Build for OCP v${BUILD_VERSION}",
-                                    body: """Encountered an error: ${err}
+			                      // notify the caller of a resumable error
+                            mail(
+                                to: "${MAIL_LIST_FAILURE}",
+                                from: "aos-cicd@redhat.com",
+                                subject: "RESUMABLE Error during Image Build for OCP v${BUILD_VERSION}",
+                                body:
+				    """Encountered an error: ${err}
     Input URL: ${env.BUILD_URL}input
     Jenkins job: ${env.BUILD_URL}
 
@@ -766,33 +879,50 @@ Please direct any questsions to the Continuous Delivery team (#aos-cd-team on IR
     ${failed_map}
     """);
 
-                            def resp = input message: "Error during Image Build for OCP v${BUILD_VERSION}",
-                                    parameters: [
-                                            [$class     : 'hudson.model.ChoiceParameterDefinition',
-                                             choices    : "RETRY\nCONTINUE\nABORT",
-                                             description: 'Retry (try the operation again). Continue (fails are OK, continue pipeline). Abort (terminate the pipeline).',
-                                             name       : 'action']
+			                      // Query the user on the CLI and get a response
+                            def resp = input(
+                                message: "Error during Image Build for OCP v${BUILD_VERSION}",
+                                parameters: [
+                                    [
+                                        name: 'action'
+                                        description: 'Retry (try the operation again). Continue (fails are OK, continue pipeline). Abort (terminate the pipeline).',
+                                        $class: 'hudson.model.ChoiceParameterDefinition',
+                                        choices: [
+                                            "RETRY",
+                                            "CONTINUE",
+                                            "ABORT"
+                                        ],join("\n")
                                     ]
+                                ]
+                            )
 
-                            if (resp == "RETRY") {
-                                return false  // cause waitUntil to loop again
-                            } else if (resp == "CONTINUE") {
-                                echo "User chose to continue. Build failures are non-fatal."
-                                BUILD_EXCLUSIONS = failed_map.keySet().join(",") //will make email show PARTIAL
-                                BUILD_CONTINUED = true //simply setting flag to keep required work out of input flow
-                                return true // Terminate waitUntil
-                            } else { // ABORT
-                                error("User chose to abort pipeline because of image build failures")
+                            // decide how to proceed after error
+                            switch (resp) {
+                                case "RETRY":
+                                    // cause waitUntil to loop again
+                                    return false
+                                case "CONTINUE":
+                                    echo "User chose continue. Build failures are non-fatal."
+                                    BUILD_CONTINUED = true
+                                    return true // Terminate waitUntil
+                                default: // ABORT
+                                    error("User chose to abort pipeline because of image build failures")
                             }
                         }
                     }
 
                     if (BUILD_CONTINUED) {
-                        buildlib.oit """
-    --working-dir ${OIT_WORKING} --group openshift-${BUILD_VERSION}
-    ${exclude} images:push --to-defaults --late-only
-    """
-                        // exclude is already set earlier in the main images:build flow
+                        buildlib.oit(
+                            [
+                                "--working-dir ${OIT_WORKING}",
+                                "--group openshift-${BUILD_VERSION}",
+                                exclude,
+                                "images:push",
+                                "--to-defaults",
+                                "--late-only"
+                            ]
+                        )
+                        // exclude is set earlier in the main images:build flow
                     }
                 }
             }

--- a/jobs/build/refresh-images/Jenkinsfile
+++ b/jobs/build/refresh-images/Jenkinsfile
@@ -24,33 +24,134 @@ ${OSE_MAJOR}.${OSE_MINOR}
 """);
 }
 
+//
+// Search the build log for 
+//
+def get_failed_builds(log_dir) {
+    record_log = buildlib.parse_record_log(log_dir)
+    builds = record_log['build']
+    failed_map = [:]
+    for (i = 0; i < builds.size(); i++) {
+        bld = builds[i]
+        distgit = bld['distgit']
+        if (bld['status'] != '0') {
+            failed_map[distgit] = bld['task_url']
+        } else if (bld['push_status'] != '0') {
+            failed_map[distgit] = 'Failed to push built image. See debug.log'
+        } else {
+            // build may have succeeded later. If so, remove.
+            failed_map.remove(distgit)
+        }
+    }
+
+    return failed_map
+}
+
+
 node('openshift-build-1') {
     checkout scm
 
     // Expose properties for a parameterized build
     properties(
-            [buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '720')),
-             [$class              : 'ParametersDefinitionProperty',
-              parameterDefinitions:
-                      [
-                              [$class: 'hudson.model.ChoiceParameterDefinition', choices: "git@github.com:openshift\ngit@github.com:jupierce\ngit@github.com:jupierce-aos-cd-bot\ngit@github.com:adammhaile-aos-cd-bot", defaultValue: 'git@github.com:openshift', description: 'Github base for repos', name: 'GITHUB_BASE'],
-                              [$class: 'hudson.model.ChoiceParameterDefinition', choices: "3", defaultValue: '3', description: 'OSE Major Version', name: 'OSE_MAJOR'],
-                              [$class: 'hudson.model.ChoiceParameterDefinition', choices: "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15", defaultValue: '9', description: 'OSE Minor Version', name: 'OSE_MINOR'],
-                              [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'auto', description: 'Optional version to use. (i.e. v3.6.17). Defaults to "auto"', name: 'VERSION_OVERRIDE'],
-                              [$class: 'hudson.model.StringParameterDefinition', defaultValue: '', description: 'Optional release to use. Must be > 1 (i.e. 2)', name: 'RELEASE_OVERRIDE'],
-                              [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'jupierce@redhat.com,ahaile@redhat.com,smunilla@redhat.com,bbarcaro@redhat.com', description: 'Success Mailing List', name: 'MAIL_LIST_SUCCESS'],
-                              [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'jupierce@redhat.com,ahaile@redhat.com,smunilla@redhat.com,bbarcaro@redhat.com', description: 'Failure Mailing List', name: 'MAIL_LIST_FAILURE'],
-                              [$class: 'BooleanParameterDefinition', defaultValue: false, description: 'Mock run to pickup new Jenkins parameters?.', name: 'MOCK'],
-                              // TODO reenable when the mirrors have the necessary puddles
-                              [$class: 'hudson.model.BooleanParameterDefinition', defaultValue: false, description: 'Build golden image after building images?', name: 'BUILD_AMI'],
-                      ]
-             ]]
+        [
+            buildDiscarder(
+                logRotator(
+                    artifactDaysToKeepStr: '',
+                    artifactNumToKeepStr: '',
+                    daysToKeepStr: '',
+                    numToKeepStr: '720'
+                )
+            ),
+            [
+                $class: 'ParametersDefinitionProperty',
+                parameterDefinitions:[
+                    [
+                        name: 'GITHUB_BASE',
+                        description: 'Github base for repos',
+                        $class: 'hudson.model.ChoiceParameterDefinition',
+                        choices: [
+                            "git@github.com:openshift",
+                            "git@github.com:jupierce",
+                            "git@github.com:jupierce-aos-cd-bot",
+                            "git@github.com:adammhaile-aos-cd-bot"
+                        ].join("\n"),
+                        defaultValue: 'git@github.com:openshift'
+                    ],
+                    [
+                        name: 'OSE_MAJOR',
+                        description: 'OSE Major Version',
+                        $class: 'hudson.model.ChoiceParameterDefinition',
+                        choices: "3",
+                        defaultValue: '3'
+                    ],
+                    [
+                        name: 'OSE_MINOR',
+                        description: 'OSE Minor Version',
+                        $class: 'hudson.model.ChoiceParameterDefinition',
+                        choices: "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15",
+                        defaultValue: '9'
+                    ],
+                    [
+                        name: 'VERSION_OVERRIDE',
+                        description: 'Optional version to use. (i.e. v3.6.17). Defaults to "auto"',
+                        $class: 'hudson.model.StringParameterDefinition',
+                        defaultValue: 'auto'
+                    ],
+                    [
+                        name: 'RELEASE_OVERRIDE',
+                        description: 'Optional release to use. Must be > 1 (i.e. 2)',
+                        $class: 'hudson.model.StringParameterDefinition',
+                        defaultValue: ''
+                    ],
+                    [
+                        name: 'MAIL_LIST_SUCCESS',
+                        description: 'Success Mailing List',
+                        $class: 'hudson.model.StringParameterDefinition',
+                        defaultValue: [
+                            'jupierce@redhat.com',
+                            'ahaile@redhat.com',
+                            'smunilla@redhat.com',
+                            'bbarcaro@redhat.com'
+                        ].join(',')
+                    ],
+                    [
+                        name: 'MAIL_LIST_FAILURE',
+                        description: 'Failure Mailing List',
+                        $class: 'hudson.model.StringParameterDefinition',
+                        defaultValue: [
+                            'jupierce@redhat.com',
+                            'ahaile@redhat.com',
+                            'smunilla@redhat.com',
+                            'bbarcaro@redhat.com'
+                        ].join(',')
+                    ],
+                    [
+                        name: 'MOCK',
+                        description: 'Mock run to pickup new Jenkins parameters?.',
+                        $class: 'BooleanParameterDefinition',
+                        defaultValue: false
+                    ],
+                    // TODO reenable when the mirrors have the necessary puddles
+                    [
+                        name: 'BUILD_AMI',
+                        description: 'Build golden image after building images?',
+                        $class: 'hudson.model.BooleanParameterDefinition',
+                        defaultValue: false
+                    ],
+                ]
+            ]
+        ]
     )
 
-    // Force Jenkins to fail early if this is the first time this job has been run/and or new parameters have not been discovered.
-    echo "${OSE_MAJOR}.${OSE_MINOR}, MAIL_LIST_SUCCESS:[${MAIL_LIST_SUCCESS}], MAIL_LIST_FAILURE:[${MAIL_LIST_FAILURE}], MOCK:${MOCK}"
+    // Force Jenkins to fail early if this is the first time this job has been
+    // run/and or new parameters have not been discovered.
+    echo "${OSE_MAJOR}.${OSE_MINOR}, " +
+        "MAIL_LIST_SUCCESS:[${MAIL_LIST_SUCCESS}], " +
+        "MAIL_LIST_FAILURE:[${MAIL_LIST_FAILURE}], " +
+        "MOCK:${MOCK}"
 
-    currentBuild.displayName = "#${currentBuild.number} - ${OSE_MAJOR}.${OSE_MINOR}"
+    currentBuild.displayName =
+        "#${currentBuild.number} - ${OSE_MAJOR}.${OSE_MINOR}"
 
     if (MOCK.toBoolean()) {
         error("Ran in mock mode")
@@ -72,10 +173,12 @@ node('openshift-build-1') {
     sh "mkdir -p ${OIT_WORKING}"
 
     stage('Refresh Images') {
-        try {
+        try {  // all refresh steps
+            // Clean up old images to conserve device mapper space
             try {
-                // Clean up old images so that we don't run out of device mapper space
-                sh "docker rmi --force \$(docker images  | grep v${OSE_MAJOR}.${OSE_MINOR} | awk '{print \$3}')"
+                sh "docker rmi --force \$(docker images  | " +
+                    "grep v${OSE_MAJOR}.${OSE_MINOR} | " +
+                    "awk '{print \$3}')"
             } catch (cce) {
                 echo "Error cleaning up old images: ${cce}"
             }
@@ -94,42 +197,138 @@ node('openshift-build-1') {
                 }
 
                 if (RELEASE_OVERRIDE != "") {
-                    oit_update_docker_args = "${oit_update_docker_args} --release ${RELEASE_OVERRIDE}"
+                    oit_update_docker_args =
+                        "${oit_update_docker_args} --release ${RELEASE_OVERRIDE}"
                 }
 
-                sh "kinit -k -t /home/jenkins/ocp-build-buildvm.openshift.eng.bos.redhat.com.keytab ocp-build/buildvm.openshift.eng.bos.redhat.com@REDHAT.COM"
+                // operations with brew require kerberos auth
+                buildlib.kinit()
 
                 /**
-                 * By default, do not specify a version or release for oit. This will preserve the version label and remove
-                 * the release label. OSBS now chooses a viable release label to prevent conflicting with pre-existing
+                 * By default, do not specify a version or release for oit.
+                 * This will preserve the version label and remove
+                 * the release label. OSBS now chooses a viable release label
+                 * to prevent conflicting with pre-existing
                  * builds. Let's use that fact to our advantage.
                  */
-                buildlib.oit """
---working-dir ${OIT_WORKING} --group 'openshift-${OSE_MAJOR}.${OSE_MINOR}'
-images:update-dockerfile
-  ${oit_update_docker_args}
-  --message 'Updating for image refresh'
-  --push
-  """
+                buildlib.oit(
+                    [
+                        "--working-dir ${OIT_WORKING}",
+                        "--group 'openshift-${OSE_MAJOR}.${OSE_MINOR}'",
+                        "images:update-dockerfile",
+                        "${oit_update_docker_args}",
+                        "--message 'Updating for image refresh'",
+                        "--push"
+                    ].join(' ')
+                )
 
-                buildlib.oit """
---working-dir ${OIT_WORKING} --group openshift-${OSE_MAJOR}.${OSE_MINOR}
-images:build
---push-to-defaults --repo-type signed
-"""
+                // The image build can fail and still be acceptble.
+                // The waitUntil wrapper allows the user to respond and
+                // accept, retry or abort the build process and the task
+                BUILD_CONTINUED = false
+                waitUntil {
+                    try {
+
+                        // intially build everything.  Retrys will ignore
+                        // failed builds and only rebuild untried images
+                        exclude = ""
+                        if (BUILD_EXCLUSIONS != "") {
+                            exclude =
+                                "-x ${BUILD_EXCLUSIONS} --ignore-missing-base"
+                        }
+
+                        buildlib.oit(
+                            [
+                                "--working-dir ${OIT_WORKING}",
+                                "--group openshift-${OSE_MAJOR}.${OSE_MINOR}",
+                                exclude,
+                                "images:build",
+                                "--push-to-defaults --repo-type signed"
+                            ].join(' ')
+                        )
+                    }
+                    catch (err) {
+
+                        failed_builds = get_failed_builds(OIT_WORKING)
+
+                        mail(
+                            to: "${MAIL_LIST_FAILURE}",
+                            from: "aos-cicd@redhat.com",
+                            subject: "RESUMABLE Error during Refresh Images for OCP v${BUILD_VERSION}",
+                            body: """Encountered an error: ${err}
+    Input URL: ${env.BUILD_URL}input
+    Jenkins job: ${env.BUILD_URL}
+
+    BUILD / PUSH FAILURES:
+    ${failed_builds}
+    """)
+
+                        def resp = input message: "Error during Image Build for OCP v${BUILD_VERSION}",
+                        parameters: [
+                            [
+                                name: 'action',
+                                description: 'Retry (try the operation again). Continue (fails are OK, continue pipeline). Abort (terminate the pipeline).',
+                                $class: 'hudson.model.ChoiceParameterDefinition',
+                                choices: [
+                                    "RETRY",
+                                    "CONTINUE",
+                                    "ABORT"
+                                ].join(',')
+                            ]
+                        ]
+
+                        switch (resp) {
+                            case "RETRY":
+                                // cause waitUntil to loop again
+                                return false
+                            case "CONTINUE":
+                                echo "User chose continue. Build failures are non-fatal."
+                                //will make email show PARTIAL
+                                // don't try to rebuild failures, only unbuilt
+                                BUILD_EXCLUSIONS =
+                                    failed_builds.keySet().join(",")
+                                //simply setting flag to keep required work
+                                // out of input flow
+                                BUILD_CONTINUED = true
+                                return true // Terminate waitUntil
+                            default: // ABORT
+                                error("User chose to abort pipeline because of image build failures")
+                        }
+                    }
+
+                }
+
+                if (BUILD_CONTINUED) {
+                    buildlib.oit(
+                        [
+                            "--working-dir ${OIT_WORKING}",
+                            "--group openshift-${BUILD_VERSION}",
+                            exclude,
+                            "images:push",
+                            "--to-defaults",
+                            "--late-only"
+                        ]
+                    )
+                    // exclude is set earlier in the main images:build flow
+                }
 
                 try {
-                    buildlib.oit """
---working-dir ${OIT_WORKING} --group openshift-${OSE_MAJOR}.${OSE_MINOR}
-images:verify
---repo-type signed
-"""
+                    buildlib.oit(
+                        [
+                            "--working-dir ${OIT_WORKING}",
+                            "--group openshift-${OSE_MAJOR}.${OSE_MINOR}",
+                            "images:verify",
+                            "--repo-type signed"
+                        ]
+                    )
+
                 } catch (vererr) {
                     echo "Error verifying images: ${vererr}"
-                    mail(to: "${MAIL_LIST_FAILURE}",
-                            from: "aos-cicd@redhat.com",
-                            subject: "Error Verifying Images During Refresh: ${OSE_MAJOR}.${OSE_MINOR}",
-                            body: """Encoutered an error while running ${env.JOB_NAME}: ${vererr}
+                    mail(
+                        to: "${MAIL_LIST_FAILURE}",
+                        from: "aos-cicd@redhat.com",
+                        subject: "Error Verifying Images During Refresh: ${OSE_MAJOR}.${OSE_MINOR}",
+                        body: """Encountered an error while running ${env.JOB_NAME}: ${vererr}
 
 
 Jenkins job: ${env.BUILD_URL}
@@ -153,16 +352,21 @@ Jenkins job: ${env.BUILD_URL}
                         MAIL_LIST_FAILURE)
             }
 
-            // Replace flow control with: https://jenkins.io/blog/2016/12/19/declarative-pipeline-beta/ when available
+            // Replace flow control with:
+            // https://jenkins.io/blog/2016/12/19/declarative-pipeline-beta/
+            // when available
             mail_success()
 
 
-        } catch (err) {
-            // Replace flow control with: https://jenkins.io/blog/2016/12/19/declarative-pipeline-beta/ when available
-            mail(to: "${MAIL_LIST_FAILURE}",
-                    from: "aos-cicd@redhat.com",
-                    subject: "Error Refreshing Images: ${OSE_MAJOR}.${OSE_MINOR}",
-                    body: """Encoutered an error while running ${env.JOB_NAME}: ${err}
+        } catch (err) { // all refresh steps
+            // Replace flow control with:
+            // https://jenkins.io/blog/2016/12/19/declarative-pipeline-beta/
+            // when available
+            mail(
+                to: "${MAIL_LIST_FAILURE}",
+                from: "aos-cicd@redhat.com",
+                subject: "Error Refreshing Images: ${OSE_MAJOR}.${OSE_MINOR}",
+                body: """Encoutered an error while running ${env.JOB_NAME}: ${err}
 
 
 Jenkins job: ${env.BUILD_URL}

--- a/jobs/build/refresh-images/Jenkinsfile
+++ b/jobs/build/refresh-images/Jenkinsfile
@@ -173,10 +173,12 @@ node('openshift-build-1') {
     sh "mkdir -p ${OIT_WORKING}"
 
     stage('Refresh Images') {
-        try {  // all refresh steps
+        try {
+            // all refresh steps
             // Clean up old images to conserve device mapper space
-            try {
-                sh "docker rmi --force \$(docker images  | " +
+             try {
+                sh "docker rmi --force " +
+                    "\$(docker images  | " +
                     "grep v${OSE_MAJOR}.${OSE_MINOR} | " +
                     "awk '{print \$3}')"
             } catch (cce) {


### PR DESCRIPTION
This change adds an interactive retry capability to the OIT refresh-images task.
The form of this change comes from the build stage of the ocp Jenkinsfile.

This change also includes some re-formatting of the groovy code for clarity.
 