### PR TITLE
prevent silly errors on dockerfile reconciliation notices

### DIFF
--- a/jobs/build/ocp/Jenkinsfile
+++ b/jobs/build/ocp/Jenkinsfile
@@ -855,10 +855,7 @@ images:rebase --version v${NEW_VERSION}
 --release ${NEW_DOCKERFILE_RELEASE}
 --message 'Updating Dockerfile version and release v${NEW_VERSION}-${NEW_DOCKERFILE_RELEASE}' --push
 """
-                buildlib.notify_dockerfile_reconciliations(DOOZER_WORKING, [
-                    "ose"              : OSE_SOURCE_BRANCH,
-                    "openshift-ansible": OPENSHIFT_ANSIBLE_SOURCE_BRANCH
-                ])
+                buildlib.notify_dockerfile_reconciliations(DOOZER_WORKING, params.BUILD_VERSION)
             }
     
             stage("build images") {

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -366,7 +366,7 @@ images:rebase --version v${NEW_VERSION}
                     return
                 }
                 buildlib.doozer cmd
-                buildlib.notify_dockerfile_reconciliations(DOOZER_WORKING, ["ose": OSE_SOURCE_BRANCH])
+                buildlib.notify_dockerfile_reconciliations(DOOZER_WORKING, params.BUILD_VERSION)
             }
 
             stage("build images") {


### PR DESCRIPTION
build/ocp4 still had a reference to `OSE_SOURCE_BRANCH` though it no longer knows about source branches. Only shows up when there's a reconciliation notice to be sent. This torpedoed my build last night: https://buildvm.openshift.eng.bos.redhat.com:8443/job/aos-cd-builds/job/build%252Focp4/33/console

Also, reconciliation notices break if they're not for repos that have an alias. So basically they're failing all the time, and the only notice we get is a message buried in the console logs, e.g. search for "Failure resolving alias for email" in https://buildvm.openshift.eng.bos.redhat.com:8443/job/aos-cd-builds/job/build%252Focp/1055/consoleFull

So, this fixes that.
