### PR TITLE
Add helper functions for updating RPM version numbers and getting versions from .spec files on github

### DIFF
--- a/pipeline-scripts/Jenkinsfile
+++ b/pipeline-scripts/Jenkinsfile
@@ -88,4 +88,10 @@ node(TARGET_NODE) {
         testlib.test_auto_mode()
         echo "END: test_auto_mode()"
     }
+
+    stage("test new_version") {
+        echo "BEGIN: test_new_version()"
+        testlib.test_new_version()
+        echo "END: test_new_version()"
+    }
 }

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -293,18 +293,33 @@ def get_releases(repo_url) {
 }
 
 /**
+ * Read an OAuth token from a file on the jenkins server.
+ * Because groovy/jenkins sandbox won't let you read it without sh()
+ * @param token_file - a file containing a single OAuth token string
+ * @return - a string containing the OAuth token
+ */
+def read_oath_token(token_file) {
+    token_string = sh (
+        returnStdout: true,
+        script: "cat ${token_file}"
+    ).trim()
+    return token_string
+}
+
+/**
  * Retrieve a single file from a Github repository
  * @param owner
  * @param repo_name
  * @param file_name
  * @param repo_token
+ * @param branch
  * @return a string containing the contents of the specified file
  */
-def get_single_file(owner, repo_name, file_name, repo_token) {
+def get_single_file(owner, repo_name, file_name, repo_token, branch='master') {
     // Get a single file from a Github repository.
 
     auth_header = "Authorization: token " + repo_token
-    file_url = "https://api.github.com/repos/${owner}/${repo_name}/contents/${file_name}"
+    file_url = "https://api.github.com/repos/${owner}/${repo_name}/contents/${file_name}?ref=${branch}"
     accept_header = "Accept: application/vnd.github.v3.raw"
 
     query = "curl --silent -H '${auth_header}' -H '${accept_header}' -L ${file_url}"
@@ -435,6 +450,105 @@ invalid mode build != master and no release branch
 """)
     }
     return mode
+}
+
+//
+// Create a new version string based on the build mode
+//
+//@NonCPS
+def new_version(mode, version_string, release_string) {
+
+    // version and release are arrays of dot-seprated decimals
+    version = version_string.tokenize('.').collect { it.toInteger() }
+    release = release_string.tokenize('.').collect { it.toInteger() }
+
+    // stage and int:
+    //   version field is N.N.N unchanged
+    //   release field is 0.I.S to differentiate builds
+    //
+
+    // pre-release and release:
+    //
+    //   version field is N.{N+1}
+    //   release field is 1
+
+    // pad release to 3 fields
+    while (version.size() < 3) { version += 0 }
+    while (release.size() < 3) { release += 0 }
+
+    switch (mode) {
+        case 'online:int':
+            release[1]++
+            release[2] = 0
+            break
+        case 'online:stg':
+            release[2]++
+            break
+        case 'release':
+        case 'pre-release':
+            version[-1]++ // this puts a colon in the final field
+            release = [1]
+            break
+    }
+
+    return [
+        'version': version.each{ it.toString() }.join('.'),
+        'release': release.each{ it.toString() }.join('.')
+    ]
+}
+
+// set the repo and branch information for each mode and build version
+// NOTE: here "origin" refers to the git reference, not to OpenShift Origin
+def get_build_branches(mode, build_version) {
+    // INPUTS:
+    //   :param: mode - a string indicating which branches to build from
+    //   :param: build_version - a version string used to compose the branch names
+    //   :return: a map containing the source origin and upstream branch names
+
+    switch(mode) {
+        case "online:int":
+            branch_names = ['origin': "master", 'upstream': "master"]
+            break
+
+        case "online:stg":
+            branch_names = ['origin': "stage", 'upstream': "stage"]
+            break
+
+        case "pre-release":
+            branch_names = ['origin': "enterprise-${build_version}", 'upstream': "release-${build_version}"]
+            break
+
+        case "release":
+            branch_names = ['origin': "enterprise-${build_version}", 'upstream': null]
+            break
+    }
+
+    return branch_names
+}
+
+// predicate: build with the web-server-console source tree?
+def use_web_console_server(version_string) {
+    // the web console server was introduced with version 3.9
+    return cmp_version(version_string, "3.9") >= 0
+}
+
+// set the merge driver for a git repo
+//
+// @param repo_dir string - a git repository workspace
+// @param files List[String] - a list of file/dir strings for the merge driver
+//
+@NonCPS
+def mock_merge_driver(repo_dir, files) {
+
+    Dir(repo_dir) {
+        sh "git config merge.ours.driver true"
+    }
+
+    // Use fake merge driver on specific packages
+    gitattrs = new File(repo_dir + "/.gitattributes")
+    files.each {
+            gitattrs << "${it}  merge=ours\n"
+    }
 }
 
 /**

--- a/pipeline-scripts/buildlib_test.groovy
+++ b/pipeline-scripts/buildlib_test.groovy
@@ -274,5 +274,143 @@ def test_auto_mode() {
     }
 }
 
+//
+// New version returns a map with the version and release strings for a new
+// build.  The change is defined by the build mode and the current version
+//
+def test_new_version() {
+    pass_count = 0
+    fail_count = 0
+
+    test_values = [
+        'online:int': [
+            [
+                'initial':  [ 'version': "3.1", 'release': "0.0.0"],
+                'expected': [ 'version': "3.1.0", 'release': "0.1.0"]
+            ],
+            [
+                'initial':  [ 'version': "3.10.1", 'release': "0.2.0"],
+                'expected': [ 'version': "3.10.1", 'release': "0.3.0"]
+            ],
+            [
+                'initial':  [ 'version': "3.1.4", 'release': "0.12.0"],
+                'expected': [ 'version': "3.1.4", 'release': "0.13.0"]
+            ],
+        ],
+
+        'online:stg': [
+            [
+                'initial':  [ 'version': "3.1", 'release': "0.0.0"],
+                'expected': [ 'version': "3.1.0", 'release': "0.0.1"]
+            ],
+            [
+                'initial':  [ 'version': "3.10", 'release': "0.2.3"],
+                'expected': [ 'version': "3.10.0", 'release': "0.2.4"]
+            ],
+            [
+                'initial':  [ 'version': "3.1.4", 'release': "0.1.12"],
+                'expected': [ 'version': "3.1.4", 'release': "0.1.13"]
+            ],
+        ],
+
+        'pre-release': [
+            [
+                'initial':  [ 'version': "3.1", 'release': "1"],
+                'expected': [ 'version': "3.1.1", 'release': "1"]
+            ],
+            [
+                'initial':  [ 'version': "3.10.2", 'release': "1"],
+                'expected': [ 'version': "3.10.3", 'release': "1"]
+            ],
+            [
+                'initial':  [ 'version': "3.1.9", 'release': "1"],
+                'expected': [ 'version': "3.1.10", 'release': "1"]
+            ],
+        ],
+
+        'release': [
+            [
+                'initial':  [ 'version': "3.1", 'release': "1"],
+                'expected': [ 'version': "3.1.1", 'release': "1"]
+            ],
+            [
+                'initial':  [ 'version': "3.10.2", 'release': "1"],
+                'expected': [ 'version': "3.10.3", 'release': "1"]
+            ],
+            [
+                'initial':  [ 'version': "3.1.9", 'release': "1"],
+                'expected': [ 'version': "3.1.10", 'release': "1"]
+            ],
+        ]
+    ]
+
+    test_values.each {
+        mode, samples ->  echo "test_new_version - mode: $mode"
+
+        samples.each { sample ->
+            //echo "test values: ${sample}"
+            try {
+                //echo "single sample ${sample['initial']}"
+                //echo "single sample initial version ${sample['initial']['version']}"
+                nv = buildlib.new_version(
+                    mode,
+                    sample['initial']['version'], sample['initial']['release']
+                )
+
+                assert nv == sample.expected
+                pass_count++
+            } catch (AssertionError e) {
+                fail_count++
+                echo "FAIL: new_version(${mode} - Input: ${sample.initial}, Expected: ${sample.expected}, Actual: ${nv}"
+            }
+        }
+    }
+
+    if (fail_count == 0) {
+        echo "PASS: new_version() - ${pass_count} tests passed"
+    } else {
+        echo "FAIL: new_version() - ${pass_count} tests passed, ${fail_count} tests failed"
+    }
+}
+
+def test_get_build_branches() {
+    pass_count = 0
+    fail_count = 0
+
+    test_values = [
+        'online:int': [
+            ['input': '3.9', 'expected': ['origin': 'master', 'upstream': 'master']]
+        ],
+
+        'online:stg': [
+            ['input': '3.3', 'expected': ['origin': 'stage', 'upstream': 'stage']]
+        ],
+
+        'pre-release': [
+            ['input': '3.9', 'expected': ['origin': 'enterprise-3.9', 'upstream': 'release-3.9']]
+        ],
+
+        'release': [
+            ['input': '3.9', 'expected': ['origin': 'enterprise-3.9', 'upstream': null]]
+        ]
+    ]
+
+    test_values.each { mode, samples ->
+        actual = buildlib.get_branch_names(mode, sample['input'])
+        try {
+            assert actual == expected
+            pass_count++
+        } catch (AssertionError e) {
+            fail_count++
+            echo("failed")
+        }
+    }
+
+    if (fail_count == 0) {
+        echo "PASS: validate_build() - ${pass_count} tests passed"
+    } else {
+        echo "FAIL: validate_build() - ${pass_count} tests passed, ${fail_count} tests failed"
+    }
+}
 // make this a function module
 return this


### PR DESCRIPTION
This PR adds functions that can be used in the future to generate version number updates and to retrieve
version number information from RPM spec files on github without cloning the entire repo.

It makes no change to existing jobs or functions.