### PR TITLE
Fix use of archiveArtifacts

### DIFF
--- a/scheduled-jobs/build/oc-mirror-quay-dev/Jenkinsfile
+++ b/scheduled-jobs/build/oc-mirror-quay-dev/Jenkinsfile
@@ -139,7 +139,8 @@ apply
     } finally {
         try {
             // Hold on to that mirror input and image stream
-            archiveArtifacts allowEmptyArchive: true, artifacts: "${MIRROR_WORKING}/*"
+            archiveArtifacts allowEmptyArchive: true, artifacts: "MIRROR_working/oc_mirror_input"
+            archiveArtifacts allowEmptyArchive: true, artifacts: "MIRROR_working/release-is.yaml"
         } catch (aae) {
         }
     }


### PR DESCRIPTION
I did it wrong before. That was a bad glob. Since there are only two files to archive, let's just point them out explicitly.