### PR TITLE
CAO: use official mao image to deploy kubemark

### DIFF
--- a/sjb/config/test_cases/pull-ci-openshift-cluster-autoscaler-operator-master-e2e.yml
+++ b/sjb/config/test_cases/pull-ci-openshift-cluster-autoscaler-operator-master-e2e.yml
@@ -46,20 +46,16 @@ extensions:
       script: |-
         export GOPATH=/data
         cd $GOPATH/src/github.com/openshift/machine-api-operator/
-
-        # TODO(jchaloup): once 220 gets merge, remove this
-        git remote add origin https://github.com/openshift/machine-api-operator
-        git fetch origin pull/220/head:220
-        git checkout 220
-
         # deploy expected cluster and machineset objects
-        sed -i "s/image: docker\.io\/openshift\/origin-machine-api-operator:v4\.0\.0/image: docker\.io\/gofed\/machine-api-operator:v0\.1\.0-181-g4b6bfc4/" install/0000_30_machine-api-operator_09_deployment.yaml
         sudo make deploy-kubemark
     - type: "script"
       title: "Deploy cluster autoscaler operator"
       script: |-
         export GOPATH=/data
         cd $GOPATH/src/github.com/openshift/cluster-autoscaler-operator/
+        go get -u github.com/openshift/imagebuilder/cmd/imagebuilder
+        sudo mv /data/bin/imagebuilder /usr/bin
+        sudo imagebuilder -t "quay.io/openshift/origin-cluster-autoscaler-operator:v4.0" .
         kustomize build | sudo kubectl apply -f -
     - type: "script"
       title: "Deploy cluster resources"

--- a/sjb/generated/pull-ci-openshift-cluster-autoscaler-operator-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-cluster-autoscaler-operator-master-e2e.xml
@@ -259,14 +259,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 export GOPATH=/data
 cd \$GOPATH/src/github.com/openshift/machine-api-operator/
-
-# TODO(jchaloup): once 220 gets merge, remove this
-git remote add origin https://github.com/openshift/machine-api-operator
-git fetch origin pull/220/head:220
-git checkout 220
-
 # deploy expected cluster and machineset objects
-sed -i &#34;s/image: docker\.io\/openshift\/origin-machine-api-operator:v4\.0\.0/image: docker\.io\/gofed\/machine-api-operator:v0\.1\.0-181-g4b6bfc4/&#34; install/0000_30_machine-api-operator_09_deployment.yaml
 sudo make deploy-kubemark
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -283,6 +276,9 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 export GOPATH=/data
 cd \$GOPATH/src/github.com/openshift/cluster-autoscaler-operator/
+go get -u github.com/openshift/imagebuilder/cmd/imagebuilder
+sudo mv /data/bin/imagebuilder /usr/bin
+sudo imagebuilder -t &#34;quay.io/openshift/origin-cluster-autoscaler-operator:v4.0&#34; .
 kustomize build | sudo kubectl apply -f -
 SCRIPT
 chmod +x &#34;${script}&#34;


### PR DESCRIPTION
Kubemark is now deployable by mao. No longer need to use
customized build of mao.