### PR TITLE
disable authentication for side effects during testing

### DIFF
--- a/jobs/build/ocp/Jenkinsfile
+++ b/jobs/build/ocp/Jenkinsfile
@@ -340,7 +340,7 @@ node(TARGET_NODE) {
     commonlib.initialize()
 
     def buildlib = load("pipeline-scripts/buildlib.groovy")
-    buildlib.initialize()
+    buildlib.initialize(IS_TEST_MODE)
     echo "Initializing build: #${currentBuild.number} - ${BUILD_VERSION}.?? (${BUILD_MODE})"
 
     // oit_working must be in WORKSPACE in order to have artifacts archived

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -6,10 +6,14 @@ commonlib.initialize()
 GITHUB_URLS = [:]
 GITHUB_BASE_PATHS = [:]
 
-def initialize() {
-    this.registry_login()
+def initialize(test=false) {
+
+    // don't bother logging into a registry or getting a krb5 ticket for tests
+    if (!test) {
+        this.registry_login()
+        this.kinit()
+    }
     this.path_setup()
-    this.kinit()
 
     GITHUB_URLS = [:]
     GITHUB_BASE_PATHS = [:]


### PR DESCRIPTION
This change avoids attempting to authenticate to Kerberos or to a docker repo during test mode.  Both of these allow the creation of side effects and neither are needed or wanted for logic testing.