### PR TITLE
ART-268 email owners when their image build fails

### DIFF
--- a/jobs/build/ocp/Jenkinsfile
+++ b/jobs/build/ocp/Jenkinsfile
@@ -83,13 +83,16 @@ def mail_success(version, mirrorURL, record_log, oa_changelog, commonlib) {
     PARTIAL = " "
     mail_list = MAIL_LIST_SUCCESS
     exclude_subject = ""
-    if (BUILD_EXCLUSIONS != "") {
+    if (BUILD_EXCLUSIONS != "" || BUILD_FAILURES != null) {
         PARTIAL = " PARTIAL "
-        mail_list = MAIL_LIST_FAILURE
-        exclude_subject = " [excluded images: ${BUILD_EXCLUSIONS}]"
-        currentBuild.result = "UNSTABLE"
         currentBuild.displayName += " (partial)"
-        currentBuild.description = "Failed images: ${BUILD_EXCLUSIONS}"
+        if (BUILD_FAILURES != null {
+            mail_list = MAIL_LIST_FAILURE
+            exclude_subject += " [failed images: ${BUILD_FAILURES}]"
+        }
+        if (BUILD_EXCLUSIONS != "") {
+            exclude_subject += " [excluded images: ${BUILD_EXCLUSIONS}]"
+        }
     }
 
     image_details = """${timing_report}
@@ -362,6 +365,7 @@ node {
     }
 
     BUILD_EXCLUSIONS = commonlib.cleanCommaList(BUILD_EXCLUSIONS)
+    BUILD_FAILURES = null
 
     // Will be used to track which atomic-openshift build was tagged before we ran.
     PREV_BUILD = null
@@ -931,7 +935,6 @@ Please direct any questions to the Automated Release Team (#aos-cd-team on IRC).
                 }
             }
 
-            BUILD_CONTINUED = false
             stage("build images") {
                 if (BUILD_CONTAINER_IMAGES) {
                     try {
@@ -949,16 +952,10 @@ images:build
                     }
                     catch (err) {
                         failed_map = buildlib.get_failed_builds(DOOZER_WORKING)
-                        BUILD_EXCLUSIONS = failed_map.keySet().join(",") //will make email show PARTIAL
-                        BUILD_CONTINUED = true //simply setting flag to keep required work out of input flow
-                    }
-
-                    if (BUILD_CONTINUED) {
-                        buildlib.doozer """
-    --working-dir ${DOOZER_WORKING} --group openshift-${BUILD_VERSION}
-    ${exclude} images:push --to-defaults --late-only
-    """
-                        // exclude is already set earlier in the main images:build flow
+                        if (!failed_map) { throw err }  // failed so badly we don't know what failed; assume all
+                        BUILD_FAILURES = failed_map.keySet().join(",")  // will make email show PARTIAL
+                        currentBuild.result = "UNSTABLE"
+                        currentBuild.description = "Failed images: ${BUILD_FAILURES}"
                     }
                 }
             }

--- a/jobs/build/ocp/Jenkinsfile
+++ b/jobs/build/ocp/Jenkinsfile
@@ -72,8 +72,8 @@ def mail_success(version, mirrorURL, record_log, oa_changelog, commonlib) {
     }
 
     def inject_notes = ""
-    if (SPECIAL_NOTES.trim() != "") {
-        inject_notes = "\n***Special notes associated with this build****\n${SPECIAL_NOTES.trim()}\n***********************************************\n"
+    if (params.SPECIAL_NOTES.trim() != "") {
+        inject_notes = "\n***Special notes associated with this build****\n${params.SPECIAL_NOTES.trim()}\n***********************************************\n"
     }
 
     def timing_report = get_build_timing_report(record_log)
@@ -81,13 +81,13 @@ def mail_success(version, mirrorURL, record_log, oa_changelog, commonlib) {
     currentBuild.description = timing_report
     currentBuild.result = "SUCCESS"
     PARTIAL = " "
-    mail_list = MAIL_LIST_SUCCESS
+    mail_list = params.MAIL_LIST_SUCCESS
     exclude_subject = ""
     if (BUILD_EXCLUSIONS != "" || BUILD_FAILURES != null) {
         PARTIAL = " PARTIAL "
         currentBuild.displayName += " (partial)"
         if (BUILD_FAILURES != null {
-            mail_list = MAIL_LIST_FAILURE
+            mail_list = params.MAIL_LIST_FAILURE
             exclude_subject += " [failed images: ${BUILD_FAILURES}]"
         }
         if (BUILD_EXCLUSIONS != "") {
@@ -103,11 +103,11 @@ ${image_list}
 """
 
 
-    if (!BUILD_CONTAINER_IMAGES) {
+    if (!params.BUILD_CONTAINER_IMAGES) {
         PARTIAL = " RPM ONLY "
         image_details = ""
         // Just inform key folks about RPM only build; this is just prepping for an advisory.
-        mail_list = MAIL_LIST_FAILURE
+        mail_list = params.MAIL_LIST_FAILURE
     }
 
     commonlib.email(
@@ -118,7 +118,7 @@ ${image_list}
 OpenShift Version: v${version}
 ${inject_notes}
 RPMs:
-    Puddle (internal): http://download-node-02.eng.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift/${BUILD_VERSION}/${OCP_PUDDLE}
+    Puddle (internal): http://download-node-02.eng.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift/${params.BUILD_VERSION}/${OCP_PUDDLE}
     Exernal Mirror: ${mirrorURL}/${OCP_PUDDLE}
 ${image_details}
 
@@ -143,7 +143,7 @@ ${oa_changelog}
 """);
 
     try {
-        if (BUILD_EXCLUSIONS == "" && BUILD_CONTAINER_IMAGES) {
+        if (BUILD_EXCLUSIONS == "" && params.BUILD_CONTAINER_IMAGES) {
             timeout(3) {
                 sendCIMessage(
                     messageContent: "New build for OpenShift ${target}: ${version}",
@@ -352,10 +352,9 @@ node {
     IS_TEST_MODE = params.TEST
     buildlib.initialize(IS_TEST_MODE)
 
-    BUILD_VERSION_MAJOR = BUILD_VERSION.tokenize('.')[0].toInteger() // Store the "X" in X.Y
-    BUILD_VERSION_MINOR = BUILD_VERSION.tokenize('.')[1].toInteger() // Store the "Y" in X.Y
+    BUILD_VERSION_MAJOR = params.BUILD_VERSION.tokenize('.')[0].toInteger() // Store the "X" in X.Y
+    BUILD_VERSION_MINOR = params.BUILD_VERSION.tokenize('.')[1].toInteger() // Store the "Y" in X.Y
     SIGN_RPMS = params.SIGN
-    BUILD_CONTAINER_IMAGES = params.BUILD_CONTAINER_IMAGES
     ODCS_MODE = params.ODCS
     ODCS_FLAG = ""
     ODCS_OPT = ""
@@ -364,43 +363,43 @@ node {
         ODCS_OPT = "--odcs unsigned"
     }
 
-    BUILD_EXCLUSIONS = commonlib.cleanCommaList(BUILD_EXCLUSIONS)
+    BUILD_EXCLUSIONS = commonlib.cleanCommaList(params.BUILD_EXCLUSIONS)
     BUILD_FAILURES = null
 
     // Will be used to track which atomic-openshift build was tagged before we ran.
     PREV_BUILD = null
 
-    AOS_CD_JOBS_COMMIT_SHA = sh(
+    aosCdJobsCommitSha = sh(
         returnStdout: true,
         script: "git rev-parse HEAD",
     ).trim()
 
     try {
         // Clean up old images so that we don't run out of device mapper space
-        sh "docker rmi --force \$(docker images  | grep v${BUILD_VERSION} | awk '{print \$3}')"
+        sh "docker rmi --force \$(docker images  | grep v${params.BUILD_VERSION} | awk '{print \$3}')"
     } catch (cce) {
         echo "Error cleaning up old images: ${cce}"
     }
 
-    PUDDLE_CONF_BASE = "https://raw.githubusercontent.com/openshift/aos-cd-jobs/${AOS_CD_JOBS_COMMIT_SHA}/build-scripts/puddle-conf"
-    PUDDLE_CONF = "${PUDDLE_CONF_BASE}/atomic_openshift-${BUILD_VERSION}.conf"
-    PUDDLE_SIGN_KEYS = SIGN_RPMS ? "b906ba72" : null
+    puddleConfBase = "https://raw.githubusercontent.com/openshift/aos-cd-jobs/${aosCdJobsCommitSha}/build-scripts/puddle-conf"
+    puddleConf = "${puddleConfBase}/atomic_openshift-${params.BUILD_VERSION}.conf"
+    puddleSignKeys = SIGN_RPMS ? "b906ba72" : null
 
-    echo "Initializing build: #${currentBuild.number} - ${BUILD_VERSION}.?? (${BUILD_MODE})"
+    echo "Initializing build: #${currentBuild.number} - ${params.BUILD_VERSION}.?? (${BUILD_MODE})"
 
     // doozer_working must be in WORKSPACE in order to have artifacts archived
-    DOOZER_WORKING = "${WORKSPACE}/doozer_working"
+    DOOZER_WORKING = "${env.WORKSPACE}/doozer_working"
     //Clear out previous work
     sh "rm -rf ${DOOZER_WORKING}"
     sh "mkdir -p ${DOOZER_WORKING}"
 
     try {
-        sshagent([SSH_KEY_ID]) {
+        sshagent([params.SSH_KEY_ID]) {
             // To work on real repos, buildlib operations must run with the permissions of openshift-bot
 
             PREV_BUILD = sh(
                 returnStdout: true,
-                script: "brew latest-build --quiet rhaos-${BUILD_VERSION}-rhel-7-candidate atomic-openshift | awk '{print \$1}'"
+                script: "brew latest-build --quiet rhaos-${params.BUILD_VERSION}-rhel-7-candidate atomic-openshift | awk '{print \$1}'"
             ).trim()
 
             stage("ose repo") {
@@ -416,10 +415,10 @@ node {
                 master_spec = buildlib.read_spec_info(GITHUB_BASE_PATHS['ose'] + "/origin.spec")
 
                 // If the target version resides in ose#master
-                IS_SOURCE_IN_MASTER = (BUILD_VERSION == master_spec.major_minor)
+                IS_SOURCE_IN_MASTER = (params.BUILD_VERSION == master_spec.major_minor)
 
                 if (BUILD_MODE == "auto") {
-                    echo "AUTO-MODE: determine mode from version and repo: BUILD_VERSION: ${BUILD_VERSION}, master_version: ${master_spec.major_minor}"
+                    echo "AUTO-MODE: determine mode from version and repo: BUILD_VERSION: ${params.BUILD_VERSION}, master_version: ${master_spec.major_minor}"
                     // INPUTS:
                     //   BUILD_MODE
                     //   BUILD_VERSION
@@ -427,14 +426,14 @@ node {
                     releases = buildlib.get_releases(GITHUB_URLS['ose'])
                     echo "AUTO-MODE: release repo: ${GITHUB_URLS['ose']}"
                     echo "AUTO-MODE: releases: ${releases}"
-                    BUILD_MODE = buildlib.auto_mode(BUILD_VERSION, master_spec.major_minor, releases)
+                    BUILD_MODE = buildlib.auto_mode(params.BUILD_VERSION, master_spec.major_minor, releases)
                     echo "BUILD_MODE = ${BUILD_MODE}"
                 }
             }
 
             stage("analyze") {
 
-                dir(env.OSE_DIR) {
+                dir(OSE_DIR) {
                     // inputs:
                     //  IS_SOURCE_IN_MASTER
                     //  BUILD_MODE
@@ -466,12 +465,12 @@ node {
                         OSE_SOURCE_BRANCH = "master"
                         UPSTREAM_SOURCE_BRANCH = "upstream/master"
                     } else {
-                        OSE_SOURCE_BRANCH = "enterprise-${BUILD_VERSION}"
+                        OSE_SOURCE_BRANCH = "enterprise-${params.BUILD_VERSION}"
                         if (BUILD_MODE == "release") {
                             // When building in release mode, no longer pull from upstream
                             UPSTREAM_SOURCE_BRANCH = null
                         } else {
-                            UPSTREAM_SOURCE_BRANCH = "upstream/release-${BUILD_VERSION}"
+                            UPSTREAM_SOURCE_BRANCH = "upstream/release-${params.BUILD_VERSION}"
                         }
                         // Create the non-master source branch and have it track the origin ose repo
                         sh "git checkout -b ${OSE_SOURCE_BRANCH} origin/${OSE_SOURCE_BRANCH}"
@@ -482,9 +481,9 @@ node {
                     spec = buildlib.read_spec_info("origin.spec")
                     rel_fields = spec.release.tokenize(".")
 
-                    if (! spec.version.startsWith("${BUILD_VERSION}.")) {
+                    if (! spec.version.startsWith("${params.BUILD_VERSION}.")) {
                         // Looks like pipeline thinks we are building something we aren't. Abort.
-                        error("Expected version consistent with ${BUILD_VERSION}.* but found: ${spec.version}")
+                        error("Expected version consistent with ${params.BUILD_VERSION}.* but found: ${spec.version}")
                     }
 
 
@@ -555,7 +554,7 @@ node {
                     }
 
                     rpmOnlyTag = ""
-                    if (!BUILD_CONTAINER_IMAGES) {
+                    if (!params.BUILD_CONTAINER_IMAGES) {
                         rpmOnlyTag = " (RPM ONLY)"
                     }
                     currentBuild.displayName = "#${currentBuild.number} - ${NEW_VERSION}-${NEW_RELEASE} (${BUILD_MODE}${rpmOnlyTag})"
@@ -607,7 +606,7 @@ node {
                     if (IS_SOURCE_IN_MASTER) {
 
                         // jwforres asked that master *not* merge into the 3.8 branch.
-                        if (BUILD_VERSION != "3.8") {
+                        if (params.BUILD_VERSION != "3.8") {
                             sh """
                             # Pull content of master into enterprise branch
                             git merge master --no-commit --no-ff
@@ -616,7 +615,7 @@ node {
                             grunt build
 
                             git add dist
-                            git commit -m "Merge master into enterprise-${BUILD_VERSION}" --allow-empty
+                            git commit -m "Merge master into enterprise-${params.BUILD_VERSION}" --allow-empty
                         """
 
                             if (!IS_TEST_MODE) {
@@ -666,7 +665,7 @@ node {
                         sh """
                             # Pull content of master into enterprise branch
                             git merge master --no-commit --no-ff
-                            git commit -m "Merge master into enterprise-${BUILD_VERSION}" --allow-empty
+                            git commit -m "Merge master into enterprise-${params.BUILD_VERSION}" --allow-empty
                         """
 
                         if (!IS_TEST_MODE) {
@@ -732,7 +731,7 @@ node {
                         if (BUILD_VERSION_MAJOR == 3 && BUILD_VERSION_MINOR < 6) {
                             OPENSHIFT_ANSIBLE_SOURCE_BRANCH = "release-1.${BUILD_VERSION_MINOR}"
                         } else {
-                            OPENSHIFT_ANSIBLE_SOURCE_BRANCH = "release-${BUILD_VERSION}"
+                            OPENSHIFT_ANSIBLE_SOURCE_BRANCH = "release-${params.BUILD_VERSION}"
                         }
                         sh "git checkout -b ${OPENSHIFT_ANSIBLE_SOURCE_BRANCH} origin/${OPENSHIFT_ANSIBLE_SOURCE_BRANCH}"
                     } else {
@@ -799,7 +798,7 @@ node {
                 dir(OSE_DIR) {
                     oseTaskId = sh(
                         returnStdout: true,
-                        script: "tito release --debug --yes --test aos-${BUILD_VERSION} | grep 'Created task:' | awk '{print \$3}'"
+                        script: "tito release --debug --yes --test aos-${params.BUILD_VERSION} | grep 'Created task:' | awk '{print \$3}'"
                     )
                     OSE_BREW_URL = "https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=${oseTaskId }"
                     echo "atomic-openshift rpm brew task: ${OSE_BREW_URL}"
@@ -808,7 +807,7 @@ node {
                 dir(OPENSHIFT_ANSIBLE_DIR) {
                     oaTaskId = sh(
                         returnStdout: true,
-                        script: "tito release --debug --yes --test aos-${BUILD_VERSION} | grep 'Created task:' | awk '{print \$3}'"
+                        script: "tito release --debug --yes --test aos-${params.BUILD_VERSION} | grep 'Created task:' | awk '{print \$3}'"
                     )
                     OA_BREW_URL = "https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=${oaTaskId}"
                     echo "openshift-ansible rpm brew task: ${OA_BREW_URL}"
@@ -837,7 +836,7 @@ node {
 
             stage("doozer build rpms") {
                 buildlib.doozer """
---working-dir ${DOOZER_WORKING} --group 'openshift-${BUILD_VERSION}'
+--working-dir ${DOOZER_WORKING} --group 'openshift-${params.BUILD_VERSION}'
 --source ose ${OSE_DIR}
 rpms:build --version v${NEW_VERSION}
 --release ${NEW_RELEASE}
@@ -846,7 +845,7 @@ rpms:build --version v${NEW_VERSION}
 
             stage("signing rpms") {
                 if (SIGN_RPMS) {
-                    sh "${env.WORKSPACE}/build-scripts/sign_rpms.sh rhaos-${BUILD_VERSION}-rhel-7-candidate openshifthosted"
+                    sh "${env.WORKSPACE}/build-scripts/sign_rpms.sh rhaos-${params.BUILD_VERSION}-rhel-7-candidate openshifthosted"
                 } else {
                     echo "RPM signing has been skipped..."
                 }
@@ -854,8 +853,8 @@ rpms:build --version v${NEW_VERSION}
 
             stage("puddle: ose 'building'") {
                 OCP_PUDDLE = buildlib.build_puddle(
-                    PUDDLE_CONF,    // The puddle configuration file to use
-                    PUDDLE_SIGN_KEYS, // openshifthosted key
+                    puddleConf,    // The puddle configuration file to use
+                    puddleSignKeys, // openshifthosted key
                     "-b",   // do not fail if we are missing dependencies
                     "-d",   // print debug information
                     "-n",   // do not send an email for this puddle
@@ -866,7 +865,7 @@ rpms:build --version v${NEW_VERSION}
 
             stage("update dist-git") {
                 buildlib.doozer """
---working-dir ${DOOZER_WORKING} --group 'openshift-${BUILD_VERSION}'
+--working-dir ${DOOZER_WORKING} --group 'openshift-${params.BUILD_VERSION}'
 --source ose ${OSE_DIR}
 ${ODCS_FLAG}
 images:rebase --version v${NEW_VERSION}
@@ -901,7 +900,7 @@ images:rebase --version v${NEW_VERSION}
                     commonlib.email(
                         to: "aos-team-art@redhat.com,${val.owners}",
                         from: "aos-cicd@redhat.com",
-                        subject: "${val.image} Dockerfile reconciliation for OCP v${BUILD_VERSION}",
+                        subject: "${val.image} Dockerfile reconciliation for OCP v${params.BUILD_VERSION}",
                         body: """
 Why am I receiving this?
 You are receiving this message because you are listed as an owner for an OpenShift related image - or
@@ -936,14 +935,14 @@ Please direct any questions to the Automated Release Team (#aos-cd-team on IRC).
             }
 
             stage("build images") {
-                if (BUILD_CONTAINER_IMAGES) {
+                if (params.BUILD_CONTAINER_IMAGES) {
                     try {
                         exclude = ""
                         if (BUILD_EXCLUSIONS != "") {
                             exclude = "-x ${BUILD_EXCLUSIONS} --ignore-missing-base"
                         }
                         buildlib.doozer """
---working-dir ${DOOZER_WORKING} --group openshift-${BUILD_VERSION}
+--working-dir ${DOOZER_WORKING} --group openshift-${params.BUILD_VERSION}
 ${ODCS_FLAG}
 ${exclude}
 images:build
@@ -963,7 +962,7 @@ images:build
             NEW_FULL_VERSION = "${NEW_VERSION}-${NEW_RELEASE}"
 
             SYMLINK_NAME = "latest"
-            if (!BUILD_CONTAINER_IMAGES) {
+            if (!params.BUILD_CONTAINER_IMAGES) {
                 SYMLINK_NAME = "no-image-latest"
             }
 
@@ -972,10 +971,10 @@ images:build
 
             // push-to-mirrors.sh sets up a different puddle name on rcm-guest and the mirrors
             OCP_PUDDLE = "v${NEW_FULL_VERSION}_${OCP_PUDDLE}"
-            final mirror_url = get_mirror_url(BUILD_MODE, BUILD_VERSION)
+            final mirror_url = get_mirror_url(BUILD_MODE, params.BUILD_VERSION)
 
             stage("ami") {
-                if (params.BUILD_AMI && BUILD_CONTAINER_IMAGES) {
+                if (params.BUILD_AMI && params.BUILD_CONTAINER_IMAGES) {
                     // define openshift ansible source branch
                     OPENSHIFT_ANSIBLE_SOURCE_BRANCH = 'master'
                     if (!IS_SOURCE_IN_MASTER) {
@@ -983,7 +982,7 @@ images:build
                         if (BUILD_VERSION_MAJOR == 3 && BUILD_VERSION_MINOR < 6) {
                             OPENSHIFT_ANSIBLE_SOURCE_BRANCH = "release-1.${BUILD_VERSION_MINOR}"
                         } else {
-                            OPENSHIFT_ANSIBLE_SOURCE_BRANCH = "release-${BUILD_VERSION}"
+                            OPENSHIFT_ANSIBLE_SOURCE_BRANCH = "release-${params.BUILD_VERSION}"
                         }
                     }
                     buildlib.build_ami(
@@ -991,23 +990,23 @@ images:build
                         NEW_VERSION, NEW_RELEASE,
                         "${mirror_url}/${OCP_PUDDLE}/x86_64/os",
                         OPENSHIFT_ANSIBLE_SOURCE_BRANCH,
-                        MAIL_LIST_FAILURE)
+                        params.MAIL_LIST_FAILURE)
                 }
             }
 
             if (NEW_RELEASE != "1") {
                 // If this is not a release candidate, push binary in a directory qualified with release field information
-                buildlib.invoke_on_rcm_guest("publish-oc-binary.sh", BUILD_VERSION, NEW_FULL_VERSION)
+                buildlib.invoke_on_rcm_guest("publish-oc-binary.sh", params.BUILD_VERSION, NEW_FULL_VERSION)
             } else {
                 // If this is a release candidate, the directory binary directory should not contain release information
-                buildlib.invoke_on_rcm_guest("publish-oc-binary.sh", BUILD_VERSION, NEW_VERSION)
+                buildlib.invoke_on_rcm_guest("publish-oc-binary.sh", params.BUILD_VERSION, NEW_VERSION)
             }
 
             echo "Finished building OCP ${NEW_FULL_VERSION}"
             PREV_BUILD = null  // We are done. Don't untag even if there is an error sending the email.
 
             // Don't make an github release unless this build it from the actual ose repo
-            if ( GITHUB_BASE == "git@github.com:openshift" ) {
+            if ( params.GITHUB_BASE == "git@github.com:openshift" ) {
                 try {
                     withCredentials([string(credentialsId: 'github_token_ose', variable: 'GITHUB_TOKEN')]) {
                         httpRequest(
@@ -1044,19 +1043,19 @@ Jenkins job: ${env.BUILD_URL}
 
         ATTN = ""
         try {
-            NEW_BUILD = sh(returnStdout: true, script: "brew latest-build --quiet rhaos-${BUILD_VERSION}-rhel-7-candidate atomic-openshift | awk '{print \$1}'").trim()
+            NEW_BUILD = sh(returnStdout: true, script: "brew latest-build --quiet rhaos-${params.BUILD_VERSION}-rhel-7-candidate atomic-openshift | awk '{print \$1}'").trim()
             if (PREV_BUILD != null && PREV_BUILD != NEW_BUILD) {
                 // Untag anything tagged by this build if an error occured at any point
-                sh "brew --user=ocp-build untag-build rhaos-${BUILD_VERSION}-rhel-7-candidate ${NEW_BUILD}"
+                sh "brew --user=ocp-build untag-build rhaos-${params.BUILD_VERSION}-rhel-7-candidate ${NEW_BUILD}"
             }
         } catch (err2) {
             ATTN = " - UNABLE TO UNTAG!"
         }
 
         commonlib.email(
-            to: "${MAIL_LIST_FAILURE}",
+            to: "${params.MAIL_LIST_FAILURE}",
             from: "aos-cicd@redhat.com",
-            subject: "Error building OSE: ${BUILD_VERSION}${ATTN}",
+            subject: "Error building OSE: ${params.BUILD_VERSION}${ATTN}",
             body: """Encountered an error while running OCP pipeline: ${err}
 
 Jenkins job: ${env.BUILD_URL}

--- a/jobs/build/ocp/Jenkinsfile
+++ b/jobs/build/ocp/Jenkinsfile
@@ -950,11 +950,20 @@ images:build
 """
                     }
                     catch (err) {
-                        failed_map = buildlib.get_failed_builds(DOOZER_WORKING)
+                        record_log = buildlib.parse_record_log(DOOZER_WORKING)
+                        def failed_map = buildlib.get_failed_builds(record_log, true)
                         if (!failed_map) { throw err }  // failed so badly we don't know what failed; assume all
+
                         BUILD_FAILURES = failed_map.keySet().join(",")  // will make email show PARTIAL
                         currentBuild.result = "UNSTABLE"
                         currentBuild.description = "Failed images: ${BUILD_FAILURES}"
+
+                        def r = buildlib.determine_build_failure_ratio(record_log)
+                        if (r.total > 10 && r.ratio > 0.25 || r.total > 1 && r.failed == r.total) {
+                            echo "${r.failed} of ${r.total} image builds failed; probably not the owners' fault, will not spam"
+                        } else {
+                            buildlib.mail_build_failure_owners(failed_map, "aos-team-art@redhat.com", params.MAIL_LIST_FAILURE)
+                        }
                     }
                 }
             }

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -83,13 +83,16 @@ def mail_success(version, mirrorURL, record_log, commonlib) {
     PARTIAL = " "
     mail_list = MAIL_LIST_SUCCESS
     exclude_subject = ""
-    if (BUILD_EXCLUSIONS != "") {
+    if (BUILD_EXCLUSIONS != "" || BUILD_FAILURES != null) {
         PARTIAL = " PARTIAL "
-        mail_list = MAIL_LIST_FAILURE
-        exclude_subject = " [excluded images: ${BUILD_EXCLUSIONS}]"
-        currentBuild.result = "UNSTABLE"
         currentBuild.displayName += " (partial)"
-        currentBuild.description = "Failed images: ${BUILD_EXCLUSIONS}"
+        if (BUILD_FAILURES != null {
+            mail_list = MAIL_LIST_FAILURE
+            exclude_subject += " [failed images: ${BUILD_FAILURES}]"
+        }
+        if (BUILD_EXCLUSIONS != "") {
+            exclude_subject += " [excluded images: ${BUILD_EXCLUSIONS}]"
+        }
     }
 
     image_details = """${timing_report}
@@ -353,6 +356,7 @@ node {
     }
 
     BUILD_EXCLUSIONS = commonlib.cleanCommaList(BUILD_EXCLUSIONS)
+    BUILD_FAILURES = null
 
     // Will be used to track which atomic-openshift build was tagged before we ran.
     PREV_BUILD = null
@@ -712,7 +716,6 @@ Please direct any questsions to the Continuous Delivery team (#aos-cd-team on IR
                 }
             }
 
-            BUILD_CONTINUED = false
             stage("build images") {
                 if (BUILD_CONTAINER_IMAGES) {
                     try {
@@ -730,16 +733,10 @@ images:build
                     }
                     catch (err) {
                         failed_map = buildlib.get_failed_builds(DOOZER_WORKING)
-                        BUILD_EXCLUSIONS = failed_map.keySet().join(",") //will make email show PARTIAL
-                        BUILD_CONTINUED = true //simply setting flag to keep required work out of input flow
-                    }
-
-                    if (BUILD_CONTINUED) {
-                        buildlib.doozer """
-    --working-dir ${DOOZER_WORKING} --group openshift-${BUILD_VERSION}
-    ${exclude} images:push --to-defaults --late-only
-    """
-                        // exclude is already set earlier in the main images:build flow
+                        if (!failed_map) { throw err }  // failed so badly we don't know what failed; assume all
+                        BUILD_FAILURES = failed_map.keySet().join(",")  // will make email show PARTIAL
+                        currentBuild.result = "UNSTABLE"
+                        currentBuild.description = "Failed images: ${BUILD_FAILURES}"
                     }
                 }
             }

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -731,11 +731,20 @@ images:build
 """
                     }
                     catch (err) {
-                        failed_map = buildlib.get_failed_builds(DOOZER_WORKING)
+                        record_log = buildlib.parse_record_log(DOOZER_WORKING)
+                        def failed_map = buildlib.get_failed_builds(record_log, true)
                         if (!failed_map) { throw err }  // failed so badly we don't know what failed; assume all
+
                         BUILD_FAILURES = failed_map.keySet().join(",")  // will make email show PARTIAL
                         currentBuild.result = "UNSTABLE"
                         currentBuild.description = "Failed images: ${BUILD_FAILURES}"
+
+                        def r = buildlib.determine_build_failure_ratio(record_log)
+                        if (r.total > 10 && r.ratio > 0.25 || r.total > 1 && r.failed == r.total) {
+                            echo "${r.failed} of ${r.total} image builds failed; probably not the owners' fault, will not spam"
+                        } else {
+                            buildlib.mail_build_failure_owners(failed_map, "aos-team-art@redhat.com", params.MAIL_LIST_FAILURE)
+                        }
                     }
                 }
             }

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -72,8 +72,8 @@ def mail_success(version, mirrorURL, record_log, commonlib) {
     }
 
     def inject_notes = ""
-    if (SPECIAL_NOTES.trim() != "") {
-        inject_notes = "\n***Special notes associated with this build****\n${SPECIAL_NOTES.trim()}\n***********************************************\n"
+    if (params.SPECIAL_NOTES.trim() != "") {
+        inject_notes = "\n***Special notes associated with this build****\n${params.SPECIAL_NOTES.trim()}\n***********************************************\n"
     }
 
     def timing_report = get_build_timing_report(record_log)
@@ -81,13 +81,13 @@ def mail_success(version, mirrorURL, record_log, commonlib) {
     currentBuild.description = timing_report
     currentBuild.result = "SUCCESS"
     PARTIAL = " "
-    mail_list = MAIL_LIST_SUCCESS
+    mail_list = params.MAIL_LIST_SUCCESS
     exclude_subject = ""
     if (BUILD_EXCLUSIONS != "" || BUILD_FAILURES != null) {
         PARTIAL = " PARTIAL "
         currentBuild.displayName += " (partial)"
         if (BUILD_FAILURES != null {
-            mail_list = MAIL_LIST_FAILURE
+            mail_list = params.MAIL_LIST_FAILURE
             exclude_subject += " [failed images: ${BUILD_FAILURES}]"
         }
         if (BUILD_EXCLUSIONS != "") {
@@ -103,11 +103,11 @@ ${image_list}
 """
 
 
-    if (!BUILD_CONTAINER_IMAGES) {
+    if (!params.BUILD_CONTAINER_IMAGES) {
         PARTIAL = " RPM ONLY "
         image_details = ""
         // Just inform key folks about RPM only build; this is just prepping for an advisory.
-        mail_list = MAIL_LIST_FAILURE
+        mail_list = params.MAIL_LIST_FAILURE
     }
 
     commonlib.email(
@@ -118,7 +118,7 @@ ${image_list}
 OpenShift Version: v${version}
 ${inject_notes}
 RPMs:
-    Puddle (internal): http://download-node-02.eng.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift/${BUILD_VERSION}/${OCP_PUDDLE}
+    Puddle (internal): http://download-node-02.eng.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift/${params.BUILD_VERSION}/${OCP_PUDDLE}
     Exernal Mirror: ${mirrorURL}/${OCP_PUDDLE}
 ${image_details}
 
@@ -137,7 +137,7 @@ ${OSE_CHANGELOG}
 """);
 
     try {
-        if (BUILD_EXCLUSIONS == "" && BUILD_CONTAINER_IMAGES) {
+        if (BUILD_EXCLUSIONS == "" && params.BUILD_CONTAINER_IMAGES) {
             timeout(3) {
                 sendCIMessage(
                     messageContent: "New build for OpenShift ${target}: ${version}",
@@ -343,10 +343,9 @@ node {
     IS_TEST_MODE = params.TEST
     buildlib.initialize(IS_TEST_MODE)
 
-    BUILD_VERSION_MAJOR = BUILD_VERSION.tokenize('.')[0].toInteger() // Store the "X" in X.Y
-    BUILD_VERSION_MINOR = BUILD_VERSION.tokenize('.')[1].toInteger() // Store the "Y" in X.Y
+    BUILD_VERSION_MAJOR = params.BUILD_VERSION.tokenize('.')[0].toInteger() // Store the "X" in X.Y
+    BUILD_VERSION_MINOR = params.BUILD_VERSION.tokenize('.')[1].toInteger() // Store the "Y" in X.Y
     SIGN_RPMS = params.SIGN
-    BUILD_CONTAINER_IMAGES = params.BUILD_CONTAINER_IMAGES
     ODCS_MODE = params.ODCS
     ODCS_FLAG = ""
     ODCS_OPT = ""
@@ -355,43 +354,43 @@ node {
         ODCS_OPT = "--odcs unsigned"
     }
 
-    BUILD_EXCLUSIONS = commonlib.cleanCommaList(BUILD_EXCLUSIONS)
+    BUILD_EXCLUSIONS = commonlib.cleanCommaList(params.BUILD_EXCLUSIONS)
     BUILD_FAILURES = null
 
     // Will be used to track which atomic-openshift build was tagged before we ran.
     PREV_BUILD = null
 
-    AOS_CD_JOBS_COMMIT_SHA = sh(
+    aosCdJobsCommitSha = sh(
         returnStdout: true,
         script: "git rev-parse HEAD",
     ).trim()
 
     try {
         // Clean up old images so that we don't run out of device mapper space
-        sh "docker rmi --force \$(docker images  | grep v${BUILD_VERSION} | awk '{print \$3}')"
+        sh "docker rmi --force \$(docker images  | grep v${params.BUILD_VERSION} | awk '{print \$3}')"
     } catch (cce) {
         echo "Error cleaning up old images: ${cce}"
     }
 
-    PUDDLE_CONF_BASE = "https://raw.githubusercontent.com/openshift/aos-cd-jobs/${AOS_CD_JOBS_COMMIT_SHA}/build-scripts/puddle-conf"
-    PUDDLE_CONF = "${PUDDLE_CONF_BASE}/atomic_openshift-${BUILD_VERSION}.conf"
-    PUDDLE_SIGN_KEYS = SIGN_RPMS ? "b906ba72" : null
+    puddleConfBase = "https://raw.githubusercontent.com/openshift/aos-cd-jobs/${aosCdJobsCommitSha}/build-scripts/puddle-conf"
+    puddleConf = "${puddleConfBase}/atomic_openshift-${params.BUILD_VERSION}.conf"
+    puddleSignKeys = SIGN_RPMS ? "b906ba72" : null
 
-    echo "Initializing build: #${currentBuild.number} - ${BUILD_VERSION}.?? (${BUILD_MODE})"
+    echo "Initializing build: #${currentBuild.number} - ${params.BUILD_VERSION}.?? (${BUILD_MODE})"
 
     // doozer_working must be in WORKSPACE in order to have artifacts archived
-    DOOZER_WORKING = "${WORKSPACE}/doozer_working"
+    DOOZER_WORKING = "${env.WORKSPACE}/doozer_working"
     //Clear out previous work
     sh "rm -rf ${DOOZER_WORKING}"
     sh "mkdir -p ${DOOZER_WORKING}"
 
     try {
-        sshagent([SSH_KEY_ID]) {
+        sshagent([params.SSH_KEY_ID]) {
             // To work on real repos, buildlib operations must run with the permissions of openshift-bot
 
             PREV_BUILD = sh(
                 returnStdout: true,
-                script: "brew latest-build --quiet rhaos-${BUILD_VERSION}-rhel-7-candidate atomic-openshift | awk '{print \$1}'"
+                script: "brew latest-build --quiet rhaos-${params.BUILD_VERSION}-rhel-7-candidate atomic-openshift | awk '{print \$1}'"
             ).trim()
 
             stage("ose repo") {
@@ -407,10 +406,10 @@ node {
                 master_spec = buildlib.read_spec_info(GITHUB_BASE_PATHS['ose'] + "/origin.spec")
 
                 // If the target version resides in ose#master
-                IS_SOURCE_IN_MASTER = (BUILD_VERSION == master_spec.major_minor)
+                IS_SOURCE_IN_MASTER = (params.BUILD_VERSION == master_spec.major_minor)
 
                 if (BUILD_MODE == "auto") {
-                    echo "AUTO-MODE: determine mode from version and repo: BUILD_VERSION: ${BUILD_VERSION}, master_version: ${master_spec.major_minor}"
+                    echo "AUTO-MODE: determine mode from version and repo: BUILD_VERSION: ${params.BUILD_VERSION}, master_version: ${master_spec.major_minor}"
                     // INPUTS:
                     //   BUILD_MODE
                     //   BUILD_VERSION
@@ -418,14 +417,14 @@ node {
                     releases = buildlib.get_releases(GITHUB_URLS['ose'])
                     echo "AUTO-MODE: release repo: ${GITHUB_URLS['ose']}"
                     echo "AUTO-MODE: releases: ${releases}"
-                    BUILD_MODE = buildlib.auto_mode(BUILD_VERSION, master_spec.major_minor, releases)
+                    BUILD_MODE = buildlib.auto_mode(params.BUILD_VERSION, master_spec.major_minor, releases)
                     echo "BUILD_MODE = ${BUILD_MODE}"
                 }
             }
 
             stage("analyze") {
 
-                dir(env.OSE_DIR) {
+                dir(OSE_DIR) {
                     // inputs:
                     //  IS_SOURCE_IN_MASTER
                     //  BUILD_MODE
@@ -456,12 +455,12 @@ node {
                         OSE_SOURCE_BRANCH = "master"
                         UPSTREAM_SOURCE_BRANCH = "upstream/master"
                     } else {
-                        OSE_SOURCE_BRANCH = "enterprise-${BUILD_VERSION}"
+                        OSE_SOURCE_BRANCH = "enterprise-${params.BUILD_VERSION}"
                         if (BUILD_MODE == "release") {
                             // When building in release mode, no longer pull from upstream
                             UPSTREAM_SOURCE_BRANCH = null
                         } else {
-                            UPSTREAM_SOURCE_BRANCH = "upstream/release-${BUILD_VERSION}"
+                            UPSTREAM_SOURCE_BRANCH = "upstream/release-${params.BUILD_VERSION}"
                         }
                         // Create the non-master source branch and have it track the origin ose repo
                         sh "git checkout -b ${OSE_SOURCE_BRANCH} origin/${OSE_SOURCE_BRANCH}"
@@ -472,9 +471,9 @@ node {
                     spec = buildlib.read_spec_info("origin.spec")
                     rel_fields = spec.release.tokenize(".")
 
-                    if (! spec.version.startsWith("${BUILD_VERSION}.")) {
+                    if (! spec.version.startsWith("${params.BUILD_VERSION}.")) {
                         // Looks like pipeline thinks we are building something we aren't. Abort.
-                        error("Expected version consistent with ${BUILD_VERSION}.* but found: ${spec.version}")
+                        error("Expected version consistent with ${params.BUILD_VERSION}.* but found: ${spec.version}")
                     }
 
 
@@ -539,7 +538,7 @@ node {
                     }
 
                     rpmOnlyTag = ""
-                    if (!BUILD_CONTAINER_IMAGES) {
+                    if (!params.BUILD_CONTAINER_IMAGES) {
                         rpmOnlyTag = " (RPM ONLY)"
                     }
                     currentBuild.displayName = "#${currentBuild.number} - ${NEW_VERSION}-${NEW_RELEASE} (${BUILD_MODE}${rpmOnlyTag})"
@@ -587,7 +586,7 @@ node {
                 dir(OSE_DIR) {
                     OSE_TASK_ID = sh(
                         returnStdout: true,
-                        script: "tito release --debug --yes --test aos-${BUILD_VERSION} | grep 'Created task:' | awk '{print \$3}'"
+                        script: "tito release --debug --yes --test aos-${params.BUILD_VERSION} | grep 'Created task:' | awk '{print \$3}'"
                     )
                     OSE_BREW_URL = "https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=${OSE_TASK_ID}"
                     echo "ose rpm brew task: ${OSE_BREW_URL}"
@@ -613,7 +612,7 @@ node {
 
             stage("doozer build rpms") {
                 buildlib.doozer """
---working-dir ${DOOZER_WORKING} --group 'openshift-${BUILD_VERSION}'
+--working-dir ${DOOZER_WORKING} --group 'openshift-${params.BUILD_VERSION}'
 --source ose ${OSE_DIR}
 rpms:build --version v${NEW_VERSION}
 --release ${NEW_RELEASE}
@@ -622,7 +621,7 @@ rpms:build --version v${NEW_VERSION}
 
             stage("signing rpms") {
                 if (SIGN_RPMS) {
-                    sh "${env.WORKSPACE}/build-scripts/sign_rpms.sh rhaos-${BUILD_VERSION}-rhel-7-candidate openshifthosted"
+                    sh "${env.WORKSPACE}/build-scripts/sign_rpms.sh rhaos-${params.BUILD_VERSION}-rhel-7-candidate openshifthosted"
                 } else {
                     echo "RPM signing has been skipped..."
                 }
@@ -630,8 +629,8 @@ rpms:build --version v${NEW_VERSION}
 
             stage("puddle: ose 'building'") {
                 OCP_PUDDLE = buildlib.build_puddle(
-                    PUDDLE_CONF,    // The puddle configuration file to use
-                    PUDDLE_SIGN_KEYS, // openshifthosted key
+                    puddleConf,    // The puddle configuration file to use
+                    puddleSignKeys, // openshifthosted key
                     "-b",   // do not fail if we are missing dependencies
                     "-d",   // print debug information
                     "-n",   // do not send an email for this puddle
@@ -642,7 +641,7 @@ rpms:build --version v${NEW_VERSION}
 
             stage("update dist-git") {
                 buildlib.doozer """
---working-dir ${DOOZER_WORKING} --group 'openshift-${BUILD_VERSION}'
+--working-dir ${DOOZER_WORKING} --group 'openshift-${params.BUILD_VERSION}'
 --source ose ${OSE_DIR}
 ${ODCS_FLAG}
 images:rebase --version v${NEW_VERSION}
@@ -677,7 +676,7 @@ images:rebase --version v${NEW_VERSION}
                         commonlib.email(
                             to: "aos-team-art@redhat.com,${val.owners}",
                             from: "aos-cicd@redhat.com",
-                            subject: "${val.image} Dockerfile reconciliation for OCP v${BUILD_VERSION}",
+                            subject: "${val.image} Dockerfile reconciliation for OCP v${params.BUILD_VERSION}",
                             body: """
 Why am I receiving this?
 You are receiving this message because you are listed as an owner for an OpenShift related image - or
@@ -717,14 +716,14 @@ Please direct any questsions to the Continuous Delivery team (#aos-cd-team on IR
             }
 
             stage("build images") {
-                if (BUILD_CONTAINER_IMAGES) {
+                if (params.BUILD_CONTAINER_IMAGES) {
                     try {
                         exclude = ""
                         if (BUILD_EXCLUSIONS != "") {
                             exclude = "-x ${BUILD_EXCLUSIONS} --ignore-missing-base"
                         }
                         buildlib.doozer """
---working-dir ${DOOZER_WORKING} --group openshift-${BUILD_VERSION}
+--working-dir ${DOOZER_WORKING} --group openshift-${params.BUILD_VERSION}
 ${ODCS_FLAG}
 ${exclude}
 images:build
@@ -744,7 +743,7 @@ images:build
             NEW_FULL_VERSION = "${NEW_VERSION}-${NEW_RELEASE}"
 
             SYMLINK_NAME = "latest"
-            if (!BUILD_CONTAINER_IMAGES) {
+            if (!params.BUILD_CONTAINER_IMAGES) {
                 SYMLINK_NAME = "no-image-latest"
             }
 
@@ -753,21 +752,21 @@ images:build
 
             // push-to-mirrors.sh sets up a different puddle name on rcm-guest and the mirrors
             OCP_PUDDLE = "v${NEW_FULL_VERSION}_${OCP_PUDDLE}"
-            final mirror_url = get_mirror_url(BUILD_MODE, BUILD_VERSION)
+            final mirror_url = get_mirror_url(BUILD_MODE, params.BUILD_VERSION)
 
             if (NEW_RELEASE != "1") {
                 // If this is not a release candidate, push binary in a directory qualified with release field information
-                buildlib.invoke_on_rcm_guest("publish-oc-binary.sh", BUILD_VERSION, NEW_FULL_VERSION)
+                buildlib.invoke_on_rcm_guest("publish-oc-binary.sh", params.BUILD_VERSION, NEW_FULL_VERSION)
             } else {
                 // If this is a release candidate, the directory binary directory should not contain release information
-                buildlib.invoke_on_rcm_guest("publish-oc-binary.sh", BUILD_VERSION, NEW_VERSION)
+                buildlib.invoke_on_rcm_guest("publish-oc-binary.sh", params.BUILD_VERSION, NEW_VERSION)
             }
 
             echo "Finished building OCP ${NEW_FULL_VERSION}"
             PREV_BUILD = null  // We are done. Don't untag even if there is an error sending the email.
 
             // Don't make an github release unless this build it from the actual ose repo
-            if ( GITHUB_BASE == "git@github.com:openshift" ) {
+            if ( params.GITHUB_BASE == "git@github.com:openshift" ) {
                 try {
                     withCredentials([string(credentialsId: 'github_token_ose', variable: 'GITHUB_TOKEN')]) {
                         httpRequest(
@@ -804,19 +803,19 @@ Jenkins job: ${env.BUILD_URL}
 
         ATTN = ""
         try {
-            NEW_BUILD = sh(returnStdout: true, script: "brew latest-build --quiet rhaos-${BUILD_VERSION}-rhel-7-candidate atomic-openshift | awk '{print \$1}'").trim()
+            NEW_BUILD = sh(returnStdout: true, script: "brew latest-build --quiet rhaos-${params.BUILD_VERSION}-rhel-7-candidate atomic-openshift | awk '{print \$1}'").trim()
             if (PREV_BUILD != null && PREV_BUILD != NEW_BUILD) {
                 // Untag anything tagged by this build if an error occured at any point
-                sh "brew --user=ocp-build untag-build rhaos-${BUILD_VERSION}-rhel-7-candidate ${NEW_BUILD}"
+                sh "brew --user=ocp-build untag-build rhaos-${params.BUILD_VERSION}-rhel-7-candidate ${NEW_BUILD}"
             }
         } catch (err2) {
             ATTN = " - UNABLE TO UNTAG!"
         }
 
         commonlib.email(
-            to: "${MAIL_LIST_FAILURE}",
+            to: "${params.MAIL_LIST_FAILURE}",
             from: "aos-cicd@redhat.com",
-            subject: "Error building OSE: ${BUILD_VERSION}${ATTN}",
+            subject: "Error building OSE: ${params.BUILD_VERSION}${ATTN}",
             body: """Encountered an error while running OCP pipeline: ${err}
 
 Jenkins job: ${env.BUILD_URL}

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -129,7 +129,7 @@ def email(args) {
         to = args.to ?: args.cc ?: args.bcc ?: "NOBODY"
         to = to.replaceAll(/[^@.\w]+/, "_")
         subject = args.get("subject", "NO SUBJECT").replaceAll(/\W+/, "_")
-        filename = String.format("email/%03d-%s-%s", ++emailIndex, to, subject)
+        filename = String.format("email/email%03d-%s-%s.txt", ++emailIndex, to, subject)
 
         // this is a bit silly but writeYaml and writeFile lack finesse
         body = args.remove("body")  // unreadable when written as yaml


### PR DESCRIPTION
Builds on https://github.com/openshift/aos-cd-jobs/pull/1724 so only last three commits are new.

When image builds fail, collect the container logs and email the owners about what happened. Unless a whole lot of images fail; in that case probably something else is going on and we shouldn't spam them.