### PR TITLE
options in parameters are newline separated, not comma

### DIFF
--- a/jobs/build/ocp/Jenkinsfile
+++ b/jobs/build/ocp/Jenkinsfile
@@ -87,7 +87,7 @@ online:stg                {origin,origin-web-console,openshift-ansible}/stage ->
                         "pre-release",
                         "online:int",
                         "online:stg"
-                    ].join(',')
+                    ].join("\n")
                 ],
                 [
                     name: 'SIGN',


### PR DESCRIPTION
Replaced newlines in build mode options