### PR TITLE
Revert "Merge pull request #1733 from vrutkovs/3.9-disable-centos-repo"

### DIFF
--- a/sjb/inventory/release-3.9.cfg
+++ b/sjb/inventory/release-3.9.cfg
@@ -4,4 +4,3 @@ openshift_master_node_labels:
   node-role.kubernetes.io/master: "true"
   node-role.kubernetes.io/infra: "true"
 openshift_dependencies_repo: "http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin39/"
-openshift_enable_origin_repo: false


### PR DESCRIPTION
This commit was intended to fix the gcp job, but had a side effect of breaking install job, so we would like to revert.

This reverts commit 7e1dfd65108dbbf034dc0fa2e26b2b101744733d, reversing
changes made to 46a12315e806d5954b738cb37504cf687aa9acb2.

/cc vrutkovs