### PR TITLE
add art libraries to manage Git repos, RPMs and versions in Jenkins jobs

### DIFF
--- a/src/com/redhat/art/GitHubRepository.groovy
+++ b/src/com/redhat/art/GitHubRepository.groovy
@@ -1,0 +1,149 @@
+//
+// Model a remote git repository
+//
+package com.redhat.art
+
+import com.redhat.art.Version
+
+class GitHubRepository {
+
+    String owner
+    String project
+    String branch
+    String path
+    String package_name
+    String password
+    def pipeline
+
+    GitHubRepository(String owner, String project, String branch=null, String package_name=null) {
+        this.owner = owner
+        this.project = project
+        this.branch = branch
+        this.path = project
+        this.package_name = package_name ? package_name : project
+        this.password = null
+        this.pipeline = pipeline
+    }
+
+    GitHubRepository(Map init) {
+        this.owner = init.owner
+        this.project = init.project
+        this.branch = init.branch 
+        this.path = init.path ? init.path : this.project
+        this.package_name = init.package_name ? init.package_name : this.project
+        this.password = init.password
+        this.pipeline = init.pipeline
+    }
+
+    def getRemote() {
+        return "git@github.com:${this.owner}/${this.project}.git"
+    }
+
+    def getUrl() {
+        return "https://github.com/${this.owner}/${this.project}.git"
+    }
+
+    def getSpecfile() {
+        return package_name + ".spec"
+    }
+
+    def getSpecpath() {
+        return [path, specfile].join('/')
+    }
+
+    /*
+     * Retrive the branch list from a remote repository
+     * @param repo_url a git@ repository URL.
+     * @param pattern a matching pattern for the branch list. Only return matching branches
+     *
+     * @return a list of branch names.  Removes the leading ref path
+     *
+     * Requires SSH_AGENT to have set a key for access to the remote repository
+     */
+    def branches(pattern="") {
+        def branch_text = pipeline.sh(
+            returnStdout: true,
+            script: [
+                "git ls-remote ${this.remote} ${pattern}",
+                "awk '{print \$2}'",
+                "cut -d/ -f3"
+            ].join(" | ")
+        )
+        return branch_text.tokenize("\n")
+    }
+
+    /**
+     * Retrive a list of release numbers from the OCP remote repository
+     * @param repo_url a git@ repository URL.
+     * @return a list of OSE release numbers.
+     *
+     * Get the branch names beginning with 'enterprise-'.
+     * Extract the release number string from each branch release name
+     * Sort in version order (compare fields as integers, not strings)
+     * Requires SSH_AGENT to have set a key for access to the remote repository
+     */
+    def releases(pattern="enterprise-") {
+        // too clever: chain - get branch names, remove prefix, suffix
+        def r = this.branches(pattern + '*')
+            .collect { it - pattern }
+            .findAll { it =~ /^\d+((\.\d+)*)$/ }
+            .collect { new Version(it) }
+            .sort()
+
+        return r
+    }
+
+    def clone() {
+        pipeline.sh(
+            returnStdout: false,
+            script: [
+                "git clone",
+                branch ? "--branch ${branch}" : "",
+                remote,
+                path
+            ].join(' ')
+        )
+        pipeline.echo("Cloning repo ${remote}")
+    }
+    
+    def addRemote(remote_name, remote_project) {
+        // git remote add ${remote_name} ${remote_spec}
+        def remote_spec = "git@github.com:${owner}/${remote_project}.git"
+        pipeline.dir(path) {
+            pipeline.sh(
+                script: "git remote add ${remote_name} ${remote_spec} --no-tags"
+            )
+        }
+    }
+
+    def fetch(remote_name) {
+        pipeline.dir(path) {
+            pipeline.sh(
+                script: "git fetch ${remote_name}"
+            )
+        }
+    }
+
+    def merge(String remote_name, String remote_branch) {
+        pipeline.dir(path) {
+            pipeline.sh(
+                script: "git merge ${remote_name}/${remote_branch}"
+            )
+        }
+    }
+
+    def config(String key, String value) {
+        pipeline.dir(path) {
+            pipeline.sh "git config ${key} ${value}"
+        }
+    }
+
+    def set_attribute(String filename, String attrname, String attrvalue) {
+        pipeline.dir(path) {
+            def gitattributes = ".gitattributes"
+            pipeline.sh(
+                script: "echo '${filename} ${attrname}=${attrvalue}' >> ${gitattributes}"
+            )
+        }
+    }
+}

--- a/src/com/redhat/art/Rpm.groovy
+++ b/src/com/redhat/art/Rpm.groovy
@@ -1,0 +1,112 @@
+package com.redhat.art
+
+import com.redhat.art.GitHubRepository
+import com.redhat.art.RpmSpec
+
+class Rpm {
+
+    GitHubRepository repo
+    String collection
+    def pipeline
+
+    def Rpm(Map init) {
+        this.repo = init.repo
+        this.collection = init.collection
+        this.pipeline = init.pipeline
+    }
+
+    String getSpecpath() {
+        return repo.specpath
+    }
+
+    RpmSpec getSpec() {
+        return new RpmSpec([filename: repo.specpath, pipeline: pipeline])
+    }
+
+    def tag(Map args) {
+
+        String version_spec
+        if (args.version && args.release) {
+            version_spec = "--use-version ${args.version} --use-release ${args.release}"
+        } else {
+            version_spec = "--keep-version"
+        }
+        
+        pipeline.echo("Tagging with ${version_spec}")
+        
+        def build_cmd = [
+            "tito tag",
+            (args.debug ? '--debug' : ''),
+            '--accept-auto-changelog',
+            version_spec
+        ].join(' ')
+        
+        if (collection) {
+            build_cmd = "scl enable ${collection} '${build_cmd}'"
+        }
+
+        pipeline.echo("tagging with cli: ${build_cmd}")
+        
+        pipeline.dir(repo.path) {
+            pipeline.sh(
+                script: build_cmd
+            )
+        }
+    }
+
+    def build(destination="./BUILD", debug=false) {
+        
+        def build_cmd = [
+            "tito build",
+            (debug ? '--debug' : ''),
+            '--offline',
+            '--rpm',
+            '--output', destination,
+        ].join(' ')
+
+        if (collection) {
+            build_cmd = "scl enable ${collection} '${build_cmd}'"
+        }
+
+        pipeline.dir(repo.path) {
+            pipeline.sh(
+                script: build_cmd
+            )
+        }
+    }
+
+    def release(scratch=true, debug=false) {
+        def s = spec
+        s.load()
+        def version = new Version(s.version)
+        pipeline.dir(repo.path) {
+            def tito_output = pipeline.sh(
+                returnStdout: true,
+                script: [
+                    'tito release',
+                    (debug ? '--debug' : ''),
+                    '--yes',
+                    '--test',
+                    (scratch ? '--scratch' : ''),
+                    "aos-${version.majorminor}"
+                ].join(' ')
+            )
+
+            def tito_lines = tito_output.tokenize('\n')
+            def task_line = tito_lines.find{ it =~ /^Created Task: / }
+            def task_matcher = task_line =~ /^Created Task:\s+([0-9]+)/
+            brew_task_id = task_matcher[0][1]
+            brew_task_url = brew_task_url_prefix + brew_task_id
+            pipeline.echo "${package_name} rpm brew task: ${brew_task_id}"
+    
+            try {
+                pipeline.sh "brew watch-task ${brew_task_id}"
+            } catch (build_err) {
+                pipeline.echo "Error in ${package_name} build task: ${brew_task_url}"
+                throw build_err
+            }
+        }
+
+        return brew_task_id
+    }
+}

--- a/src/com/redhat/art/RpmSpec.groovy
+++ b/src/com/redhat/art/RpmSpec.groovy
@@ -1,0 +1,105 @@
+#!/usr/bin/groovy
+package com.redhat.art
+
+// ===========================================================================
+//
+// Operations on an RPM Spec File
+//
+// ===========================================================================
+
+class RpmSpec {
+
+    def filename
+    def lines
+    def pipeline
+
+    def RpmSpec(Map init) {
+        this.filename = init.filename
+        this.lines = init.lines
+        this.pipeline = init.pipeline
+
+    }
+    
+    def load() {
+        lines = pipeline.readFile(filename).tokenize("\n")
+    }
+
+    def save() {
+        pipeline.writeFile(file: filename, text: body)
+    }
+    
+    String getBody() {
+        return lines.join('\n')
+    }
+    
+    String getVersion() {
+        // find the line with the Version tag
+        def v_line = lines.find { it =~ /^Version: / }
+        if (v_line == null) {
+            return null
+        }
+
+        // extract the version string and return that
+        def v_match = v_line =~ /^Version:\s*([.0-9]+)/
+        return v_match[0][1].trim()
+    }
+
+    void setVersion(String new_version) {
+        // find the version line
+        def line_no = lines.findIndexOf{ it =~ /^Version: / }
+        assert line_no > -1
+        
+        // replace it with the new version line
+        lines[line_no] = "Version: ${new_version}"
+    }
+
+    String getRelease() {
+        // find the line with the Version tag
+        def v_line = lines.find { it =~ /^Release: / }
+        if (v_line == null) {
+            return null
+        }
+
+        // extract the version string and return that
+        def v_match = v_line =~ /^Release:\s*([.0-9]+)/
+        return v_match[0][1].trim()
+    }
+    void setRelease(String new_release) {
+        // find the version line
+        def line_no = lines.findIndexOf{ it =~ /^Release: / }
+        assert line_no > -1
+        
+        // replace it with the new version line
+        lines[line_no] = "Release: ${new_release}"        
+    }
+
+    String getChangelog(truncate=true) {
+        // find the start of the changelog section
+        def start = lines.findIndexOf{ it =~ /%changelog/ }
+
+        // the real changelog starts the next line
+        if ( start == -1 ) {
+            error "no changelog section in spec file"
+        }
+        // skip the begin tag
+        start++ 
+
+        def end = lines[start..-1].findIndexOf { it =~ /^%/ }
+        // the changelog ends with the start of another section or EOF
+        //def end = lines.size() -1 // lines[start..-1].findIndexOf 
+        if (end == -1) {
+            end = lines.size()
+        }
+        // exclude the end tag
+        end--
+
+        def changelines = lines[start..end]
+
+        if (truncate && changelines.size() > 100) {
+            changelines = changelines[0..99]
+            changelines << '....Truncated....'
+        }
+
+        return changelines.join('\n')
+    }
+}

--- a/src/com/redhat/art/Version.groovy
+++ b/src/com/redhat/art/Version.groovy
@@ -1,0 +1,115 @@
+#!/usr/bin/groovy
+package com.redhat.art
+
+// ===========================================================================
+//
+// Version Strings and Operations
+//
+// ===========================================================================
+
+class Version implements Comparable<Version>{
+    def v_array
+
+    def Version(String v_in) {
+        v_array = v_in.tokenize('.').collect { it as int }
+    }
+
+    def Version(Version model) {
+        v_array = model.v_array.collect()
+    }
+
+    def Version(o_array) {
+        v_array = o_array.collect()
+    }
+
+    @NonCPS
+    int compareTo(Version other) {
+
+        // make a copy so you can change it safely
+        def a = v_array.collect()
+        def b = other.v_array.collect()
+
+        // pad one if necessary with zeros
+        def max_size = Math.max(a.size(), b.size())
+        while (a.size() < max_size) { a << 0 }
+        while (b.size() < max_size) { b << 0 }
+
+        // zip the two arrays together so matching elements are together
+        def t = [a, b].transpose()
+
+        // check each pair until all are exhausted.
+        for (f in t) {
+            def cmp = f[0] <=> f[1]
+            if (cmp != 0) { return cmp }
+        }
+        return 0
+    }
+
+    @NonCPS
+    String toString() {
+        return v_array.collect{ it as String }.join('.')
+    }
+
+    // Major number property
+    void setMajor(int m) { v_array[0] = m }
+    int getMajor() { return v_array[0] }
+
+    // Minor number property
+    void setMinor(int m) { v_array[1] = m }
+    int getMinor() { return v_array[1] }
+
+    // Revision number property
+    void setRevision(int m) { v_array[1] = m }
+    int getRevision() { return v_array[2] }
+
+    // Major/Minor number string
+
+    String getMajorminor() {
+        return v_array[0..1].collect { it as String }.join('.')
+    }
+
+    @NonCPS
+    Version incrMajor() {
+        assert v_array.size() >= 1 :
+            "version string must have >= 1 fields. actual: ${v_array.size()}"
+        def new_v_array = v_array.collect()
+
+        new_v_array[0]++
+        // reset the remaining fields to 0
+        if (new_v_array.size() > 1) {
+            for (i in 1..(new_v_array.size()-1)) {
+                new_v_array[i] = 0
+            }
+        }
+        return new Version(new_v_array)
+    }
+
+    @NonCPS
+    Version incrMinor() {
+        assert v_array.size() >= 2 :
+            "version string must have >= 2 fields. actual: ${v_array.size()}"
+        def new_v_array = v_array.collect()
+        new_v_array[1]++
+        if (new_v_array.size() > 2) {
+            for (i in 2..(new_v_array.size()-1)) {
+                new_v_array[i] = 0
+            }
+        }
+        
+        return new Version(new_v_array)
+    }
+
+    @NonCPS
+    Version incrRevision() {
+        assert v_array.size() >= 3 :
+            "version string must have >= 3 fields. actual: ${v_array.size()}"
+        def new_v_array = v_array.collect()
+        new_v_array[2]++
+        if (new_v_array.size() > 3) {
+            for (i in 3..(new_v_array.size()-1)) {
+                new_v_array[i] = 0
+            }
+        }
+        return new Version(new_v_array)
+    }
+}

--- a/src/com/redhat/art/VersionTest.groovy
+++ b/src/com/redhat/art/VersionTest.groovy
@@ -1,0 +1,95 @@
+#!/usr/bin/groovy
+//package com.redhat.art
+
+import com.redhat.art.Version
+
+class VersionTest extends GroovyTestCase {
+    def env
+    
+    def VersionTest(pipeline_env=null) {
+        env = pipeline_env
+    }
+    
+    void testConstructorString() {
+        def vs = new Version('3.2.1')
+
+        def expected = [3, 2, 1]
+        def actual = vs.v_array
+
+        assertEquals(actual, expected)
+    }
+
+    void testConstructorVersion() {
+        def vs0 = new Version('3.2.1')
+        def vs1 = new Version(vs0)
+
+        def expected = [3, 2, 1]
+        def actual = vs1.v_array
+
+        assertEquals(actual, expected)
+    }
+    
+    void testConstructorVersionStrin() {
+        def v_array = [3, 2, 1]
+        def vs1 = new Version(v_array)
+
+        def expected = [3, 2, 1]
+        def actual = vs1.v_array
+
+        assertEquals(actual, expected)
+    }
+
+    void testCompareTo() {
+
+        def inputs = [
+            [
+                testValue: new Version('3.2.1'),
+                greater: [
+                    new Version('3.2.1.1'),
+                    new Version('3.2.2'),
+                    new Version('3.3.0'),
+                    new Version('3.3'),
+                    new Version('4.0.0'),
+                    new Version('4.0'),
+                    new Version('4'),
+                ],
+                less: [
+                    new Version('3.2.0'),
+                    new Version('3.1.9.1'),
+                    new Version('2.3.0'),
+                    new Version('1.0.0'),
+                    new Version('3.2'),
+                    new Version('2.9'),
+                    new Version('2'),                    
+                ],
+                equal: [
+                    new Version('3.2.1'),
+                    new Version('3.2.1.0'),
+                ]
+            ]
+        ]
+
+        inputs.each { c -> 
+            c.greater.each { t ->  assert t > c.testValue }
+            c.less.each { t -> assert t < c.testValue }
+            c.equal.each { t -> assert t == c.testValue }
+        }
+    }
+
+    void testToString() { }
+
+    void testPropertyMajor() { }
+    void testPropertyMinor() { }
+    void testPropertyRevision() { }
+
+    void testPropertyMajorMinor() { }
+
+    void testIncrMajor() { }
+
+    void testIncrMinor() { }
+
+    void testIncrRevision() { }
+}
+
+// mock the NonCPS annotation for groovy testing
+@interface NonCPS {}


### PR DESCRIPTION
This change adds a set of libraries that can be used in accord with the standard Groovy/Jenkins library mechanisms.  This avoids the single file require clauses and unifies the library structures.

These libraries are object-oriented and allow the treatment of the components as types and classes. For example it allows comparison of version strings in an idiomatic way in Groovy, simplifying the code and offering clearer interpretation by the reader.