### PR TITLE
build/ocp: sanitize and add in some status

### DIFF
--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -16,6 +16,16 @@ def initialize() {
 
 }
 
+def safeArchiveArtifacts(List patterns) {
+    for (pattern in patterns) {
+        try {
+            archiveArtifacts allowEmptyArchive: true, artifacts: pattern
+        } catch (err) {
+            echo "Failed to archive artifacts like ${pattern}: ${err}"
+        }
+    }
+}
+
 /**
  * Jenkins doesn't seems to whitelist .asList(),
  * so this is an awful workaround.


### PR DESCRIPTION
Removed some cruft, changed some things to seem more sane (like using
params.VAR instead of manually converting env.VAR).

Also added updates to job information to make it easier to see at a
glance what happened with a particular build in the list of builds.