### PR TITLE
3.10 logging - use ansible vars.yaml files for branch specific params

### DIFF
--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging_310.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging_310.yml
@@ -8,7 +8,7 @@ overrides:
     - "openshift,origin-aggregated-logging=release-3.10"
     - "openshift,kubernetes-metrics-server=release-3.10"
     - "openshift,origin-web-console-server=release-3.10"
-  evars: "-e skip_sanity_checks=true -e openshift_disable_check=* -e openshift_install_examples=false -e debug_level=2"
+  evars: "-e@/data/src/github.com/openshift/origin-aggregated-logging/ci-ansible-common.yaml -e@/data/src/github.com/openshift/origin-aggregated-logging/ci-ansible-journald.yaml"
 extensions:
   actions:
     - type: "script"

--- a/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file_310.yml
+++ b/sjb/config/test_cases/test_branch_openshift_ansible_logging_json_file_310.yml
@@ -8,7 +8,7 @@ overrides:
     - "openshift,origin-aggregated-logging=release-3.10"
     - "openshift,kubernetes-metrics-server=release-3.10"
     - "openshift,origin-web-console-server=release-3.10"
-  evars: "-e skip_sanity_checks=true -e openshift_disable_check=* -e openshift_docker_log_driver=json-file -e openshift_docker_options=--log-driver=json-file -e openshift_install_examples=false -e debug_level=2"
+  evars: "-e@/data/src/github.com/openshift/origin-aggregated-logging/ci-ansible-common.yaml -e@/data/src/github.com/openshift/origin-aggregated-logging/ci-ansible-json-file.yaml"
 extensions:
   actions:
     - type: "script"

--- a/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_journald_310.yml
+++ b/sjb/config/test_cases/test_pull_request_origin_aggregated_logging_journald_310.yml
@@ -8,7 +8,7 @@ overrides:
     - "openshift,openshift-ansible=release-3.10"
     - "openshift,kubernetes-metrics-server=release-3.10"
     - "openshift,origin-web-console-server=release-3.10"
-  evars: "-e skip_sanity_checks=true -e openshift_disable_check=* -e openshift_docker_log_driver=journald -e openshift_docker_options=--log-driver=journald -e openshift_install_examples=false -e debug_level=2"
+  evars: "-e@/data/src/github.com/openshift/origin-aggregated-logging/ci-ansible-common.yaml -e@/data/src/github.com/openshift/origin-aggregated-logging/ci-ansible-journald.yaml"
 extensions:
   actions:
     - type: "script"

--- a/sjb/generated/test_branch_openshift_ansible_logging_310.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_310.xml
@@ -185,7 +185,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo chmod o+rw /etc/environment
-echo &#39;EXTRA_EVARS=&#34;-e skip_sanity_checks=true -e openshift_disable_check=* -e openshift_install_examples=false -e debug_level=2&#34;&#39; &gt;&gt; /etc/environment
+echo &#39;EXTRA_EVARS=&#34;-e@/data/src/github.com/openshift/origin-aggregated-logging/ci-ansible-common.yaml -e@/data/src/github.com/openshift/origin-aggregated-logging/ci-ansible-journald.yaml&#34;&#39; &gt;&gt; /etc/environment
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file_310.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file_310.xml
@@ -185,7 +185,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo chmod o+rw /etc/environment
-echo &#39;EXTRA_EVARS=&#34;-e skip_sanity_checks=true -e openshift_disable_check=* -e openshift_docker_log_driver=json-file -e openshift_docker_options=--log-driver=json-file -e openshift_install_examples=false -e debug_level=2&#34;&#39; &gt;&gt; /etc/environment
+echo &#39;EXTRA_EVARS=&#34;-e@/data/src/github.com/openshift/origin-aggregated-logging/ci-ansible-common.yaml -e@/data/src/github.com/openshift/origin-aggregated-logging/ci-ansible-json-file.yaml&#34;&#39; &gt;&gt; /etc/environment
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_aggregated_logging_json_file_310.xml
+++ b/sjb/generated/test_branch_origin_aggregated_logging_json_file_310.xml
@@ -185,7 +185,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo chmod o+rw /etc/environment
-echo &#39;EXTRA_EVARS=&#34;-e skip_sanity_checks=true -e openshift_disable_check=* -e openshift_docker_log_driver=json-file -e openshift_docker_options=--log-driver=json-file -e openshift_install_examples=false -e debug_level=2&#34;&#39; &gt;&gt; /etc/environment
+echo &#39;EXTRA_EVARS=&#34;-e@/data/src/github.com/openshift/origin-aggregated-logging/ci-ansible-common.yaml -e@/data/src/github.com/openshift/origin-aggregated-logging/ci-ansible-json-file.yaml&#34;&#39; &gt;&gt; /etc/environment
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_310.xml
@@ -185,7 +185,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo chmod o+rw /etc/environment
-echo &#39;EXTRA_EVARS=&#34;-e skip_sanity_checks=true -e openshift_disable_check=* -e openshift_install_examples=false -e debug_level=2&#34;&#39; &gt;&gt; /etc/environment
+echo &#39;EXTRA_EVARS=&#34;-e@/data/src/github.com/openshift/origin-aggregated-logging/ci-ansible-common.yaml -e@/data/src/github.com/openshift/origin-aggregated-logging/ci-ansible-journald.yaml&#34;&#39; &gt;&gt; /etc/environment
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_310.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_310.xml
@@ -185,7 +185,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo chmod o+rw /etc/environment
-echo &#39;EXTRA_EVARS=&#34;-e skip_sanity_checks=true -e openshift_disable_check=* -e openshift_docker_log_driver=journald -e openshift_docker_options=--log-driver=journald -e openshift_install_examples=false -e debug_level=2&#34;&#39; &gt;&gt; /etc/environment
+echo &#39;EXTRA_EVARS=&#34;-e@/data/src/github.com/openshift/origin-aggregated-logging/ci-ansible-common.yaml -e@/data/src/github.com/openshift/origin-aggregated-logging/ci-ansible-journald.yaml&#34;&#39; &gt;&gt; /etc/environment
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_310.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_310.xml
@@ -185,7 +185,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 sudo chmod o+rw /etc/environment
-echo &#39;EXTRA_EVARS=&#34;-e skip_sanity_checks=true -e openshift_disable_check=* -e openshift_docker_log_driver=json-file -e openshift_docker_options=--log-driver=json-file -e openshift_install_examples=false -e debug_level=2&#34;&#39; &gt;&gt; /etc/environment
+echo &#39;EXTRA_EVARS=&#34;-e@/data/src/github.com/openshift/origin-aggregated-logging/ci-ansible-common.yaml -e@/data/src/github.com/openshift/origin-aggregated-logging/ci-ansible-json-file.yaml&#34;&#39; &gt;&gt; /etc/environment
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;


### PR DESCRIPTION
This is like https://github.com/openshift/aos-cd-jobs/pull/1722
except for 3.10 branch builds.

Requires https://github.com/openshift/origin-aggregated-logging/pull/1536