### PR TITLE
Added msg to the messageContent body to detect on datagrepper searches.

### DIFF
--- a/jobs/starter/send-ci-msg/Jenkinsfile
+++ b/jobs/starter/send-ci-msg/Jenkinsfile
@@ -28,7 +28,7 @@ node('openshift-build-1') {
             msg = deploylib.run("build-ci-msg", null, true, false)
             echo "Sending CI Message:\n${msg}"
                 timeout(3) {
-                        sendCIMessage messageContent: '',
+                        sendCIMessage messageContent: msg,
                                 messageProperties: msg,
                                 messageType: 'ComponentBuildDone',
                                 overrides: [topic: 'VirtualTopic.qe.ci.jenkins'],


### PR DESCRIPTION
By adding information in the messageContent body, we can detect OSO messages using the datagrepper [1] utility, and help us refine our searches.

[1] https://datagrepper-prod-datanommer.int.open.paas.redhat.com