### PR TITLE
Persist azure launch artifacts.

### DIFF
--- a/sjb/config/common/test_cases/origin_release_install_azure.yml
+++ b/sjb/config/common/test_cases/origin_release_install_azure.yml
@@ -169,8 +169,9 @@ extensions:
         set +a -o xtrace
 
         cd /data/src/github.com/Azure/acs-engine
-        mkdir -p _output
-        cp /var/tmp/${RESOURCE_GROUP}.json _output/
+        mkdir -p _output/${RESOURCE_GROUP}
+        cp -a /var/tmp/deploy/* _output/${RESOURCE_GROUP}/
+        cp _output/${RESOURCE_GROUP}/apimodel.json _output/${RESOURCE_GROUP}.json
         export GOPATH="/data"
         export PATH="${PATH}:${GOPATH}/bin"
         make build

--- a/sjb/config/common/test_cases/origin_release_install_azure_310.yml
+++ b/sjb/config/common/test_cases/origin_release_install_azure_310.yml
@@ -169,8 +169,9 @@ extensions:
         set +a -o xtrace
 
         cd /data/src/github.com/Azure/acs-engine
-        mkdir -p _output
-        cp /var/tmp/${RESOURCE_GROUP}.json _output/
+        mkdir -p _output/${RESOURCE_GROUP}
+        cp -a /var/tmp/deploy/* _output/${RESOURCE_GROUP}/
+        cp _output/${RESOURCE_GROUP}/apimodel.json _output/${RESOURCE_GROUP}.json
         export GOPATH="/data"
         export PATH="${PATH}:${GOPATH}/bin"
         make build

--- a/sjb/config/common/test_cases/origin_release_install_azure_39.yml
+++ b/sjb/config/common/test_cases/origin_release_install_azure_39.yml
@@ -169,8 +169,9 @@ extensions:
         set +a -o xtrace
 
         cd /data/src/github.com/Azure/acs-engine
-        mkdir -p _output
-        cp /var/tmp/${RESOURCE_GROUP}.json _output/
+        mkdir -p _output/${RESOURCE_GROUP}
+        cp -a /var/tmp/deploy/* _output/${RESOURCE_GROUP}/
+        cp _output/${RESOURCE_GROUP}/apimodel.json _output/${RESOURCE_GROUP}.json
         export GOPATH="/data"
         export PATH="${PATH}:${GOPATH}/bin"
         make build

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_azure.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_azure.xml
@@ -669,8 +669,9 @@ set -a +o xtrace
 set +a -o xtrace
 
 cd /data/src/github.com/Azure/acs-engine
-mkdir -p _output
-cp /var/tmp/\${RESOURCE_GROUP}.json _output/
+mkdir -p _output/\${RESOURCE_GROUP}
+cp -a /var/tmp/deploy/* _output/\${RESOURCE_GROUP}/
+cp _output/\${RESOURCE_GROUP}/apimodel.json _output/\${RESOURCE_GROUP}.json
 export GOPATH=&#34;/data&#34;
 export PATH=&#34;\${PATH}:\${GOPATH}/bin&#34;
 make build

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_azure_310.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_azure_310.xml
@@ -669,8 +669,9 @@ set -a +o xtrace
 set +a -o xtrace
 
 cd /data/src/github.com/Azure/acs-engine
-mkdir -p _output
-cp /var/tmp/\${RESOURCE_GROUP}.json _output/
+mkdir -p _output/\${RESOURCE_GROUP}
+cp -a /var/tmp/deploy/* _output/\${RESOURCE_GROUP}/
+cp _output/\${RESOURCE_GROUP}/apimodel.json _output/\${RESOURCE_GROUP}.json
 export GOPATH=&#34;/data&#34;
 export PATH=&#34;\${PATH}:\${GOPATH}/bin&#34;
 make build

--- a/sjb/generated/test_branch_origin_extended_conformance_azure.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_azure.xml
@@ -669,8 +669,9 @@ set -a +o xtrace
 set +a -o xtrace
 
 cd /data/src/github.com/Azure/acs-engine
-mkdir -p _output
-cp /var/tmp/\${RESOURCE_GROUP}.json _output/
+mkdir -p _output/\${RESOURCE_GROUP}
+cp -a /var/tmp/deploy/* _output/\${RESOURCE_GROUP}/
+cp _output/\${RESOURCE_GROUP}/apimodel.json _output/\${RESOURCE_GROUP}.json
 export GOPATH=&#34;/data&#34;
 export PATH=&#34;\${PATH}:\${GOPATH}/bin&#34;
 make build

--- a/sjb/generated/test_branch_origin_extended_conformance_azure_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_azure_310.xml
@@ -669,8 +669,9 @@ set -a +o xtrace
 set +a -o xtrace
 
 cd /data/src/github.com/Azure/acs-engine
-mkdir -p _output
-cp /var/tmp/\${RESOURCE_GROUP}.json _output/
+mkdir -p _output/\${RESOURCE_GROUP}
+cp -a /var/tmp/deploy/* _output/\${RESOURCE_GROUP}/
+cp _output/\${RESOURCE_GROUP}/apimodel.json _output/\${RESOURCE_GROUP}.json
 export GOPATH=&#34;/data&#34;
 export PATH=&#34;\${PATH}:\${GOPATH}/bin&#34;
 make build

--- a/sjb/generated/test_branch_origin_extended_conformance_azure_39.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_azure_39.xml
@@ -652,8 +652,9 @@ set -a +o xtrace
 set +a -o xtrace
 
 cd /data/src/github.com/Azure/acs-engine
-mkdir -p _output
-cp /var/tmp/\${RESOURCE_GROUP}.json _output/
+mkdir -p _output/\${RESOURCE_GROUP}
+cp -a /var/tmp/deploy/* _output/\${RESOURCE_GROUP}/
+cp _output/\${RESOURCE_GROUP}/apimodel.json _output/\${RESOURCE_GROUP}.json
 export GOPATH=&#34;/data&#34;
 export PATH=&#34;\${PATH}:\${GOPATH}/bin&#34;
 make build

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_azure.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_azure.xml
@@ -669,8 +669,9 @@ set -a +o xtrace
 set +a -o xtrace
 
 cd /data/src/github.com/Azure/acs-engine
-mkdir -p _output
-cp /var/tmp/\${RESOURCE_GROUP}.json _output/
+mkdir -p _output/\${RESOURCE_GROUP}
+cp -a /var/tmp/deploy/* _output/\${RESOURCE_GROUP}/
+cp _output/\${RESOURCE_GROUP}/apimodel.json _output/\${RESOURCE_GROUP}.json
 export GOPATH=&#34;/data&#34;
 export PATH=&#34;\${PATH}:\${GOPATH}/bin&#34;
 make build

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_azure_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_azure_310.xml
@@ -669,8 +669,9 @@ set -a +o xtrace
 set +a -o xtrace
 
 cd /data/src/github.com/Azure/acs-engine
-mkdir -p _output
-cp /var/tmp/\${RESOURCE_GROUP}.json _output/
+mkdir -p _output/\${RESOURCE_GROUP}
+cp -a /var/tmp/deploy/* _output/\${RESOURCE_GROUP}/
+cp _output/\${RESOURCE_GROUP}/apimodel.json _output/\${RESOURCE_GROUP}.json
 export GOPATH=&#34;/data&#34;
 export PATH=&#34;\${PATH}:\${GOPATH}/bin&#34;
 make build

--- a/sjb/generated/test_pull_request_origin_extended_conformance_azure.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_azure.xml
@@ -669,8 +669,9 @@ set -a +o xtrace
 set +a -o xtrace
 
 cd /data/src/github.com/Azure/acs-engine
-mkdir -p _output
-cp /var/tmp/\${RESOURCE_GROUP}.json _output/
+mkdir -p _output/\${RESOURCE_GROUP}
+cp -a /var/tmp/deploy/* _output/\${RESOURCE_GROUP}/
+cp _output/\${RESOURCE_GROUP}/apimodel.json _output/\${RESOURCE_GROUP}.json
 export GOPATH=&#34;/data&#34;
 export PATH=&#34;\${PATH}:\${GOPATH}/bin&#34;
 make build

--- a/sjb/generated/test_pull_request_origin_extended_conformance_azure_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_azure_310.xml
@@ -669,8 +669,9 @@ set -a +o xtrace
 set +a -o xtrace
 
 cd /data/src/github.com/Azure/acs-engine
-mkdir -p _output
-cp /var/tmp/\${RESOURCE_GROUP}.json _output/
+mkdir -p _output/\${RESOURCE_GROUP}
+cp -a /var/tmp/deploy/* _output/\${RESOURCE_GROUP}/
+cp _output/\${RESOURCE_GROUP}/apimodel.json _output/\${RESOURCE_GROUP}.json
 export GOPATH=&#34;/data&#34;
 export PATH=&#34;\${PATH}:\${GOPATH}/bin&#34;
 make build

--- a/sjb/generated/test_pull_request_origin_extended_conformance_azure_39.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_azure_39.xml
@@ -652,8 +652,9 @@ set -a +o xtrace
 set +a -o xtrace
 
 cd /data/src/github.com/Azure/acs-engine
-mkdir -p _output
-cp /var/tmp/\${RESOURCE_GROUP}.json _output/
+mkdir -p _output/\${RESOURCE_GROUP}
+cp -a /var/tmp/deploy/* _output/\${RESOURCE_GROUP}/
+cp _output/\${RESOURCE_GROUP}/apimodel.json _output/\${RESOURCE_GROUP}.json
 export GOPATH=&#34;/data&#34;
 export PATH=&#34;\${PATH}:\${GOPATH}/bin&#34;
 make build


### PR DESCRIPTION
Follow up to https://github.com/openshift/openshift-ansible/pull/8972.  This is required for e2e testing to occur.

The previous version was throwing an exception in the openshift-ansible code when attempting to deploy acs-engine cluster.

@kargakis @jim-minter @pweil- 