### PR TITLE
Increase timeout for cri-o e2e testing

### DIFF
--- a/sjb/config/test_cases/test_branch_crio_e2e_rhel.yml
+++ b/sjb/config/test_cases/test_branch_crio_e2e_rhel.yml
@@ -18,6 +18,7 @@ extensions:
       git checkout "${PULL_BASE_SHA}"
   - type: "script"
     title: "run the cri-o e2e tests"
+    timeout: "21600"  # 6 hours.  Playbook has shorter timeout for the test-task.
     script: |-
       ansible-playbook -vv --become  \
                        -i localhost, \

--- a/sjb/config/test_cases/test_pull_request_crio_ami_rhel.yml
+++ b/sjb/config/test_cases/test_pull_request_crio_ami_rhel.yml
@@ -55,6 +55,7 @@ extensions:
         oct package ami --stage=crio
     - type: "script"
       title: "run the cri-o tests"
+      timeout: "21600"  # 6 hours.  Playbook has shorter timeout for the test-task.
       script: |-
         ansible-playbook -vv --become  \
                          -i localhost, \

--- a/sjb/config/test_cases/test_pull_request_crio_e2e_rhel.yml
+++ b/sjb/config/test_cases/test_pull_request_crio_e2e_rhel.yml
@@ -26,6 +26,7 @@ extensions:
       git merge "${PULL_PULL_SHA}"
   - type: "script"
     title: "run the cri-o e2e tests"
+    timeout: "21600"  # 6 hours.  Playbook has shorter timeout for the test-task.
     script: |-
       ansible-playbook -vv --become  \
                        -i localhost, \

--- a/sjb/generated/test_branch_crio_e2e_fedora.xml
+++ b/sjb/generated/test_branch_crio_e2e_fedora.xml
@@ -211,7 +211,7 @@ ansible-playbook -vv --become  \
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
-ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 14400 ${script}\&#34;&#34; </command>
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 21600 ${script}\&#34;&#34; </command>
         </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/sjb/generated/test_branch_crio_e2e_rhel.xml
+++ b/sjb/generated/test_branch_crio_e2e_rhel.xml
@@ -211,7 +211,7 @@ ansible-playbook -vv --become  \
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
-ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 14400 ${script}\&#34;&#34; </command>
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 21600 ${script}\&#34;&#34; </command>
         </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/sjb/generated/test_pull_request_crio_ami_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_ami_fedora.xml
@@ -271,7 +271,7 @@ ansible-playbook -vv --become  \
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
-ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 14400 ${script}\&#34;&#34; </command>
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 21600 ${script}\&#34;&#34; </command>
         </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/sjb/generated/test_pull_request_crio_ami_rhel.xml
+++ b/sjb/generated/test_pull_request_crio_ami_rhel.xml
@@ -271,7 +271,7 @@ ansible-playbook -vv --become  \
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
-ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 14400 ${script}\&#34;&#34; </command>
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 21600 ${script}\&#34;&#34; </command>
         </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/sjb/generated/test_pull_request_crio_e2e_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_e2e_fedora.xml
@@ -219,7 +219,7 @@ ansible-playbook -vv --become  \
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
-ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 14400 ${script}\&#34;&#34; </command>
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 21600 ${script}\&#34;&#34; </command>
         </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/sjb/generated/test_pull_request_crio_e2e_rhel.xml
+++ b/sjb/generated/test_pull_request_crio_e2e_rhel.xml
@@ -219,7 +219,7 @@ ansible-playbook -vv --become  \
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
-ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 14400 ${script}\&#34;&#34; </command>
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 21600 ${script}\&#34;&#34; </command>
         </hudson.tasks.Shell>
   </builders>
   <publishers>


### PR DESCRIPTION
The timeout for the cri-o e2e tests is set at 4-hours.  However, the
default timeout for the shell process running Ansible (remotely) is
shorter.  On occasion, depending on many factors, this has caused
intermittant run failures.  Increase the shell timeout for all jobs
that execute the e2e test playbook.  This provides a much larger window
where the tests may fail more naturally.

Signed-off-by: Chris Evich <cevich@redhat.com>