### PR TITLE
use commonlib.email to archive and suppress email

### DIFF
--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -64,6 +64,7 @@ node {
                         $class: 'hudson.model.BooleanParameterDefinition',
                         defaultValue: false
                     ],
+                    commonlib.suppressEmailParam(),
                     [
                         name: 'MAIL_LIST_SUCCESS',
                         description: 'Success Mailing List',
@@ -205,23 +206,25 @@ node {
                 buildlib.doozer command
             }
 
-            mail(to: "${params.MAIL_LIST_SUCCESS}",
+            commonlib.email(
+                to: "${params.MAIL_LIST_SUCCESS}",
                 from: "aos-team-art@redhat.com",
                 subject: "Successful custom OCP build: ${currentBuild.displayName}",
                 body: "Jenkins job: ${env.BUILD_URL}\n${currentBuild.description}");
         }
     } catch (err) {
         currentBuild.description = "failed with error: ${err}\n${currentBuild.description}"
-        mail(to: "${params.MAIL_LIST_FAILURE}",
-             from: "aos-team-art@redhat.com",
-             subject: "Error building custom OCP: ${currentBuild.displayName}",
-             body: """Encountered an error while running OCP pipeline:
+        commonlib.email(
+            to: "${params.MAIL_LIST_FAILURE}",
+            from: "aos-team-art@redhat.com",
+            subject: "Error building custom OCP: ${currentBuild.displayName}",
+            body: """Encountered an error while running OCP pipeline:
 
 ${currentBuild.description}
 
 Jenkins job: ${env.BUILD_URL}
 Job console: ${env.BUILD_URL}/console
-    """);
+    """)
 
         currentBuild.result = "FAILURE"
         throw err

--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -14,7 +14,7 @@ node {
             [
                 $class: 'ParametersDefinitionProperty',
                 parameterDefinitions: [
-                    commonlib.oseVersionParam('BUILD_VERSION'),
+                    commonlib.ocpVersionParam('BUILD_VERSION'),
                     [
                         name: 'VERSION',
                         description: 'Version string for build (e.g. 4.0.0)',

--- a/jobs/build/incremental/Jenkinsfile
+++ b/jobs/build/incremental/Jenkinsfile
@@ -44,7 +44,7 @@ node {
             [
                 $class: 'ParametersDefinitionProperty',
                 parameterDefinitions: [
-                    commonlib.oseVersionParam('MINOR_VERSION'),
+                    commonlib.ocpVersionParam('MINOR_VERSION', '4'),
                     [
                         name: 'VERSION_OVERRIDE',
                         description: 'Optional full version for build (e.g. v4.0.1). Defaults to atomic-openshift version',

--- a/jobs/build/merge_ocp/Jenkinsfile
+++ b/jobs/build/merge_ocp/Jenkinsfile
@@ -21,6 +21,7 @@ node {
                         $class: 'hudson.model.StringParameterDefinition',
                         defaultValue: "3.9,3.10,3.11,4.0"
                     ],
+                    commonlib.suppressEmailParam(),
                     [
                         name: 'MAIL_LIST_SUCCESS',
                         description: 'Success Mailing List',
@@ -83,7 +84,8 @@ node {
                     } catch (err) {
                         currentBuild.result = "UNSTABLE"
                         echo "Error running ${VERSION} merge:\n${err}"
-                        mail(to: "${MAIL_LIST_FAILURE}",
+                        commonlib.email(
+                            to: "${MAIL_LIST_FAILURE}",
                             from: "aos-team-art@redhat.com",
                             subject: "Error merging OCP v${VERSION}",
                             body: "Encountered an error while running OCP merge:\n${env.BUILD_URL}\n\n${err}"
@@ -105,10 +107,11 @@ node {
 
     } catch (err) {
         // This job is so simple that this should never really happen. But might as well have it.
-        mail(to: "${MAIL_LIST_FAILURE}",
-             from: "aos-team-art@redhat.com",
-             subject: "Unexpected error during OCP Merge!",
-             body: "Encountered an unexpected error while running OCP merge: ${err}"
+        commonlib.email(
+            to: "${MAIL_LIST_FAILURE}",
+            from: "aos-team-art@redhat.com",
+            subject: "Unexpected error during OCP Merge!",
+            body: "Encountered an unexpected error while running OCP merge: ${err}"
         );
 
         currentBuild.result = "FAILURE"

--- a/jobs/build/ocp/Jenkinsfile
+++ b/jobs/build/ocp/Jenkinsfile
@@ -260,7 +260,7 @@ node {
                         ].join("\n"),
                         defaultValue: 'aos-cd-test'
                     ],
-                    commonlib.oseVersionParam('BUILD_VERSION'),
+                    commonlib.ocpVersionParam('BUILD_VERSION', '3'),
                     [
                         name: 'MAIL_LIST_SUCCESS',
                         description: 'Success Mailing List',

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -251,7 +251,7 @@ node {
                         ].join("\n"),
                         defaultValue: 'aos-cd-test'
                     ],
-                    commonlib.ocp4VersionParam('BUILD_VERSION'),
+                    commonlib.ocpVersionParam('BUILD_VERSION', '4'),
                     [
                         name: 'MAIL_LIST_SUCCESS',
                         description: 'Success Mailing List',

--- a/jobs/build/refresh-images/Jenkinsfile
+++ b/jobs/build/refresh-images/Jenkinsfile
@@ -43,7 +43,7 @@ node {
                         choices: "git@github.com:openshift\ngit@github.com:jupierce\ngit@github.com:jupierce-aos-cd-bot\ngit@github.com:adammhaile-aos-cd-bot",
                         defaultValue: 'git@github.com:openshift'
                     ],
-                    commonlib.oseVersionParam('BUILD_VERSION'),
+                    commonlib.ocpVersionParam('BUILD_VERSION'),
                     [
                         name: 'VERSION_OVERRIDE',
                         description: 'Optional version to use. (i.e. v3.6.17). Defaults to "auto"',

--- a/jobs/build/refresh-images/Jenkinsfile
+++ b/jobs/build/refresh-images/Jenkinsfile
@@ -5,8 +5,8 @@ def version(f) {
     matcher ? matcher[0][1] : null
 }
 
-def mail_success() {
-    mail(
+def mail_success(commonlib) {
+    commonlib.email(
             to: "${MAIL_LIST_SUCCESS}",
             from: "aos-cicd@redhat.com",
             replyTo: 'aos-team-art@redhat.com',
@@ -57,6 +57,7 @@ node {
                         $class: 'hudson.model.StringParameterDefinition',
                         defaultValue: ''
                     ],
+                    commonlib.suppressEmailParam(),
                     [
                         name: 'MAIL_LIST_SUCCESS',
                         description: 'Success Mailing List',
@@ -214,7 +215,7 @@ images:build
                     } catch (err) {
                         failed_builds = buildlib.get_failed_builds(DOOZER_WORKING)
 
-                        mail(
+                        commonlib.email(
                             to: "${MAIL_LIST_FAILURE}",
                             from: "aos-cicd@redhat.com",
                             subject: "RESUMABLE Error during Refresh Images for OCP v${OSE_MAJOR}.${OSE_MINOR}",
@@ -270,10 +271,11 @@ images:verify
 """
             } catch (vererr) {
                 echo "Error verifying images: ${vererr}"
-                mail(to: "${MAIL_LIST_FAILURE}",
-                     from: "aos-cicd@redhat.com",
-                     subject: "Error Verifying Images During Refresh: ${OSE_MAJOR}.${OSE_MINOR}",
-                     body: """Encoutered an error while running ${env.JOB_NAME}: ${vererr}
+                commonlib.email(
+                    to: "${MAIL_LIST_FAILURE}",
+                    from: "aos-cicd@redhat.com",
+                    subject: "Error Verifying Images During Refresh: ${OSE_MAJOR}.${OSE_MINOR}",
+                    body: """Encoutered an error while running ${env.JOB_NAME}: ${vererr}
 
 
 Jenkins job: ${env.BUILD_URL}
@@ -297,15 +299,16 @@ Jenkins job: ${env.BUILD_URL}
             }
 
             // Replace flow control with: https://jenkins.io/blog/2016/12/19/declarative-pipeline-beta/ when available
-            mail_success()
+            mail_success(commonlib)
 
 
         } catch (err) {
             // Replace flow control with: https://jenkins.io/blog/2016/12/19/declarative-pipeline-beta/ when available
-            mail(to: "${MAIL_LIST_FAILURE}",
-                    from: "aos-cicd@redhat.com",
-                    subject: "Error Refreshing Images: ${OSE_MAJOR}.${OSE_MINOR}",
-                    body: """Encoutered an error while running ${env.JOB_NAME}: ${err}
+            commonlib.email(
+                to: "${MAIL_LIST_FAILURE}",
+                from: "aos-cicd@redhat.com",
+                subject: "Error Refreshing Images: ${OSE_MAJOR}.${OSE_MINOR}",
+                body: """Encoutered an error while running ${env.JOB_NAME}: ${err}
 
 
 Jenkins job: ${env.BUILD_URL}
@@ -335,7 +338,8 @@ Jenkins job: ${env.BUILD_URL}
 """
             } catch ( attach_err ) {
                 // Replace flow control with: https://jenkins.io/blog/2016/12/19/declarative-pipeline-beta/ when available
-                mail(to: "${MAIL_LIST_FAILURE}",
+                commonlib.email(
+                    to: "${MAIL_LIST_FAILURE}",
                     from: "aos-cicd@redhat.com",
                     subject: "Error Attaching ${OSE_MAJOR}.${OSE_MINOR} images to ${ADVISORY_ID}","""
 

--- a/jobs/build/reposync/Jenkinsfile
+++ b/jobs/build/reposync/Jenkinsfile
@@ -14,7 +14,7 @@ node {
             [
                 $class: 'ParametersDefinitionProperty',
                 parameterDefinitions: [
-                    commonlib.oseVersionParam('SYNC_VERSION'),
+                    commonlib.ocpVersionParam('SYNC_VERSION'),
                     [
                         name: 'REPO_TYPE',
                         description: 'Type of repos to sync',

--- a/jobs/build/reposync/Jenkinsfile
+++ b/jobs/build/reposync/Jenkinsfile
@@ -22,6 +22,7 @@ node {
                         choices: "unsigned\nsigned",
                         defaultValue: 'unsigned'
                     ],
+                    commonlib.suppressEmailParam(),
                     [
                         name: 'MAIL_LIST_SUCCESS',
                         description: 'Success Mailing List',
@@ -77,13 +78,14 @@ node {
             }
         }
     } catch (err) {
-        mail(to: "${MAIL_LIST_FAILURE}",
-             from: "aos-team-art@redhat.com",
-             subject: "Error syncing v${SYNC_VERSION} repos",
-             body: """Encountered an error while running OCP pipeline: ${err}
+        commonlib.email(
+            to: "${MAIL_LIST_FAILURE}",
+            from: "aos-team-art@redhat.com",
+            subject: "Error syncing v${SYNC_VERSION} repos",
+            body: """Encountered an error while running OCP pipeline: ${err}
 
-    Jenkins job: ${env.BUILD_URL}
-    """);
+Jenkins job: ${env.BUILD_URL}
+        """);
 
         currentBuild.result = "FAILURE"
         throw err

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -1,8 +1,6 @@
 
-ocpDefaultVersion = "4.0"
-ocpVersions = [
-    "4.1",
-    "4.0",
+ocp3DefaultVersion = "3.11"
+ocp3Versions = [
     "3.11",
     "3.10",
     "3.9",
@@ -22,10 +20,23 @@ ocp4Versions = [
     "4.0",
 ]
 
+ocpDefaultVersion = ocp4DefaultVersion
+ocpVersions = ocp4Versions + ocp3Versions
+
+ocpMajorVersions = [
+    "4": ocp4Versions,
+    "3": ocp3Versions,
+    "all": ocpVersions,
+]
+ocpMajorDefaultVersion = [
+    "4": ocp4DefaultVersion,
+    "3": ocp3DefaultVersion,
+    "all": ocp4DefaultVersion,
+]
+
 /**
  * Handles any common setup required by the library
  */
-
 def initialize() {
     // https://issues.jenkins-ci.org/browse/JENKINS-33511 no longer appears relevant
 }
@@ -49,26 +60,20 @@ def mockParam() {
     ]
 }
 
-def oseVersionParam(name='MINOR_VERSION') {
+def ocpVersionParam(name='MINOR_VERSION', majorVersion='all') {
     return [
         name: name,
         description: 'OSE Version',
         $class: 'hudson.model.ChoiceParameterDefinition',
-        choices: ocpVersions.join('\n'),
-        defaultValue: ocpDefaultVersion,
+        choices: ocpMajorVersions[majorVersion].join('\n'),
+        defaultValue: ocpMajorDefaultVersion[majorVersion],
     ]
 }
 
-def ocp4VersionParam(name='MINOR_VERSION') {
-    return [
-        name: name,
-        description: 'OSE Version',
-        $class: 'hudson.model.ChoiceParameterDefinition',
-        choices: ocp4Versions.join('\n'),
-        defaultValue: ocp4DefaultVersion,
-    ]
-}
-
+/**
+ * Normalize input so whether the user supplies "v" or not we get what we want.
+ * Also, for totally bogus versions we get an error early on.
+ */
 def standardVersion(String version, Boolean withV=true) {
     version = version.trim()
     def match = version =~ /(?ix) ^v? (  \d+ (\.\d+)+  )$/


### PR DESCRIPTION
Builds on https://github.com/openshift/aos-cd-jobs/pull/1720/ so first commit is from that.

This provides a wrapper method that archives emails with the other job artifacts. It also makes it easy to suppress sending the actual emails (and marks builds that do this so that we don't wonder why email didn't show up). Together, this makes it easy to test the jobs without having to consult email, or running the risk of emailing the team. It also means we can see what emails were actually sent even though we're not the recipients.