### PR TITLE
Add temporary call to openshift_node_groups in gce_upgrade job

### DIFF
--- a/sjb/config/common/test_cases/origin_release_install_upgrade_gce.yml
+++ b/sjb/config/common/test_cases/origin_release_install_upgrade_gce.yml
@@ -54,6 +54,12 @@ extensions:
         suffix='origin-${component}'
         suffix="${suffix}:$( cat /data/src/github.com/openshift/aos-cd-jobs/ORIGIN_TAG )"
         cd cluster/test-deploy/
+        # temporary addition until make file is modified
+        WORK_DIR=$PWD
+        PROFILE=${UPGRADE_CLUSTER_PROFILE:-$CLUSTER_PROFILE}
+        cd ${PROFILE}/ && ../../bin/ansible.sh ansible-playbook -e openshift_release="3.9" playbooks/gcp/openshift-cluster/openshift_node_group.yml || true
+        cd $WORK_DIR
+        # end temporary addition
         make upgrade WHAT=${INSTANCE_PREFIX} PROFILE=${UPGRADE_CLUSTER_PROFILE:-$CLUSTER_PROFILE}
 
     - type: "script"

--- a/sjb/generated/test_pull_request_openshift_ansible_install_upgrade_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_install_upgrade_gce.xml
@@ -721,6 +721,12 @@ fi
 suffix=&#39;origin-\${component}&#39;
 suffix=&#34;\${suffix}:\$( cat /data/src/github.com/openshift/aos-cd-jobs/ORIGIN_TAG )&#34;
 cd cluster/test-deploy/
+# temporary addition until make file is modified
+WORK_DIR=\$PWD
+PROFILE=\${UPGRADE_CLUSTER_PROFILE:-\$CLUSTER_PROFILE}
+cd \${PROFILE}/ &amp;&amp; ../../bin/ansible.sh ansible-playbook -e openshift_release=&#34;3.9&#34; playbooks/gcp/openshift-cluster/openshift_node_group.yml || true
+cd \$WORK_DIR
+# end temporary addition
 make upgrade WHAT=\${INSTANCE_PREFIX} PROFILE=\${UPGRADE_CLUSTER_PROFILE:-\$CLUSTER_PROFILE}
 SCRIPT
 chmod +x &#34;${script}&#34;


### PR DESCRIPTION
This commit adds temporary code until we can modify the
release repo.