### PR TITLE
Tito tag 9999 - Added %dist back to tag string

### DIFF
--- a/sjb/config/common/test_cases/origin_release_with_ecosystem.yml
+++ b/sjb/config/common/test_cases/origin_release_with_ecosystem.yml
@@ -14,7 +14,7 @@ extensions:
       script: |-
         tito_tmp_dir="tito"
         mkdir -p "${tito_tmp_dir}"
-        tito tag --offline --accept-auto-changelog --use-release 9999
+        tito tag --offline --accept-auto-changelog --use-release '9999%{?dist}'
         tito build --output="${tito_tmp_dir}" --rpm --test --offline --quiet
         createrepo "${tito_tmp_dir}/noarch"
         cat << EOR > ./openshift-ansible-local-release.repo

--- a/sjb/config/common/test_cases/origin_release_with_ecosystem_36.yml
+++ b/sjb/config/common/test_cases/origin_release_with_ecosystem_36.yml
@@ -10,7 +10,7 @@ extensions:
       script: |-
         tito_tmp_dir="tito"
         mkdir -p "${tito_tmp_dir}"
-        tito tag --offline --accept-auto-changelog --use-release 9999
+        tito tag --offline --accept-auto-changelog --use-release '9999%{?dist}'
         tito build --output="${tito_tmp_dir}" --rpm --test --offline --quiet
         createrepo "${tito_tmp_dir}/noarch"
         cat << EOR > ./openshift-ansible-local-release.repo

--- a/sjb/config/common/test_cases/origin_release_with_ecosystem_37.yml
+++ b/sjb/config/common/test_cases/origin_release_with_ecosystem_37.yml
@@ -10,7 +10,7 @@ extensions:
       script: |-
         tito_tmp_dir="tito"
         mkdir -p "${tito_tmp_dir}"
-        tito tag --offline --accept-auto-changelog --use-release 9999
+        tito tag --offline --accept-auto-changelog --use-release '9999%{?dist}'
         tito build --output="${tito_tmp_dir}" --rpm --test --offline --quiet
         createrepo "${tito_tmp_dir}/noarch"
         cat << EOR > ./openshift-ansible-local-release.repo

--- a/sjb/config/common/test_cases/origin_release_with_ecosystem_38.yml
+++ b/sjb/config/common/test_cases/origin_release_with_ecosystem_38.yml
@@ -8,7 +8,7 @@ extensions:
       script: |-
         tito_tmp_dir="tito"
         mkdir -p "${tito_tmp_dir}"
-        tito tag --offline --accept-auto-changelog --use-release 9999
+        tito tag --offline --accept-auto-changelog --use-release '9999%{?dist}'
         tito build --output="${tito_tmp_dir}" --rpm --test --offline --quiet
         createrepo "${tito_tmp_dir}/noarch"
         cat << EOR > ./openshift-ansible-local-release.repo

--- a/sjb/config/common/test_cases/origin_release_with_ecosystem_39.yml
+++ b/sjb/config/common/test_cases/origin_release_with_ecosystem_39.yml
@@ -13,7 +13,7 @@ extensions:
       script: |-
         tito_tmp_dir="tito"
         mkdir -p "${tito_tmp_dir}"
-        tito tag --offline --accept-auto-changelog --use-release 9999
+        tito tag --offline --accept-auto-changelog --use-release '9999%{?dist}'
         tito build --output="${tito_tmp_dir}" --rpm --test --offline --quiet
         createrepo "${tito_tmp_dir}/noarch"
         cat << EOR > ./openshift-ansible-local-release.repo

--- a/sjb/generated/push_origin_release.xml
+++ b/sjb/generated/push_origin_release.xml
@@ -340,7 +340,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/push_origin_release_36.xml
+++ b/sjb/generated/push_origin_release_36.xml
@@ -340,7 +340,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/push_origin_release_37.xml
+++ b/sjb/generated/push_origin_release_37.xml
@@ -340,7 +340,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/push_origin_release_38.xml
+++ b/sjb/generated/push_origin_release_38.xml
@@ -340,7 +340,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/push_origin_release_39.xml
+++ b/sjb/generated/push_origin_release_39.xml
@@ -340,7 +340,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_image_registry_extended.xml
+++ b/sjb/generated/test_branch_image_registry_extended.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_jenkins_client_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_client_plugin.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_openshift_login_plugin.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_jenkins_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_plugin.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_jenkins_sync_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_sync_plugin.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce.xml
@@ -378,7 +378,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_37.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_37.xml
@@ -378,7 +378,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_39.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_39.xml
@@ -378,7 +378,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_openshift_ansible_logging.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging.xml
@@ -350,7 +350,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
@@ -350,7 +350,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_origin_aggregated_logging_json_file.xml
+++ b/sjb/generated/test_branch_origin_aggregated_logging_json_file.xml
@@ -350,7 +350,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_origin_end_to_end.xml
+++ b/sjb/generated/test_branch_origin_end_to_end.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_origin_extended_builds.xml
+++ b/sjb/generated/test_branch_origin_extended_builds.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_origin_extended_conformance_azure.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_azure.xml
@@ -363,7 +363,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_origin_extended_conformance_azure_39.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_azure_39.xml
@@ -363,7 +363,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce.xml
@@ -374,7 +374,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_origin_extended_conformance_gce_37.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce_37.xml
@@ -374,7 +374,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_origin_extended_conformance_gce_38.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce_38.xml
@@ -374,7 +374,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_origin_extended_conformance_gce_39.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce_39.xml
@@ -374,7 +374,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_origin_extended_conformance_install_36.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_36.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_origin_extended_conformance_install_37.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_37.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_origin_extended_conformance_install_38.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_38.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_origin_extended_conformance_install_39.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_39.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
@@ -355,7 +355,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_origin_extended_conformance_k8s.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_k8s.xml
@@ -379,7 +379,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_origin_extended_conformance_k8s_39.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_k8s_39.xml
@@ -379,7 +379,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_origin_extended_gssapi.xml
+++ b/sjb/generated/test_branch_origin_extended_gssapi.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_origin_extended_image_ecosystem.xml
+++ b/sjb/generated/test_branch_origin_extended_image_ecosystem.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_origin_extended_image_registry.xml
+++ b/sjb/generated/test_branch_origin_extended_image_registry.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_branch_origin_extended_ldap_groups.xml
+++ b/sjb/generated/test_branch_origin_extended_ldap_groups.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_descheduler_gce_39.xml
+++ b/sjb/generated/test_pull_request_descheduler_gce_39.xml
@@ -369,7 +369,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_image_registry_extended.xml
+++ b/sjb/generated/test_pull_request_image_registry_extended.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_jenkins_client_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_client_plugin.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_openshift_login_plugin.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_jenkins_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_plugin.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_jenkins_sync_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_sync_plugin.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce.xml
@@ -373,7 +373,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_37.xml
@@ -373,7 +373,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_39.xml
@@ -373,7 +373,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha.xml
@@ -373,7 +373,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha_39.xml
@@ -373,7 +373,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_36.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_37.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_39.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
@@ -355,7 +355,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_36.xml
@@ -355,7 +355,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_37.xml
@@ -355,7 +355,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_39.xml
@@ -355,7 +355,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_openshift_ansible_install_upgrade_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_install_upgrade_gce.xml
@@ -378,7 +378,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_openshift_ansible_launch_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_launch_gce.xml
@@ -369,7 +369,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_openshift_ansible_logging.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging.xml
@@ -350,7 +350,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_36.xml
@@ -350,7 +350,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_37.xml
@@ -350,7 +350,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_39.xml
@@ -350,7 +350,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald.xml
@@ -350,7 +350,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_36.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_36.xml
@@ -350,7 +350,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_37.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_37.xml
@@ -350,7 +350,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_39.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_39.xml
@@ -350,7 +350,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file.xml
@@ -350,7 +350,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_36.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_36.xml
@@ -350,7 +350,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_37.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_37.xml
@@ -350,7 +350,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_39.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_39.xml
@@ -350,7 +350,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_origin_end_to_end.xml
+++ b/sjb/generated/test_pull_request_origin_end_to_end.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_origin_extended_builds.xml
+++ b/sjb/generated/test_pull_request_origin_extended_builds.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_origin_extended_conformance_azure.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_azure.xml
@@ -363,7 +363,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_origin_extended_conformance_azure_39.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_azure_39.xml
@@ -363,7 +363,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
@@ -373,7 +373,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce_37.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce_37.xml
@@ -373,7 +373,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce_39.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce_39.xml
@@ -373,7 +373,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_36.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_36.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_37.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_37.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_38.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_38.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_39.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_39.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_origin_extended_conformance_k8s.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_k8s.xml
@@ -374,7 +374,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_origin_extended_gssapi.xml
+++ b/sjb/generated/test_pull_request_origin_extended_gssapi.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_origin_extended_image_ecosystem.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_ecosystem.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_origin_extended_image_registry.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_registry.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_origin_extended_ldap_groups.xml
+++ b/sjb/generated/test_pull_request_origin_extended_ldap_groups.xml
@@ -335,7 +335,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo

--- a/sjb/generated/test_pull_request_origin_launch_gce.xml
+++ b/sjb/generated/test_pull_request_origin_launch_gce.xml
@@ -369,7 +369,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/openshift-ansible&#34;
 tito_tmp_dir=&#34;tito&#34;
 mkdir -p &#34;\${tito_tmp_dir}&#34;
-tito tag --offline --accept-auto-changelog --use-release 9999
+tito tag --offline --accept-auto-changelog --use-release &#39;9999%{?dist}&#39;
 tito build --output=&#34;\${tito_tmp_dir}&#34; --rpm --test --offline --quiet
 createrepo &#34;\${tito_tmp_dir}/noarch&#34;
 cat &lt;&lt; EOR &gt; ./openshift-ansible-local-release.repo


### PR DESCRIPTION
The tag string for openshift-ansible is derived from the release number and some arch information contained in %{dist}.  Restored the %{dist} substring to the tag.