### PR TITLE
commonlib.shell wrapper for useful shell errors

### DIFF
--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -122,7 +122,7 @@ node {
 
             stage("puddle: ose 'building'") {
                 if (rpms.toUpperCase() != "NONE") {
-                    AOS_CD_JOBS_COMMIT_SHA = sh(
+                    AOS_CD_JOBS_COMMIT_SHA = commonlib.shell(
                         returnStdout: true,
                         script: "git rev-parse HEAD",
                     ).trim()
@@ -206,7 +206,7 @@ node {
             )
         }
     } catch (err) {
-        currentBuild.description = "failed with error: ${err}\n${currentBuild.description}"
+        currentBuild.description += "\nerror: ${err.getMessage()}"
         commonlib.email(
             to: "${params.MAIL_LIST_FAILURE}",
             from: "aos-team-art@redhat.com",

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -89,7 +89,7 @@ def initialize_openshift_dir() {
 def doozer(cmd, opts=[:]){
     cmd = cmd.replaceAll( '\n', ' ' ) // Allow newlines in command for readability, but don't let them flow into the sh
     cmd = cmd.replaceAll( ' \\ ', ' ' ) // If caller included line continuation characters, remove them
-    return sh(
+    return commonlib.shell(
         returnStdout: opts.capture ?: false,
         script: "doozer ${cmd.trim()}")
 }
@@ -97,7 +97,7 @@ def doozer(cmd, opts=[:]){
 def elliott(cmd, opts=[:]){
     cmd = cmd.replaceAll( '\n', ' ' ) // Allow newlines in command for readability, but don't let them flow into the sh
     cmd = cmd.replaceAll( ' \\ ', ' ' ) // If caller included line continuation characters, remove them
-    return sh(
+    return commonlib.shell(
         returnStdout: opts.capture ?: false,
         script: "${env.ENTERPRISE_IMAGES_DIR}/tools/bin/elliott --user=ocp-build ${cmd.trim()}")
 }
@@ -105,7 +105,7 @@ def elliott(cmd, opts=[:]){
 def oc(cmd, opts=[:]){
     cmd = cmd.replaceAll( '\n', ' ' ) // Allow newlines in command for readability, but don't let them flow into the sh
     cmd = cmd.replaceAll( ' \\ ', ' ' ) // If caller included line continuation characters, remove them
-    return sh(
+    return commonlib.shell(
         returnStdout: opts.capture ?: false,
         script: "/usr/bin/oc ${cmd.trim()}"
     )
@@ -1044,13 +1044,13 @@ List<List<?>> mapToList(Map map) {
 def watch_brew_task_and_retry(name, taskId, brewUrl) {
     // Watch brew task to make sure it succeeds. If it fails, retry twice before giving up.
     try {
-        sh "brew watch-task ${taskId}"
+        commonlib.shell "brew watch-task ${taskId}"
     } catch (err) {
         msg = "Error in ${name} build task: ${err}\nSee failed brew task ${brewUrl}"
         echo msg
         try {
             retry(2) {
-                sh "brew resubmit ${taskId}"
+                commonlib.shell "brew resubmit ${taskId}"
             }
         } catch (err2) {
             echo "giving up on ${name} build after three failures"

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -162,6 +162,86 @@ def safeArchiveArtifacts(List patterns) {
     }
 }
 
+shellIndex = 0
+/**
+ * Wraps the Jenkins Pipeline sh step in order to get actually useful exceptions.
+ * Because https://issues.jenkins-ci.org/browse/JENKINS-44930 is ridiculous.
+ *
+ * N.B. the returnStatus value is wrong. It's not because of the bash wrapper,
+ * which propagates the correct rc fine if run outside Jenkins. Presumably it's
+ * Jenkins being screwy. It does at least return an rc with the same truthiness
+ * (0 for success, 1 for failure).
+ * If your code really cares about the rc being right then do not use.
+ *
+ * @param returnAll true causes to return map with stderr, stdout, combined, and returnStatus
+ * @param otherwise same as sh() command
+ * @return same as sh() command, unless returnAll set
+ * @throws error (unless returnAll or returnStatus set) with useful message (and archives)
+ */
+def shell(arg) {
+    if (arg instanceof CharSequence) {  // https://stackoverflow.com/a/13880841
+        arg = [script: arg]
+    }
+    arg = [:] + arg  // make a copy
+    def returnAll = arg.remove("returnAll")
+    def script = arg.script  // keep a copy of original script
+    def truncScript = (script.size() <= 75) ? script : script[0..35] + "..." + script[-36..-1]
+
+    // ensure a clean space to save output files
+    if (!shellIndex++) { sh("rm -rf shell") }
+
+    def filename = "shell/sh.${shellIndex}." + truncScript.replaceAll( /[^\w-.]+/ , "_").take(80)
+    sh("mkdir -p ${filename}")
+    filename += "/sh.${shellIndex}"
+
+    arg.script =
+    """
+        set +x
+        set -euo pipefail
+        # many thanks to https://stackoverflow.com/a/9113604
+        {
+            {
+                {
+                    ${script}
+                }  2>&3 |  tee ${filename}.out.txt   # redirect stderr to fd 3, capture stdout
+            } 3>&1 1>&2 |  tee ${filename}.err.txt   # turn captured stderr (3) into stdout and stdout>stderr
+        }               |& tee ${filename}.combo.txt # and then capture both (though maybe out of order)
+    """
+
+    // run it, capture rc, and don't error
+    def rc = sh(arg + [returnStatus: true])
+
+    if (returnAll) {
+        return [
+            stdout: readFile("${filename}.out.txt"),
+            stderr: readFile("${filename}.err.txt"),
+            combined: readFile("${filename}.combo.txt"),
+            returnStatus: rc,
+        ]
+    }
+    if (arg.returnStatus) { return rc } // same as sh() so why bother?
+    if (arg.returnStdout && rc == 0) { return readFile("${filename}.out.txt")}
+    if (rc) {
+        // error like sh() would but with useful content. and archive it.
+        writeFile file: "${filename}.cmd.txt", text: script  // context for archive
+        safeArchiveArtifacts(["${filename}.*"])
+        def output = readFile("${filename}.combo.txt").split("\n")
+
+        // want the error message to be user-directed, so trim it a bit
+        if (output.size() > 3) {
+            output = [ "[...see full archive #${shellIndex}...]" ] + array_to_list(output)[-3..-1] 
+        }
+        error(  // TODO: use a custom exception class with attrs
+"""\
+failed shell command: ${truncScript}
+with rc=${rc} and output:
+${output.join("\n")}
+""")
+    }
+
+    return  // nothing, like normal sh()
+}
+
 /**
  * Jenkins doesn't seems to whitelist .asList(),
  * so this is an awful workaround.

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -194,6 +194,7 @@ def shell(arg) {
     sh("mkdir -p ${filename}")
     filename += "/sh.${shellIndex}"
 
+    echo "Running shell script via commonlib.shell:\n${script}"
     arg.script =
     """
         set +x

--- a/pipeline-scripts/commonlib_test.groovy
+++ b/pipeline-scripts/commonlib_test.groovy
@@ -1,0 +1,53 @@
+#!/usr/bin/groovy
+
+cl = load("pipeline-scripts/commonlib.groovy")
+
+// this is testing at its most hacky and disgusting... TODO: use a real framework
+def assertEquals(result, expected) {
+    assert result == expected : "expected ${expected}; got ${result}"
+}
+def assertContains(result, expected) {
+    assert result.contains(expected) : "expected ${expected} to be in ${result}"
+}
+
+// how to run tests? write a job that loads this and runs method(s), then run the job.
+// be careful not to merge such test jobs...
+
+def test_shell() {
+    assertEquals cl.shell("echo foo"), null  // and no error thrown
+
+    def retval = cl.shell(script: "echo foo >&2; echo bar", returnAll: true)
+    echo "${retval}"
+    assertEquals retval.stderr.trim(), "foo"
+    assertEquals retval.stdout.trim(), "bar"
+    assertEquals retval.returnStatus, 0
+
+    retval = cl.shell(script: "borky bork bork", returnAll: true)
+    echo "${retval}"
+    assertEquals retval.returnStatus, 1 // should be 127 though
+
+    assertEquals cl.shell(script: "borky bork bork", returnStatus: true), 1 // should be 127 though
+    assertEquals cl.shell(script: "echo bar", returnStdout: true).trim(), "bar"
+
+    try {
+        cl.shell(returnStdout: true, script: "borky bork bork  # padding this to make it long enough that it gets truncated")
+        assert false : "should throw err"
+    } catch(err) {
+        echo "message is:\n${err.getMessage()}"  // doesn't show useless exception class
+        assertContains "${err}", "borky bork bork"
+        assertContains "${err}", "command not found"
+        assertContains "${err}", "..."
+    }
+
+    try {
+        cl.shell("for i in 1 2 3 4; do echo \$i >&2; done; borkinate")
+        assert false : "should throw err"
+    } catch(err) {
+        echo "message is:\n${err.getMessage()}"  // doesn't show useless exception class
+        assertContains "${err}", "see full archive"
+        assert !err.getMessage().contains("1\n2") : "only three lines of stderr should be included"
+    }
+
+}
+
+return this


### PR DESCRIPTION
"Script exited with result 1" isn't a very useful message for the end
user. Jenkins sh() step is woefully lacking in options for capturing
what happened. This fixes those problems by wrapping sh commands to
capture output and stderr and provide a meaningful error message when
there is an error.

Here be much devilry, but I'll take it for the signal boost in errors. See the build description and the shell/email artifacts at https://buildvm.openshift.eng.bos.redhat.com:8443/job/hack/job/lmeyer-stage/job/build%252Fcustom/2/ to see how much more context we can get.