### PR TITLE
Updating logging component images used

### DIFF
--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file.yml
@@ -64,6 +64,8 @@ extensions:
                          -e openshift_logging_mux_allow_external=True                             \
                          -e openshift_logging_es_allow_external=True                              \
                          -e openshift_logging_es_ops_allow_external=True                          \
+                         -e oreg_url='openshift/origin-${component}:'"${release_commit:-latest}"                 \
+                         -e openshift_logging_elasticsearch_proxy_image="docker.io/openshift/oauth-proxy:v1.0.0" \
                          ${EXTRA_EVARS:-} \
                          ${playbook} \
                          ${logging_extras} \

--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_journald.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_journald.yml
@@ -56,6 +56,8 @@ extensions:
                          -e openshift_logging_es_allow_external=True                              \
                          -e openshift_logging_es_ops_allow_external=True                          \
                          -e openshift_logging_image_version=latest                                \
+                         -e oreg_url='openshift/origin-${component}:'"${release_commit:-latest}"                 \
+                         -e openshift_logging_elasticsearch_proxy_image="docker.io/openshift/oauth-proxy:v1.0.0" \
                          ${EXTRA_EVARS:-} \
                          ${logging_extras}                                                        \
                          ${playbook} \

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
@@ -714,6 +714,8 @@ ansible-playbook -vv --become               \
                  -e openshift_logging_mux_allow_external=True                             \
                  -e openshift_logging_es_allow_external=True                              \
                  -e openshift_logging_es_ops_allow_external=True                          \
+                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\${release_commit:-latest}&#34;                 \
+                 -e openshift_logging_elasticsearch_proxy_image=&#34;docker.io/openshift/oauth-proxy:v1.0.0&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook} \
                  \${logging_extras} \

--- a/sjb/generated/test_branch_origin_aggregated_logging_json_file.xml
+++ b/sjb/generated/test_branch_origin_aggregated_logging_json_file.xml
@@ -714,6 +714,8 @@ ansible-playbook -vv --become               \
                  -e openshift_logging_mux_allow_external=True                             \
                  -e openshift_logging_es_allow_external=True                              \
                  -e openshift_logging_es_ops_allow_external=True                          \
+                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\${release_commit:-latest}&#34;                 \
+                 -e openshift_logging_elasticsearch_proxy_image=&#34;docker.io/openshift/oauth-proxy:v1.0.0&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook} \
                  \${logging_extras} \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald.xml
@@ -706,6 +706,8 @@ ansible-playbook -vv --become               \
                  -e openshift_logging_es_allow_external=True                              \
                  -e openshift_logging_es_ops_allow_external=True                          \
                  -e openshift_logging_image_version=latest                                \
+                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\${release_commit:-latest}&#34;                 \
+                 -e openshift_logging_elasticsearch_proxy_image=&#34;docker.io/openshift/oauth-proxy:v1.0.0&#34; \
                  \${EXTRA_EVARS:-} \
                  \${logging_extras}                                                        \
                  \${playbook} \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_36.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_36.xml
@@ -706,6 +706,8 @@ ansible-playbook -vv --become               \
                  -e openshift_logging_es_allow_external=True                              \
                  -e openshift_logging_es_ops_allow_external=True                          \
                  -e openshift_logging_image_version=latest                                \
+                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\${release_commit:-latest}&#34;                 \
+                 -e openshift_logging_elasticsearch_proxy_image=&#34;docker.io/openshift/oauth-proxy:v1.0.0&#34; \
                  \${EXTRA_EVARS:-} \
                  \${logging_extras}                                                        \
                  \${playbook} \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_37.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_37.xml
@@ -706,6 +706,8 @@ ansible-playbook -vv --become               \
                  -e openshift_logging_es_allow_external=True                              \
                  -e openshift_logging_es_ops_allow_external=True                          \
                  -e openshift_logging_image_version=latest                                \
+                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\${release_commit:-latest}&#34;                 \
+                 -e openshift_logging_elasticsearch_proxy_image=&#34;docker.io/openshift/oauth-proxy:v1.0.0&#34; \
                  \${EXTRA_EVARS:-} \
                  \${logging_extras}                                                        \
                  \${playbook} \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_39.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_39.xml
@@ -706,6 +706,8 @@ ansible-playbook -vv --become               \
                  -e openshift_logging_es_allow_external=True                              \
                  -e openshift_logging_es_ops_allow_external=True                          \
                  -e openshift_logging_image_version=latest                                \
+                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\${release_commit:-latest}&#34;                 \
+                 -e openshift_logging_elasticsearch_proxy_image=&#34;docker.io/openshift/oauth-proxy:v1.0.0&#34; \
                  \${EXTRA_EVARS:-} \
                  \${logging_extras}                                                        \
                  \${playbook} \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file.xml
@@ -714,6 +714,8 @@ ansible-playbook -vv --become               \
                  -e openshift_logging_mux_allow_external=True                             \
                  -e openshift_logging_es_allow_external=True                              \
                  -e openshift_logging_es_ops_allow_external=True                          \
+                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\${release_commit:-latest}&#34;                 \
+                 -e openshift_logging_elasticsearch_proxy_image=&#34;docker.io/openshift/oauth-proxy:v1.0.0&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook} \
                  \${logging_extras} \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_36.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_36.xml
@@ -714,6 +714,8 @@ ansible-playbook -vv --become               \
                  -e openshift_logging_mux_allow_external=True                             \
                  -e openshift_logging_es_allow_external=True                              \
                  -e openshift_logging_es_ops_allow_external=True                          \
+                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\${release_commit:-latest}&#34;                 \
+                 -e openshift_logging_elasticsearch_proxy_image=&#34;docker.io/openshift/oauth-proxy:v1.0.0&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook} \
                  \${logging_extras} \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_37.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_37.xml
@@ -714,6 +714,8 @@ ansible-playbook -vv --become               \
                  -e openshift_logging_mux_allow_external=True                             \
                  -e openshift_logging_es_allow_external=True                              \
                  -e openshift_logging_es_ops_allow_external=True                          \
+                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\${release_commit:-latest}&#34;                 \
+                 -e openshift_logging_elasticsearch_proxy_image=&#34;docker.io/openshift/oauth-proxy:v1.0.0&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook} \
                  \${logging_extras} \

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_39.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_39.xml
@@ -714,6 +714,8 @@ ansible-playbook -vv --become               \
                  -e openshift_logging_mux_allow_external=True                             \
                  -e openshift_logging_es_allow_external=True                              \
                  -e openshift_logging_es_ops_allow_external=True                          \
+                 -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\${release_commit:-latest}&#34;                 \
+                 -e openshift_logging_elasticsearch_proxy_image=&#34;docker.io/openshift/oauth-proxy:v1.0.0&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook} \
                  \${logging_extras} \


### PR DESCRIPTION
@stevekuznetsov  -- this inventory is only used for the origin-aggregated-logging jobs, correct?

This is to address the change in image name specification from https://github.com/openshift/openshift-ansible/pull/8489

Image prefix and image version are no longer honored for logging components

CC @jcantrill  @sdodson 
