### PR TITLE
Add release-3.9 specific ansible config

### DIFF
--- a/sjb/inventory/release-3.9.cfg
+++ b/sjb/inventory/release-3.9.cfg
@@ -1,0 +1,5 @@
+openshift_node_labels:
+  region: infra
+  zone: default
+  node-role.kubernetes.io/infra: "true"
+openshift_dependencies_repo: "http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin39/"


### PR DESCRIPTION
This should fix 3.9 jobs in origin. It sets `openshift_node_labels` and a custom `openshift_dependencies_repo`

PTAL @stevekuznetsov @patrickdillon 