### PR TITLE
Use origin-cli for 3.10+ to get oc for console tests

### DIFF
--- a/sjb/config/test_cases/test_branch_origin_web_console_310.yml
+++ b/sjb/config/test_cases/test_branch_origin_web_console_310.yml
@@ -22,8 +22,8 @@ extensions:
           echo "IMAGE_VERSION=latest" > IMAGE_VERSION_VAR
         fi
         source IMAGE_VERSION_VAR
-        sudo docker pull openshift/origin:"${IMAGE_VERSION}"
-        sudo docker create --name temp-container openshift/origin:"${IMAGE_VERSION}"
+        sudo docker pull openshift/origin-cli:"${IMAGE_VERSION}"
+        sudo docker create --name temp-container openshift/origin-cli:"${IMAGE_VERSION}"
         sudo docker cp temp-container:/usr/bin/oc ./
         sudo docker rm temp-container
         sudo mv -f ./oc /bin/oc

--- a/sjb/config/test_cases/test_branch_origin_web_console_311.yml
+++ b/sjb/config/test_cases/test_branch_origin_web_console_311.yml
@@ -22,8 +22,8 @@ extensions:
           echo "IMAGE_VERSION=latest" > IMAGE_VERSION_VAR
         fi
         source IMAGE_VERSION_VAR
-        sudo docker pull openshift/origin:"${IMAGE_VERSION}"
-        sudo docker create --name temp-container openshift/origin:"${IMAGE_VERSION}"
+        sudo docker pull openshift/origin-cli:"${IMAGE_VERSION}"
+        sudo docker create --name temp-container openshift/origin-cli:"${IMAGE_VERSION}"
         sudo docker cp temp-container:/usr/bin/oc ./
         sudo docker rm temp-container
         sudo mv -f ./oc /bin/oc

--- a/sjb/generated/test_branch_origin_web_console_310.xml
+++ b/sjb/generated/test_branch_origin_web_console_310.xml
@@ -294,8 +294,8 @@ else
   echo &#34;IMAGE_VERSION=latest&#34; &gt; IMAGE_VERSION_VAR
 fi
 source IMAGE_VERSION_VAR
-sudo docker pull openshift/origin:&#34;\${IMAGE_VERSION}&#34;
-sudo docker create --name temp-container openshift/origin:&#34;\${IMAGE_VERSION}&#34;
+sudo docker pull openshift/origin-cli:&#34;\${IMAGE_VERSION}&#34;
+sudo docker create --name temp-container openshift/origin-cli:&#34;\${IMAGE_VERSION}&#34;
 sudo docker cp temp-container:/usr/bin/oc ./
 sudo docker rm temp-container
 sudo mv -f ./oc /bin/oc

--- a/sjb/generated/test_branch_origin_web_console_311.xml
+++ b/sjb/generated/test_branch_origin_web_console_311.xml
@@ -294,8 +294,8 @@ else
   echo &#34;IMAGE_VERSION=latest&#34; &gt; IMAGE_VERSION_VAR
 fi
 source IMAGE_VERSION_VAR
-sudo docker pull openshift/origin:&#34;\${IMAGE_VERSION}&#34;
-sudo docker create --name temp-container openshift/origin:&#34;\${IMAGE_VERSION}&#34;
+sudo docker pull openshift/origin-cli:&#34;\${IMAGE_VERSION}&#34;
+sudo docker create --name temp-container openshift/origin-cli:&#34;\${IMAGE_VERSION}&#34;
 sudo docker cp temp-container:/usr/bin/oc ./
 sudo docker rm temp-container
 sudo mv -f ./oc /bin/oc

--- a/sjb/generated/test_pull_request_origin_web_console_310.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_310.xml
@@ -294,8 +294,8 @@ else
   echo &#34;IMAGE_VERSION=latest&#34; &gt; IMAGE_VERSION_VAR
 fi
 source IMAGE_VERSION_VAR
-sudo docker pull openshift/origin:&#34;\${IMAGE_VERSION}&#34;
-sudo docker create --name temp-container openshift/origin:&#34;\${IMAGE_VERSION}&#34;
+sudo docker pull openshift/origin-cli:&#34;\${IMAGE_VERSION}&#34;
+sudo docker create --name temp-container openshift/origin-cli:&#34;\${IMAGE_VERSION}&#34;
 sudo docker cp temp-container:/usr/bin/oc ./
 sudo docker rm temp-container
 sudo mv -f ./oc /bin/oc

--- a/sjb/generated/test_pull_request_origin_web_console_311.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_311.xml
@@ -294,8 +294,8 @@ else
   echo &#34;IMAGE_VERSION=latest&#34; &gt; IMAGE_VERSION_VAR
 fi
 source IMAGE_VERSION_VAR
-sudo docker pull openshift/origin:&#34;\${IMAGE_VERSION}&#34;
-sudo docker create --name temp-container openshift/origin:&#34;\${IMAGE_VERSION}&#34;
+sudo docker pull openshift/origin-cli:&#34;\${IMAGE_VERSION}&#34;
+sudo docker create --name temp-container openshift/origin-cli:&#34;\${IMAGE_VERSION}&#34;
 sudo docker cp temp-container:/usr/bin/oc ./
 sudo docker rm temp-container
 sudo mv -f ./oc /bin/oc


### PR DESCRIPTION
For 3.10 and also 3.11 we need to get the `oc` binary from the `origin-cli` image.
This should be a quick fix, so we free our merge queue. Will refactor je jobs as follow-up.

@spadgett FYI

@stevekuznetsov PTAL

