### PR TITLE
use buildlib function for kerberos ticket

### DIFF
--- a/jobs/build/refresh-images/Jenkinsfile
+++ b/jobs/build/refresh-images/Jenkinsfile
@@ -97,7 +97,7 @@ node('openshift-build-1') {
                     oit_update_docker_args = "${oit_update_docker_args} --release ${RELEASE_OVERRIDE}"
                 }
 
-                sh "kinit -k -t /home/jenkins/ocp-build-buildvm.openshift.eng.bos.redhat.com.keytab ocp-build/buildvm.openshift.eng.bos.redhat.com@REDHAT.COM"
+                buildlib.kinit() // Sets up credentials for dist-git access
 
                 /**
                  * By default, do not specify a version or release for oit. This will preserve the version label and remove


### PR DESCRIPTION
This change removes an inline call to kinit and replaces it with a call from buildlib.