### PR TITLE
fix rpm release at 1

### DIFF
--- a/jobs/build/ose/scripts/merge-and-build.sh
+++ b/jobs/build/ose/scripts/merge-and-build.sh
@@ -243,7 +243,7 @@ echo "=========="
 ${OIT_PATH} --user=ocp-build --metadata-dir ${OIT_DIR} --working-dir ${OIT_WORKING} --group openshift-${OSE_VERSION} \
 --sources ${OIT_WORKING}/sources.yml \
 rpms:build --version v${VERSION} \
---release ${NEW_RELEASE}
+--release 1
 
 echo
 echo "=========="


### PR DESCRIPTION
This change fixes the "NEW_RELEASE" value for RPM builds at 1
Removes unbound variable NEW_RELEASE from merge-and-build.sh