### PR TITLE
Lock pulled oc binary to v3.11 version when testing against master branch

### DIFF
--- a/sjb/config/test_cases/test_branch_origin_web_console.yml
+++ b/sjb/config/test_cases/test_branch_origin_web_console.yml
@@ -6,35 +6,8 @@ extensions:
       title: "determine binary and image version"
       repository: "origin"
       script: |-
-        if [[ "${PULL_BASE_REF}" = "enterprise-"* ]]; then
-          case $PULL_BASE_REF in
-          enterprise-3.[2-5])
-            echo "IMAGE_VERSION=${PULL_BASE_REF/enterprise-3/v1}.1" > IMAGE_VERSION_VAR
-            ;;
-          enterprise-3.1)
-            echo "IMAGE_VERSION=v1.1.6" > IMAGE_VERSION_VAR
-            ;;
-          *)
-            echo "IMAGE_VERSION=${PULL_BASE_REF/enterprise-/v}" > IMAGE_VERSION_VAR
-            ;;
-          esac
-        else
-          echo "IMAGE_VERSION=latest" > IMAGE_VERSION_VAR
-        fi
-        # We copy oc from the image to get the right version. Use
-        # openshift/origin-cli in 3.10 and newer. Use openshift/origin for
-        # earlier releases.
-        case $PULL_BASE_REF in
-        enterprise-3.[3-9])
-          CLI_IMAGE="origin"
-          ;;
-        *)
-          CLI_IMAGE="origin-cli"
-          ;;
-        esac
-        source IMAGE_VERSION_VAR
-        sudo docker pull "openshift/${CLI_IMAGE}:${IMAGE_VERSION}"
-        sudo docker create --name temp-container "openshift/${CLI_IMAGE}:${IMAGE_VERSION}"
+        sudo docker pull "openshift/origin-cli:v3.11"
+        sudo docker create --name temp-container "openshift/origin-cli:v3.11"
         sudo docker cp temp-container:/usr/bin/oc ./
         sudo docker rm temp-container
         sudo mv -f ./oc /bin/oc
@@ -44,13 +17,8 @@ extensions:
       script: |-
         wget https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm
         sudo yum install ./google-chrome-stable_current_*.rpm -y
-        source IMAGE_VERSION_VAR
         oc version
-        if [ "${IMAGE_VERSION}" == "latest" ]; then
-          oc cluster up --tag="${IMAGE_VERSION}" --public-hostname=localhost --loglevel=5 --server-loglevel=5
-        else
-          oc cluster up --public-hostname=localhost --loglevel=5 --server-loglevel=5
-        fi
+        oc cluster up --public-hostname=localhost --loglevel=5 --server-loglevel=5
     - type: "script"
       title: "run web console tests"
       repository: "origin-web-console"

--- a/sjb/generated/test_branch_origin_web_console.xml
+++ b/sjb/generated/test_branch_origin_web_console.xml
@@ -278,35 +278,8 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-if [[ &#34;\${PULL_BASE_REF}&#34; = &#34;enterprise-&#34;* ]]; then
-  case \$PULL_BASE_REF in
-  enterprise-3.[2-5])
-    echo &#34;IMAGE_VERSION=\${PULL_BASE_REF/enterprise-3/v1}.1&#34; &gt; IMAGE_VERSION_VAR
-    ;;
-  enterprise-3.1)
-    echo &#34;IMAGE_VERSION=v1.1.6&#34; &gt; IMAGE_VERSION_VAR
-    ;;
-  *)
-    echo &#34;IMAGE_VERSION=\${PULL_BASE_REF/enterprise-/v}&#34; &gt; IMAGE_VERSION_VAR
-    ;;
-  esac
-else
-  echo &#34;IMAGE_VERSION=latest&#34; &gt; IMAGE_VERSION_VAR
-fi
-# We copy oc from the image to get the right version. Use
-# openshift/origin-cli in 3.10 and newer. Use openshift/origin for
-# earlier releases.
-case \$PULL_BASE_REF in
-enterprise-3.[3-9])
-  CLI_IMAGE=&#34;origin&#34;
-  ;;
-*)
-  CLI_IMAGE=&#34;origin-cli&#34;
-  ;;
-esac
-source IMAGE_VERSION_VAR
-sudo docker pull &#34;openshift/\${CLI_IMAGE}:\${IMAGE_VERSION}&#34;
-sudo docker create --name temp-container &#34;openshift/\${CLI_IMAGE}:\${IMAGE_VERSION}&#34;
+sudo docker pull &#34;openshift/origin-cli:v3.11&#34;
+sudo docker create --name temp-container &#34;openshift/origin-cli:v3.11&#34;
 sudo docker cp temp-container:/usr/bin/oc ./
 sudo docker rm temp-container
 sudo mv -f ./oc /bin/oc
@@ -325,13 +298,8 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
 wget https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm
 sudo yum install ./google-chrome-stable_current_*.rpm -y
-source IMAGE_VERSION_VAR
 oc version
-if [ &#34;\${IMAGE_VERSION}&#34; == &#34;latest&#34; ]; then
-  oc cluster up --tag=&#34;\${IMAGE_VERSION}&#34; --public-hostname=localhost --loglevel=5 --server-loglevel=5
-else
-  oc cluster up --public-hostname=localhost --loglevel=5 --server-loglevel=5
-fi
+oc cluster up --public-hostname=localhost --loglevel=5 --server-loglevel=5
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_web_console.xml
+++ b/sjb/generated/test_pull_request_origin_web_console.xml
@@ -278,35 +278,8 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
-if [[ &#34;\${PULL_BASE_REF}&#34; = &#34;enterprise-&#34;* ]]; then
-  case \$PULL_BASE_REF in
-  enterprise-3.[2-5])
-    echo &#34;IMAGE_VERSION=\${PULL_BASE_REF/enterprise-3/v1}.1&#34; &gt; IMAGE_VERSION_VAR
-    ;;
-  enterprise-3.1)
-    echo &#34;IMAGE_VERSION=v1.1.6&#34; &gt; IMAGE_VERSION_VAR
-    ;;
-  *)
-    echo &#34;IMAGE_VERSION=\${PULL_BASE_REF/enterprise-/v}&#34; &gt; IMAGE_VERSION_VAR
-    ;;
-  esac
-else
-  echo &#34;IMAGE_VERSION=latest&#34; &gt; IMAGE_VERSION_VAR
-fi
-# We copy oc from the image to get the right version. Use
-# openshift/origin-cli in 3.10 and newer. Use openshift/origin for
-# earlier releases.
-case \$PULL_BASE_REF in
-enterprise-3.[3-9])
-  CLI_IMAGE=&#34;origin&#34;
-  ;;
-*)
-  CLI_IMAGE=&#34;origin-cli&#34;
-  ;;
-esac
-source IMAGE_VERSION_VAR
-sudo docker pull &#34;openshift/\${CLI_IMAGE}:\${IMAGE_VERSION}&#34;
-sudo docker create --name temp-container &#34;openshift/\${CLI_IMAGE}:\${IMAGE_VERSION}&#34;
+sudo docker pull &#34;openshift/origin-cli:v3.11&#34;
+sudo docker create --name temp-container &#34;openshift/origin-cli:v3.11&#34;
 sudo docker cp temp-container:/usr/bin/oc ./
 sudo docker rm temp-container
 sudo mv -f ./oc /bin/oc
@@ -325,13 +298,8 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/origin&#34;
 wget https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm
 sudo yum install ./google-chrome-stable_current_*.rpm -y
-source IMAGE_VERSION_VAR
 oc version
-if [ &#34;\${IMAGE_VERSION}&#34; == &#34;latest&#34; ]; then
-  oc cluster up --tag=&#34;\${IMAGE_VERSION}&#34; --public-hostname=localhost --loglevel=5 --server-loglevel=5
-else
-  oc cluster up --public-hostname=localhost --loglevel=5 --server-loglevel=5
-fi
+oc cluster up --public-hostname=localhost --loglevel=5 --server-loglevel=5
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;


### PR DESCRIPTION
Since post 3.11 we dropped the `oc cluster up` command we need to lock version of pulled image to v3.11 when sending PR against master branch. 

/assign @spadgett

@stevekuznetsov fyi