### PR TITLE
build/ocp4: unblock building 4.y with openshift package and new versioning

### DIFF
--- a/build-scripts/rcm-guest/publish-oc-binary.sh
+++ b/build-scripts/rcm-guest/publish-oc-binary.sh
@@ -20,11 +20,11 @@ extract() {
         else
             rpm2cpio "${rpm}" \
                 | cpio -idm --quiet \
-                    ./usr/share/atomic-openshift/{linux,macosx}/oc \
-                    ./usr/share/atomic-openshift/windows/oc.exe
-            mv usr/share/atomic-openshift/linux/oc x86_64/
-            mv usr/share/atomic-openshift/macosx/oc macosx/
-            mv usr/share/atomic-openshift/windows/oc.exe windows/
+                    ./usr/share/${PKG}/{linux,macosx}/oc \
+                    ./usr/share/${PKG}/windows/oc.exe
+            mv usr/share/${PKG}/linux/oc x86_64/
+            mv usr/share/${PKG}/macosx/oc macosx/
+            mv usr/share/${PKG}/windows/oc.exe windows/
         fi
     done
 }
@@ -42,8 +42,9 @@ pkg_tar() {
 
 OSE_VERSION=$1
 VERSION=$2
+PKG=${3:-atomic-openshift}
 RPM=/mnt/rcm-guest/puddles/RHAOS/AtomicOpenShift/${OSE_VERSION}/building/%s
-RPM=${RPM}/os/Packages/atomic-openshift-clients
+RPM=${RPM}/os/Packages/${PKG}-clients
 ARCH='aarch64 ppc64le s390x'
 TMPDIR=$(mktemp -dt ocbinary.XXXXXXXXXX)
 trap "rm -rf '${TMPDIR}'" EXIT INT TERM

--- a/build-scripts/rcm-guest/show-rpm-simple-errata-diff.sh
+++ b/build-scripts/rcm-guest/show-rpm-simple-errata-diff.sh
@@ -13,7 +13,7 @@ ERRATALINK="building"
 BASEDIR="/mnt/rcm-guest/puddles/RHAOS"
 SIMPLEDIR="${BASEDIR}/AtomicOpenShift/${VERSION}/${SIMPLELINK}/x86_64/os/Packages"
 ERRATADIR="${BASEDIR}/AtomicOpenShift-errata/${VERSION}/${ERRATALINK}/RH7-RHAOS-${VERSION}/x86_64/os/Packages"
-GITEXCLUDE="-e cockpit -e python-jsonschema -e python-ruamel-yaml -e python-wheel -e openshift-ansible -e atomic-openshift-clients-redistributable"
+GITEXCLUDE="-e cockpit -e python-jsonschema -e python-ruamel-yaml -e python-wheel -e openshift-ansible -e atomic-openshift-clients-redistributable -e openshift-clients-redistributable"
 
 # Find out differences, put them in a file
 echo

--- a/build-scripts/rcm-guest/show-srpm-simple-errata-diff.sh
+++ b/build-scripts/rcm-guest/show-srpm-simple-errata-diff.sh
@@ -14,7 +14,7 @@ ERRATALINK="building"
 BASEDIR="/mnt/rcm-guest/puddles/RHAOS"
 SIMPLEDIR="${BASEDIR}/AtomicOpenShift/${VERSION}/${SIMPLELINK}/x86_64/os/Packages"
 ERRATADIR="${BASEDIR}/AtomicOpenShift-errata/${VERSION}/${ERRATALINK}/RH7-RHAOS-${VERSION}/x86_64/os/Packages"
-GITEXCLUDE="-e cockpit -e python-jsonschema -e python-ruamel-yaml -e python-wheel -e openshift-ansible -e atomic-openshift-clients-redistributable"
+GITEXCLUDE="-e cockpit -e python-jsonschema -e python-ruamel-yaml -e python-wheel -e openshift-ansible -e atomic-openshift-clients-redistributable -e openshift-clients-redistributable"
 
 # Find out differences, put them in a file
 diff --brief -r ${SIMPLEDIR}/ ${ERRATADIR}/ | grep "${SIMPLEDIR}" | grep -v ${GITEXCLUDE} | awk '{print "'${SIMPLEDIR}'/" $4}' | while read line

--- a/build-scripts/rcm-guest/update-errata-with-diffs.sh
+++ b/build-scripts/rcm-guest/update-errata-with-diffs.sh
@@ -15,7 +15,7 @@ RELEASEVERSION="RHEL-7-OSE-${VERSION}"
 BASEDIR="/mnt/rcm-guest/puddles/RHAOS"
 SIMPLEDIR="${BASEDIR}/AtomicOpenShift/${VERSION}/${SIMPLELINK}/x86_64/os/Packages"
 ERRATADIR="${BASEDIR}/AtomicOpenShift-errata/${VERSION}/${ERRATALINK}/RH7-RHAOS-${VERSION}/x86_64/os/Packages"
-GITEXCLUDE="-e cockpit -e atomic-openshift-clients-redistributable -e python-jsonschema -e python-ruamel-yaml -e python-wheel -e python-typing -e python-ruamel-ordereddict -e openshift-ansible"
+GITEXCLUDE="-e cockpit -e atomic-openshift-clients-redistributable -e openshift-clients-redistributable -e python-jsonschema -e python-ruamel-yaml -e python-wheel -e python-typing -e python-ruamel-ordereddict -e openshift-ansible"
 
 # Figure out the ERRATAID
 #ERRATAID="25181"

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -8,61 +8,6 @@ def get_mirror_url(build_mode, version) {
     return "https://mirror.openshift.com/enterprise/enterprise-${version}"
 }
 
-def get_changelog(rpm_name, record_log) {
-    //
-    // INPUTS:
-    //   rpm_name - the name of an RPM build previously
-    //   record_log - an array of build records with | separated fields
-
-    rpm_builds = record_log['build_rpm']
-    if (rpm_builds == null || rpm_builds.size() == 0) {
-        return ""
-    }
-
-    // filter for the desired RPM using name
-    build_record_index = rpm_builds.findIndexOf {
-        it['rpm'] == rpm_name
-    }
-    if (build_record_index == -1) {
-        return ""
-    }
-    build_record = rpm_builds[build_record_index]
-
-    // then get the task_id and task_url out of it
-    // task_id = build_record['task_id']
-    task_url = build_record['task_url']
-
-    // get the build ID from the web page
-    // there must be an API way to do this MAL 20180622
-    try {
-        build_id = sh(
-            returnStdout: true,
-            script: [
-                "curl --silent --insecure ${task_url}",
-                "sed -n -e 's/.*buildID=\\([0-9]*\\).*/\\1/p'"
-            ].join(" | ")
-        ).trim()
-    } catch (err) {
-        error("failed to retrieve task page from brew: ${task_url}")
-    }
-
-    // buildinfo can return the changelog.  Return just the text after
-    // the Changelog: line
-    try {
-        changelog = sh(
-            returnStdout: true,
-            script: [
-                "brew buildinfo ${build_id} --changelog",
-                "sed -n '/Changelog/,\$p'"
-            ].join(' | ')
-        ).trim()
-    } catch (err) {
-        error "failed to get build info and changelog for build ${build_id}"
-    }
-
-    return changelog
-}
-
 def mail_success(version, mirrorURL, record_log, commonlib) {
 
     def target = "(Release Candidate)"
@@ -130,10 +75,6 @@ Jenkins job: ${env.BUILD_URL}
 Are your Atomic OpenShift changes in this build? Check here:
 https://github.com/openshift/ose/commits/v${NEW_VERSION}-${NEW_RELEASE}/
 
-===Atomic OpenShift changelog snippet===
-${OSE_CHANGELOG}
-
-
 """);
 
     try {
@@ -199,7 +140,7 @@ def get_image_build_report(record_log) {
 }
 
 // Search the RPM build logs for the named package
-// extract the path to the spec file and return the changelog section.
+// extract the path to the spec file and return that.
 def get_rpm_specfile_path(record_log, package_name) {
     rpms = record_log['build_rpm']
     if (rpms == null) {
@@ -402,36 +343,13 @@ node {
                 buildlib.initialize_ose()
             }
 
-            stage("set build mode") {
-                master_spec = buildlib.read_spec_info(GITHUB_BASE_PATHS['ose'] + "/origin.spec")
-
-                // If the target version resides in ose#master
-                IS_SOURCE_IN_MASTER = (params.BUILD_VERSION == master_spec.major_minor)
-
-                if (BUILD_MODE == "auto") {
-                    echo "AUTO-MODE: determine mode from version and repo: BUILD_VERSION: ${params.BUILD_VERSION}, master_version: ${master_spec.major_minor}"
-                    // INPUTS:
-                    //   BUILD_MODE
-                    //   BUILD_VERSION
-                    //   GITHUB_URLS["ose"]
-                    releases = buildlib.get_releases(GITHUB_URLS['ose'])
-                    echo "AUTO-MODE: release repo: ${GITHUB_URLS['ose']}"
-                    echo "AUTO-MODE: releases: ${releases}"
-                    BUILD_MODE = buildlib.auto_mode(params.BUILD_VERSION, master_spec.major_minor, releases)
-                    echo "BUILD_MODE = ${BUILD_MODE}"
-                }
-            }
-
             stage("analyze") {
 
                 dir(OSE_DIR) {
                     // inputs:
-                    //  IS_SOURCE_IN_MASTER
-                    //  BUILD_MODE
                     //  BUILD_VERSION
 
                     // defines
-                    //  BUILD_MODE (if auto)
                     //  OSE_SOURCE_BRANCH
                     //  UPSTREAM_SOURCE_BRANCH
                     //  NEW_VERSION
@@ -441,34 +359,23 @@ node {
                     //  sets:
                     //    currentBuild.displayName
 
-                    if (IS_SOURCE_IN_MASTER) {
-                        if (BUILD_MODE == "release") {
-                            error("You cannot build a release while it resides in master; cut an enterprise branch")
-                        }
-                    } else {
-                        if (BUILD_MODE != "release" && BUILD_MODE != "pre-release") {
-                            error("Invalid build mode for a release that does not reside in master: ${BUILD_MODE}")
-                        }
-                    }
+                    // If the target version resides in ose#master
+                    spec = buildlib.read_spec_info("origin.spec")
+                    IS_SOURCE_IN_MASTER = (params.BUILD_VERSION == spec.major_minor)
 
                     if (IS_SOURCE_IN_MASTER) {
                         OSE_SOURCE_BRANCH = "master"
                         UPSTREAM_SOURCE_BRANCH = "upstream/master"
                     } else {
                         OSE_SOURCE_BRANCH = "enterprise-${params.BUILD_VERSION}"
-                        if (BUILD_MODE == "release") {
-                            // When building in release mode, no longer pull from upstream
-                            UPSTREAM_SOURCE_BRANCH = null
-                        } else {
-                            UPSTREAM_SOURCE_BRANCH = "upstream/release-${params.BUILD_VERSION}"
-                        }
+                        UPSTREAM_SOURCE_BRANCH = "upstream/release-${params.BUILD_VERSION}"
                         // Create the non-master source branch and have it track the origin ose repo
                         sh "git checkout -b ${OSE_SOURCE_BRANCH} origin/${OSE_SOURCE_BRANCH}"
+                        spec = buildlib.read_spec_info("origin.spec")
                     }
 
                     echo "Building from ose branch: ${OSE_SOURCE_BRANCH}"
 
-                    spec = buildlib.read_spec_info("origin.spec")
                     rel_fields = spec.release.tokenize(".")
 
                     if (! spec.version.startsWith("${params.BUILD_VERSION}.")) {
@@ -477,65 +384,9 @@ node {
                     }
 
 
-                    if (BUILD_MODE == "online:int") {
-                        /**
-                         * In non-release candidates, we need the following fields
-                         *      REL.INT.STG
-                         * REL = 0    means pre-release,  1 means release
-                         * INT = fields used to differentiate online:int builds
-                         */
-
-                        while (rel_fields.size() < 3) {
-                            rel_fields << "0"    // Ensure there are enough fields in the array
-                        }
-
-                        if (rel_fields[0].toInteger() != 0) {
-                            // Don't build release candidate images this way since they can't wind up
-                            // in registry.access with a tag OCP can pull.
-                            error("Do not build released products in ${BUILD_MODE}; just build in release or pre-release mode")
-                        }
-
-                        if (rel_fields.size() != 3) {
-                            // Did we start with > 3? That's too weird to continue
-                            error("Unexpected number of fields in release: ${spec.release}")
-                        }
-
-                        if (BUILD_MODE == "online:int") {
-                            rel_fields[1] = rel_fields[1].toInteger() + 1  // Bump the INT version
-                            rel_fields[2] = 0  // If we are bumping the INT field, everything following is reset to zero
-                        }
-
-                        NEW_VERSION = spec.version   // Keep the existing spec's version
-                        NEW_RELEASE = "${rel_fields[0]}.${rel_fields[1]}.${rel_fields[2]}"
-
-                        // Add a bumpable field for Doozer to increment for image refreshes (i.e. REL.INT.STG.BUMP)
-                        NEW_DOCKERFILE_RELEASE = "${NEW_RELEASE}.0"
-
-                    } else if (BUILD_MODE == "release" || BUILD_MODE == "pre-release") {
-
-                        /**
-                         * Once someone sets the origin.spec Release to 1, we are building release candidates.
-                         * If a release candidate is released, its associated images will show up in registry.access
-                         * with the tags X.Y.Z-R  and  X.Y.Z. The "R" cannot be used since the fields is bumped by
-                         * refresh-images when building images with signed RPMs. That is, if OCP tried to load images
-                         * with the X.Y.Z-R' its RPM was built with, the R != R' (since R' < R) and the image
-                         * would not be found.
-                         * For release candidates, therefore, we must only use X.Y.Z to differentiate builds.
-                         */
-                        if (rel_fields[0].toInteger() != 1) {
-                            error("You need to set the spec Release field to 1 in order to build in this mode")
-                        }
-
-                        // Undertake to increment the last field in the version (e.g. 3.7.0 -> 3.7.1)
-                        ver_fields = spec.version.tokenize(".")
-                        ver_fields[ver_fields.size() - 1] = "${ver_fields[ver_fields.size() - 1].toInteger() + 1}"
-                        NEW_VERSION = ver_fields.join(".")
-                        NEW_RELEASE = "1"
-                        NEW_DOCKERFILE_RELEASE = NEW_RELEASE
-
-                    } else {
-                        error("Unknown BUILD_MODE: ${BUILD_MODE}")
-                    }
+                    NEW_VERSION = params.NEW_VERSION ?: spec.version
+                    NEW_RELEASE = new Date().format("yyyy.MM.dd.HH.mm")
+                    NEW_DOCKERFILE_RELEASE = NEW_RELEASE
 
                     rpmOnlyTag = ""
                     if (!params.BUILD_CONTAINER_IMAGES) {
@@ -546,6 +397,7 @@ node {
             }
 
             stage("merge origin") {
+                // note, this will go away once merge is handled in its own job
                 dir(OSE_DIR) {
                     // Enable fake merge driver used in our .gitattributes
                     sh "git config merge.ours.driver true"
@@ -553,31 +405,35 @@ node {
                     sh "echo 'pkg/assets/bindata.go merge=ours' >> .gitattributes"
                     sh "echo 'pkg/assets/java/bindata.go merge=ours' >> .gitattributes"
 
-                    if (UPSTREAM_SOURCE_BRANCH != null) {
-                        // Merge upstream origin code into the ose branch
-                        sh "git merge -m 'Merge remote-tracking branch ${UPSTREAM_SOURCE_BRANCH}' ${UPSTREAM_SOURCE_BRANCH}"
-                    } else {
-                        echo "No origin upstream in this build"
+                    // Merge upstream origin code into the ose branch
+                    sh "git merge -m 'Merge remote-tracking branch ${UPSTREAM_SOURCE_BRANCH}' ${UPSTREAM_SOURCE_BRANCH}"
+                    if (!IS_TEST_MODE) {
+                        sh "git push"
                     }
+
                 }
             }
 
             stage("ose tag") {
                 dir(OSE_DIR) {
+                    // we no longer want to push tito's changes (and tags) to ose.
+                    // but push a tag for tito to generate the next changelog against and to match historical practice.
+                    def tag = "v${NEW_VERSION}-${NEW_RELEASE}"
+
+                    sh "git tag -am '' ${tag}"
+                    if (!IS_TEST_MODE) {
+                        sh "git push origin ${tag}"
+                    }
+                    // but tito needs to believe it owns the new tag so make way for that
+                    sh "git tag -d ${tag}"
+
                     // Set the new version/release value in the file and tell tito to keep the version & release in the spec.
+                    // Cannot tito tag --use-release because it does not maintain variables like %{?dist}.
                     buildlib.set_rpm_spec_version("origin.spec", NEW_VERSION)
                     buildlib.set_rpm_spec_release_prefix("origin.spec", NEW_RELEASE)
-                    // Note that I did not use --use-release because it did not maintain variables like %{?dist}
 
-                    commit_msg = "Automatic commit of package [atomic-openshift] release [${NEW_VERSION}-${NEW_RELEASE}]"
-
-                    sh "git commit --allow-empty -m '${commit_msg}'" // add commit to capture our change message
-                    sh "tito tag --accept-auto-changelog --keep-version --debug"
-                    if (!IS_TEST_MODE) {
-                        sh "git push"
-                        sh "git push --tags"
-                    }
-                    OSE_CHANGELOG = buildlib.read_changelog("origin.spec")
+                    // tito tag commits above changes along with its own.
+                    sh "tito tag --no-auto-changelog --keep-version --debug"
                 }
             }
 
@@ -671,73 +527,44 @@ images:build
                 }
             }
 
-            NEW_FULL_VERSION = "${NEW_VERSION}-${NEW_RELEASE}"
+            stage("mirror RPMs") {
 
-            SYMLINK_NAME = "latest"
-            if (!params.BUILD_CONTAINER_IMAGES) {
-                SYMLINK_NAME = "no-image-latest"
-            }
+                NEW_FULL_VERSION = "${NEW_VERSION}-${NEW_RELEASE}"
 
-            // Push the building puddle out to the correct directory on the mirrors (e.g. online-int, online-stg, or enterprise-X.Y)
-            buildlib.invoke_on_rcm_guest("push-to-mirrors.sh", SYMLINK_NAME, NEW_FULL_VERSION, BUILD_MODE)
-
-            // push-to-mirrors.sh sets up a different puddle name on rcm-guest and the mirrors
-            OCP_PUDDLE = "v${NEW_FULL_VERSION}_${OCP_PUDDLE}"
-            final mirror_url = get_mirror_url(BUILD_MODE, params.BUILD_VERSION)
-
-            if (NEW_RELEASE != "1") {
-                // If this is not a release candidate, push binary in a directory qualified with release field information
-                buildlib.invoke_on_rcm_guest("publish-oc-binary.sh", params.BUILD_VERSION, NEW_FULL_VERSION)
-            } else {
-                // If this is a release candidate, the directory binary directory should not contain release information
-                buildlib.invoke_on_rcm_guest("publish-oc-binary.sh", params.BUILD_VERSION, NEW_VERSION)
-            }
-
-            echo "Finished building OCP ${NEW_FULL_VERSION}"
-            PREV_BUILD = null  // We are done. Don't untag even if there is an error sending the email.
-
-            // Don't make an github release unless this build it from the actual ose repo
-            if ( params.GITHUB_BASE == "git@github.com:openshift" ) {
-                try {
-                    withCredentials([string(credentialsId: 'github_token_ose', variable: 'GITHUB_TOKEN')]) {
-                        httpRequest(
-                            consoleLogResponseBody: true,
-                            httpMode: 'POST',
-                            ignoreSslErrors: true,
-                            responseHandle: 'NONE',
-                            url: "https://api.github.com/repos/openshift/ose/releases?access_token=${GITHUB_TOKEN}",
-                            requestBody: """{"tag_name": "v${NEW_VERSION}-${NEW_RELEASE}",
-"target_commitish": "${OSE_SOURCE_BRANCH}",
-"name": "v${NEW_VERSION}-${NEW_RELEASE}",
-"draft": true,
-"prerelease": false,
-"body": "Release of OpenShift Container Platform v${NEW_VERSION}-${NEW_RELEASE}\\nPuddle: ${mirror_url}/${OCP_PUDDLE}"
-}"""
-                        )
-                    }
-
-                } catch( release_ex ) {
-                    commonlib.email(
-                        to: "aos-team-art@redhat.com",
-                        from: "aos-cicd@redhat.com",
-                        subject: "Error creating ose release in github",
-                        body: """
-Jenkins job: ${env.BUILD_URL}
-"""
-                    );
-                    currentBuild.description = "Error creating ose release in github:\n${release_ex}"
+                SYMLINK_NAME = "latest"
+                if (!params.BUILD_CONTAINER_IMAGES) {
+                    SYMLINK_NAME = "no-image-latest"
                 }
-            }
-            mail_success(NEW_FULL_VERSION, mirror_url, record_log, commonlib)
-        }
 
-        stage('sync images') {
-            buildlib.sync_images(
-                BUILD_VERSION_MAJOR,
-                BUILD_VERSION_MINOR,
-                "aos-team-art@redhat.com",
-                currentBuild.number
-            )
+                // Push the building puddle out to the correct directory on the mirrors (e.g. online-int, online-stg, or enterprise-X.Y)
+                buildlib.invoke_on_rcm_guest("push-to-mirrors.sh", SYMLINK_NAME, NEW_FULL_VERSION, BUILD_MODE)
+
+                // push-to-mirrors.sh sets up a different puddle name on rcm-guest and the mirrors
+                OCP_PUDDLE = "v${NEW_FULL_VERSION}_${OCP_PUDDLE}"
+                final mirror_url = get_mirror_url(BUILD_MODE, params.BUILD_VERSION)
+
+                if (NEW_RELEASE != "1") {
+                    // If this is not a release candidate, push binary in a directory qualified with release field information
+                    buildlib.invoke_on_rcm_guest("publish-oc-binary.sh", params.BUILD_VERSION, NEW_FULL_VERSION)
+                } else {
+                    // If this is a release candidate, the directory binary directory should not contain release information
+                    buildlib.invoke_on_rcm_guest("publish-oc-binary.sh", params.BUILD_VERSION, NEW_VERSION)
+                }
+
+                echo "Finished building OCP ${NEW_FULL_VERSION}"
+                PREV_BUILD = null  // We are done. Don't untag even if there is an error sending the email.
+                mail_success(NEW_FULL_VERSION, mirror_url, record_log, commonlib)
+
+            }
+
+            stage('sync images') {
+                buildlib.sync_images(
+                    BUILD_VERSION_MAJOR,
+                    BUILD_VERSION_MINOR,
+                    "aos-team-art@redhat.com",
+                    currentBuild.number
+                )
+            }
         }
     } catch (err) {
 

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -298,7 +298,7 @@ node {
     BUILD_EXCLUSIONS = commonlib.cleanCommaList(params.BUILD_EXCLUSIONS)
     BUILD_FAILURES = null
 
-    // Will be used to track which atomic-openshift build was tagged before we ran.
+    // Will be used to track which openshift pkg build was tagged before we ran.
     PREV_BUILD = null
 
     aosCdJobsCommitSha = sh(
@@ -331,7 +331,7 @@ node {
 
             PREV_BUILD = sh(
                 returnStdout: true,
-                script: "brew latest-build --quiet rhaos-${params.BUILD_VERSION}-rhel-7-candidate atomic-openshift | awk '{print \$1}'"
+                script: "brew latest-build --quiet rhaos-${params.BUILD_VERSION}-rhel-7-candidate openshift | awk '{print \$1}'"
             ).trim()
 
             stage("ose repo") {
@@ -449,7 +449,7 @@ node {
                 }
 
                 // Watch the task to make sure it succeeds, or retry if it fails.
-                buildlib.watch_brew_task_and_retry("atomic-openshift RPM", oseTaskId, OSE_BREW_URL)
+                buildlib.watch_brew_task_and_retry("openshift RPM", oseTaskId, OSE_BREW_URL)
             }
 
             stage("doozer build rpms") {
@@ -543,13 +543,7 @@ images:build
                 OCP_PUDDLE = "v${NEW_FULL_VERSION}_${OCP_PUDDLE}"
                 final mirror_url = get_mirror_url(BUILD_MODE, params.BUILD_VERSION)
 
-                if (NEW_RELEASE != "1") {
-                    // If this is not a release candidate, push binary in a directory qualified with release field information
-                    buildlib.invoke_on_rcm_guest("publish-oc-binary.sh", params.BUILD_VERSION, NEW_FULL_VERSION)
-                } else {
-                    // If this is a release candidate, the directory binary directory should not contain release information
-                    buildlib.invoke_on_rcm_guest("publish-oc-binary.sh", params.BUILD_VERSION, NEW_VERSION)
-                }
+                buildlib.invoke_on_rcm_guest("publish-oc-binary.sh", params.BUILD_VERSION, NEW_FULL_VERSION, "openshift")
 
                 echo "Finished building OCP ${NEW_FULL_VERSION}"
                 PREV_BUILD = null  // We are done. Don't untag even if there is an error sending the email.
@@ -570,7 +564,7 @@ images:build
 
         ATTN = ""
         try {
-            NEW_BUILD = sh(returnStdout: true, script: "brew latest-build --quiet rhaos-${params.BUILD_VERSION}-rhel-7-candidate atomic-openshift | awk '{print \$1}'").trim()
+            NEW_BUILD = sh(returnStdout: true, script: "brew latest-build --quiet rhaos-${params.BUILD_VERSION}-rhel-7-candidate openshift | awk '{print \$1}'").trim()
             if (PREV_BUILD != null && PREV_BUILD != NEW_BUILD) {
                 // Untag anything tagged by this build if an error occured at any point
                 sh "brew --user=ocp-build untag-build rhaos-${params.BUILD_VERSION}-rhel-7-candidate ${NEW_BUILD}"

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -139,26 +139,6 @@ def get_image_build_report(record_log) {
         image_set.toSorted().join("\n    ")
 }
 
-// Search the RPM build logs for the named package
-// extract the path to the spec file and return that.
-def get_rpm_specfile_path(record_log, package_name) {
-    rpms = record_log['build_rpm']
-    if (rpms == null) {
-        return null
-    }
-
-    // find the named package and the spec file path
-    specfile_path = ""
-    for (i = 0 ; i < rpms.size(); i++) {
-        if (rpms[i]['distgit_key'] == package_name) {
-            specfile_path = rpms[i]['specfile']
-            break
-        }
-    }
-
-    return specfile_path
-}
-
 node {
     checkout scm
     def buildlib = load("pipeline-scripts/buildlib.groovy")
@@ -197,8 +177,8 @@ node {
                     ],
                     commonlib.mockParam(),
                     [
-                        name: 'TEST',
-                        description: 'Run as much code as possible without pushing / building?',
+                        name: 'DRY_RUN',
+                        description: 'Take no action, just echo what the build would have done.',
                         $class: 'hudson.model.BooleanParameterDefinition',
                         defaultValue: false
                     ],
@@ -248,47 +228,29 @@ Determines where the compose is mirrored:
     )
 
     GITHUB_BASE = "git@github.com:openshift"  // buildlib uses this :eyeroll:
-    IS_TEST_MODE = params.TEST
     commonlib.checkMock()
 
     BUILD_VERSION_MAJOR = params.BUILD_VERSION.tokenize('.')[0].toInteger() // Store the "X" in X.Y
     BUILD_VERSION_MINOR = params.BUILD_VERSION.tokenize('.')[1].toInteger() // Store the "Y" in X.Y
-    SIGN_RPMS = false  // expose param for this if we get to sign RPMs
-    ODCS_MODE = false  // expose param for this if we ever get serious about ODCS again
-    ODCS_FLAG = ""
-    ODCS_OPT = ""
-    if (ODCS_MODE) {
-        ODCS_FLAG = "--odcs-mode"
-        ODCS_OPT = "--odcs unsigned"
-    }
 
     BUILD_EXCLUSIONS = commonlib.cleanCommaList(params.BUILD_EXCLUSIONS)
     BUILD_FAILURES = null
-
-    // Will be used to track which openshift pkg build was tagged before we ran.
-    prevBuild = ""
 
     aosCdJobsCommitSha = sh(
         returnStdout: true,
         script: "git rev-parse HEAD",
     ).trim()
 
-    try {
-        // Clean up old images so that we don't run out of device mapper space
-        sh "docker rmi --force \$(docker images  | grep v${params.BUILD_VERSION} | awk '{print \$3}')"
-    } catch (cce) {
-        echo "Error cleaning up old images: ${cce}"
-    }
-
     puddleConfBase = "https://raw.githubusercontent.com/openshift/aos-cd-jobs/${aosCdJobsCommitSha}/build-scripts/puddle-conf"
     puddleConf = "${puddleConfBase}/atomic_openshift-${params.BUILD_VERSION}.conf"
-    puddleSignKeys = SIGN_RPMS ? "b906ba72" : null
 
     currentBuild.displayName = "#${currentBuild.number} - ${params.BUILD_VERSION}.??"
     echo "Initializing build: ${currentBuild.displayName}"
 
     // doozer_working must be in WORKSPACE in order to have artifacts archived
     DOOZER_WORKING = "${env.WORKSPACE}/doozer_working"
+    // get a fresh one, but delay removing the old one
+    sh "mkdir -p ${DOOZER_WORKING}; mv ${DOOZER_WORKING} ${DOOZER_WORKING}.${currentBuild.number}; mkdir -p ${DOOZER_WORKING}"
 
     try {
         stage("version") {
@@ -296,14 +258,13 @@ Determines where the compose is mirrored:
             //  BUILD_VERSION
 
             // defines:
-            //  prevBuild
             //  NEW_VERSION
             //  NEW_RELEASE
             //  NEW_DOCKERFILE_RELEASE
             //
             //  sets currentBuild.displayName
 
-            prevBuild = sh(
+            def prevBuild = sh(
                 returnStdout: true,
                 script: "brew latest-build --quiet rhaos-${params.BUILD_VERSION}-rhel-7-candidate openshift | awk '{print \$1}'"
             ).trim()
@@ -346,134 +307,41 @@ Determines where the compose is mirrored:
             NEW_RELEASE = new Date().format("yyyyMMddHHmm")
             NEW_DOCKERFILE_RELEASE = NEW_RELEASE
 
-            rpmOnlyTag = params.BUILD_CONTAINER_IMAGES ? "" : " (RPM ONLY)"
-            currentBuild.displayName = "#${currentBuild.number} - ${NEW_VERSION}-${NEW_RELEASE} ${rpmOnlyTag}"
+            currentBuild.displayName = "#${currentBuild.number} - ${NEW_VERSION}-${NEW_RELEASE}"
+            if (!params.BUILD_CONTAINER_IMAGES) { currentBuild.displayName += " (RPM ONLY)" }
+            if (params.DRY_RUN) { currentBuild.displayName += " (DRY RUN)" }
         }
 
         sshagent(["openshift-bot"]) {
             // To work on private repos, buildlib operations must run with the permissions of openshift-bot
 
-            stage("ose repo") {
-                // defines:
-                //   OPENSHIFT_DIR // by calling initialize_openshift_dir()
-                //   OSE_DIR
-                //   GITHUB_URLS["ose"]
-                //   GITHUB_BASE_PATHS["ose"]
-                //   OSE_SOURCE_BRANCH
-                //   UPSTREAM_SOURCE_BRANCH
-
-                parallel "clone ose": { ->
-                    buildlib.initialize(IS_TEST_MODE)
-                    // TODO: clone a single branch
-                    buildlib.initialize_ose_4()
-                },
-                "remove previous workspace": { ->
-                    num = currentBuild.number
-                    sh "mkdir -p ${DOOZER_WORKING}; mv ${DOOZER_WORKING} ${DOOZER_WORKING}.${num}"
-                    sh "mkdir -p ${DOOZER_WORKING}"
-                    // this can take a while, and even fail, given NFS. do while cloning ose.
-                    sh script: "rm -rf ${DOOZER_WORKING}.${num}", returnStatus: true
-                }
-
-                // If the target version resides in ose#master
-                if (params.BUILD_VERSION == commonlib.ocp4MasterVersion) {
-                    OSE_SOURCE_BRANCH = "master"
-                    UPSTREAM_SOURCE_BRANCH = "upstream/master"
-                } else {
-                    OSE_SOURCE_BRANCH = "enterprise-${params.BUILD_VERSION}"
-                    UPSTREAM_SOURCE_BRANCH = "upstream/release-${params.BUILD_VERSION}"
-                    dir(OSE_DIR) {
-                        // Create the non-master source branch and have it track the origin ose repo
-                        sh "git checkout -b ${OSE_SOURCE_BRANCH} origin/${OSE_SOURCE_BRANCH}"
-                    }
-                }
-
-                echo "Building from ose branch: ${OSE_SOURCE_BRANCH}"
-            }
-
-            stage("merge origin") {
-                // note, this can go away once merge is handled in its own job
-                dir(OSE_DIR) {
-                    // Enable fake merge driver used in our .gitattributes
-                    sh "git config merge.ours.driver true"
-                    // Use fake merge driver on specific packages
-                    sh "echo 'pkg/assets/bindata.go merge=ours' >> .gitattributes"
-                    sh "echo 'pkg/assets/java/bindata.go merge=ours' >> .gitattributes"
-
-                    // Merge upstream origin code into the ose branch
-                    sh "git merge -m 'Merge remote-tracking branch ${UPSTREAM_SOURCE_BRANCH}' ${UPSTREAM_SOURCE_BRANCH}"
-                    if (!IS_TEST_MODE) {
-                        sh "git push"
-                    }
-
-                }
-            }
-
-            stage("ose tag") {
-                dir(OSE_DIR) {
-                    // we no longer want to push tito's changes (and tags) to ose.
-                    // but push a tag for tito to generate the next changelog against and to match historical practice.
-                    def tag = "v${NEW_VERSION}-${NEW_RELEASE}"
-
-                    sh "git tag -am '' ${tag}"
-                    if (!IS_TEST_MODE) {
-                        sh "git push origin ${tag}"
-                    }
-                    // but tito needs to believe it owns the new tag so make way for that
-                    sh "git tag -d ${tag}"
-
-                    // Set the new version/release value in the file and tell tito to keep the version & release in the spec.
-                    // Cannot tito tag --use-release because it does not maintain variables like %{?dist}.
-                    buildlib.set_rpm_spec_version_release("origin.spec", NEW_VERSION, NEW_RELEASE)
-
-                    // tito tag commits above changes along with its own.
-                    sh "tito tag --no-auto-changelog --keep-version --debug"
-                }
-            }
-
-            // stages after this have side effects. Testing must stop here.
-            if (IS_TEST_MODE) {
-                currentBuild.description = "TEST MODE complete: no builds executed"
-                currentBuild.result = "SUCCESS"
-                return
-            }
-
-            stage("ose rpm build") {
-
-                dir(OSE_DIR) {
-                    oseTaskId = sh(
-                        returnStdout: true,
-                        script: "tito release --debug --yes --test aos-${params.BUILD_VERSION} | grep 'Created task:' | awk '{print \$3}'"
-                    )
-                    OSE_BREW_URL = "https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=${oseTaskId}"
-                    echo "ose rpm brew task: ${OSE_BREW_URL}"
-                }
-
-                // Watch the task to make sure it succeeds, or retry if it fails.
-                buildlib.watch_brew_task_and_retry("openshift RPM", oseTaskId, OSE_BREW_URL)
-            }
-
             stage("doozer build rpms") {
-                buildlib.doozer """
+                def cmd =
+"""
 --working-dir ${DOOZER_WORKING} --group 'openshift-${params.BUILD_VERSION}'
---source ose ${OSE_DIR}
 rpms:build --version v${NEW_VERSION}
 --release ${NEW_RELEASE}
 """
-            }
 
-            stage("signing rpms") {
-                if (SIGN_RPMS) {
-                    sh "${env.WORKSPACE}/build-scripts/sign_rpms.sh rhaos-${params.BUILD_VERSION}-rhel-7-candidate openshifthosted"
-                } else {
-                    echo "RPM signing has been skipped..."
+                parallel "remove previous workspace(s)": { ->
+                    // this can take a while, given NFS. do while building RPMs.
+                    sh script: "rm -rf ${DOOZER_WORKING}.*", returnStatus: true
+                },
+                "build RPMs": { ->
+                    params.DRY_RUN ? echo("doozer ${cmd}") : buildlib.doozer(cmd)
                 }
+
+
             }
 
             stage("puddle: ose 'building'") {
+                if(params.DRY_RUN) {
+                    echo "Build puddle with conf ${puddleConf}"
+                    return
+                }
                 OCP_PUDDLE = buildlib.build_puddle(
                     puddleConf,    // The puddle configuration file to use
-                    puddleSignKeys, // openshifthosted key
+                    null,   // signing key
                     "-b",   // do not fail if we are missing dependencies
                     "-d",   // print debug information
                     "-n",   // do not send an email for this puddle
@@ -486,14 +354,18 @@ rpms:build --version v${NEW_VERSION}
                 if (!params.BUILD_CONTAINER_IMAGES) {
                     return
                 }
-                buildlib.doozer """
+                def cmd =
+"""
 --working-dir ${DOOZER_WORKING} --group 'openshift-${params.BUILD_VERSION}'
---source ose ${OSE_DIR}
-${ODCS_FLAG}
 images:rebase --version v${NEW_VERSION}
 --release ${NEW_DOCKERFILE_RELEASE}
 --message 'Updating Dockerfile version and release v${NEW_VERSION}-${NEW_DOCKERFILE_RELEASE}' --push
 """
+                if(params.DRY_RUN) {
+                    echo "doozer ${cmd}"
+                    return
+                }
+                buildlib.doozer cmd
                 buildlib.notify_dockerfile_reconciliations(DOOZER_WORKING, ["ose": OSE_SOURCE_BRANCH])
             }
 
@@ -504,13 +376,18 @@ images:rebase --version v${NEW_VERSION}
                         if (BUILD_EXCLUSIONS != "") {
                             exclude = "-x ${BUILD_EXCLUSIONS} --ignore-missing-base"
                         }
-                        buildlib.doozer """
+                        def cmd =
+"""
 --working-dir ${DOOZER_WORKING} --group openshift-${params.BUILD_VERSION}
-${ODCS_FLAG}
 ${exclude}
 images:build
---push-to-defaults --repo-type unsigned ${ODCS_OPT}
+--push-to-defaults --repo-type unsigned
 """
+                        if(params.DRY_RUN) {
+                            echo "doozer ${cmd}"
+                            return
+                        }
+                        buildlib.doozer cmd
                     }
                     catch (err) {
                         record_log = buildlib.parse_record_log(DOOZER_WORKING)
@@ -532,6 +409,9 @@ images:build
             }
 
             stage("mirror RPMs") {
+                if(params.DRY_RUN) {
+                    return
+                }
 
                 NEW_FULL_VERSION = "${NEW_VERSION}-${NEW_RELEASE}"
 
@@ -555,7 +435,7 @@ images:build
             }
 
             stage('sync images') {
-                if (!params.BUILD_CONTAINER_IMAGES) {
+                if (params.DRY_RUN || !params.BUILD_CONTAINER_IMAGES) {
                     return
                 }
                 buildlib.sync_images(

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -398,6 +398,13 @@ Determines where the compose is mirrored:
                 }
             }
 
+            // stages after this have side effects. Testing must stop here.
+            if (IS_TEST_MODE) {
+                currentBuild.description = "TEST MODE complete: no builds executed"
+                currentBuild.result = "SUCCESS"
+                return
+            }
+
             stage("ose rpm build") {
 
                 dir(OSE_DIR) {
@@ -443,6 +450,9 @@ rpms:build --version v${NEW_VERSION}
             }
 
             stage("update dist-git") {
+                if (!params.BUILD_CONTAINER_IMAGES) {
+                    return
+                }
                 buildlib.doozer """
 --working-dir ${DOOZER_WORKING} --group 'openshift-${params.BUILD_VERSION}'
 --source ose ${OSE_DIR}
@@ -513,6 +523,9 @@ images:build
             }
 
             stage('sync images') {
+                if (!params.BUILD_CONTAINER_IMAGES) {
+                    return
+                }
                 buildlib.sync_images(
                     BUILD_VERSION_MAJOR,
                     BUILD_VERSION_MINOR,

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -178,6 +178,12 @@ node {
                 parameterDefinitions: [
                     commonlib.ocpVersionParam('BUILD_VERSION', '4'),
                     [
+                        name: 'NEW_VERSION',
+                        description: '(Optional) version for build instead of most recent\nor "+" to bump most recent version',
+                        $class: 'hudson.model.StringParameterDefinition',
+                        defaultValue: ""
+                    ],
+                    [
                         name: 'BUILD_CONTAINER_IMAGES',
                         description: 'Build container images? Otherwise just RPMs',
                         $class: 'hudson.model.BooleanParameterDefinition',
@@ -243,7 +249,7 @@ Determines where the compose is mirrored:
 
     GITHUB_BASE = "git@github.com:openshift"  // buildlib uses this :eyeroll:
     IS_TEST_MODE = params.TEST
-    buildlib.initialize(IS_TEST_MODE)
+    commonlib.checkMock()
 
     BUILD_VERSION_MAJOR = params.BUILD_VERSION.tokenize('.')[0].toInteger() // Store the "X" in X.Y
     BUILD_VERSION_MINOR = params.BUILD_VERSION.tokenize('.')[1].toInteger() // Store the "Y" in X.Y
@@ -260,7 +266,7 @@ Determines where the compose is mirrored:
     BUILD_FAILURES = null
 
     // Will be used to track which openshift pkg build was tagged before we ran.
-    PREV_BUILD = null
+    prevBuild = ""
 
     aosCdJobsCommitSha = sh(
         returnStdout: true,
@@ -278,87 +284,115 @@ Determines where the compose is mirrored:
     puddleConf = "${puddleConfBase}/atomic_openshift-${params.BUILD_VERSION}.conf"
     puddleSignKeys = SIGN_RPMS ? "b906ba72" : null
 
-    echo "Initializing build: #${currentBuild.number} - ${params.BUILD_VERSION}.??"
+    currentBuild.displayName = "#${currentBuild.number} - ${params.BUILD_VERSION}.??"
+    echo "Initializing build: ${currentBuild.displayName}"
 
     // doozer_working must be in WORKSPACE in order to have artifacts archived
     DOOZER_WORKING = "${env.WORKSPACE}/doozer_working"
-    //Clear out previous work
-    sh "rm -rf ${DOOZER_WORKING}"
-    sh "mkdir -p ${DOOZER_WORKING}"
 
     try {
-        sshagent(["openshift-bot"]) {
-            // To work on real repos, buildlib operations must run with the permissions of openshift-bot
+        stage("version") {
+            // inputs:
+            //  BUILD_VERSION
 
-            PREV_BUILD = sh(
+            // defines:
+            //  prevBuild
+            //  NEW_VERSION
+            //  NEW_RELEASE
+            //  NEW_DOCKERFILE_RELEASE
+            //
+            //  sets currentBuild.displayName
+
+            prevBuild = sh(
                 returnStdout: true,
                 script: "brew latest-build --quiet rhaos-${params.BUILD_VERSION}-rhel-7-candidate openshift | awk '{print \$1}'"
             ).trim()
 
+            def extractBuildVersion = { build ->
+                // closure also keeps regex away from pipeline steps (error|echo)
+                def match = build =~ /(?x) ^openshift- (  \d+  ( \. \d+ )+  )-/
+                return match ? match[0][1] : "" // first group in the regex
+            }
+
+            NEW_VERSION = "${params.BUILD_VERSION}.0"  // default
+            if(params.NEW_VERSION.trim() == "+") {
+                // increment previous build version
+                NEW_VERSION = extractBuildVersion(prevBuild)
+                if (!NEW_VERSION) {
+                    error("Could not determine version from last build '${prevBuild}'")
+                }
+                def segments = NEW_VERSION.split("\\.").collect { it.toInteger() }
+                segments[-1]++
+                NEW_VERSION = segments.join(".")
+                echo("Using version ${NEW_VERSION} incremented from latest openshift package ${prevBuild}")
+            } else if(params.NEW_VERSION) {
+                // explicit version given
+                NEW_VERSION = commonlib.standardVersion(params.NEW_VERSION, false)
+                echo("Using NEW_VERSION parameter for version: ${NEW_VERSION}")
+            } else if (prevBuild) {
+                // use version from previous build
+                NEW_VERSION = extractBuildVersion(prevBuild)
+                if (!NEW_VERSION) {
+                    error("Could not determine version from last build '${prevBuild}'")
+                }
+                echo("Using version ${NEW_VERSION} from latest openshift package ${prevBuild}")
+            }
+
+            if (! NEW_VERSION.startsWith("${params.BUILD_VERSION}.")) {
+                // The version we came up with somehow doesn't match what we expect to build; abort
+                error("Determined a version, '${NEW_VERSION}', that does not begin with ${params.BUILD_VERSION}!")
+            }
+
+            NEW_RELEASE = new Date().format("yyyyMMddHHmm")
+            NEW_DOCKERFILE_RELEASE = NEW_RELEASE
+
+            rpmOnlyTag = params.BUILD_CONTAINER_IMAGES ? "" : " (RPM ONLY)"
+            currentBuild.displayName = "#${currentBuild.number} - ${NEW_VERSION}-${NEW_RELEASE} ${rpmOnlyTag}"
+        }
+
+        sshagent(["openshift-bot"]) {
+            // To work on private repos, buildlib operations must run with the permissions of openshift-bot
+
             stage("ose repo") {
                 // defines:
                 //   OPENSHIFT_DIR // by calling initialize_openshift_dir()
-                ///  OSE_DIR
+                //   OSE_DIR
                 //   GITHUB_URLS["ose"]
                 //   GITHUB_BASE_PATHS["ose"]
-                buildlib.initialize_ose()
-            }
+                //   OSE_SOURCE_BRANCH
+                //   UPSTREAM_SOURCE_BRANCH
 
-            stage("analyze") {
+                parallel "clone ose": { ->
+                    buildlib.initialize(IS_TEST_MODE)
+                    // TODO: clone a single branch
+                    buildlib.initialize_ose_4()
+                },
+                "remove previous workspace": { ->
+                    num = currentBuild.number
+                    sh "mkdir -p ${DOOZER_WORKING}; mv ${DOOZER_WORKING} ${DOOZER_WORKING}.${num}"
+                    sh "mkdir -p ${DOOZER_WORKING}"
+                    // this can take a while, and even fail, given NFS. do while cloning ose.
+                    sh script: "rm -rf ${DOOZER_WORKING}.${num}", returnStatus: true
+                }
 
-                dir(OSE_DIR) {
-                    // inputs:
-                    //  BUILD_VERSION
-
-                    // defines
-                    //  OSE_SOURCE_BRANCH
-                    //  UPSTREAM_SOURCE_BRANCH
-                    //  NEW_VERSION
-                    //  NEW_RELEASE
-                    //  NEW_DOCKERFILE_RELEASE
-                    //
-                    //  sets:
-                    //    currentBuild.displayName
-
-                    // If the target version resides in ose#master
-                    spec = buildlib.read_spec_info("origin.spec")
-                    IS_SOURCE_IN_MASTER = (params.BUILD_VERSION == spec.major_minor)
-
-                    if (IS_SOURCE_IN_MASTER) {
-                        OSE_SOURCE_BRANCH = "master"
-                        UPSTREAM_SOURCE_BRANCH = "upstream/master"
-                    } else {
-                        OSE_SOURCE_BRANCH = "enterprise-${params.BUILD_VERSION}"
-                        UPSTREAM_SOURCE_BRANCH = "upstream/release-${params.BUILD_VERSION}"
+                // If the target version resides in ose#master
+                if (params.BUILD_VERSION == commonlib.ocp4MasterVersion) {
+                    OSE_SOURCE_BRANCH = "master"
+                    UPSTREAM_SOURCE_BRANCH = "upstream/master"
+                } else {
+                    OSE_SOURCE_BRANCH = "enterprise-${params.BUILD_VERSION}"
+                    UPSTREAM_SOURCE_BRANCH = "upstream/release-${params.BUILD_VERSION}"
+                    dir(OSE_DIR) {
                         // Create the non-master source branch and have it track the origin ose repo
                         sh "git checkout -b ${OSE_SOURCE_BRANCH} origin/${OSE_SOURCE_BRANCH}"
-                        spec = buildlib.read_spec_info("origin.spec")
                     }
-
-                    echo "Building from ose branch: ${OSE_SOURCE_BRANCH}"
-
-                    rel_fields = spec.release.tokenize(".")
-
-                    if (! spec.version.startsWith("${params.BUILD_VERSION}.")) {
-                        // Looks like pipeline thinks we are building something we aren't. Abort.
-                        error("Expected version consistent with ${params.BUILD_VERSION}.* but found: ${spec.version}")
-                    }
-
-
-                    NEW_VERSION = params.NEW_VERSION ?: spec.version
-                    NEW_RELEASE = new Date().format("yyyy.MM.dd.HH.mm")
-                    NEW_DOCKERFILE_RELEASE = NEW_RELEASE
-
-                    rpmOnlyTag = ""
-                    if (!params.BUILD_CONTAINER_IMAGES) {
-                        rpmOnlyTag = " (RPM ONLY)"
-                    }
-                    currentBuild.displayName = "#${currentBuild.number} - ${NEW_VERSION}-${NEW_RELEASE} ${rpmOnlyTag}"
                 }
+
+                echo "Building from ose branch: ${OSE_SOURCE_BRANCH}"
             }
 
             stage("merge origin") {
-                // note, this will go away once merge is handled in its own job
+                // note, this can go away once merge is handled in its own job
                 dir(OSE_DIR) {
                     // Enable fake merge driver used in our .gitattributes
                     sh "git config merge.ours.driver true"
@@ -390,8 +424,7 @@ Determines where the compose is mirrored:
 
                     // Set the new version/release value in the file and tell tito to keep the version & release in the spec.
                     // Cannot tito tag --use-release because it does not maintain variables like %{?dist}.
-                    buildlib.set_rpm_spec_version("origin.spec", NEW_VERSION)
-                    buildlib.set_rpm_spec_release_prefix("origin.spec", NEW_RELEASE)
+                    buildlib.set_rpm_spec_version_release("origin.spec", NEW_VERSION, NEW_RELEASE)
 
                     // tito tag commits above changes along with its own.
                     sh "tito tag --no-auto-changelog --keep-version --debug"
@@ -517,7 +550,6 @@ images:build
                 buildlib.invoke_on_rcm_guest("publish-oc-binary.sh", params.BUILD_VERSION, NEW_FULL_VERSION, "openshift")
 
                 echo "Finished building OCP ${NEW_FULL_VERSION}"
-                PREV_BUILD = null  // We are done. Don't untag even if there is an error sending the email.
                 mail_success(NEW_FULL_VERSION, mirror_url, record_log, commonlib)
 
             }
@@ -536,21 +568,10 @@ images:build
         }
     } catch (err) {
 
-        ATTN = ""
-        try {
-            NEW_BUILD = sh(returnStdout: true, script: "brew latest-build --quiet rhaos-${params.BUILD_VERSION}-rhel-7-candidate openshift | awk '{print \$1}'").trim()
-            if (PREV_BUILD != null && PREV_BUILD != NEW_BUILD) {
-                // Untag anything tagged by this build if an error occured at any point
-                sh "brew --user=ocp-build untag-build rhaos-${params.BUILD_VERSION}-rhel-7-candidate ${NEW_BUILD}"
-            }
-        } catch (err2) {
-            ATTN = " - UNABLE TO UNTAG!"
-        }
-
         commonlib.email(
             to: "${params.MAIL_LIST_FAILURE}",
             from: "aos-cicd@redhat.com",
-            subject: "Error building OSE: ${params.BUILD_VERSION}${ATTN}",
+            subject: "Error building OSE: ${params.BUILD_VERSION}",
             body: """Encountered an error while running OCP pipeline: ${err}
 
 Jenkins job: ${env.BUILD_URL}

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -176,26 +176,40 @@ node {
             [
                 $class: 'ParametersDefinitionProperty',
                 parameterDefinitions: [
-                    [
-                        name: 'GITHUB_BASE',
-                        description: 'Github base for repos',
-                        $class: 'hudson.model.ChoiceParameterDefinition',
-                        choices: [
-                            "git@github.com:openshift",
-                        ].join("\n"),
-                        defaultValue: 'git@github.com:openshift'
-                    ],
-                    [
-                        name: 'SSH_KEY_ID',
-                        description: 'SSH credential id to use',
-                        $class: 'hudson.model.ChoiceParameterDefinition',
-                        choices: [
-                            "openshift-bot",
-                            "aos-cd-test",
-                        ].join("\n"),
-                        defaultValue: 'aos-cd-test'
-                    ],
                     commonlib.ocpVersionParam('BUILD_VERSION', '4'),
+                    [
+                        name: 'BUILD_CONTAINER_IMAGES',
+                        description: 'Build container images? Otherwise just RPMs',
+                        $class: 'hudson.model.BooleanParameterDefinition',
+                        defaultValue: true
+                    ],
+                    [
+                        name: 'BUILD_EXCLUSIONS',
+                        description: 'Exclude these images from builds. Comma or space separated list. (i.e cri-o-docker,aos3-installation-docker)',
+                        $class: 'hudson.model.StringParameterDefinition',
+                        defaultValue: ""
+                    ],
+                    commonlib.mockParam(),
+                    [
+                        name: 'TEST',
+                        description: 'Run as much code as possible without pushing / building?',
+                        $class: 'hudson.model.BooleanParameterDefinition',
+                        defaultValue: false
+                    ],
+                    [
+                        name: 'BUILD_MODE',
+                        description: '''
+Determines where the compose is mirrored:
+    pre-release               origin/release-X.Y ->  https://mirror.openshift.com/enterprise/enterprise-X.Y/
+    online:int                origin/master -> online-int yum repo
+    ''',
+                        $class: 'hudson.model.ChoiceParameterDefinition',
+                        choices: [
+                            "pre-release",
+                            "online:int"
+                        ].join("\n"),
+                        defaultValue: "pre-release"
+                    ],
                     commonlib.suppressEmailParam(),
                     [
                         name: 'MAIL_LIST_SUCCESS',
@@ -216,64 +230,10 @@ node {
                         ].join(',')
                     ],
                     [
-                        name: 'BUILD_MODE',
-                        description: '''
-    auto                      BUILD_VERSION and ocp repo contents determine the mode<br>
-    release                   ose/release-X.Y ->  https://mirror.openshift.com/enterprise/enterprise-X.Y/<br>
-    pre-release               origin/release-X.Y ->  https://mirror.openshift.com/enterprise/enterprise-X.Y/<br>
-    online:int                origin/master -> online-int yum repo<br>
-    ''',
-                        $class: 'hudson.model.ChoiceParameterDefinition',
-                        choices: [
-                            "auto",
-                            "release",
-                            "pre-release",
-                            "online:int"
-                        ].join("\n"),
-                        defaultValue: "auto"
-                    ],
-                    [
-                        name: 'ODCS',
-                        description: 'Run in ODCS Mode?',
-                        $class: 'hudson.model.BooleanParameterDefinition',
-                        defaultValue: false
-                    ],
-                    [
-                        name: 'SIGN',
-                        description: 'Sign RPMs with openshifthosted?',
-                        $class: 'hudson.model.BooleanParameterDefinition',
-                        defaultValue: false
-                    ],
-                    commonlib.mockParam(),
-                    [
-                        name: 'TEST',
-                        description: 'Run as much code as possible without pushing / building?',
-                        $class: 'hudson.model.BooleanParameterDefinition',
-                        defaultValue: false
-                    ],
-                    [
                         name: 'SPECIAL_NOTES',
                         description: 'Include special notes in the build email?',
                         $class: 'hudson.model.TextParameterDefinition',
                         defaultValue: ""
-                    ],
-                    [
-                        name: 'BUILD_EXCLUSIONS',
-                        description: 'Exclude these images from builds. Comma or space separated list. (i.e cri-o-docker,aos3-installation-docker)',
-                        $class: 'hudson.model.StringParameterDefinition',
-                        defaultValue: ""
-                    ],
-                    [
-                        name: 'BUILD_CONTAINER_IMAGES',
-                        description: 'Build container images?',
-                        $class: 'hudson.model.BooleanParameterDefinition',
-                        defaultValue: true
-                    ],
-                    [
-                        name: 'BUILD_AMI',
-                        description: 'Build golden image after building images?',
-                        $class: 'hudson.model.BooleanParameterDefinition',
-                        defaultValue: true
                     ],
                 ]
             ],
@@ -281,13 +241,14 @@ node {
         ]
     )
 
+    GITHUB_BASE = "git@github.com:openshift"  // buildlib uses this :eyeroll:
     IS_TEST_MODE = params.TEST
     buildlib.initialize(IS_TEST_MODE)
 
     BUILD_VERSION_MAJOR = params.BUILD_VERSION.tokenize('.')[0].toInteger() // Store the "X" in X.Y
     BUILD_VERSION_MINOR = params.BUILD_VERSION.tokenize('.')[1].toInteger() // Store the "Y" in X.Y
-    SIGN_RPMS = params.SIGN
-    ODCS_MODE = params.ODCS
+    SIGN_RPMS = false  // expose param for this if we get to sign RPMs
+    ODCS_MODE = false  // expose param for this if we ever get serious about ODCS again
     ODCS_FLAG = ""
     ODCS_OPT = ""
     if (ODCS_MODE) {
@@ -317,7 +278,7 @@ node {
     puddleConf = "${puddleConfBase}/atomic_openshift-${params.BUILD_VERSION}.conf"
     puddleSignKeys = SIGN_RPMS ? "b906ba72" : null
 
-    echo "Initializing build: #${currentBuild.number} - ${params.BUILD_VERSION}.?? (${BUILD_MODE})"
+    echo "Initializing build: #${currentBuild.number} - ${params.BUILD_VERSION}.??"
 
     // doozer_working must be in WORKSPACE in order to have artifacts archived
     DOOZER_WORKING = "${env.WORKSPACE}/doozer_working"
@@ -326,7 +287,7 @@ node {
     sh "mkdir -p ${DOOZER_WORKING}"
 
     try {
-        sshagent([params.SSH_KEY_ID]) {
+        sshagent(["openshift-bot"]) {
             // To work on real repos, buildlib operations must run with the permissions of openshift-bot
 
             PREV_BUILD = sh(
@@ -392,7 +353,7 @@ node {
                     if (!params.BUILD_CONTAINER_IMAGES) {
                         rpmOnlyTag = " (RPM ONLY)"
                     }
-                    currentBuild.displayName = "#${currentBuild.number} - ${NEW_VERSION}-${NEW_RELEASE} (${BUILD_MODE}${rpmOnlyTag})"
+                    currentBuild.displayName = "#${currentBuild.number} - ${NEW_VERSION}-${NEW_RELEASE} ${rpmOnlyTag}"
                 }
             }
 

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -234,6 +234,16 @@ def set_rpm_spec_release_prefix( filename, new_rel ) {
     writeFile( file: filename, text: content )
 }
 
+// Just like the separate calls except it doesn't expect existing version/release to look like anything
+def set_rpm_spec_version_release( filename, new_ver, new_rel ) {
+    echo "Setting Version-Release in ${filename}: ${new_ver}-${new_rel}"
+    content = readFile( filename )
+    content = content.replaceFirst( /(?mxi) ^( \s* Version: \s* ) .+/, "\$1${new_ver}" ) // \$1 is a backref to "Version:    "
+    content = content.replaceFirst( /(?mxi) ^( \s* Release: \s* ) .+/, "\$1${new_rel}%{?dist}" )
+    writeFile( file: filename, text: content )
+}
+
+
 /**
  * Reads the specified RPM spec and parses version information from
  * it.
@@ -574,6 +584,20 @@ def mock_merge_driver(repo_dir, files) {
     files.each {
             gitattrs << "${it}  merge=ours\n"
     }
+}
+
+/**
+ * Clones ose (with origin as 'upstream')
+ * Sets OSE_DIR to ose repo directory
+ * @return Returns the directory where ose is cloned
+ */
+def initialize_ose_4() {
+    this.initialize_ose_dir()
+    dir( OSE_DIR ) {
+        sh "git remote add upstream ${GITHUB_BASE}/origin.git --no-tags"
+        sh 'git fetch --all'
+    }
+    return OSE_DIR
 }
 
 /**

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -587,20 +587,6 @@ def mock_merge_driver(repo_dir, files) {
 }
 
 /**
- * Clones ose (with origin as 'upstream')
- * Sets OSE_DIR to ose repo directory
- * @return Returns the directory where ose is cloned
- */
-def initialize_ose_4() {
-    this.initialize_ose_dir()
-    dir( OSE_DIR ) {
-        sh "git remote add upstream ${GITHUB_BASE}/origin.git --no-tags"
-        sh 'git fetch --all'
-    }
-    return OSE_DIR
-}
-
-/**
  * Extracts ose (with origin as 'upstream') and:
  * Sets OSE_MASTER to major.minor ("X.Y") from current ose#master origin.spec
  * Sets OSE_MASTER_MAJOR to X

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -1,4 +1,3 @@
-
 ocp3DefaultVersion = "3.11"
 ocp3Versions = [
     "3.11",
@@ -15,6 +14,8 @@ ocp3Versions = [
 ]
 
 ocp4DefaultVersion = "4.0"
+// Determines which version is currently the master branch:
+// update when development switches streams
 ocp4MasterVersion = "4.1"
 ocp4Versions = [
     "4.1",


### PR DESCRIPTION
This is basically temporary (a good stopping point while I go about dismantling most of this and turning it into usually-incremental builds) with fixes to allow us to build at all, pretty similarly to before. Even that much turns out to be kind of involved, but keep in mind a lot of it probably goes away or transforms in the end.

Temporary home at https://buildvm.openshift.eng.bos.redhat.com:8443/job/hack/job/lmeyer-stage/job/build%252Focp4/ until merged.
Can also hack around at https://buildvm.openshift.eng.bos.redhat.com:8443/job/hack/job/lmeyer-dev/job/build%252Focp4/ while real builds are happening at the other.