### PR TITLE
Fix a typo in openshift-origin-common repo excludes

### DIFF
--- a/jjb/playbooks/openshift/roles/setup/templates/openshift-origin-common-repo.j2
+++ b/jjb/playbooks/openshift/roles/setup/templates/openshift-origin-common-repo.j2
@@ -4,5 +4,5 @@ baseurl="http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin"
 enabled=1
 gpgcheck=0
 {% if repo_from_source is defined %}
-exclude=ansible atomc-openshift-utils openshift-ansible-* *origin*
+exclude=ansible atomic-openshift-utils openshift-ansible-* *origin*
 {% endif %}


### PR DESCRIPTION
Hopefully this should fix 3.11 packages leak in pre-3.10 test jobs