### PR TITLE
Add functions to compare and sort version strings, and to select "build mode" automatically

### DIFF
--- a/pipeline-scripts/Jenkinsfile
+++ b/pipeline-scripts/Jenkinsfile
@@ -1,0 +1,91 @@
+#!/usr/bin/groovy
+
+// Test the functions in the buildlib for OCP builds
+
+properties(
+    [
+        buildDiscarder(
+            logRotator(
+                artifactDaysToKeepStr: '',
+                artifactNumToKeepStr: '',
+                daysToKeepStr: '',
+                numToKeepStr: '1000')),
+        [
+            $class: 'ParametersDefinitionProperty',
+            parameterDefinitions: [
+                [
+                    name: 'TARGET_NODE',
+                    description: 'Jenkins agent node',
+                    $class: 'hudson.model.StringParameterDefinition',
+                    defaultValue: 'openshift-build-1'
+                ],
+                [
+                    name: 'MOCK',
+                    description: 'dont do anything if true',
+                    $class: 'hudson.model.BooleanParameterDefinition',
+                    defaultValue: false
+                ],
+                // all these are required as silent magic vars for buildlib
+                // initialization
+                [
+                    name: 'TEST',
+                    description: 'just try running',
+                    $class: 'hudson.model.BooleanParameterDefinition',
+                    defaultValue: false
+                ],
+                [
+                    name: 'BUILD_VERSION',
+                    description: 'version string',
+                    $class: 'hudson.model.StringParameterDefinition',
+                    defaultValue: "0.0"
+                ],
+                [
+                    name: 'BUILD_MODE',
+                    description: 'version string',
+                    $class: 'hudson.model.StringParameterDefinition',
+                    defaultValue: "dummy"
+                ],
+            ]
+        ],
+        disableConcurrentBuilds()
+    ]
+)
+
+IS_TEST_MODE = TEST.toBoolean()
+
+node(TARGET_NODE) {
+
+    checkout scm
+    
+//    def buildlib = load("pipeline-scripts/buildlib.groovy")
+//    buildlib.initialize(IS_TEST_MODE)
+//    echo "Initializing build: #${currentBuild.number} - ${BUILD_VERSION}.?? (${BUILD_MODE})"
+
+    def testlib = load("pipeline-scripts/buildlib_test.groovy")
+
+    // now start testing
+
+    stage("test cmp_version") {
+        echo "BEGIN: test_cmp_version()"
+        testlib.test_cmp_version()
+        echo "END: test_cmp_version()"
+    }
+
+    stage("test eq_version") {
+        echo "BEGIN: test_eq_version()"
+        testlib.test_eq_version()
+        echo "END: test_eq_version()"
+    }
+
+    stage("test sort_versions") {
+        echo "BEGIN: test_sort_versions()"
+        testlib.test_sort_versions()
+        echo "END: test_sort_versions()"
+    }
+
+    stage("test auto-mode resolution") {
+        echo "BEGIN: test_auto_mode()"
+        testlib.test_auto_mode()
+        echo "END: test_auto_mode()"
+    }
+}

--- a/pipeline-scripts/buildlib_test.groovy
+++ b/pipeline-scripts/buildlib_test.groovy
@@ -1,0 +1,280 @@
+#!/usr/bin/groovy
+
+
+buildlib = load("pipeline-scripts/buildlib.groovy")
+
+buildlib.initialize(IS_TEST_MODE)
+echo "Initializing build: #${currentBuild.number} - ${BUILD_VERSION}.?? (${BUILD_MODE})"
+
+// define tests for the functions in buildlib.groovy
+
+//
+// test_cmp_version - test comparing version strings
+//
+def test_cmp_version() {
+    pass_count = 0
+    fail_count = 0
+    
+    // initial values
+    values = [
+        "1.2",
+        "3.0",
+        "3.0.2",
+        "3.0.5",
+        "3.1",
+        "3.10",
+        "3.10.1",
+        "3.11",
+        "5.3",
+        "6" // can you do single digit ones?
+    ]
+
+    // test "equals"
+    expected = 0
+    values.each {
+        actual = buildlib.cmp_version(it, it)
+        try {
+            assert actual == expected
+            pass_count++
+        } catch (AssertionError e) {
+            fail_count++
+            echo "FAIL: cmp_version(${values[it]}, ${values[it + 1]}) - expected: ${expected}, actual: ${actual}"
+        }
+    }
+
+    /// test equality of different length versions
+    actual = buildlib.cmp_version("3.1", "3.1.0")
+    try {
+        assert actual == expected
+        pass_count++
+    } catch (AssertionError e) {
+        fail_count++
+        echo "FAIL: cmp_version(\"3.1\"}, \"3.1.0\") - expected: ${expected}, actual: ${actual}"
+    }
+
+    // test "less than"
+    expected = -1
+    (0..(values.size() - 2)).each {
+        actual = buildlib.cmp_version(values[it], values[it + 1])
+        try {
+            assert actual == expected
+            pass_count++
+        } catch (AssertionError e) {
+            fail_count++
+            echo "FAIL: cmp_version(${values[it]}, ${values[it + 1]}) - expected: ${expected}, actual: ${actual}"
+        }
+    }
+
+    /// test different length versions
+    actual = buildlib.cmp_version("3.1", "3.1.1")
+    try {
+        assert actual == expected
+        pass_count++
+    } catch (AssertionError e) {
+        fail_count++
+        echo "FAIL: cmp_version(\"3.1\"}, \"3.1.1\") - expected: ${expected}, actual: ${actual}"
+    }
+
+    // test "greater than"
+    expected = 1
+    (1..(values.size() - 1)).each {
+        actual = buildlib.cmp_version(values[it], values[it - 1])
+        try {
+            assert actual == expected
+            pass_count++
+        } catch (AssertionError e) {
+            fail_count++
+            echo "FAIL: cmp_version(${values[it]}, ${values[it - 1]}) - expected: ${expected}, actual: ${actual}"
+        }
+    }
+    
+    // test different length versions
+    actual = buildlib.cmp_version("3.1.1", "3.1")
+    try {
+        assert actual == expected
+        pass_count++
+    } catch (AssertionError e) {
+        fail_count++
+        echo "FAIL: cmp_version(\"3.1.1\"}, \"3.1\") - expected: ${expected}, actual: ${actual}"
+    }
+
+    if (fail_count == 0) {
+        echo "PASS: cmp_versopm() - ${pass_count} tests passed"
+    } else {
+        echo "FAIL: cmp_version() - ${pass_count} tests passed, ${fail_count} tests failed"
+    }
+}
+
+def test_eq_version() {
+    pass_count = 0
+    fail_count = 0
+
+    values = [
+        "1.2",
+        "3.0",
+        "3.0.2",
+        "3.0.5",
+        "3.1",
+        "3.10",
+        "3.10.1",
+        "3.11",
+        "5.3",
+        "6" // can you do single digit ones?
+    ]
+
+    // test "equals"
+    expected = true
+    values.each {
+        actual = buildlib.eq_version(it, it)
+        try {
+            assert actual == expected
+            pass_count++
+        } catch (AssertionError e) {
+            fail_count++
+            echo "FAIL: eq_version(${values[it]}, ${values[it + 1]}) - expected: ${expected}, actual: ${actual}"
+        }
+    }
+
+    /// test equality of different length versions
+    actual = buildlib.eq_version("3.1", "3.1.0")
+    try {
+        assert actual == expected
+        pass_count++
+    } catch (AssertionError e) {
+        fail_count++
+        echo "FAIL: eq_version(\"3.1\"}, \"3.1.0\") - expected: ${expected}, actual: ${actual}"
+    }
+    
+    /// test equality of different length versions
+    actual = buildlib.eq_version("3.1.0", "3.1")
+    try {
+        assert actual == expected
+        pass_count++
+    } catch (AssertionError e) {
+        fail_count++
+        echo "FAIL: eq_version(\"3.1.0\", \"3.1\") - expected: ${expected}, actual: ${actual}"
+    }
+
+    expected = false
+    (0..(values.size() - 2)).each {
+        /// test equality of different length versions
+        actual = buildlib.eq_version(values[it], values[it + 1])
+        try {
+            assert actual == expected
+            pass_count++
+        } catch (AssertionError e) {
+            fail_count++
+            echo "FAIL: eq_version(${values[it]}, ${values[it + 1]}) - expected: ${expected}, actual: ${actual}"
+        }
+    }
+
+    if (fail_count == 0) {
+        echo "PASS: eq_version() - ${pass_count} tests passed"
+    } else {
+        echo "FAIL: eq_version() - ${pass_count} tests passed, ${fail_count} tests failed"
+    }
+}
+
+//
+// Test sorting arrays of version strings made up of decimal numbers separated by dots (.)
+//
+def test_sort_versions() {
+    pass_count = 0
+    fail_count = 0
+    
+    values = ["3.1", "3.9", "3.5.3", "3.5", "3.10", "3.12", "3.1.3", "3.10.1"]
+
+    // sort operates in place.  Make a copy so the initial unsorted list isn't destroyed
+    actual = values.collect()
+    expected = ["3.1", "3.1.3", "3.5", "3.5.3", "3.9", "3.10", "3.10.1", "3.12"]
+
+    // sort works in-place but also returns the sorted array.  Curious.
+    result = buildlib.sort_versions(actual)
+
+    try {
+        assert actual == expected
+        pass_count++
+    } catch (AssertionError e) {
+        echo "FAIL sort_versions() in-place failed: actual = ${actual}, expected: ${expected}"
+        fail_count++
+    }
+
+    try {
+        assert result == expected
+        pass_count++
+    } catch (AssertionError e) {
+        echo "FAIL sort_versions() return value failed: actual = ${actual}, expected: ${expected}"
+        fail_count++
+    }
+
+    if (fail_count == 0) {
+        echo "PASS: sort_versions() - ${pass_count} tests passed"
+    } else {
+        echo "FAIL: sort_version() - ${pass_count} tests passed, ${fail_count} tests failed"
+    }
+}
+
+//
+// Test the automatic "build mode" selection for different version and release number inputs
+//
+// The auto_mode() function returns 1 of 4 values:
+//   'dev':         The version to build matches the master:HEAD version and is not in the current release set
+//   'pre-release': The version matches master:HEAD and a release branch for that version exists
+//   'release':     The version matches a release branch but is not the version at master:HEAD
+//   null:          The version is neither on a release branch or in master:HEAD
+//
+def test_auto_mode() {
+    pass_count = 0
+    fail_count = 0
+
+    releases = ["3.0", "3.1", "3.2"]
+
+    expected = 'dev'
+    actual = buildlib.auto_mode("3.3", "3.3", releases)
+    try {
+        assert actual == expected
+        pass_count++
+    } catch (AssertionError e) {
+        fail_count++
+        echo "FAIL: auto_mode(\"3.3\", \"3.3\", ${releases}): actual: ${actual}, expected ${expected}"
+    }
+
+    expected = 'pre-release'
+    actual = buildlib.auto_mode("3.2", "3.2", releases)
+    try {
+        assert actual == expected
+        pass_count++
+    } catch (AssertionError e) {
+        fail_count++
+        echo "FAIL: auto_mode(\"3.2\", \"3.2\", ${releases}): actual: ${actual}, expected ${expected}"
+    }
+
+    expected = 'release'
+    actual = buildlib.auto_mode("3.2", "3.3", releases)
+    try {
+        assert actual == expected
+        pass_count++
+    } catch (AssertionError e) {
+        fail_count++
+        echo "FAIL: auto_mode(\"3.2\", \"3.3\", ${releases}): actual: ${actual}, expected ${expected}"
+    }
+
+    expected = null
+    actual = buildlib.auto_mode("3.4", "3.3", releases)
+    try {
+        assert actual == expected
+        pass_count++
+    } catch (AssertionError e) {
+        fail_count++
+        echo "FAIL: auto_mode(\"3.4\", \"3.3\", ${releases}): actual: ${actual}, expected ${expected}"
+    }
+
+    if (fail_count == 0) {
+        echo "PASS: auto_mode() - ${pass_count} tests passed"
+    } else {
+        echo "FAIL: auto_mode() - ${pass_count} tests passed, ${fail_count} tests failed"
+    }
+}
+
+// make this a function module
+return this


### PR DESCRIPTION
This change adds seven (7) functions to the `pipeline-scripts/buildlib.groovy` library:

*`get_branches()` - get the list of branches from a github remote repository
* `get_releases()` - get the list of release numbers from a github remote repository branch list
* `get_single_file()` - get a single file from a github repo (given an OAuth key)
* `sort_versions()` - sort version strings
* `cmp_version()` - compare version strings
* `eq_version()` - determine if two version strings are equal
* `auto_mode()` - select the _build mode_ for a build when given only the desired version

These functions together will make it possible to allow users of the Jenkins CD build service of OCP to let the _build mode_ default when they give the version they wish to build.

Additional work is needed to integrate this functionality into the build jobs.