### PR TITLE
Fixing 310 image build rpm URL.

### DIFF
--- a/sjb/config/test_cases/azure_build_node_image_centos_310.yml
+++ b/sjb/config/test_cases/azure_build_node_image_centos_310.yml
@@ -46,7 +46,7 @@ actions:
         -e "openshift_azure_storage_account=openshiftimages" \
         -e "openshift_azure_storage_account_ns=images" \
         -e "openshift_azure_container=images" \
-        -e "openshift_azure_install_repo=$(curl -qs https://storage.googleapis.com/origin-ci-test/releases/openshift/origin/master/.latest-rpms)" \
+        -e "openshift_azure_install_repo=$(curl -qs https://storage.googleapis.com/origin-ci-test/releases/openshift/origin/release-3.10/.latest-rpms)" \
         playbooks/azure/openshift-cluster/build_node_image.yml
 
   - type: "script"

--- a/sjb/generated/azure_build_node_image_centos_310.xml
+++ b/sjb/generated/azure_build_node_image_centos_310.xml
@@ -229,7 +229,7 @@ TYPE=azure INSTANCE_PREFIX=unused ../../bin/ansible.sh ansible-playbook \
   -e &#34;openshift_azure_storage_account=openshiftimages&#34; \
   -e &#34;openshift_azure_storage_account_ns=images&#34; \
   -e &#34;openshift_azure_container=images&#34; \
-  -e &#34;openshift_azure_install_repo=\$(curl -qs https://storage.googleapis.com/origin-ci-test/releases/openshift/origin/master/.latest-rpms)&#34; \
+  -e &#34;openshift_azure_install_repo=\$(curl -qs https://storage.googleapis.com/origin-ci-test/releases/openshift/origin/release-3.10/.latest-rpms)&#34; \
   playbooks/azure/openshift-cluster/build_node_image.yml
 SCRIPT
 chmod +x &#34;${script}&#34;


### PR DESCRIPTION
The image URL for 3.10 was pointed to latest.  This points it at the branched 3.10 version.