### PR TITLE
Change release-3.9 inventory label to openshift_node_label.

### DIFF
--- a/sjb/inventory/release-3.9.cfg
+++ b/sjb/inventory/release-3.9.cfg
@@ -1,4 +1,4 @@
-openshift_master_node_labels:
+openshift_node_labels:
   region: infra
   zone: default
   node-role.kubernetes.io/master: "true"


### PR DESCRIPTION
Release-3.9 is still failing after removing the branch specific hack. I'm switching the label to match what worked in the hack. 

