### PR TITLE
Add missing test_pull_request_origin_web_console jobs for 3.9 and 3.11

### DIFF
--- a/sjb/config/test_cases/test_pull_request_origin_web_console_311.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_web_console_311.yml
@@ -1,0 +1,4 @@
+---
+parent: 'test_cases/test_branch_origin_web_console_311.yml'
+overrides:
+  test: "origin-web-console"

--- a/sjb/config/test_cases/test_pull_request_origin_web_console_39.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_web_console_39.yml
@@ -1,0 +1,4 @@
+---
+parent: 'test_cases/test_branch_origin_web_console_39.yml'
+overrides:
+  test: "origin-web-console"


### PR DESCRIPTION
Looks like I missed these in #1629

@stevekuznetsov @jcantrill 