### PR TITLE
Remove sjb extra_var openshift_cockpit_deployer_image

### DIFF
--- a/sjb/config/common/test_cases/origin_built_installed_release.yml
+++ b/sjb/config/common/test_cases/origin_built_installed_release.yml
@@ -83,7 +83,6 @@ extensions:
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                       \
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
-                         -e openshift_cockpit_deployer_image='docker.io/cockpit/kubernetes:latest' \
                          "${evars:-}" \
                          ${EXTRA_EVARS:-} \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -107,7 +106,6 @@ extensions:
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                       \
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
-                         -e openshift_cockpit_deployer_image='docker.io/cockpit/kubernetes:latest' \
                          ${EXTRA_EVARS:-} \
                          ${playbook}
         if [[ -s "${playbook_base}deploy_cluster.yml" ]]; then
@@ -132,7 +130,6 @@ extensions:
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
                          -e openshift_node_port_range='30000-32000'                             \
                          -e 'osm_controller_args={"enable-hostpath-provisioner":["true"]}'      \
-                         -e openshift_cockpit_deployer_image='docker.io/cockpit/kubernetes:latest' \
                          "${evars:-}" \
                          ${EXTRA_EVARS:-} \
                          ${playbook}

--- a/sjb/generated/test_branch_image_registry_extended.xml
+++ b/sjb/generated/test_branch_image_registry_extended.xml
@@ -577,7 +577,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -609,7 +608,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -634,7 +632,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_branch_jenkins_client_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_client_plugin.xml
@@ -577,7 +577,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -609,7 +608,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -634,7 +632,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_branch_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_openshift_login_plugin.xml
@@ -577,7 +577,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -609,7 +608,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -634,7 +632,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_branch_jenkins_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_plugin.xml
@@ -577,7 +577,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -609,7 +608,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -634,7 +632,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_branch_jenkins_sync_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_sync_plugin.xml
@@ -577,7 +577,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -609,7 +608,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -634,7 +632,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_branch_openshift_ansible_logging.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging.xml
@@ -592,7 +592,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -624,7 +623,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -649,7 +647,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
@@ -592,7 +592,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -624,7 +623,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -649,7 +647,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_branch_origin_aggregated_logging_json_file.xml
+++ b/sjb/generated/test_branch_origin_aggregated_logging_json_file.xml
@@ -592,7 +592,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -624,7 +623,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -649,7 +647,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_branch_origin_extended_builds.xml
+++ b/sjb/generated/test_branch_origin_extended_builds.xml
@@ -577,7 +577,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -609,7 +608,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -634,7 +632,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_branch_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install.xml
@@ -577,7 +577,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -609,7 +608,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -634,7 +632,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
@@ -597,7 +597,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -629,7 +628,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -654,7 +652,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_branch_origin_extended_image_ecosystem.xml
+++ b/sjb/generated/test_branch_origin_extended_image_ecosystem.xml
@@ -577,7 +577,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -609,7 +608,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -634,7 +632,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_branch_origin_extended_image_registry.xml
+++ b/sjb/generated/test_branch_origin_extended_image_registry.xml
@@ -577,7 +577,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -609,7 +608,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -634,7 +632,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_image_registry_extended.xml
+++ b/sjb/generated/test_pull_request_image_registry_extended.xml
@@ -577,7 +577,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -609,7 +608,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -634,7 +632,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_jenkins_client_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_client_plugin.xml
@@ -577,7 +577,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -609,7 +608,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -634,7 +632,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_openshift_login_plugin.xml
@@ -577,7 +577,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -609,7 +608,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -634,7 +632,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_jenkins_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_plugin.xml
@@ -577,7 +577,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -609,7 +608,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -634,7 +632,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_jenkins_sync_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_sync_plugin.xml
@@ -577,7 +577,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -609,7 +608,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -634,7 +632,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
@@ -577,7 +577,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -609,7 +608,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -634,7 +632,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_36.xml
@@ -577,7 +577,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -609,7 +608,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -634,7 +632,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_37.xml
@@ -577,7 +577,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -609,7 +608,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -634,7 +632,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_39.xml
@@ -577,7 +577,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -609,7 +608,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -634,7 +632,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
@@ -597,7 +597,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -629,7 +628,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -654,7 +652,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_36.xml
@@ -597,7 +597,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -629,7 +628,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -654,7 +652,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_37.xml
@@ -597,7 +597,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -629,7 +628,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -654,7 +652,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_39.xml
@@ -597,7 +597,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -629,7 +628,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -654,7 +652,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
@@ -577,7 +577,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -609,7 +608,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -634,7 +632,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_openshift_ansible_logging.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging.xml
@@ -592,7 +592,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -624,7 +623,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -649,7 +647,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_36.xml
@@ -592,7 +592,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -624,7 +623,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -649,7 +647,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_37.xml
@@ -592,7 +592,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -624,7 +623,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -649,7 +647,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_39.xml
@@ -592,7 +592,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -624,7 +623,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -649,7 +647,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald.xml
@@ -592,7 +592,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -624,7 +623,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -649,7 +647,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_36.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_36.xml
@@ -592,7 +592,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -624,7 +623,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -649,7 +647,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_37.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_37.xml
@@ -592,7 +592,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -624,7 +623,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -649,7 +647,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_39.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_39.xml
@@ -592,7 +592,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -624,7 +623,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -649,7 +647,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file.xml
@@ -592,7 +592,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -624,7 +623,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -649,7 +647,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_36.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_36.xml
@@ -592,7 +592,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -624,7 +623,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -649,7 +647,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_37.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_37.xml
@@ -592,7 +592,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -624,7 +623,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -649,7 +647,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_39.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_39.xml
@@ -592,7 +592,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -624,7 +623,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -649,7 +647,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_origin_extended_builds.xml
+++ b/sjb/generated/test_pull_request_origin_extended_builds.xml
@@ -577,7 +577,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -609,7 +608,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -634,7 +632,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
@@ -577,7 +577,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -609,7 +608,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -634,7 +632,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_39.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_39.xml
@@ -577,7 +577,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -609,7 +608,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -634,7 +632,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_origin_extended_image_ecosystem.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_ecosystem.xml
@@ -577,7 +577,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -609,7 +608,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -634,7 +632,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}

--- a/sjb/generated/test_pull_request_origin_extended_image_registry.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_registry.xml
@@ -577,7 +577,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
@@ -609,7 +608,6 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}
 if [[ -s &#34;\${playbook_base}deploy_cluster.yml&#34; ]]; then
@@ -634,7 +632,6 @@ ansible-playbook -vv --become               \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
                  -e openshift_node_port_range=&#39;30000-32000&#39;                             \
                  -e &#39;osm_controller_args={&#34;enable-hostpath-provisioner&#34;:[&#34;true&#34;]}&#39;      \
-                 -e openshift_cockpit_deployer_image=&#39;docker.io/cockpit/kubernetes:latest&#39; \
                  &#34;\${evars:-}&#34; \
                  \${EXTRA_EVARS:-} \
                  \${playbook}


### PR DESCRIPTION
This commit removes extra_var openshift_cockpit_deployer_image
as it is no longer needed because it is defined in sjb/inventory.