### PR TITLE
Adding install repo parameter to build node image.

### DIFF
--- a/sjb/config/test_cases/azure_build_node_image_centos.yml
+++ b/sjb/config/test_cases/azure_build_node_image_centos.yml
@@ -44,6 +44,7 @@ actions:
         -e "openshift_azure_storage_account=openshiftimages" \
         -e "openshift_azure_storage_account_ns=images" \
         -e "openshift_azure_container=images" \
+        -e "openshift_azure_install_repo=$(curl -qs https://storage.googleapis.com/origin-ci-test/releases/openshift/origin/master/.latest-rpms)" \
         playbooks/azure/openshift-cluster/build_node_image.yml
 
 post_actions:

--- a/sjb/generated/azure_build_node_image_centos.xml
+++ b/sjb/generated/azure_build_node_image_centos.xml
@@ -228,6 +228,7 @@ TYPE=azure INSTANCE_PREFIX=unused ../../bin/ansible.sh ansible-playbook \
   -e &#34;openshift_azure_storage_account=openshiftimages&#34; \
   -e &#34;openshift_azure_storage_account_ns=images&#34; \
   -e &#34;openshift_azure_container=images&#34; \
+  -e &#34;openshift_azure_install_repo=\$(curl -qs https://storage.googleapis.com/origin-ci-test/releases/openshift/origin/master/.latest-rpms)&#34; \
   playbooks/azure/openshift-cluster/build_node_image.yml
 SCRIPT
 chmod +x &#34;${script}&#34;


### PR DESCRIPTION
This was brought up from @kargakis yesterday when I saw that we could not find the correct packages during our node image build.

I added the install repo here but was unsuccessful after running generate.sh and push-update.sh.  I did however edit the job manually to test in the jenkins UI and it was successful.
```
+ cd cluster/test-deploy/azure
+ TYPE=azure
+ INSTANCE_PREFIX=unused
+ ../../bin/ansible.sh ansible-playbook 
-e openshift_azure_resource_group_name=ci-azure_build_node_image_centos-6 
-e openshift_azure_resource_location=eastus 
-e openshift_azure_input_image_ns=images 
-e openshift_azure_input_image_prefix=centos7-base 
-e openshift_azure_output_image_ns=images 
-e openshift_azure_output_image_prefix=centos7 
-e openshift_azure_storage_account=openshiftimages 
-e openshift_azure_storage_account_ns=images 
-e openshift_azure_container=images
-e openshift_azure_install_repo=https://storage.googleapis.com/origin-ci-test/logs/test_branch_origin_extended_conformance_azure/11/artifacts/rpms 
playbooks/azure/openshift-cluster/build_node_image.yml
```

I'm not sure if I've edited the correct files here but this is essentially what made the build job successful.

@jim-minter @kargakis, please take a look and advise.