### PR TITLE
Set system_images_registry=docker to enable prepull in openshift-ansible

### DIFF
--- a/sjb/config/common/test_cases/origin_built_installed_release.yml
+++ b/sjb/config/common/test_cases/origin_built_installed_release.yml
@@ -66,6 +66,7 @@ extensions:
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                       \
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
+                         -e system_images_registry=docker                                       \
                          "${evars:-}" \
                          ${EXTRA_EVARS:-} \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -89,6 +90,7 @@ extensions:
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                       \
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
+                         -e system_images_registry=docker                                       \
                          ${EXTRA_EVARS:-} \
                          ${playbook}
         if [[ -s "${playbook_base}deploy_cluster.yml" ]]; then
@@ -111,6 +113,7 @@ extensions:
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                       \
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
+                         -e system_images_registry=docker                                       \
                          -e openshift_node_port_range='30000-32000'                             \
                          -e 'osm_controller_args={"enable-hostpath-provisioner":["true"]}'      \
                          "${evars:-}" \

--- a/sjb/config/common/test_cases/origin_installed_release.yml
+++ b/sjb/config/common/test_cases/origin_installed_release.yml
@@ -100,6 +100,7 @@ extensions:
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                       \
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
+                         -e system_images_registry=docker                                       \
                          -e openshift_node_port_range='30000-32000'                             \
                          -e 'osm_controller_args={"enable-hostpath-provisioner":["true"]}'      \
                          "${evars:-}" \

--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_crio.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_crio.yml
@@ -151,6 +151,7 @@ extensions:
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"            \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
+                         -e system_images_registry=docker                                       \
                          -e openshift_node_port_range='30000-32000'                             \
                          -e 'osm_controller_args={"enable-hostpath-provisioner":["true"]}'      \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -204,6 +205,7 @@ extensions:
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"            \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
+                         -e system_images_registry=docker                                       \
                          -e openshift_node_port_range='30000-32000'                             \
                          -e 'osm_controller_args={"enable-hostpath-provisioner":["true"]}'      \
                          ${playbook}

--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_crio_rpm.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_crio_rpm.yml
@@ -141,6 +141,7 @@ extensions:
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"            \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
+                         -e system_images_registry=docker                                       \
                          -e openshift_node_port_range='30000-32000'                             \
                          -e 'osm_controller_args={"enable-hostpath-provisioner":["true"]}'      \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -195,6 +196,7 @@ extensions:
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"            \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
+                         -e system_images_registry=docker                                       \
                          -e openshift_node_port_range='30000-32000'                             \
                          -e 'osm_controller_args={"enable-hostpath-provisioner":["true"]}'      \
                          ${playbook}

--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_install_containerized.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_install_containerized.yml
@@ -111,6 +111,7 @@ extensions:
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"            \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_TAG )" \
+                         -e system_images_registry=docker                                       \
                          -e openshift_node_port_range='30000-32000'                          \
                          -e 'osm_controller_args={"enable-hostpath-provisioner":["true"]}'   \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -133,6 +134,7 @@ extensions:
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"            \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_TAG )" \
+                         -e system_images_registry=docker                                       \
                          -e openshift_node_port_range='30000-32000'                          \
                          -e 'osm_controller_args={"enable-hostpath-provisioner":["true"]}'   \
                          ${playbook}
@@ -150,6 +152,7 @@ extensions:
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"            \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_TAG )" \
+                         -e system_images_registry=docker                                       \
                          -e openshift_node_port_range='30000-32000'                          \
                          -e 'osm_controller_args={"enable-hostpath-provisioner":["true"]}'   \
                          ${playbook}

--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update.yml
@@ -213,6 +213,7 @@ extensions:
                           -e openshift_deployment_type=$( cat ./DEPLOYMENT_TYPE)                  \
                           -e openshift_node_port_range='30000-32000'                    \
                           -e 'osm_controller_args={"enable-hostpath-provisioner":["true"]}' \
+                          -e system_images_registry=docker                                       \
                           -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )"
     - type: "script"
       title: "expose the kubeconfig"

--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update_containerized.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update_containerized.yml
@@ -144,6 +144,7 @@ extensions:
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"            \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_TAG )" \
+                         -e system_images_registry=docker                                       \
                          -e openshift_node_port_range='30000-32000'                          \
                          -e 'osm_controller_args={"enable-hostpath-provisioner":["true"]}'   \
                          ${playbook}
@@ -170,6 +171,7 @@ extensions:
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )" \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
+                         -e system_images_registry=docker                                       \
                          -e openshift_node_port_range='30000-32000'                    \
                          -e 'osm_controller_args={"enable-hostpath-provisioner":["true"]}' \
                          -e openshift_disable_check="disk_availability,memory_availability,package_availability,docker_image_availability,docker_storage,package_version" \

--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update_system_containers.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_install_update_system_containers.yml
@@ -195,6 +195,7 @@ extensions:
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"            \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_TAG )" \
+                         -e system_images_registry=docker                                       \
                          -e openshift_node_port_range='30000-32000'                          \
                          -e 'osm_controller_args={"enable-hostpath-provisioner":["true"]}'   \
                          ${playbook}
@@ -235,6 +236,7 @@ extensions:
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"            \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                    \
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_TAG )" \
+                         -e system_images_registry=docker                                       \
                          -e openshift_node_port_range='30000-32000'                          \
                          -e 'osm_controller_args={"enable-hostpath-provisioner":["true"]}'   \
                          -e openshift_disable_check="disk_availability,memory_availability,package_availability,docker_image_availability,docker_storage,package_version" \

--- a/sjb/generated/test_branch_image_registry_extended.xml
+++ b/sjb/generated/test_branch_image_registry_extended.xml
@@ -535,6 +535,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -566,6 +567,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -588,6 +590,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_branch_jenkins_client_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_client_plugin.xml
@@ -402,6 +402,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_branch_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_openshift_login_plugin.xml
@@ -402,6 +402,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_branch_jenkins_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_plugin.xml
@@ -402,6 +402,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_branch_jenkins_sync_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_sync_plugin.xml
@@ -402,6 +402,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_branch_openshift_ansible_logging.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging.xml
@@ -550,6 +550,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -581,6 +582,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -603,6 +605,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
@@ -550,6 +550,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -581,6 +582,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -603,6 +605,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_branch_origin_aggregated_logging_json_file.xml
+++ b/sjb/generated/test_branch_origin_aggregated_logging_json_file.xml
@@ -550,6 +550,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -581,6 +582,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -603,6 +605,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_branch_origin_extended_builds.xml
+++ b/sjb/generated/test_branch_origin_extended_builds.xml
@@ -402,6 +402,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_branch_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_crio.xml
@@ -495,6 +495,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -556,6 +557,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  \${playbook}

--- a/sjb/generated/test_branch_origin_extended_conformance_crio_rpm.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_crio_rpm.xml
@@ -570,6 +570,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -632,6 +633,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  \${playbook}

--- a/sjb/generated/test_branch_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install.xml
@@ -535,6 +535,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -566,6 +567,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -588,6 +590,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_branch_origin_extended_conformance_install_containerized.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_containerized.xml
@@ -436,6 +436,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_TAG )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                          \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;   \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -467,6 +468,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_TAG )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                          \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;   \
                  \${playbook}
@@ -484,6 +486,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_TAG )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                          \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;   \
                  \${playbook}

--- a/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
@@ -555,6 +555,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -586,6 +587,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -608,6 +610,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
@@ -574,6 +574,7 @@ ansible-playbook  -vv                    \
                   -e openshift_deployment_type=\$( cat ./DEPLOYMENT_TYPE)                  \
                   -e openshift_node_port_range=&#39;30000-32000&#39;                    \
                   -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39; \
+                  -e system_images_registry=docker                                       \
                   -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34;
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized.xml
@@ -478,6 +478,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_TAG )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                          \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;   \
                  \${playbook}
@@ -520,6 +521,7 @@ ansible-playbook -vv                    \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34; \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                    \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39; \
                  -e openshift_disable_check=&#34;disk_availability,memory_availability,package_availability,docker_image_availability,docker_storage,package_version&#34; \

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers.xml
@@ -531,6 +531,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_TAG )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                          \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;   \
                  \${playbook}
@@ -587,6 +588,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_TAG )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                          \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;   \
                  -e openshift_disable_check=&#34;disk_availability,memory_availability,package_availability,docker_image_availability,docker_storage,package_version&#34; \

--- a/sjb/generated/test_branch_origin_extended_image_ecosystem.xml
+++ b/sjb/generated/test_branch_origin_extended_image_ecosystem.xml
@@ -402,6 +402,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_branch_origin_extended_image_registry.xml
+++ b/sjb/generated/test_branch_origin_extended_image_registry.xml
@@ -402,6 +402,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_image_registry_extended.xml
+++ b/sjb/generated/test_pull_request_image_registry_extended.xml
@@ -535,6 +535,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -566,6 +567,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -588,6 +590,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_jenkins_client_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_client_plugin.xml
@@ -402,6 +402,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_openshift_login_plugin.xml
@@ -402,6 +402,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_jenkins_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_plugin.xml
@@ -402,6 +402,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_jenkins_sync_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_sync_plugin.xml
@@ -402,6 +402,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
@@ -535,6 +535,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -566,6 +567,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -588,6 +590,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized.xml
@@ -436,6 +436,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_TAG )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                          \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;   \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -467,6 +468,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_TAG )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                          \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;   \
                  \${playbook}
@@ -484,6 +486,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_TAG )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                          \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;   \
                  \${playbook}

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio.xml
@@ -495,6 +495,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -556,6 +557,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  \${playbook}

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio_rpm.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio_rpm.xml
@@ -623,6 +623,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -685,6 +686,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  \${playbook}

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_36.xml
@@ -535,6 +535,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -566,6 +567,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -588,6 +590,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_37.xml
@@ -535,6 +535,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -566,6 +567,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -588,6 +590,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_39.xml
@@ -535,6 +535,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -566,6 +567,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -588,6 +590,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
@@ -555,6 +555,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -586,6 +587,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -608,6 +610,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_36.xml
@@ -555,6 +555,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -586,6 +587,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -608,6 +610,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_37.xml
@@ -555,6 +555,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -586,6 +587,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -608,6 +610,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_39.xml
@@ -555,6 +555,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -586,6 +587,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -608,6 +610,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
@@ -574,6 +574,7 @@ ansible-playbook  -vv                    \
                   -e openshift_deployment_type=\$( cat ./DEPLOYMENT_TYPE)                  \
                   -e openshift_node_port_range=&#39;30000-32000&#39;                    \
                   -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39; \
+                  -e system_images_registry=docker                                       \
                   -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34;
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized.xml
@@ -478,6 +478,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_TAG )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                          \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;   \
                  \${playbook}
@@ -520,6 +521,7 @@ ansible-playbook -vv                    \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34; \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                    \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39; \
                  -e openshift_disable_check=&#34;disk_availability,memory_availability,package_availability,docker_image_availability,docker_storage,package_version&#34; \

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers.xml
@@ -531,6 +531,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_TAG )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                          \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;   \
                  \${playbook}
@@ -587,6 +588,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_TAG )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                          \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;   \
                  -e openshift_disable_check=&#34;disk_availability,memory_availability,package_availability,docker_image_availability,docker_storage,package_version&#34; \

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
@@ -535,6 +535,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -566,6 +567,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -588,6 +590,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_openshift_ansible_logging.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging.xml
@@ -550,6 +550,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -581,6 +582,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -603,6 +605,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_36.xml
@@ -550,6 +550,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -581,6 +582,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -603,6 +605,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_37.xml
@@ -550,6 +550,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -581,6 +582,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -603,6 +605,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_39.xml
@@ -550,6 +550,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -581,6 +582,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -603,6 +605,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald.xml
@@ -550,6 +550,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -581,6 +582,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -603,6 +605,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_36.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_36.xml
@@ -550,6 +550,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -581,6 +582,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -603,6 +605,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_37.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_37.xml
@@ -550,6 +550,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -581,6 +582,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -603,6 +605,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_39.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_39.xml
@@ -550,6 +550,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -581,6 +582,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -603,6 +605,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file.xml
@@ -550,6 +550,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -581,6 +582,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -603,6 +605,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_36.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_36.xml
@@ -550,6 +550,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -581,6 +582,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -603,6 +605,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_37.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_37.xml
@@ -550,6 +550,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -581,6 +582,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -603,6 +605,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_39.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_39.xml
@@ -550,6 +550,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -581,6 +582,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -603,6 +605,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_origin_extended_builds.xml
+++ b/sjb/generated/test_pull_request_origin_extended_builds.xml
@@ -535,6 +535,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -566,6 +567,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -588,6 +590,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
@@ -495,6 +495,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -556,6 +557,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;            \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                    \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  \${playbook}

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
@@ -535,6 +535,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -566,6 +567,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -588,6 +590,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_39.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_39.xml
@@ -535,6 +535,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -566,6 +567,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -588,6 +590,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
@@ -574,6 +574,7 @@ ansible-playbook  -vv                    \
                   -e openshift_deployment_type=\$( cat ./DEPLOYMENT_TYPE)                  \
                   -e openshift_node_port_range=&#39;30000-32000&#39;                    \
                   -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39; \
+                  -e system_images_registry=docker                                       \
                   -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34;
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_image_ecosystem.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_ecosystem.xml
@@ -535,6 +535,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -566,6 +567,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -588,6 +590,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \

--- a/sjb/generated/test_pull_request_origin_extended_image_registry.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_registry.xml
@@ -535,6 +535,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -566,6 +567,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -588,6 +590,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
+                 -e system_images_registry=docker                                       \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
                  &#34;\${evars:-}&#34; \


### PR DESCRIPTION
Prerequisite for https://github.com/openshift/openshift-ansible/pull/8172

In order to enable prepull of control plane and node images CI should set 
system_images_registry flag to avoid pulling images from docker.io and use 
local images