### PR TITLE
Run sync job after full/incremental ocp4 builds

### DIFF
--- a/jobs/build/build-sync/Jenkinsfile
+++ b/jobs/build/build-sync/Jenkinsfile
@@ -1,0 +1,111 @@
+#!/usr/bin/env groovy
+
+node {
+    checkout scm
+    def buildlib = load("pipeline-scripts/buildlib.groovy")
+    def commonlib = buildlib.commonlib
+
+    properties(
+        [
+            buildDiscarder(
+                logRotator(
+                    artifactDaysToKeepStr: '',
+                    artifactNumToKeepStr: '',
+                    daysToKeepStr: '',
+                    numToKeepStr: '360'
+                )
+            ),
+            [
+                $class : 'ParametersDefinitionProperty',
+                parameterDefinitions: [
+                    commonlib.mockParam(),
+		     commonlib.ocpVersionParam('BUILD_VERSION', '4'),
+                ]
+            ],
+            disableConcurrentBuilds(),
+            timestamps(),
+        ]
+    )
+
+    echo "Initializing ${params.BUILD_VERSION} sync: #${currentBuild.number}"
+
+    // doozer_working must be in WORKSPACE in order to have artifacts archived
+    def mirrorWorking = "${env.WORKSPACE}/MIRROR_working"
+    // Location of the SRC=DEST input file
+    def ocMirrorInput = "${mirrorWorking}/oc_mirror_input"
+    // Location of the image stream to apply
+    def ocIsObject = "${mirrorWorking}/release-is.yaml"
+    // Locally stored image stream stub
+    def baseImageStream = "/home/jenkins/base-art-latest-imagestream.yaml"
+    // Kubeconfig allowing ART to interact with api.ci.openshift.org
+    def ciKubeconfig = "/home/jenkins/kubeconfigs/art-publish.kubeconfig"
+
+    // See 'oc image mirror --help' for more information.
+    // This is the template for the SRC=DEST strings mentioned above.
+    def ocFmtStr = "registry.reg-aws.openshift.com:443/{repository}=quay.io/openshift-release-dev/ocp-v4.0-art-dev:{version}-{release}-{image_name_short}"
+
+    //Clear out previous work
+    sh "rm -rf ${mirrorWorking}"
+    sh "mkdir -p ${mirrorWorking}"
+
+    stage("Version dumps") {
+        buildlib.doozer "--version"
+        sh "which doozer"
+        sh "oc version"
+    }
+
+    // TRY all of this so we can save the generated artifacts before
+    // throwing the exceptions
+    try {
+        // ######################################################################
+        // This should create a list of SOURCE=DEST strings in the output file
+        // May take a few minutes because doozer must query brew for each image
+        stage("Generate SRC=DEST input") {
+            buildlib.doozer """
+--working-dir "${mirrorWorking}" --group 'openshift-${params.BUILD_VERSION}'
+beta:release-gen
+--src-dest ${ocMirrorInput}
+--image-stream ${ocIsObject}
+--is-base ${baseImageStream}
+'${ocFmtStr}'
+"""
+            images_count = sh(returnStdout: true, script: "wc -l ${ocMirrorInput}").trim().split().first()
+            currentBuild.description = "Preparing to sync ${images_count} images"
+        }
+
+        // ######################################################################
+        // Now run the actual mirroring command. Wrapped this in a
+        // retry loop because it is known to fail occassionally
+        // depending on the health of the source/destination endpoints.
+        stage("oc image mirror") {
+            echo "Mirror SRC=DEST input:"
+            sh "cat ${ocMirrorInput}"
+            try {
+                retry (3) {
+                    buildlib.registry_quay_dev_login()
+                    buildlib.oc "image mirror --filename=${ocMirrorInput}"
+                }
+            } catch (mirror_error) {
+                currentBuild.description = "Error mirroring images after 3 attempts:\n${mirror_error}"
+                error(currentBuild.description)
+            }
+        }
+
+        stage("oc apply") {
+            echo "ImageStream Object to apply:"
+            sh "cat ${ocIsObject}"
+            try {
+                buildlib.oc "apply --filename=${ocIsObject} --kubeconfig ${ciKubeconfig}"
+            } catch (apply_error) {
+                currentBuild.description = "Error updating image stream:\n${apply_error}"
+                error(currentBuild.description)
+            }
+        }
+    } finally {
+        commonlib.safeArchiveArtifacts([
+                "MIRROR_working/oc_mirror_input",
+                "MIRROR_working/release-is.yaml"
+            ]
+        )
+    }
+}

--- a/jobs/build/build-sync/README.md
+++ b/jobs/build/build-sync/README.md
@@ -1,0 +1,1 @@
+Mirrors latest 4.x images to https://quay.io/repository/openshift-release-dev/ocp-v4.0-art-dev

--- a/jobs/build/incremental/Jenkinsfile
+++ b/jobs/build/incremental/Jenkinsfile
@@ -143,7 +143,7 @@ ${extra_body}""")
             gather_children = { all, data, changed, gather ->
                 // all(list): all images gathered so far while traversing tree
                 // data(map): the part of the yaml image tree we're looking at
-                // changed(list): all images initially found to have changed 
+                // changed(list): all images initially found to have changed
                 // gather(bool): whether this is a subtree of an image with changed source
                 data.each { image, children ->
                     def gather_this = gather || image in changed
@@ -286,6 +286,15 @@ ${extra_body}""")
             ])
         }
 
+    }
+
+    stage('sync images') {
+	buildlib.sync_images(
+	    OSE_MAJOR,
+	    OSE_MINOR,
+	    "aos-team-art@redhat.com",
+	    currentBuild.number
+	)
     }
 
     // we probably don't want to spam email on success.

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -808,6 +808,15 @@ Jenkins job: ${env.BUILD_URL}
             }
             mail_success(NEW_FULL_VERSION, mirror_url, record_log, commonlib)
         }
+
+	stage('sync images') {
+	    buildlib.sync_images(
+		BUILD_VERSION_MAJOR,
+		BUILD_VERSION_MINOR,
+		"aos-team-art@redhat.com",
+		currentBuild.number
+	    )
+	}
     } catch (err) {
 
         ATTN = ""

--- a/scheduled-jobs/build/oc-mirror-quay-dev/Jenkinsfile
+++ b/scheduled-jobs/build/oc-mirror-quay-dev/Jenkinsfile
@@ -1,68 +1,58 @@
-
-
-properties(
-    [
-        buildDiscarder(
-            logRotator(
-                artifactDaysToKeepStr: '',
-                artifactNumToKeepStr: '',
-                daysToKeepStr: '',
-                numToKeepStr: '360'
-            )
-        ),
-        [
-            $class : 'ParametersDefinitionProperty',
-            parameterDefinitions: [
-                [
-                    name: 'MOCK',
-                    description: 'Mock run to pickup new Jenkins parameters?',
-                    $class: 'hudson.model.BooleanParameterDefinition',
-                    defaultValue: false,
-                ],
-                [
-                    name: 'BUILD_VERSION',
-                    description: 'OCP Version to build',
-                    $class: 'hudson.model.ChoiceParameterDefinition',
-                    choices: "4.0",
-                    defaultValue: '4.0'
-                ],
-                [
-                    name: 'TARGET_NODE',
-                    description: 'Jenkins agent node',
-                    $class: 'hudson.model.StringParameterDefinition',
-                    defaultValue: 'openshift-build-1'
-                ],
-                [
-                    name: 'MAIL_LIST_SUCCESS',
-                    description: 'Success Mailing List',
-                    $class: 'hudson.model.StringParameterDefinition',
-                    defaultValue: [
-                        'aos-team-art@redhat.com',
-                    ].join(',')
-                ],
-                [
-                    name: 'MAIL_LIST_FAILURE',
-                    description: 'Failure Mailing List',
-                    $class: 'hudson.model.StringParameterDefinition',
-                    defaultValue: [
-                        'aos-team-art@redhat.com',
-                    ].join(',')
-                ],
-
-            ]
-        ],
-        disableConcurrentBuilds()
-    ]
-)
-
-node(TARGET_NODE) {
+node {
     checkout scm
 
     def commonlib = load( "pipeline-scripts/commonlib.groovy")
-    commonlib.initialize()
-
     def buildlib = load("pipeline-scripts/buildlib.groovy")
-    // buildlib.initialize()
+
+    properties(
+        [
+            buildDiscarder(
+                logRotator(
+                    artifactDaysToKeepStr: '',
+                    artifactNumToKeepStr: '',
+                    daysToKeepStr: '',
+                    numToKeepStr: '360'
+                )
+            ),
+            [
+                $class : 'ParametersDefinitionProperty',
+                parameterDefinitions: [
+                    [
+                        name: 'MOCK',
+                        description: 'Mock run to pickup new Jenkins parameters?',
+                        $class: 'hudson.model.BooleanParameterDefinition',
+                        defaultValue: false,
+                    ],
+                    commonlib.ocpVersionParam('BUILD_VERSION', '4'),
+                    [
+                        name: 'TARGET_NODE',
+                        description: 'Jenkins agent node',
+                        $class: 'hudson.model.StringParameterDefinition',
+                        defaultValue: 'openshift-build-1'
+                    ],
+                    [
+                        name: 'MAIL_LIST_SUCCESS',
+                        description: 'Success Mailing List',
+                        $class: 'hudson.model.StringParameterDefinition',
+                        defaultValue: [
+                            'aos-team-art@redhat.com',
+                        ].join(',')
+                    ],
+                    [
+                        name: 'MAIL_LIST_FAILURE',
+                        description: 'Failure Mailing List',
+                        $class: 'hudson.model.StringParameterDefinition',
+                        defaultValue: [
+                            'aos-team-art@redhat.com',
+                        ].join(',')
+                    ],
+
+                ]
+            ],
+            disableConcurrentBuilds()
+        ]
+    )
+
     buildlib.registry_quay_dev_login()
 
     echo "Initializing ${BUILD_VERSION} sync: #${currentBuild.number}"


### PR DESCRIPTION
Presently we run the image sync job on an hourly schedule. That's simply overkill. It has always been intended to be ran as an additional job stage. That's what this PR enables.

The existing sync job is copied to the regular builds jobs directory. It will be eliminated from `scheduled-job` after successful implementation as a build step.

This PR also updates the new sync job to use the new commonlib method for archiving artifacts. A `4.1` option has also been added to the sync job.

I am _hoping_ that a job with defaults set for its parameters does not require passing an explicit value for those parameters when using the `build()` function. 

I didn't **wrap** the `commonlib.sync_images()` call with a `try/catch` because I think that we won't have errors bubble up by having the call to the sync job wrapped in a `try/catch` inside the `sync_images` function.