### PR TITLE
Switch to using the AWS cluster operator account for co e2e

### DIFF
--- a/sjb/config/test_cases/test_branch_cluster_operator_e2e.yml
+++ b/sjb/config/test_cases/test_branch_cluster_operator_e2e.yml
@@ -22,7 +22,7 @@ extensions:
     - type: "host_script"
       title: "transfer aws credentials to remote host"
       script: |-
-        scp -F ./.config/origin-ci-tool/inventory/.ssh_config ~/.aws/clusteroperator-credentials openshiftdevel:/tmp/.aws/credentials
+        scp -F ./.config/origin-ci-tool/inventory/.ssh_config ~/.aws/clusteroperator-ci-credentials openshiftdevel:/tmp/.aws/credentials
     - type: "script"
       title: "start cluster up environment"
       timeout: 600

--- a/sjb/generated/test_branch_cluster_operator_e2e.xml
+++ b/sjb/generated/test_branch_cluster_operator_e2e.xml
@@ -297,7 +297,7 @@ ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config -t openshiftdev
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: TRANSFER AWS CREDENTIALS TO REMOTE HOST ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: TRANSFER AWS CREDENTIALS TO REMOTE HOST [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-scp -F ./.config/origin-ci-tool/inventory/.ssh_config ~/.aws/clusteroperator-credentials openshiftdevel:/tmp/.aws/credentials</command>
+scp -F ./.config/origin-ci-tool/inventory/.ssh_config ~/.aws/clusteroperator-ci-credentials openshiftdevel:/tmp/.aws/credentials</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_cluster_operator_e2e.xml
+++ b/sjb/generated/test_pull_request_cluster_operator_e2e.xml
@@ -297,7 +297,7 @@ ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config -t openshiftdev
         <hudson.tasks.Shell>
           <command>#!/bin/bash
 SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: TRANSFER AWS CREDENTIALS TO REMOTE HOST ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: TRANSFER AWS CREDENTIALS TO REMOTE HOST [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
-scp -F ./.config/origin-ci-tool/inventory/.ssh_config ~/.aws/clusteroperator-credentials openshiftdevel:/tmp/.aws/credentials</command>
+scp -F ./.config/origin-ci-tool/inventory/.ssh_config ~/.aws/clusteroperator-ci-credentials openshiftdevel:/tmp/.aws/credentials</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash


### PR DESCRIPTION
The initial vm will still be created in the regular account but all test artifacts will now be created in the cluster operator AWS account, making it easier to manage and cleanup and reducing the risk to the regular account. After this is in place, the credentials to the regular account may be removed from Jenkins.