### PR TITLE
auto-mode should fail on bad mode

### DIFF
--- a/pipeline-scripts/buildlib_test.groovy
+++ b/pipeline-scripts/buildlib_test.groovy
@@ -259,14 +259,12 @@ def test_auto_mode() {
         echo "FAIL: auto_mode(\"3.2\", \"3.3\", ${releases}): actual: ${actual}, expected ${expected}"
     }
 
-    expected = null
-    actual = buildlib.auto_mode("3.4", "3.3", releases)
     try {
-        assert actual == expected
-        pass_count++
-    } catch (AssertionError e) {
+        actual = buildlib.auto_mode("3.4", "3.3", releases)
         fail_count++
-        echo "FAIL: auto_mode(\"3.4\", \"3.3\", ${releases}): actual: ${actual}, expected ${expected}"
+        echo "FAIL: auto_mode(\"3.4\", \"3.3\", ${releases}): actual: ${actual}, expected error"
+    } catch (hudson.AbortException e) {
+        pass_count++
     }
 
     if (fail_count == 0) {


### PR DESCRIPTION
Updated buildlib test for auto_mode to correctly expect execption on invalid mode:
  build version != master version && build_version not in release branch versions.

All tests passed https://buildvm.openshift.eng.bos.redhat.com:8443/job/dev-buildlib-markllama/