### PR TITLE
build/merge_ocp: reuse a single clone and limit depth

### DIFF
--- a/jobs/build/merge_ocp/Jenkinsfile
+++ b/jobs/build/merge_ocp/Jenkinsfile
@@ -10,7 +10,7 @@ node {
                     artifactDaysToKeepStr: '',
                     artifactNumToKeepStr: '',
                     daysToKeepStr: '',
-                    numToKeepStr: '1000')
+                    numToKeepStr: '100')
             ),
             [
                 $class: 'ParametersDefinitionProperty',
@@ -21,14 +21,18 @@ node {
                         $class: 'hudson.model.StringParameterDefinition',
                         defaultValue: commonlib.ocpMergeVersions.join(',')
                     ],
+                    [
+                        name: 'COMMIT_DEPTH',
+                        description: 'How deep to clone to ensure merges have a common base',
+                        $class: 'hudson.model.StringParameterDefinition',
+                        defaultValue: "100"
+                    ],
                     commonlib.suppressEmailParam(),
                     [
                         name: 'MAIL_LIST_SUCCESS',
                         description: 'Success Mailing List',
                         $class: 'hudson.model.StringParameterDefinition',
-                        defaultValue: [
-                            'aos-team-art@redhat.com',
-                        ].join(',')
+                        defaultValue: ""
                     ],
                     [
                         name: 'MAIL_LIST_FAILURE',
@@ -47,74 +51,79 @@ node {
 
     commonlib.checkMock()
 
-    SSH_KEY_ID = "openshift-bot"
-    MERGE_VERSIONS = VERSIONS.split(',')
-    CURRENT_MASTER = commonlib.ocp4MasterVersion
+    mergeVersions = params.VERSIONS.split(',')
+    mergeWorking = "${env.WORKSPACE}/ose"
+    upstreamRemote = "git@github.com:openshift/origin.git"
+    downstreamRemote = "git@github.com:openshift/ose.git"
+    commitDepth = params.COMMIT_DEPTH.trim().toInteger()
+
+    currentBuild.displayName = "#${currentBuild.number} Merging versions ${params.VERSIONS}"
+    currentBuild.description = ""
 
     try {
-        sshagent([SSH_KEY_ID]) {
-            for(int i = 0; i < MERGE_VERSIONS.size(); ++i) {
-                def VERSION = MERGE_VERSIONS[i]
-                MERGE_WORKING = "${WORKSPACE}/${VERSION}"
-                sh "rm -rf ${MERGE_WORKING}"
-                sh "mkdir -p ${MERGE_WORKING}"
-
-                if(VERSION == CURRENT_MASTER) {
-                    UPSTREAM = "master"
-                    DOWNSTREAM = "master"
+        successful = []
+        sshagent(["openshift-bot"]) {
+            stage("Clone ose") {
+                sh "rm -rf ${mergeWorking}"
+                sh "git clone ${downstreamRemote} --single-branch --branch master --depth 1 ${mergeWorking}"
+                dir(mergeWorking) {
+                    sh "git remote add upstream ${upstreamRemote}"
                 }
-                else {
-                    UPSTREAM = "release-${VERSION}"
-                    DOWNSTREAM = "enterprise-${VERSION}"
-                }
+            }
 
-                stage("Merge ${VERSION}") {
+            stage("Merge") {
+                for(int i = 0; i < mergeVersions.size(); ++i) {
+                    def version = mergeVersions[i]
                     try {
-                        sh "./merge_ocp.sh ${MERGE_WORKING} ${DOWNSTREAM} ${UPSTREAM}"
 
-                        echo "Success running ${VERSION} merge"
+                        if(version == commonlib.ocp4MasterVersion) {
+                            sh "./merge_ocp.sh ${mergeWorking} master master ${commitDepth}"
+                        } else {
+                            upstream = "release-${version}"
+                            downstream = "enterprise-${version}"
+                            sh "./merge_ocp.sh ${mergeWorking} ${downstream} ${upstream} ${commitDepth}"
+                        }
 
-                        // AMH - No email for now. There would be WAY too may emails.
-                        // mail(to: "${MAIL_LIST_SUCCESS}",
-                        //     from: "aos-team-art@redhat.com",
-                        //     subject: "Success merging OCP v${VERSION}",
-                        //     body: "Success running OCP merge:\n${env.BUILD_URL}"
-                        // );
+                        successful.add(version)
+                        echo "Success running ${version} merge"
 
                     } catch (err) {
                         currentBuild.result = "UNSTABLE"
-                        echo "Error running ${VERSION} merge:\n${err}"
+                        currentBuild.description += "failed to merge ${version}\n"
+                        echo "Error running ${version} merge:\n${err}"
+
                         commonlib.email(
-                            to: "${MAIL_LIST_FAILURE}",
+                            to: "${params.MAIL_LIST_FAILURE}",
                             from: "aos-team-art@redhat.com",
-                            subject: "Error merging OCP v${VERSION}",
+                            subject: "Error merging OCP v${version}",
                             body: "Encountered an error while running OCP merge:\n${env.BUILD_URL}\n\n${err}"
-                        );
+                        )
                     }
                 }
             }
         }
 
-        currentBuild.result = "SUCCESS"
-
-        // AMH - No email for now. There would be WAY too may emails.
-        // As this is supposed to run multiple times per day
-        // mail(to: "${MAIL_LIST_SUCCESS}",
-        //     from: "aos-team-art@redhat.com",
-        //     subject: "Success merging OCP versions: ${VERSIONS}",
-        //     body: "Success running OCP merges:\n${env.BUILD_URL}"
-        // );
+        if (!successful) {
+            // no merges succeeded, consider it a failed build.
+            currentBuild.result = "FAILURE"
+        } else if (params.MAIL_LIST_SUCCESS.trim()) {
+            // success email only if requested for this build
+            commonlib.email(
+                to: "${params.MAIL_LIST_SUCCESS}",
+                from: "aos-team-art@redhat.com",
+                subject: "Success merging OCP versions: ${successful.join(', ')}",
+                body: "Success running OCP merges:\n${env.BUILD_URL}"
+            )
+        }
 
     } catch (err) {
-        // This job is so simple that this should never really happen. But might as well have it.
         commonlib.email(
-            to: "${MAIL_LIST_FAILURE}",
+            to: "${params.MAIL_LIST_FAILURE}",
             from: "aos-team-art@redhat.com",
             subject: "Unexpected error during OCP Merge!",
             body: "Encountered an unexpected error while running OCP merge: ${err}"
-        );
+        )
 
-        currentBuild.result = "FAILURE"
         throw err
     }
 }

--- a/jobs/build/merge_ocp/merge_ocp.sh
+++ b/jobs/build/merge_ocp/merge_ocp.sh
@@ -1,34 +1,28 @@
-# usage: ./merge_ocp.sh ./working/ enterprise-3.11 release-3.11
+# usage: ./merge_ocp.sh ./working/ enterprise-3.11 release-3.11 1000
 set -e
 set -x
 WORKING_DIR=$1
 OSE_SOURCE_BRANCH=$2
 UPSTREAM_SOURCE_BRANCH=$3
-
-GITHUB_BASE="git@github.com:openshift"
+DEPTH=$4
 
 pushd ${WORKING_DIR}
 
-# pull OSE
-git clone ${GITHUB_BASE}/ose.git
-cd ose
+# clean up anything left behind in other merges
+git reset --hard HEAD
+git clean -f
 
-if [ "${OSE_SOURCE_BRANCH}" != "master" ]
-then
-    git checkout -b ${OSE_SOURCE_BRANCH} origin/${OSE_SOURCE_BRANCH}
-fi
-
-# Add origin remote so we can merge it in
-git remote add upstream ${GITHUB_BASE}/origin.git --no-tags
-git fetch upstream "${UPSTREAM_SOURCE_BRANCH}"
+git fetch origin "${OSE_SOURCE_BRANCH}:origin-${OSE_SOURCE_BRANCH}" --depth "${DEPTH}"
+git fetch upstream "${UPSTREAM_SOURCE_BRANCH}:upstream-${UPSTREAM_SOURCE_BRANCH}" --depth "${DEPTH}"
+git checkout -B "${OSE_SOURCE_BRANCH}" "origin-${OSE_SOURCE_BRANCH}"
 
 # Enable fake merge driver used in our .gitattributes
 git config merge.ours.driver true
 # Use fake merge driver on specific packages
 echo 'pkg/assets/bindata.go merge=ours' >> .gitattributes
 echo 'pkg/assets/java/bindata.go merge=ours' >> .gitattributes
-git merge -m "Merge remote-tracking branch ${UPSTREAM_SOURCE_BRANCH}" "upstream/${UPSTREAM_SOURCE_BRANCH}"
+git merge -m "Merge remote-tracking branch ${UPSTREAM_SOURCE_BRANCH}" "upstream-${UPSTREAM_SOURCE_BRANCH}"
 
-git push
+git push origin "${OSE_SOURCE_BRANCH}:${OSE_SOURCE_BRANCH}"
 
 popd


### PR DESCRIPTION
This brings the merge job down from an average 34 minutes to about 11 minutes.
https://buildvm.openshift.eng.bos.redhat.com:8443/job/hack/job/lmeyer-stage/job/build%252Fmerge_ocp/

Once I got going I couldn't help myself. So, um, lots of cosmetic changes too.