### PR TITLE
Don't set openshift_node_labels

### DIFF
--- a/sjb/inventory/host_vars/localhost.yml
+++ b/sjb/inventory/host_vars/localhost.yml
@@ -1,8 +1,4 @@
 ---
-openshift_node_labels:
-  region: infra
-  zone: default
-  node-role.kubernetes.io/infra: "true"
 openshift_schedulable: true
 
 openshift_node_group_name: "node-config-all-in-one"


### PR DESCRIPTION
openshift-ansible would now stop install if `openshift_node_labels`  as 3.10+ installs should have `openshift_node_group_name` set instead

Related to https://github.com/openshift/openshift-ansible/pull/11061