### PR TITLE
Remove quotes from evars flag so it is not skipped.

### DIFF
--- a/sjb/config/common/test_cases/origin_built_installed_release.yml
+++ b/sjb/config/common/test_cases/origin_built_installed_release.yml
@@ -83,7 +83,7 @@ extensions:
                          -e openshift_pkg_version="$( cat ./ORIGIN_PKG_VERSION )"               \
                          -e openshift_release="$( cat ./ORIGIN_RELEASE )"                       \
                          -e oreg_url='openshift/origin-${component}:'"$( cat ./ORIGIN_COMMIT )" \
-                         "${evars:-}" \
+                         ${evars:-} \
                          ${EXTRA_EVARS:-} \
                          /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
     - type: "script"

--- a/sjb/generated/test_branch_openshift_ansible_logging.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging.xml
@@ -532,7 +532,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
@@ -532,7 +532,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_branch_origin_aggregated_logging_json_file.xml
+++ b/sjb/generated/test_branch_origin_aggregated_logging_json_file.xml
@@ -532,7 +532,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_branch_origin_extended_builds_311.xml
+++ b/sjb/generated/test_branch_origin_extended_builds_311.xml
@@ -517,7 +517,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_branch_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install.xml
@@ -517,7 +517,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
@@ -537,7 +537,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_origin_device_manager_plugin_gpu.xml
+++ b/sjb/generated/test_origin_device_manager_plugin_gpu.xml
@@ -519,7 +519,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
@@ -517,7 +517,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_36.xml
@@ -517,7 +517,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_37.xml
@@ -517,7 +517,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_39.xml
@@ -517,7 +517,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
@@ -537,7 +537,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_36.xml
@@ -537,7 +537,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_37.xml
@@ -537,7 +537,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_39.xml
@@ -537,7 +537,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
@@ -517,7 +517,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_logging.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging.xml
@@ -532,7 +532,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_36.xml
@@ -532,7 +532,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_37.xml
@@ -532,7 +532,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_39.xml
@@ -532,7 +532,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald.xml
@@ -532,7 +532,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_36.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_36.xml
@@ -532,7 +532,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_37.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_37.xml
@@ -532,7 +532,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_39.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_39.xml
@@ -532,7 +532,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file.xml
@@ -532,7 +532,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_36.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_36.xml
@@ -532,7 +532,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_37.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_37.xml
@@ -532,7 +532,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_39.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_39.xml
@@ -532,7 +532,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
@@ -517,7 +517,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_39.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_39.xml
@@ -517,7 +517,7 @@ ansible-playbook -vv --become               \
                  -e openshift_pkg_version=&#34;\$( cat ./ORIGIN_PKG_VERSION )&#34;               \
                  -e openshift_release=&#34;\$( cat ./ORIGIN_RELEASE )&#34;                       \
                  -e oreg_url=&#39;openshift/origin-\${component}:&#39;&#34;\$( cat ./ORIGIN_COMMIT )&#34; \
-                 &#34;\${evars:-}&#34; \
+                 \${evars:-} \
                  \${EXTRA_EVARS:-} \
                  /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
 SCRIPT


### PR DESCRIPTION
We should remove the quotation marks around the `evars` variable in the parent conformance test script.

After merging #1732, it seems region:infra nodes are still not being set and I see this in the logs:
```
+ evars='-e @sjb/inventory/release-3.9.cfg'
[...]
+ ansible-playbook -vv --become --become-user root --connection local --inventory sjb/inventory/ -e openshift_deployment_type=origin -e openshift_pkg_version=-3.9.0-1.35.7559441 -e openshift_release=3.9 -e 'oreg_url=openshift/origin-${component}:7559441' '-e @sjb/inventory/release-3.9.cfg' /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml
```
I think the quotation marks are causing the flag to be skipped, but am not certain of the exact reason. 

Local testing without quotes:
```
[padillon@localhost ansible-playground]$ ansible-playbook evars.yml -e @inventory/a.cfg

PLAY [localhost] ***************************************************************

TASK [PRINT] *******************************************************************
ok: [localhost] => {
    "msg": "node label: a"
}

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0   
```

Local testing with quotes results in vars not being loaded:
```
[padillon@localhost ansible-playground]$ ansible-playbook evars.yml '-e @inventory/a.cfg'

PLAY [localhost] ***************************************************************

TASK [PRINT] *******************************************************************
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'openshift_node_labels' is undefined\n\nThe error appears to have been in '/home/padillon/learn/ansible-playground/evars.yml': line 4, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n  tasks:\n    - name: PRINT\n      ^ here\n"}
	to retry, use: --limit @/home/padillon/learn/ansible-playground/evars.retry

PLAY RECAP *********************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1  
```
