### PR TITLE
Refresh version check

### DIFF
--- a/jobs/build/refresh-images/Jenkinsfile
+++ b/jobs/build/refresh-images/Jenkinsfile
@@ -91,35 +91,26 @@ node('openshift-build-1') {
                         error("Version overrides must start with 'v'")
                     }
                     oit_update_docker_args = "--version ${VERSION_OVERRIDE}"
+                }
 
-                    // Get the OCP version from the current build
-                    // query-rpm-version returns "version: v3.10.0" for example
-                    def detected_version = buildlib.oit("""
+                // Get the OCP version from the current build
+                // query-rpm-version returns "version: v3.10.0" for example
+                def detected_version = buildlib.oit("""
 --working-dir ${OIT_WORKING} --group 'openshift-${OSE_MAJOR}.${OSE_MINOR}'
 --quiet
 images:query-rpm-version
---repo-type unsigned
-""", [capture: true]).split(' ')[1]
+--repo-type signed
+""", [capture: true]).split(' ').last()
 
-                    def proceed = input(
-                        message: """\
+                def proceed = input(
+                    message: """\
 Remember to rebuild signed puddles before proceeding. 
 You have specified version: ${VERSION_OVERRIDE}
 oit has detected the signed puddle contains: ${detected_version}
 Proceed?
-""",
-                        parameters: [
-                            [
-                                name: "confirm",
-                                description: "User accepts the version settings",
-                                class: 'BooleanParameterDefinition',
-                                default: false
-                            ]
-                        ]
-                    )
-                    if (!proceed) {
-                        error("User aborted refresh: Detected Version ${detected_version}, Specified Version: ${VERSION_OVERRIDE}")                           
-                    }
+""")
+                if (!proceed) {
+                    error("User aborted refresh: Detected Version ${detected_version}, Specified Version: ${VERSION_OVERRIDE}")                           
                 }
 
                 if (RELEASE_OVERRIDE != "") {

--- a/jobs/build/refresh-images/Jenkinsfile
+++ b/jobs/build/refresh-images/Jenkinsfile
@@ -102,16 +102,13 @@ images:query-rpm-version
 --repo-type signed
 """, [capture: true]).split(' ').last()
 
-                def proceed = input(
+                input(
                     message: """\
 Remember to rebuild signed puddles before proceeding. 
 You have specified version: ${VERSION_OVERRIDE}
 oit has detected the signed puddle contains: ${detected_version}
 Proceed?
 """)
-                if (!proceed) {
-                    error("User aborted refresh: Detected Version ${detected_version}, Specified Version: ${VERSION_OVERRIDE}")                           
-                }
 
                 if (RELEASE_OVERRIDE != "") {
                     oit_update_docker_args = "${oit_update_docker_args} --release ${RELEASE_OVERRIDE}"

--- a/jobs/build/refresh-images/Jenkinsfile
+++ b/jobs/build/refresh-images/Jenkinsfile
@@ -71,6 +71,9 @@ node('openshift-build-1') {
     sh "rm -rf ${OIT_WORKING}"
     sh "mkdir -p ${OIT_WORKING}"
 
+    // Get the OCP version from the current build
+    // query-rpm-version returns "version: v3.10.0" for example
+
     stage('Refresh Images') {
         try {
             try {
@@ -91,6 +94,37 @@ node('openshift-build-1') {
                         error("Version overrides must start with 'v'")
                     }
                     oit_update_docker_args = "--version ${VERSION_OVERRIDE}"
+
+                    //
+                    // Check that the version the user has specified matches
+                    // the version that is actually available for image builds
+                    //
+                    def detected_version = buildlib.oit("""
+--working-dir ${OIT_WORKING} --group 'openshift-${OSE_MAJOR}.${OSE_MINOR}'
+--quiet
+images:query-rpm-version
+--repo-type unsigned
+""", [capture: true]).split(' ')[1]
+
+                    def proceed = input(
+                        message: """\
+Remember to rebuild signed puddles before proceeding. 
+You have specified version: ${VERSION_OVERRIDE}
+oit has detected the signed puddle contains: ${detected_version}
+Proceed?
+""",
+                        parameters: [
+                            [
+                                name: "confirm",
+                                description: "User accepts the version settings",
+                                class: 'BooleanParameterDefinition',
+                                default: false
+                            ]
+                        ]
+                    )
+                    if (!proceed) {
+                        error("User aborted refresh: Detected Version ${detected_version}, Specified Version: ${VERSION_OVERRIDE}")                           
+                    }
                 }
 
                 if (RELEASE_OVERRIDE != "") {

--- a/jobs/build/refresh-images/Jenkinsfile
+++ b/jobs/build/refresh-images/Jenkinsfile
@@ -71,9 +71,6 @@ node('openshift-build-1') {
     sh "rm -rf ${OIT_WORKING}"
     sh "mkdir -p ${OIT_WORKING}"
 
-    // Get the OCP version from the current build
-    // query-rpm-version returns "version: v3.10.0" for example
-
     stage('Refresh Images') {
         try {
             try {
@@ -95,10 +92,8 @@ node('openshift-build-1') {
                     }
                     oit_update_docker_args = "--version ${VERSION_OVERRIDE}"
 
-                    //
-                    // Check that the version the user has specified matches
-                    // the version that is actually available for image builds
-                    //
+                    // Get the OCP version from the current build
+                    // query-rpm-version returns "version: v3.10.0" for example
                     def detected_version = buildlib.oit("""
 --working-dir ${OIT_WORKING} --group 'openshift-${OSE_MAJOR}.${OSE_MINOR}'
 --quiet


### PR DESCRIPTION
This change offers the caller a chance to cancel a refresh build.  It detects the version of the RPMs available and displays the version the user requested.