### PR TITLE
Add sync to custom build. Maybe fix missing body?

### DIFF
--- a/jobs/build/build-sync/Jenkinsfile
+++ b/jobs/build/build-sync/Jenkinsfile
@@ -23,7 +23,6 @@ node {
                 ]
             ],
             disableConcurrentBuilds(),
-            timestamps(),
         ]
     )
 

--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -220,6 +220,15 @@ node {
                 }
             }
 
+            stage('sync images') {
+                buildlib.sync_images(
+                    params.BUILD_VERSION.split()[0],
+                    params.BUILD_VERSION.split()[1],
+                    "aos-team-art@redhat.com",
+                    currentBuild.number
+                )
+            }
+
             commonlib.email(
                 to: "${params.MAIL_LIST_SUCCESS}",
                 from: "aos-team-art@redhat.com",
@@ -245,9 +254,9 @@ Job console: ${env.BUILD_URL}/console
         throw err
     } finally {
         commonlib.safeArchiveArtifacts([
-            "doozer_working/*.log",
-            "doozer_working/*.yaml",
-            "doozer_working/brew-logs/**",
-        ])
+                "doozer_working/*.log",
+                "doozer_working/*.yaml",
+                "doozer_working/brew-logs/**",
+            ])
     }
 }


### PR DESCRIPTION
The `timestamps()` function _seemed to be_ breaking this last time. I have removed it.

This adds the build-sync job to the custom job as well.