### PR TITLE
catalog: specify version to execute

### DIFF
--- a/sjb/config/test_cases/test_pull_request_origin_service_catalog_39.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_service_catalog_39.yml
@@ -47,7 +47,7 @@ extensions:
       repository: "origin"
       timeout: 2700
       script: |-
-        sudo yum -y install etcd       
+        sudo yum -y install etcd
         NO_DOCKER=1 make -C cmd/service-catalog/go/src/github.com/kubernetes-incubator/service-catalog scBuildImageTarget=.scBuildImage test-integration
     - type: "script"
       title: "build Service Catalog image"
@@ -72,7 +72,7 @@ extensions:
       repository: "origin"
       timeout: 1800
       script: |-
-        ./_output/local/bin/linux/amd64/oc cluster up --loglevel=5 --version=latest --service-catalog
+        ./_output/local/bin/linux/amd64/oc cluster up --loglevel=5 --version=v3.9.0 --service-catalog
         ./_output/local/bin/linux/amd64/oc login -u system:admin
         ./_output/local/bin/linux/amd64/oc describe po --all-namespaces
     - type: "script"

--- a/sjb/generated/test_pull_request_origin_service_catalog_39.xml
+++ b/sjb/generated/test_pull_request_origin_service_catalog_39.xml
@@ -429,7 +429,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-sudo yum -y install etcd       
+sudo yum -y install etcd
 NO_DOCKER=1 make -C cmd/service-catalog/go/src/github.com/kubernetes-incubator/service-catalog scBuildImageTarget=.scBuildImage test-integration
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -486,7 +486,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-./_output/local/bin/linux/amd64/oc cluster up --loglevel=5 --version=latest --service-catalog
+./_output/local/bin/linux/amd64/oc cluster up --loglevel=5 --version=v3.9.0 --service-catalog
 ./_output/local/bin/linux/amd64/oc login -u system:admin
 ./_output/local/bin/linux/amd64/oc describe po --all-namespaces
 SCRIPT


### PR DESCRIPTION
There's really no good way currently to quickly build images for
non-HEAD branches as hack/build-local-images.py doesn't support anything
other than using a latest tag. So given that this branch is highly
unlikely to have breaking catalog changes, just use oc cluster up
without the version tag and pull the latest images.

(This fixed the build for openshift/origin/pull/19880.)