### PR TITLE
send email to aos-art-requests on fail

### DIFF
--- a/jobs/build/ocp/Jenkinsfile
+++ b/jobs/build/ocp/Jenkinsfile
@@ -63,7 +63,8 @@ properties(
                     description: 'Failure Mailing List',
                     $class: 'hudson.model.StringParameterDefinition',
                     defaultValue: [
-                        'aos-team-art@redhat.com'
+                        'aos-team-art@redhat.com',
+                        'aos-art-requests@redhat.com'
                     ].join(',')
                 ],
                 [
@@ -1091,7 +1092,7 @@ images:build
 
                 } catch( release_ex ) {
                     mail(
-                        to: "aos-team-art@redhat.com",
+                        to: "aos-art-requests@redhat.com,aos-team-art@redhat.com",
                         from: "aos-cicd@redhat.com",
                         subject: "Error creating ose release in github",
                         body: """

--- a/jobs/build/ose/Jenkinsfile
+++ b/jobs/build/ose/Jenkinsfile
@@ -126,12 +126,9 @@ properties(
                     description: 'Success Mailing List',
                     $class: 'hudson.model.StringParameterDefinition',
                     defaultValue: [
+                        'aos-team-art@redhat.com',
                         'aos-cicd@redhat.com',
                         'aos-qe@redhat.com',
-                        'tbielawa@redhat.com',
-                        'jupierce@redhat.com',
-                        'smunilla@redhat.com',
-                        'ahaile@redhat.com'
                     ].join(',')
                 ],
                 [
@@ -139,11 +136,8 @@ properties(
                     description: 'Failure Mailing List',
                     $class: 'hudson.model.StringParameterDefinition',
                     defaultValue: [
-                        'tbielawa@redhat.com',
-                        'jupierce@redhat.com',
-                        'smunilla@redhat.com',
-                        'ahaile@redhat.com',
-                        'mlamouri@redhat.com',
+                        'aos-team-art@redhat.com',
+                        'aos-art-requests@redhat.com'
                     ].join(',')
                 ],
                 [


### PR DESCRIPTION
clean OCP and OSE build email messaging
add aos-art-requests (jira) to fail messaging.