### PR TITLE
cluster-operator e2e: Install python-devel tools

### DIFF
--- a/sjb/config/test_cases/test_branch_cluster_operator_e2e.yml
+++ b/sjb/config/test_cases/test_branch_cluster_operator_e2e.yml
@@ -8,6 +8,7 @@ extensions:
     - type: "script"
       title: "setup prerequisites"
       script: |-
+        sudo yum -y install python-devel
         sudo pip install --upgrade setuptools
         sudo pip install openshift
         sudo pip install --upgrade awscli

--- a/sjb/generated/test_branch_cluster_operator_e2e.xml
+++ b/sjb/generated/test_branch_cluster_operator_e2e.xml
@@ -278,6 +278,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
+sudo yum -y install python-devel
 sudo pip install --upgrade setuptools
 sudo pip install openshift
 sudo pip install --upgrade awscli

--- a/sjb/generated/test_pull_request_cluster_operator_e2e.xml
+++ b/sjb/generated/test_pull_request_cluster_operator_e2e.xml
@@ -278,6 +278,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
+sudo yum -y install python-devel
 sudo pip install --upgrade setuptools
 sudo pip install openshift
 sudo pip install --upgrade awscli


### PR DESCRIPTION
This patches up the e2e job for cluster-operator by installing the python-devel package. The real long-term fix is to use the ansible image to run any playbooks and not rely on software installed on the ami. That will be coming in a follow-up fix.