### PR TITLE
Adding in /ORIGIN_RELEASE file

### DIFF
--- a/jobs/package-dockertested/install-origin-release.sh
+++ b/jobs/package-dockertested/install-origin-release.sh
@@ -9,6 +9,7 @@ cd /data/src/github.com/openshift/origin
 jobs_repo="/data/src/github.com/openshift/aos-cd-jobs/"
 git log -1 --pretty=%h >> "${jobs_repo}/ORIGIN_COMMIT"
 ( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo "-${OS_RPM_VERSION}-${OS_RPM_RELEASE}" ) >> "${jobs_repo}/ORIGIN_PKG_VERSION"
+( source hack/lib/init.sh; os::build::rpm::get_nvra_vars; echo "v${OS_RPM_VERSION}" ) >> "${jobs_repo}/ORIGIN_RELEASE"
 
 docker pull openshift/origin-docker-registry:latest
 docker tag openshift/origin-docker-registry:latest "openshift/origin-docker-registry:$( cat "${jobs_repo}/ORIGIN_COMMIT" )"


### PR DESCRIPTION
https://buildvm.openshift.eng.bos.redhat.com:8443/job/ci/job/package-dockertested/2032/

```
TASK [openshift_version : assert openshift_release in openshift_image_tag] *****
task path: /usr/share/ansible/openshift-ansible/roles/openshift_version/tasks/first_master.yml:38
fatal: [localhost]: FAILED! => {
    "assertion": "openshift_release in openshift_image_tag", 
    "changed": false, 
    "evaluated_to": false, 
    "generated_timestamp": "2018-05-25 21:04:43.360462", 
    "msg": "openshift_image_tag must match same major version as openshift_release. You provided: 3.10 and \n"
}
```