### PR TITLE
only specify to sync openshift/origin for openshift/service-catalog prs

### DIFF
--- a/sjb/config/test_cases/test_branch_origin_service_catalog.yml
+++ b/sjb/config/test_cases/test_branch_origin_service_catalog.yml
@@ -1,8 +1,6 @@
 ---
 parent: 'common/test_cases/origin_minimal.yml'
 overrides:
-  sync:
-    - "openshift,origin=master"
   junit_analysis: False
   email:
     - jpeeler@redhat.com
@@ -19,6 +17,7 @@ extensions:
         source hack/lib/init.sh
         export ORIGIN_BUILT_VERSION=$(os::build::rpm::format_nvra)
         echo $ORIGIN_BUILT_VERSION > "${jobs_repo}/ORIGIN_BUILT_VERSION"
+        printf "Last two commits for Origin:\n$(git log -2 --pretty='%H  %an, %ai.  %s')\n"
     - type: "script"
       title: "build Origin"
       repository: "origin"
@@ -30,7 +29,7 @@ extensions:
       repository: "service-catalog"
       timeout: 1800
       script: |-
-        echo Last two commits for Service Catalog: $(git log -2 --pretty="%h  %an, %ai.  %s")
+        printf "Last two commits for Service Catalog:\n$(git log -2 --pretty='%H  %an, %ai.  %s')\n"
     - type: "script"
       title: "build service-catalog user-broker image"
       repository: "service-catalog"
@@ -111,8 +110,8 @@ extensions:
         trap 'exit 0' EXIT
         ( source hack/lib/init.sh; os::cleanup::dump_container_logs )
   generated_artifacts:
-    catalog-apiserver.log: '/data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/oc login -u system:admin && /data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/kubectl logs -n kube-service-catalog -lapp=apiserver -c apiserver'
-    catalog-controller.log: '/data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/oc login -u system:admin && /data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/kubectl logs -n kube-service-catalog -lapp=controller-manager'
+    catalog-apiserver.log: '/data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/oc login -u system:admin && /data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/oc logs -n kube-service-catalog deploy/apiserver -c apiserver'
+    catalog-controller.log: '/data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/oc login -u system:admin && /data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/oc logs -n kube-service-catalog deploy/controller-manager'
   system_journals:
     - origin-master.service
     - origin-master-api.service

--- a/sjb/config/test_cases/test_branch_origin_service_catalog_310.yml
+++ b/sjb/config/test_cases/test_branch_origin_service_catalog_310.yml
@@ -1,8 +1,6 @@
 ---
 parent: 'common/test_cases/origin_minimal.yml'
 overrides:
-  sync:
-    - "openshift,origin=release-3.10"
   junit_analysis: False
   email:
     - jpeeler@redhat.com

--- a/sjb/config/test_cases/test_pull_request_openshift_service_catalog.yml
+++ b/sjb/config/test_cases/test_pull_request_openshift_service_catalog.yml
@@ -1,2 +1,5 @@
 ---
 parent: 'test_cases/test_branch_origin_service_catalog.yml'
+overrides:
+  sync:
+    - "openshift,origin=master"

--- a/sjb/config/test_cases/test_pull_request_openshift_service_catalog_310.yml
+++ b/sjb/config/test_cases/test_pull_request_openshift_service_catalog_310.yml
@@ -1,2 +1,5 @@
 ---
 parent: 'test_cases/test_branch_origin_service_catalog_310.yml'
+overrides:
+  sync:
+    - "openshift,origin=release-3.10"

--- a/sjb/generated/test_branch_origin_service_catalog.xml
+++ b/sjb/generated/test_branch_origin_service_catalog.xml
@@ -165,7 +165,7 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
         fi
     done
 done
-clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=master }
+clonerefs_args=\${CLONEREFS_ARGS:-}
 docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
 docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
@@ -284,6 +284,7 @@ echo \$ORIGIN_COMMIT &gt; &#34;\${jobs_repo}/ORIGIN_COMMIT&#34;
 source hack/lib/init.sh
 export ORIGIN_BUILT_VERSION=\$(os::build::rpm::format_nvra)
 echo \$ORIGIN_BUILT_VERSION &gt; &#34;\${jobs_repo}/ORIGIN_BUILT_VERSION&#34;
+printf &#34;Last two commits for Origin:\n\$(git log -2 --pretty=&#39;%H  %an, %ai.  %s&#39;)\n&#34;
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -311,7 +312,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/service-catalog&#34;
-echo Last two commits for Service Catalog: \$(git log -2 --pretty=&#34;%h  %an, %ai.  %s&#34;)
+printf &#34;Last two commits for Service Catalog:\n\$(git log -2 --pretty=&#39;%H  %an, %ai.  %s&#39;)\n&#34;
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -520,12 +521,12 @@ rm -rf &#34;${ARTIFACT_DIR}&#34;
 mkdir &#34;${ARTIFACT_DIR}&#34;
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo docker version &amp;&amp; sudo docker info &amp;&amp; sudo docker images &amp;&amp; sudo docker ps -a 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/docker.info&#34; || true
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo cat /etc/sysconfig/docker /etc/sysconfig/docker-network /etc/sysconfig/docker-storage /etc/sysconfig/docker-storage-setup /etc/systemd/system/docker.service 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/docker.config&#34; || true
-ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;/data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/oc login -u system:admin &amp;&amp; /data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/kubectl logs -n kube-service-catalog -lapp=controller-manager 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/catalog-controller.log&#34; || true
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;/data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/oc login -u system:admin &amp;&amp; /data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/oc logs -n kube-service-catalog deploy/controller-manager 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/catalog-controller.log&#34; || true
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo find /var/lib/docker/containers -name *.log | sudo xargs tail -vn +1 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/containers.log&#34; || true
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;oc get --raw /metrics --server=https://\$( uname --nodename ):10250 --config=/etc/origin/master/admin.kubeconfig 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/node-metrics.log&#34; || true
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo ausearch -m AVC -m SELINUX_ERR -m USER_AVC 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/avc_denials.log&#34; || true
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;oc get --raw /metrics --config=/etc/origin/master/admin.kubeconfig 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/master-metrics.log&#34; || true
-ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;/data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/oc login -u system:admin &amp;&amp; /data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/kubectl logs -n kube-service-catalog -lapp=apiserver -c apiserver 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/catalog-apiserver.log&#34; || true
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;/data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/oc login -u system:admin &amp;&amp; /data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/oc logs -n kube-service-catalog deploy/apiserver -c apiserver 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/catalog-apiserver.log&#34; || true
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo df -T -h &amp;&amp; sudo pvs &amp;&amp; sudo vgs &amp;&amp; sudo lvs &amp;&amp; sudo findmnt --all 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/filesystem.info&#34; || true
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo yum list installed 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/installed_packages.log&#34; || true
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo journalctl --dmesg --no-pager --all --lines=all 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/dmesg.log&#34; || true

--- a/sjb/generated/test_branch_origin_service_catalog_310.xml
+++ b/sjb/generated/test_branch_origin_service_catalog_310.xml
@@ -165,7 +165,7 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
         fi
     done
 done
-clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.10 }
+clonerefs_args=\${CLONEREFS_ARGS:-}
 docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
 docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 

--- a/sjb/generated/test_pull_request_openshift_service_catalog.xml
+++ b/sjb/generated/test_pull_request_openshift_service_catalog.xml
@@ -284,6 +284,7 @@ echo \$ORIGIN_COMMIT &gt; &#34;\${jobs_repo}/ORIGIN_COMMIT&#34;
 source hack/lib/init.sh
 export ORIGIN_BUILT_VERSION=\$(os::build::rpm::format_nvra)
 echo \$ORIGIN_BUILT_VERSION &gt; &#34;\${jobs_repo}/ORIGIN_BUILT_VERSION&#34;
+printf &#34;Last two commits for Origin:\n\$(git log -2 --pretty=&#39;%H  %an, %ai.  %s&#39;)\n&#34;
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -311,7 +312,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/service-catalog&#34;
-echo Last two commits for Service Catalog: \$(git log -2 --pretty=&#34;%h  %an, %ai.  %s&#34;)
+printf &#34;Last two commits for Service Catalog:\n\$(git log -2 --pretty=&#39;%H  %an, %ai.  %s&#39;)\n&#34;
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -520,12 +521,12 @@ rm -rf &#34;${ARTIFACT_DIR}&#34;
 mkdir &#34;${ARTIFACT_DIR}&#34;
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo docker version &amp;&amp; sudo docker info &amp;&amp; sudo docker images &amp;&amp; sudo docker ps -a 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/docker.info&#34; || true
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo cat /etc/sysconfig/docker /etc/sysconfig/docker-network /etc/sysconfig/docker-storage /etc/sysconfig/docker-storage-setup /etc/systemd/system/docker.service 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/docker.config&#34; || true
-ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;/data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/oc login -u system:admin &amp;&amp; /data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/kubectl logs -n kube-service-catalog -lapp=controller-manager 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/catalog-controller.log&#34; || true
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;/data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/oc login -u system:admin &amp;&amp; /data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/oc logs -n kube-service-catalog deploy/controller-manager 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/catalog-controller.log&#34; || true
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo find /var/lib/docker/containers -name *.log | sudo xargs tail -vn +1 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/containers.log&#34; || true
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;oc get --raw /metrics --server=https://\$( uname --nodename ):10250 --config=/etc/origin/master/admin.kubeconfig 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/node-metrics.log&#34; || true
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo ausearch -m AVC -m SELINUX_ERR -m USER_AVC 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/avc_denials.log&#34; || true
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;oc get --raw /metrics --config=/etc/origin/master/admin.kubeconfig 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/master-metrics.log&#34; || true
-ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;/data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/oc login -u system:admin &amp;&amp; /data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/kubectl logs -n kube-service-catalog -lapp=apiserver -c apiserver 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/catalog-apiserver.log&#34; || true
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;/data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/oc login -u system:admin &amp;&amp; /data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/oc logs -n kube-service-catalog deploy/apiserver -c apiserver 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/catalog-apiserver.log&#34; || true
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo df -T -h &amp;&amp; sudo pvs &amp;&amp; sudo vgs &amp;&amp; sudo lvs &amp;&amp; sudo findmnt --all 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/filesystem.info&#34; || true
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo yum list installed 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/installed_packages.log&#34; || true
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo journalctl --dmesg --no-pager --all --lines=all 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/dmesg.log&#34; || true

--- a/sjb/generated/test_pull_request_origin_service_catalog.xml
+++ b/sjb/generated/test_pull_request_origin_service_catalog.xml
@@ -165,7 +165,7 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
         fi
     done
 done
-clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=master }
+clonerefs_args=\${CLONEREFS_ARGS:-}
 docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
 docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
@@ -284,6 +284,7 @@ echo \$ORIGIN_COMMIT &gt; &#34;\${jobs_repo}/ORIGIN_COMMIT&#34;
 source hack/lib/init.sh
 export ORIGIN_BUILT_VERSION=\$(os::build::rpm::format_nvra)
 echo \$ORIGIN_BUILT_VERSION &gt; &#34;\${jobs_repo}/ORIGIN_BUILT_VERSION&#34;
+printf &#34;Last two commits for Origin:\n\$(git log -2 --pretty=&#39;%H  %an, %ai.  %s&#39;)\n&#34;
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -311,7 +312,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/service-catalog&#34;
-echo Last two commits for Service Catalog: \$(git log -2 --pretty=&#34;%h  %an, %ai.  %s&#34;)
+printf &#34;Last two commits for Service Catalog:\n\$(git log -2 --pretty=&#39;%H  %an, %ai.  %s&#39;)\n&#34;
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -520,12 +521,12 @@ rm -rf &#34;${ARTIFACT_DIR}&#34;
 mkdir &#34;${ARTIFACT_DIR}&#34;
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo docker version &amp;&amp; sudo docker info &amp;&amp; sudo docker images &amp;&amp; sudo docker ps -a 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/docker.info&#34; || true
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo cat /etc/sysconfig/docker /etc/sysconfig/docker-network /etc/sysconfig/docker-storage /etc/sysconfig/docker-storage-setup /etc/systemd/system/docker.service 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/docker.config&#34; || true
-ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;/data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/oc login -u system:admin &amp;&amp; /data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/kubectl logs -n kube-service-catalog -lapp=controller-manager 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/catalog-controller.log&#34; || true
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;/data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/oc login -u system:admin &amp;&amp; /data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/oc logs -n kube-service-catalog deploy/controller-manager 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/catalog-controller.log&#34; || true
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo find /var/lib/docker/containers -name *.log | sudo xargs tail -vn +1 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/containers.log&#34; || true
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;oc get --raw /metrics --server=https://\$( uname --nodename ):10250 --config=/etc/origin/master/admin.kubeconfig 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/node-metrics.log&#34; || true
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo ausearch -m AVC -m SELINUX_ERR -m USER_AVC 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/avc_denials.log&#34; || true
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;oc get --raw /metrics --config=/etc/origin/master/admin.kubeconfig 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/master-metrics.log&#34; || true
-ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;/data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/oc login -u system:admin &amp;&amp; /data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/kubectl logs -n kube-service-catalog -lapp=apiserver -c apiserver 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/catalog-apiserver.log&#34; || true
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;/data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/oc login -u system:admin &amp;&amp; /data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/oc logs -n kube-service-catalog deploy/apiserver -c apiserver 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/catalog-apiserver.log&#34; || true
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo df -T -h &amp;&amp; sudo pvs &amp;&amp; sudo vgs &amp;&amp; sudo lvs &amp;&amp; sudo findmnt --all 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/filesystem.info&#34; || true
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo yum list installed 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/installed_packages.log&#34; || true
 ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;sudo journalctl --dmesg --no-pager --all --lines=all 2&gt;&amp;1&#34; &gt;&gt; &#34;${ARTIFACT_DIR}/dmesg.log&#34; || true

--- a/sjb/generated/test_pull_request_origin_service_catalog_310.xml
+++ b/sjb/generated/test_pull_request_origin_service_catalog_310.xml
@@ -165,7 +165,7 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
         fi
     done
 done
-clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.10 }
+clonerefs_args=\${CLONEREFS_ARGS:-}
 docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
 docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 


### PR DESCRIPTION
We were getting errors from Non Service Catalog origin & openshift prs complaining that a sync for origin was specified more then once.  This has been corrected, we only specify the origin sync now for the Service Catalog PRs.

Also cleaned up the reporting of commits for origin & service-catalog and fixed the commands used to pull the Catalog pod logs (it was failing).