### PR TITLE
moved changelog extraction up a couple of levels

### DIFF
--- a/jobs/build/ocp/Jenkinsfile
+++ b/jobs/build/ocp/Jenkinsfile
@@ -159,7 +159,7 @@ def get_mirror_url(build_mode, version) {
     return "https://mirror.openshift.com/enterprise/enterprise-${version}"
 }
 
-def mail_success(buildlib, version, mirrorURL, record_log) {
+def mail_success(version, mirrorURL, record_log, oa_changelog) {
 
     def target = "(Release Candidate)"
 
@@ -178,8 +178,6 @@ def mail_success(buildlib, version, mirrorURL, record_log) {
 
     def timing_report = get_build_timing_report(record_log)
     def image_list = get_image_build_report(record_log)
-
-    def oa_changelog = get_rpm_changelog(buildlib, record_log, "openshift-ansible")
 
     PARTIAL = " "
     exclude_subject = ""
@@ -296,11 +294,11 @@ def get_image_build_report(record_log) {
 
 // Search the RPM build logs for the named package
 // extract the path to the spec file and return the changelog section.
-def get_rpm_changelog(buildlib, record_log, package_name) {
+def get_rpm_specfile_path(record_log, package_name) {
     rpms = record_log['build_rpm']
 
     // find the named package and the spec file path
-    specfile_path = null
+    specfile_path = ""
     for (i = 0 ; i < rpms.size(); i++) {
         if (rpms[i]['distgit_key'] == package_name) {
             specfile_path = rpms[i]['specfile']
@@ -308,13 +306,7 @@ def get_rpm_changelog(buildlib, record_log, package_name) {
         }
     }
 
-    // if no matching package found, return an empty string
-    if (specfile_path == null) {
-        return ""
-    }
-
-    // read the spec file and extract the changelog
-    return buildlib.read_changelog(specfile_path)
+    return specfile_path
 }
 
 // Will be used to track which atomic-openshift build was tagged before we ran.
@@ -933,7 +925,10 @@ Jenkins job: ${env.BUILD_URL}
             }
 
             record_log = buildlib.parse_record_log(OIT_WORKING)
-            mail_success(buildlib, NEW_FULL_VERSION, mirror_url, record_log)
+            oa_spec_file = get_rpm_specfile_path(record_log, "openshift-ansible")
+            oa_changelog = buildlib.read_changelog(oa_specfile)
+
+            mail_success(NEW_FULL_VERSION, mirror_url, record_log, oa_changelog)
         }
     } catch (err) {
 


### PR DESCRIPTION
Per https://trello.com/c/nAaO8zc1/639-buildauto-1-avoid-passing-buildlib-module-deep

This change moves the task of extracting the changelog data up to avoid passing the buildlib module down into mail_success().  The parameters to mail_success() and it's children indicate the purpose in the calling signature: 

```
 mail_success(NEW_FULL_VERSION, mirror_url, record_log, oa_changelog)
```