### PR TITLE
build doesnt need sources since theyre RPMs

### DIFF
--- a/jobs/build/ose/scripts/merge-and-build.sh
+++ b/jobs/build/ose/scripts/merge-and-build.sh
@@ -241,7 +241,6 @@ echo "=========="
 echo "OIT Building RPMs"
 echo "=========="
 ${OIT_PATH} --user=ocp-build --metadata-dir ${OIT_DIR} --working-dir ${OIT_WORKING} --group openshift-${OSE_VERSION} \
---sources ${OIT_WORKING}/sources.yml \
 rpms:build --version v${VERSION} \
 --release 1
 


### PR DESCRIPTION
Remove unneeded reference to sources.  RPMs are built in Brew.