### PR TITLE
Fix cluster-operator image push job

### DIFF
--- a/sjb/config/test_cases/push_cluster_operator_images.yml
+++ b/sjb/config/test_cases/push_cluster_operator_images.yml
@@ -7,9 +7,6 @@ extensions:
       repository: "cluster-operator"
       script: |-
         make images
-        sudo mkdir -p $(pwd)/bin/cluster-api
-        sudo chmod 777 $(pwd)/bin/cluster-api
-        make kubernetes-cluster-api
     - type: "script"
       title: "create directory for docker config"
       script: |-
@@ -35,10 +32,7 @@ extensions:
         docker push registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:latest
 
         docker tag cluster-operator-ansible:v3.10 registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:v3.10
-        docker push registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:latest
+        docker push registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:v3.10
 
         docker tag cluster-operator-ansible:v3.9 registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:v3.9
-        docker push registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:latest
-
-        docker tag clusterapi:latest registry.svc.ci.openshift.org/openshift-cluster-operator/kubernetes-cluster-api:latest
-        docker push registry.svc.ci.openshift.org/openshift-cluster-operator/kubernetes-cluster-api:latest
+        docker push registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:v3.9

--- a/sjb/generated/push_cluster_operator_images.xml
+++ b/sjb/generated/push_cluster_operator_images.xml
@@ -307,9 +307,6 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/cluster-operator&#34;
 make images
-sudo mkdir -p \$(pwd)/bin/cluster-api
-sudo chmod 777 \$(pwd)/bin/cluster-api
-make kubernetes-cluster-api
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -353,13 +350,10 @@ docker tag cluster-operator-ansible:canary registry.svc.ci.openshift.org/openshi
 docker push registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:latest
 
 docker tag cluster-operator-ansible:v3.10 registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:v3.10
-docker push registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:latest
+docker push registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:v3.10
 
 docker tag cluster-operator-ansible:v3.9 registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:v3.9
-docker push registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:latest
-
-docker tag clusterapi:latest registry.svc.ci.openshift.org/openshift-cluster-operator/kubernetes-cluster-api:latest
-docker push registry.svc.ci.openshift.org/openshift-cluster-operator/kubernetes-cluster-api:latest
+docker push registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:v3.9
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;


### PR DESCRIPTION
Fixes cluster-operator image push job by removing an old image build and pushing the cluster-operator-ansible image to the right tag by version.