### PR TITLE
Set openshift_master_node_labels for 3.9 clusters

### DIFF
--- a/sjb/inventory/release-3.9.cfg
+++ b/sjb/inventory/release-3.9.cfg
@@ -1,6 +1,7 @@
-openshift_node_labels:
+openshift_master_node_labels:
   region: infra
   zone: default
+  node-role.kubernetes.io/master: "true"
   node-role.kubernetes.io/infra: "true"
 openshift_dependencies_repo: "http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin39/"
 openshift_enable_origin_repo: false


### PR DESCRIPTION
By default masters would get only openshift_master_node_labels masters 
set, so all-in-one cluster would effectively ignore 
openshift_node_labels