### PR TITLE
Add all required env to azure jobs

### DIFF
--- a/sjb/config/test_cases/azure_build_base_image_centos.yml
+++ b/sjb/config/test_cases/azure_build_base_image_centos.yml
@@ -9,6 +9,30 @@ sync:
 parameters:
 - name: "AZURE_VM_SIZE"
   default_value: "Standard_D2s_v3"
+- name: JOB_SPEC
+  description: "JSON form of job specification."
+- name: BUILD_ID
+  description: "Unique build number for each run."
+- name: REPO_OWNER
+  description: "GitHub org that triggered the job."
+  default_value: openshift
+- name: REPO_NAME
+  description: "GitHub repo that triggered the job."
+  default_value: origin
+- name: PULL_BASE_REF
+  description: "Ref name of the base branch."
+- name: PULL_BASE_SHA
+  description: "Git SHA of the base branch."
+- name: PULL_REFS
+  description: "All refs to test."
+- name: PULL_NUMBER
+  description: "Pull request number."
+- name: PULL_PULL_SHA
+  description: "Pull request head SHA."
+- name: JOB_SPEC
+  description: "The job spec definition."
+- name: PROW_JOB_ID
+  description: "The ID that prow sets on a Jenkins job in order to correlate it with a ProwJob."
 actions:
   - type: "forward_parameters"
     parameters:

--- a/sjb/config/test_cases/azure_build_base_image_rhel.yml
+++ b/sjb/config/test_cases/azure_build_base_image_rhel.yml
@@ -9,6 +9,30 @@ sync:
 parameters:
 - name: "AZURE_VM_SIZE"
   default_value: "Standard_D2s_v3"
+- name: JOB_SPEC
+  description: "JSON form of job specification."
+- name: BUILD_ID
+  description: "Unique build number for each run."
+- name: REPO_OWNER
+  description: "GitHub org that triggered the job."
+  default_value: openshift
+- name: REPO_NAME
+  description: "GitHub repo that triggered the job."
+  default_value: origin
+- name: PULL_BASE_REF
+  description: "Ref name of the base branch."
+- name: PULL_BASE_SHA
+  description: "Git SHA of the base branch."
+- name: PULL_REFS
+  description: "All refs to test."
+- name: PULL_NUMBER
+  description: "Pull request number."
+- name: PULL_PULL_SHA
+  description: "Pull request head SHA."
+- name: JOB_SPEC
+  description: "The job spec definition."
+- name: PROW_JOB_ID
+  description: "The ID that prow sets on a Jenkins job in order to correlate it with a ProwJob."
 actions:
   - type: "forward_parameters"
     parameters:

--- a/sjb/config/test_cases/azure_build_node_image_centos.yml
+++ b/sjb/config/test_cases/azure_build_node_image_centos.yml
@@ -10,6 +10,30 @@ sync:
 parameters:
 - name: "AZURE_VM_SIZE"
   default_value: "Standard_D2s_v3"
+- name: JOB_SPEC
+  description: "JSON form of job specification."
+- name: BUILD_ID
+  description: "Unique build number for each run."
+- name: REPO_OWNER
+  description: "GitHub org that triggered the job."
+  default_value: openshift
+- name: REPO_NAME
+  description: "GitHub repo that triggered the job."
+  default_value: origin
+- name: PULL_BASE_REF
+  description: "Ref name of the base branch."
+- name: PULL_BASE_SHA
+  description: "Git SHA of the base branch."
+- name: PULL_REFS
+  description: "All refs to test."
+- name: PULL_NUMBER
+  description: "Pull request number."
+- name: PULL_PULL_SHA
+  description: "Pull request head SHA."
+- name: JOB_SPEC
+  description: "The job spec definition."
+- name: PROW_JOB_ID
+  description: "The ID that prow sets on a Jenkins job in order to correlate it with a ProwJob."
 actions:
   - type: "forward_parameters"
     parameters:

--- a/sjb/config/test_cases/azure_build_node_image_centos_310.yml
+++ b/sjb/config/test_cases/azure_build_node_image_centos_310.yml
@@ -12,6 +12,30 @@ parameters:
   default_value: "Standard_D2s_v3"
 - name: "OPENSHIFT_RELEASE"
   default_value: "3.10"
+- name: JOB_SPEC
+  description: "JSON form of job specification."
+- name: BUILD_ID
+  description: "Unique build number for each run."
+- name: REPO_OWNER
+  description: "GitHub org that triggered the job."
+  default_value: openshift
+- name: REPO_NAME
+  description: "GitHub repo that triggered the job."
+  default_value: origin
+- name: PULL_BASE_REF
+  description: "Ref name of the base branch."
+- name: PULL_BASE_SHA
+  description: "Git SHA of the base branch."
+- name: PULL_REFS
+  description: "All refs to test."
+- name: PULL_NUMBER
+  description: "Pull request number."
+- name: PULL_PULL_SHA
+  description: "Pull request head SHA."
+- name: JOB_SPEC
+  description: "The job spec definition."
+- name: PROW_JOB_ID
+  description: "The ID that prow sets on a Jenkins job in order to correlate it with a ProwJob."
 actions:
   - type: "forward_parameters"
     parameters:

--- a/sjb/config/test_cases/azure_build_node_image_centos_39.yml
+++ b/sjb/config/test_cases/azure_build_node_image_centos_39.yml
@@ -12,6 +12,30 @@ parameters:
   default_value: "Standard_D2s_v3"
 - name: "OPENSHIFT_RELEASE"
   default_value: "3.9"
+- name: JOB_SPEC
+  description: "JSON form of job specification."
+- name: BUILD_ID
+  description: "Unique build number for each run."
+- name: REPO_OWNER
+  description: "GitHub org that triggered the job."
+  default_value: openshift
+- name: REPO_NAME
+  description: "GitHub repo that triggered the job."
+  default_value: origin
+- name: PULL_BASE_REF
+  description: "Ref name of the base branch."
+- name: PULL_BASE_SHA
+  description: "Git SHA of the base branch."
+- name: PULL_REFS
+  description: "All refs to test."
+- name: PULL_NUMBER
+  description: "Pull request number."
+- name: PULL_PULL_SHA
+  description: "Pull request head SHA."
+- name: JOB_SPEC
+  description: "The job spec definition."
+- name: PROW_JOB_ID
+  description: "The ID that prow sets on a Jenkins job in order to correlate it with a ProwJob."
 actions:
   - type: "forward_parameters"
     parameters:

--- a/sjb/config/test_cases/azure_build_node_image_rhel_310.yml
+++ b/sjb/config/test_cases/azure_build_node_image_rhel_310.yml
@@ -12,6 +12,30 @@ parameters:
   default_value: "Standard_D2s_v3"
 - name: "OPENSHIFT_RELEASE"
   default_value: "3.10"
+- name: JOB_SPEC
+  description: "JSON form of job specification."
+- name: BUILD_ID
+  description: "Unique build number for each run."
+- name: REPO_OWNER
+  description: "GitHub org that triggered the job."
+  default_value: openshift
+- name: REPO_NAME
+  description: "GitHub repo that triggered the job."
+  default_value: origin
+- name: PULL_BASE_REF
+  description: "Ref name of the base branch."
+- name: PULL_BASE_SHA
+  description: "Git SHA of the base branch."
+- name: PULL_REFS
+  description: "All refs to test."
+- name: PULL_NUMBER
+  description: "Pull request number."
+- name: PULL_PULL_SHA
+  description: "Pull request head SHA."
+- name: JOB_SPEC
+  description: "The job spec definition."
+- name: PROW_JOB_ID
+  description: "The ID that prow sets on a Jenkins job in order to correlate it with a ProwJob."
 actions:
   - type: "forward_parameters"
     parameters:
@@ -71,7 +95,7 @@ actions:
         -e "oreg_url=$OREG_URL" \
         -e "oreg_auth_user=unused" \
         -e "oreg_auth_password=$AWS_REGISTRY_TOKEN" \
-        playbooks/azure/openshift-cluster/build_node_image.yml 
+        playbooks/azure/openshift-cluster/build_node_image.yml
       set -x
 
   - type: "script"

--- a/sjb/config/test_cases/azure_build_node_image_rhel_39.yml
+++ b/sjb/config/test_cases/azure_build_node_image_rhel_39.yml
@@ -12,6 +12,30 @@ parameters:
   default_value: "Standard_D2s_v3"
 - name: "OPENSHIFT_RELEASE"
   default_value: "3.9"
+- name: JOB_SPEC
+  description: "JSON form of job specification."
+- name: BUILD_ID
+  description: "Unique build number for each run."
+- name: REPO_OWNER
+  description: "GitHub org that triggered the job."
+  default_value: openshift
+- name: REPO_NAME
+  description: "GitHub repo that triggered the job."
+  default_value: origin
+- name: PULL_BASE_REF
+  description: "Ref name of the base branch."
+- name: PULL_BASE_SHA
+  description: "Git SHA of the base branch."
+- name: PULL_REFS
+  description: "All refs to test."
+- name: PULL_NUMBER
+  description: "Pull request number."
+- name: PULL_PULL_SHA
+  description: "Pull request head SHA."
+- name: JOB_SPEC
+  description: "The job spec definition."
+- name: PROW_JOB_ID
+  description: "The ID that prow sets on a Jenkins job in order to correlate it with a ProwJob."
 actions:
   - type: "forward_parameters"
     parameters:

--- a/sjb/generated/azure_build_base_image_centos.xml
+++ b/sjb/generated/azure_build_base_image_centos.xml
@@ -24,6 +24,11 @@
           <defaultValue>Standard_D2s_v3</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
+          <name>PROW_JOB_ID</name>
+          <description>The ID that prow sets on a Jenkins job in order to correlate it with a ProwJob.</description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>JOB_SPEC</name>
           <description></description>
           <defaultValue></defaultValue>

--- a/sjb/generated/azure_build_base_image_rhel.xml
+++ b/sjb/generated/azure_build_base_image_rhel.xml
@@ -24,6 +24,11 @@
           <defaultValue>Standard_D2s_v3</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
+          <name>PROW_JOB_ID</name>
+          <description>The ID that prow sets on a Jenkins job in order to correlate it with a ProwJob.</description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>JOB_SPEC</name>
           <description></description>
           <defaultValue></defaultValue>

--- a/sjb/generated/azure_build_node_image_centos.xml
+++ b/sjb/generated/azure_build_node_image_centos.xml
@@ -24,6 +24,11 @@
           <defaultValue>Standard_D2s_v3</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
+          <name>PROW_JOB_ID</name>
+          <description>The ID that prow sets on a Jenkins job in order to correlate it with a ProwJob.</description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>JOB_SPEC</name>
           <description></description>
           <defaultValue></defaultValue>

--- a/sjb/generated/azure_build_node_image_centos_310.xml
+++ b/sjb/generated/azure_build_node_image_centos_310.xml
@@ -29,6 +29,11 @@
           <defaultValue>3.10</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
+          <name>PROW_JOB_ID</name>
+          <description>The ID that prow sets on a Jenkins job in order to correlate it with a ProwJob.</description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>JOB_SPEC</name>
           <description></description>
           <defaultValue></defaultValue>

--- a/sjb/generated/azure_build_node_image_centos_39.xml
+++ b/sjb/generated/azure_build_node_image_centos_39.xml
@@ -29,6 +29,11 @@
           <defaultValue>3.9</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
+          <name>PROW_JOB_ID</name>
+          <description>The ID that prow sets on a Jenkins job in order to correlate it with a ProwJob.</description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>JOB_SPEC</name>
           <description></description>
           <defaultValue></defaultValue>

--- a/sjb/generated/azure_build_node_image_rhel_310.xml
+++ b/sjb/generated/azure_build_node_image_rhel_310.xml
@@ -29,6 +29,11 @@
           <defaultValue>3.10</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
+          <name>PROW_JOB_ID</name>
+          <description>The ID that prow sets on a Jenkins job in order to correlate it with a ProwJob.</description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>JOB_SPEC</name>
           <description></description>
           <defaultValue></defaultValue>
@@ -254,7 +259,7 @@ cd cluster/test-deploy/azure
    -e &#34;oreg_url=\$OREG_URL&#34; \
    -e &#34;oreg_auth_user=unused&#34; \
    -e &#34;oreg_auth_password=\$AWS_REGISTRY_TOKEN&#34; \
-   playbooks/azure/openshift-cluster/build_node_image.yml 
+   playbooks/azure/openshift-cluster/build_node_image.yml
  set -x
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/azure_build_node_image_rhel_39.xml
+++ b/sjb/generated/azure_build_node_image_rhel_39.xml
@@ -29,6 +29,11 @@
           <defaultValue>3.9</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
+          <name>PROW_JOB_ID</name>
+          <description>The ID that prow sets on a Jenkins job in order to correlate it with a ProwJob.</description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>JOB_SPEC</name>
           <description></description>
           <defaultValue></defaultValue>

--- a/sjb/generated/ci-kubernetes-aws-actuator.xml
+++ b/sjb/generated/ci-kubernetes-aws-actuator.xml
@@ -402,7 +402,7 @@ done
 echo &#34;### Remove the instance&#34;
 sudo kubectl delete -f machine.yaml
 
-echo &#34;### Wait until the instnance is terminated&#34;
+echo &#34;### Wait until the instance is terminated&#34;
 retry=0
 terminated=0
 while [[ \$retry -le 150 ]]; do


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

@kwoodson you were missing the `$PROW_JOB_ID` var since you don't use a common parent. Fixed the jobs now.