### PR TITLE
atomic-openshift-utils deprecated

### DIFF
--- a/jobs/package-dockertested/install-openshift-ansible-release.sh
+++ b/jobs/package-dockertested/install-openshift-ansible-release.sh
@@ -8,4 +8,4 @@ set -o xtrace
 cd /data/src/github.com/openshift/openshift-ansible
 last_tag="$( git describe --tags --abbrev=0 --exact-match HEAD )"
 last_commit="$( git log -n 1 --pretty=%h )"
-sudo yum install -y "atomic-openshift-utils${last_tag/openshift-ansible/}.git.0.${last_commit}.el7"
+sudo yum install -y "openshift-ansible-playbooks${last_tag/openshift-ansible/}.git.0.${last_commit}.el7"


### PR DESCRIPTION
@stevekuznetsov probably need your input when you are back, but dockertested as been failing since this package was removed from o-a. 