### PR TITLE
add auto-mode stage

### DIFF
--- a/jobs/build/ocp/Jenkinsfile
+++ b/jobs/build/ocp/Jenkinsfile
@@ -426,7 +426,7 @@ node(TARGET_NODE) {
             }
 
             stage("set build mode") {
-                master_spec = read_spec_info(GITHUB_BASE_PATHS['ose'] + "/origin.spec")
+                master_spec = buildlib.read_spec_info(GITHUB_BASE_PATHS['ose'] + "/origin.spec")
                                              
                 // If the target version resides in ose#master
                 IS_SOURCE_IN_MASTER = (BUILD_VERSION == master_spec.major_minor)

--- a/jobs/build/ocp/Jenkinsfile
+++ b/jobs/build/ocp/Jenkinsfile
@@ -422,12 +422,15 @@ node(TARGET_NODE) {
                 ///  OSE_DIR
                 //   GITHUB_URLS["ose"]
                 //   GITHUB_BASE_PATHS["ose"]
-                master_spec = buildlib.initialize_ose()
-                // If the target version resides in ose#master
-                IS_SOURCE_IN_MASTER = (BUILD_VERSION == master_spec.major_minor)
+                buildlib.initialize_ose()
             }
 
             stage("set build mode") {
+                master_spec = read_spec_info(GITHUB_BASE_PATHS['ose'] + "/origin.spec")
+                                             
+                // If the target version resides in ose#master
+                IS_SOURCE_IN_MASTER = (BUILD_VERSION == master_spec.major_minor)
+                                             
                 if (BUILD_MODE == "auto") {
                     echo "AUTO-MODE: determine mode from version and repo"
                     // INPUTS:

--- a/jobs/build/ocp/Jenkinsfile
+++ b/jobs/build/ocp/Jenkinsfile
@@ -79,6 +79,7 @@ properties(
                 [
                     name: 'BUILD_MODE',
                     description: '''
+auto                      BUILD_VERSION and ocp repo contents determine the mode<br>
 release                   {ose,origin-web-console,openshift-ansible}/release-X.Y ->  https://mirror.openshift.com/enterprise/enterprise-X.Y/<br>
 pre-release               {origin,origin-web-console,openshift-ansible}/release-X.Y ->  https://mirror.openshift.com/enterprise/enterprise-X.Y/<br>
 online:int                {origin,origin-web-console,openshift-ansible}/master -> online-int yum repo<br>
@@ -86,11 +87,13 @@ online:stg                {origin,origin-web-console,openshift-ansible}/stage ->
 ''',
                     $class: 'hudson.model.ChoiceParameterDefinition',
                     choices: [
+                        "auto",
                         "release",
                         "pre-release",
                         "online:int",
                         "online:stg"
-                    ].join("\n")
+                    ].join("\n"),
+                    defaultValue: "auto"
                 ],
                 [
                     name: 'SIGN',
@@ -422,6 +425,19 @@ node(TARGET_NODE) {
                 master_spec = buildlib.initialize_ose()
                 // If the target version resides in ose#master
                 IS_SOURCE_IN_MASTER = (BUILD_VERSION == master_spec.major_minor)
+            }
+
+            stage("set build mode") {
+                if (BUILD_MODE == "auto") {
+                    echo "AUTO-MODE: determine mode from version and repo"
+                    // INPUTS:
+                    //   BUILD_MODE
+                    //   BUILD_VERSION
+                    //   GITHUB_URLS["ose"]
+                    releases = buildlib.get_releases(GITHUB_URLS["ose"])
+                    BUILD_MODE = buildlib.auto_mode(BUILD_VERSION, master_spec.major_minor, releases)
+                    echo "BUILD_MODE = ${BUILD_MODE}"
+                }
             }
 
             stage("analyze") {

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -383,7 +383,7 @@ def eq_version(String v0, String v1) {
  * @param releases an array of version strings.  Each version string is from a release branch name
  * @return string the "build mode" to use when creating the local workspaces for OCP builds
  *
- * dev: build from master
+ * online:int: build from master
  * pre-release: build on release branch, merge master and upstream master before build
  * release: build from release branch
  *
@@ -399,13 +399,13 @@ def auto_mode(build_version, master_version, releases) {
     // --------------------------------------------
     // build = master |   true      |   false     |
     // --------------------------------------------
-    //      true      | pre-release |    dev      |
+    //      true      | pre-release |    online:int      |
     // -------------------------------------------
     //      false     |   release   |     X       |
     // -------------------------------------------
     // non-string map keys require parens during definition
     mode_table = [
-        (true):  [ (true): "pre-release", (false): "dev" ],
+        (true):  [ (true): "pre-release", (false): "online:int" ],
         (false): [ (true): "release",     (false): null  ]
     ]
 

--- a/pipeline-scripts/buildlib_test.groovy
+++ b/pipeline-scripts/buildlib_test.groovy
@@ -218,7 +218,7 @@ def test_sort_versions() {
 // Test the automatic "build mode" selection for different version and release number inputs
 //
 // The auto_mode() function returns 1 of 4 values:
-//   'dev':         The version to build matches the master:HEAD version and is not in the current release set
+//   'online:int':  The version to build matches the master:HEAD version and is not in the current release set
 //   'pre-release': The version matches master:HEAD and a release branch for that version exists
 //   'release':     The version matches a release branch but is not the version at master:HEAD
 //   null:          The version is neither on a release branch or in master:HEAD
@@ -229,7 +229,7 @@ def test_auto_mode() {
 
     releases = ["3.0", "3.1", "3.2"]
 
-    expected = 'dev'
+    expected = 'online:int'
     actual = buildlib.auto_mode("3.3", "3.3", releases)
     try {
         assert actual == expected


### PR DESCRIPTION
This PR adds the 'auto' build mode and defines that as the default  It uses the `auto_mode()` function from PR-1500 to set the build mode when the user provides a version to build and selects "auto" mode.

This allows users to ignore the mode in most cases and prevents mis-configuration  by combining invalid build version and build mode.