### PR TITLE
Don't mail ART JIRA build results anymore

### DIFF
--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -68,7 +68,6 @@ properties(
                     $class: 'hudson.model.StringParameterDefinition',
                     defaultValue: [
                         'aos-team-art@redhat.com',
-                        // 'aos-art-requests@redhat.com'
                     ].join(',')
                 ],
                 [

--- a/jobs/build/merge_ocp/Jenkinsfile
+++ b/jobs/build/merge_ocp/Jenkinsfile
@@ -32,7 +32,6 @@ properties(
                     $class: 'hudson.model.StringParameterDefinition',
                     defaultValue: [
                         'aos-team-art@redhat.com',
-                        // 'aos-art-requests@redhat.com'
                     ].join(',')
                 ],
                 [

--- a/jobs/build/ocp/Jenkinsfile
+++ b/jobs/build/ocp/Jenkinsfile
@@ -1052,7 +1052,7 @@ images:build
 
                 } catch( release_ex ) {
                     mail(
-                        to: "aos-art-requests@redhat.com,aos-team-art@redhat.com",
+                        to: "aos-team-art@redhat.com",
                         from: "aos-cicd@redhat.com",
                         subject: "Error creating ose release in github",
                         body: """

--- a/jobs/build/ose/Jenkinsfile
+++ b/jobs/build/ose/Jenkinsfile
@@ -137,7 +137,6 @@ properties(
                     $class: 'hudson.model.StringParameterDefinition',
                     defaultValue: [
                         'aos-team-art@redhat.com',
-                        'aos-art-requests@redhat.com'
                     ].join(',')
                 ],
                 [

--- a/jobs/build/reposync/Jenkinsfile
+++ b/jobs/build/reposync/Jenkinsfile
@@ -39,7 +39,6 @@ properties(
                     $class: 'hudson.model.StringParameterDefinition',
                     defaultValue: [
                         'aos-team-art@redhat.com',
-                        // 'aos-art-requests@redhat.com'
                     ].join(',')
                 ],
                 [


### PR DESCRIPTION
We stopped caring about this a while ago. We just forgot to remove all instances of the JIRA email.