### PR TITLE
Use origin-cli for 3.10+ to get oc for console tests

### DIFF
--- a/sjb/config/test_cases/test_branch_origin_web_console.yml
+++ b/sjb/config/test_cases/test_branch_origin_web_console.yml
@@ -21,9 +21,20 @@ extensions:
         else
           echo "IMAGE_VERSION=latest" > IMAGE_VERSION_VAR
         fi
+        # We copy oc from the image to get the right version. Use
+        # openshift/origin-cli in 3.10 and newer. Use openshift/origin for
+        # earlier releases.
+        case $PULL_BASE_REF in
+        enterprise-3.[3-9])
+          CLI_IMAGE="origin"
+          ;;
+        *)
+          CLI_IMAGE="origin-cli"
+          ;;
+        esac
         source IMAGE_VERSION_VAR
-        sudo docker pull openshift/origin:"${IMAGE_VERSION}"
-        sudo docker create --name temp-container openshift/origin:"${IMAGE_VERSION}"
+        sudo docker pull "openshift/${CLI_IMAGE}:${IMAGE_VERSION}"
+        sudo docker create --name temp-container "openshift/${CLI_IMAGE}:${IMAGE_VERSION}"
         sudo docker cp temp-container:/usr/bin/oc ./
         sudo docker rm temp-container
         sudo mv -f ./oc /bin/oc

--- a/sjb/generated/test_branch_origin_web_console.xml
+++ b/sjb/generated/test_branch_origin_web_console.xml
@@ -293,9 +293,20 @@ if [[ &#34;\${PULL_BASE_REF}&#34; = &#34;enterprise-&#34;* ]]; then
 else
   echo &#34;IMAGE_VERSION=latest&#34; &gt; IMAGE_VERSION_VAR
 fi
+# We copy oc from the image to get the right version. Use
+# openshift/origin-cli in 3.10 and newer. Use openshift/origin for
+# earlier releases.
+case \$PULL_BASE_REF in
+enterprise-3.[3-9])
+  CLI_IMAGE=&#34;origin&#34;
+  ;;
+*)
+  CLI_IMAGE=&#34;origin-cli&#34;
+  ;;
+esac
 source IMAGE_VERSION_VAR
-sudo docker pull openshift/origin:&#34;\${IMAGE_VERSION}&#34;
-sudo docker create --name temp-container openshift/origin:&#34;\${IMAGE_VERSION}&#34;
+sudo docker pull &#34;openshift/\${CLI_IMAGE}:\${IMAGE_VERSION}&#34;
+sudo docker create --name temp-container &#34;openshift/\${CLI_IMAGE}:\${IMAGE_VERSION}&#34;
 sudo docker cp temp-container:/usr/bin/oc ./
 sudo docker rm temp-container
 sudo mv -f ./oc /bin/oc

--- a/sjb/generated/test_pull_request_origin_web_console.xml
+++ b/sjb/generated/test_pull_request_origin_web_console.xml
@@ -293,9 +293,20 @@ if [[ &#34;\${PULL_BASE_REF}&#34; = &#34;enterprise-&#34;* ]]; then
 else
   echo &#34;IMAGE_VERSION=latest&#34; &gt; IMAGE_VERSION_VAR
 fi
+# We copy oc from the image to get the right version. Use
+# openshift/origin-cli in 3.10 and newer. Use openshift/origin for
+# earlier releases.
+case \$PULL_BASE_REF in
+enterprise-3.[3-9])
+  CLI_IMAGE=&#34;origin&#34;
+  ;;
+*)
+  CLI_IMAGE=&#34;origin-cli&#34;
+  ;;
+esac
 source IMAGE_VERSION_VAR
-sudo docker pull openshift/origin:&#34;\${IMAGE_VERSION}&#34;
-sudo docker create --name temp-container openshift/origin:&#34;\${IMAGE_VERSION}&#34;
+sudo docker pull &#34;openshift/\${CLI_IMAGE}:\${IMAGE_VERSION}&#34;
+sudo docker create --name temp-container &#34;openshift/\${CLI_IMAGE}:\${IMAGE_VERSION}&#34;
 sudo docker cp temp-container:/usr/bin/oc ./
 sudo docker rm temp-container
 sudo mv -f ./oc /bin/oc


### PR DESCRIPTION
Fixes cluster up failures in origin-web-console tests. See https://github.com/openshift/origin-web-console/pull/3040#issuecomment-407105460

/assign @stevekuznetsov 