### PR TITLE
Don't install CentOS Origin repo in 3.9

### DIFF
--- a/sjb/inventory/release-3.9.cfg
+++ b/sjb/inventory/release-3.9.cfg
@@ -3,3 +3,4 @@ openshift_node_labels:
   zone: default
   node-role.kubernetes.io/infra: "true"
 openshift_dependencies_repo: "http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin39/"
+openshift_enable_origin_repo: false


### PR DESCRIPTION
This ensures GCP test in 3.9 won't install latest centos repos (these are 3.11 now)

@stevekuznetsov @patrickdillon PTAL