### PR TITLE
build/ocp4: converged incremental or full build

### DIFF
--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -1,148 +1,9 @@
 #!/usr/bin/env groovy
 
-
-def get_mirror_url(build_mode, version) {
-    if (build_mode == "online:int") {
-        return "https://mirror.openshift.com/enterprise/online-int"
-    }
-    return "https://mirror.openshift.com/enterprise/enterprise-${version}"
-}
-
-def mail_success(version, mirrorURL, record_log, commonlib) {
-
-    def target = "(Release Candidate)"
-
-    if (BUILD_MODE == "online:int") {
-        target = "(Integration Testing)"
-    }
-
-    def inject_notes = ""
-    if (params.SPECIAL_NOTES.trim() != "") {
-        inject_notes = "\n***Special notes associated with this build****\n${params.SPECIAL_NOTES.trim()}\n***********************************************\n"
-    }
-
-    def timing_report = get_build_timing_report(record_log)
-    def image_list = get_image_build_report(record_log)
-    currentBuild.description = timing_report
-    currentBuild.result = "SUCCESS"
-    PARTIAL = " "
-    mail_list = params.MAIL_LIST_SUCCESS
-    exclude_subject = ""
-    if (BUILD_EXCLUSIONS != "" || BUILD_FAILURES != null) {
-        PARTIAL = " PARTIAL "
-        currentBuild.displayName += " (partial)"
-        if (BUILD_FAILURES != null) {
-            mail_list = params.MAIL_LIST_FAILURE
-            exclude_subject += " [failed images: ${BUILD_FAILURES}]"
-        }
-        if (BUILD_EXCLUSIONS != "") {
-            exclude_subject += " [excluded images: ${BUILD_EXCLUSIONS}]"
-        }
-    }
-
-    image_details = """${timing_report}
-Images:
-  - Images have been pushed to registry.reg-aws.openshift.com:443     (Get pull access [1])
-    [1] https://github.com/openshift/ops-sop/blob/master/services/opsregistry.asciidoc#using-the-registry-manually-using-rh-sso-user
-${image_list}
-"""
-
-
-    if (!params.BUILD_CONTAINER_IMAGES) {
-        PARTIAL = " RPM ONLY "
-        image_details = ""
-        // Just inform key folks about RPM only build; this is just prepping for an advisory.
-        mail_list = params.MAIL_LIST_FAILURE
-    }
-
-    commonlib.email(
-        to: "${mail_list}",
-        from: "aos-cicd@redhat.com",
-        subject: "[aos-cicd] New${PARTIAL}build for OpenShift ${target}: ${version}${exclude_subject}",
-        body: """\
-OpenShift Version: v${version}
-${inject_notes}
-RPMs:
-    Puddle (internal): http://download-node-02.eng.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift/${params.BUILD_VERSION}/${OCP_PUDDLE}
-    Exernal Mirror: ${mirrorURL}/${OCP_PUDDLE}
-${image_details}
-
-Brew:
-  - Openshift: ${OSE_BREW_URL}
-
-Jenkins job: ${env.BUILD_URL}
-
-Are your Atomic OpenShift changes in this build? Check here:
-https://github.com/openshift/ose/commits/v${NEW_VERSION}-${NEW_RELEASE}/
-
-""");
-
-    try {
-        if (BUILD_EXCLUSIONS == "" && params.BUILD_CONTAINER_IMAGES) {
-            timeout(3) {
-                sendCIMessage(
-                    messageContent: "New build for OpenShift ${target}: ${version}",
-                    messageProperties:
-                        """build_mode=${BUILD_MODE}
-                        puddle_url=${mirrorURL}/${OCP_PUDDLE}
-                        image_registry_root=registry.reg-aws.openshift.com:443
-                        brew_task_url_openshift=${OSE_BREW_URL}
-                        product=OpenShift Container Platform
-                        """,
-                    messageType: 'ProductBuildDone',
-                    overrides: [topic: 'VirtualTopic.qe.ci.jenkins'],
-                    providerName: 'Red Hat UMB'
-                )
-            }
-        }
-    } catch (mex) {
-        echo "Error while sending CI message: ${mex}"
-    }
-}
-
-// extract timing information from the record_log and write a report string
-// the timing record log entry has this form:
-// image_build_metrics|elapsed_total_minutes={d}|task_count={d}|elapsed_wait_minutes={d}|
-def get_build_timing_report(record_log) {
-    metrics = record_log['image_build_metrics']
-
-    if (metrics == null || metrics.size() == 0) {
-        return ""
-    }
-
-    return """
-Images built: ${metrics[0]['task_count']}
-Elapsed image build time: ${metrics[0]['elapsed_total_minutes']} minutes
-Time spent waiting for OSBS capacity: ${metrics[0]['elapsed_wait_minutes']} minutes
-"""
-}
-
-// get the list of images built
-def get_image_build_report(record_log) {
-    builds = record_log['build']
-
-    if ( builds == null ) {
-        return ""
-    }
-
-    Set image_set = []
-    for (i = 0; i < builds.size(); i++) {
-        bld = builds[i]
-        if (bld['status'] == "0" && bld['push_status'] == "0") {
-            image_spec_string =
-                "${bld['image']}:${bld['version']}-${bld['release']}"
-            image_set << image_spec_string
-        }
-    }
-
-    return "\nImages included in build:\n    " +
-        image_set.toSorted().join("\n    ")
-}
-
 node {
     checkout scm
-    def buildlib = load("pipeline-scripts/buildlib.groovy")
-    def commonlib = buildlib.commonlib
+    def build = load("build.groovy")
+    def commonlib = build.commonlib
 
     // Expose properties for a parameterized build
     properties(
@@ -156,6 +17,13 @@ node {
             [
                 $class: 'ParametersDefinitionProperty',
                 parameterDefinitions: [
+                    [
+                        name: 'DRY_RUN',
+                        description: 'Take no action, just echo what the build would have done.',
+                        $class: 'hudson.model.BooleanParameterDefinition',
+                        defaultValue: false
+                    ],
+                    commonlib.mockParam(),
                     commonlib.ocpVersionParam('BUILD_VERSION', '4'),
                     [
                         name: 'NEW_VERSION',
@@ -164,48 +32,53 @@ node {
                         defaultValue: ""
                     ],
                     [
-                        name: 'BUILD_CONTAINER_IMAGES',
-                        description: 'Build container images? Otherwise just RPMs',
-                        $class: 'hudson.model.BooleanParameterDefinition',
-                        defaultValue: true
-                    ],
-                    [
-                        name: 'BUILD_EXCLUSIONS',
-                        description: 'Exclude these images from builds. Comma or space separated list. (i.e cri-o-docker,aos3-installation-docker)',
-                        $class: 'hudson.model.StringParameterDefinition',
-                        defaultValue: ""
-                    ],
-                    commonlib.mockParam(),
-                    [
-                        name: 'DRY_RUN',
-                        description: 'Take no action, just echo what the build would have done.',
+                        name: 'FORCE_BUILD',
+                        description: 'Build regardless of whether source has changed',
                         $class: 'hudson.model.BooleanParameterDefinition',
                         defaultValue: false
                     ],
                     [
-                        name: 'BUILD_MODE',
-                        description: '''
-Determines where the compose is mirrored:
-    pre-release               origin/release-X.Y ->  https://mirror.openshift.com/enterprise/enterprise-X.Y/
-    online:int                origin/master -> online-int yum repo
-    ''',
+                        name: 'BUILD_RPMS',
+                        description: 'Which RPMs are candidates for building? "only/except" refer to list below',
                         $class: 'hudson.model.ChoiceParameterDefinition',
                         choices: [
-                            "pre-release",
-                            "online:int"
+                            "all",
+                            "only",
+                            "except",
+                            "none",
                         ].join("\n"),
-                        defaultValue: "pre-release"
+                        defaultValue: true
+                    ],
+                    [
+                        name: 'RPM_LIST',
+                        description: '(Optional) Comma/space-separated list to include/exclude per BUILD_RPMS (e.g. openshift,openshift-kuryr.yml)',
+                        $class: 'hudson.model.StringParameterDefinition',
+                        defaultValue: ""
+                    ],
+                    [
+                        name: 'BUILD_IMAGES',
+                        description: 'Which images are candidates for building? "only/except" refer to list below',
+                        $class: 'hudson.model.ChoiceParameterDefinition',
+                        choices: [
+                            "all",
+                            "only",
+                            "except",
+                            "none",
+                        ].join("\n"),
+                        defaultValue: true
+                    ],
+                    [
+                        name: 'IMAGE_LIST',
+                        description: '(Optional) Comma/space-separated list to include/exclude per BUILD_IMAGES (e.g. logging-kibana5,openshift-jenkins-2)',
+                        $class: 'hudson.model.StringParameterDefinition',
+                        defaultValue: ""
                     ],
                     commonlib.suppressEmailParam(),
                     [
                         name: 'MAIL_LIST_SUCCESS',
-                        description: 'Success Mailing List',
+                        description: '(Optional) Success Mailing List\naos-cicd@redhat.com,aos-qe@redhat.com',
                         $class: 'hudson.model.StringParameterDefinition',
-                        defaultValue: [
-                            'aos-cicd@redhat.com',
-                            'aos-qe@redhat.com',
-                            'aos-team-art@redhat.com',
-                        ].join(',')
+                        defaultValue: "",
                     ],
                     [
                         name: 'MAIL_LIST_FAILURE',
@@ -217,248 +90,55 @@ Determines where the compose is mirrored:
                     ],
                     [
                         name: 'SPECIAL_NOTES',
-                        description: 'Include special notes in the build email?',
+                        description: '(Optional) special notes to include in the build email',
                         $class: 'hudson.model.TextParameterDefinition',
                         defaultValue: ""
                     ],
                 ]
             ],
-            disableConcurrentBuilds()
         ]
     )
 
-    GITHUB_BASE = "git@github.com:openshift"  // buildlib uses this :eyeroll:
     commonlib.checkMock()
 
-    BUILD_VERSION_MAJOR = params.BUILD_VERSION.tokenize('.')[0].toInteger() // Store the "X" in X.Y
-    BUILD_VERSION_MINOR = params.BUILD_VERSION.tokenize('.')[1].toInteger() // Store the "Y" in X.Y
-
-    BUILD_EXCLUSIONS = commonlib.cleanCommaList(params.BUILD_EXCLUSIONS)
-    BUILD_FAILURES = null
-
-    aosCdJobsCommitSha = sh(
-        returnStdout: true,
-        script: "git rev-parse HEAD",
-    ).trim()
-
-    puddleConfBase = "https://raw.githubusercontent.com/openshift/aos-cd-jobs/${aosCdJobsCommitSha}/build-scripts/puddle-conf"
-    puddleConf = "${puddleConfBase}/atomic_openshift-${params.BUILD_VERSION}.conf"
-
-    currentBuild.displayName = "#${currentBuild.number} - ${params.BUILD_VERSION}.??"
-    echo "Initializing build: ${currentBuild.displayName}"
-
-    // doozer_working must be in WORKSPACE in order to have artifacts archived
-    DOOZER_WORKING = "${env.WORKSPACE}/doozer_working"
-    // get a fresh one, but delay removing the old one
-    sh "mkdir -p ${DOOZER_WORKING}; mv ${DOOZER_WORKING} ${DOOZER_WORKING}.${currentBuild.number}; mkdir -p ${DOOZER_WORKING}"
-
+    currentBuild.description = ""
     try {
-        stage("version") {
-            // inputs:
-            //  BUILD_VERSION
-
-            // defines:
-            //  NEW_VERSION
-            //  NEW_RELEASE
-            //  NEW_DOCKERFILE_RELEASE
-            //
-            //  sets currentBuild.displayName
-
-            def prevBuild = sh(
-                returnStdout: true,
-                script: "brew latest-build --quiet rhaos-${params.BUILD_VERSION}-rhel-7-candidate openshift | awk '{print \$1}'"
-            ).trim()
-
-            def extractBuildVersion = { build ->
-                // closure also keeps regex away from pipeline steps (error|echo)
-                def match = build =~ /(?x) ^openshift- (  \d+  ( \. \d+ )+  )-/
-                return match ? match[0][1] : "" // first group in the regex
-            }
-
-            NEW_VERSION = "${params.BUILD_VERSION}.0"  // default
-            if(params.NEW_VERSION.trim() == "+") {
-                // increment previous build version
-                NEW_VERSION = extractBuildVersion(prevBuild)
-                if (!NEW_VERSION) {
-                    error("Could not determine version from last build '${prevBuild}'")
-                }
-                def segments = NEW_VERSION.split("\\.").collect { it.toInteger() }
-                segments[-1]++
-                NEW_VERSION = segments.join(".")
-                echo("Using version ${NEW_VERSION} incremented from latest openshift package ${prevBuild}")
-            } else if(params.NEW_VERSION) {
-                // explicit version given
-                NEW_VERSION = commonlib.standardVersion(params.NEW_VERSION, false)
-                echo("Using NEW_VERSION parameter for version: ${NEW_VERSION}")
-            } else if (prevBuild) {
-                // use version from previous build
-                NEW_VERSION = extractBuildVersion(prevBuild)
-                if (!NEW_VERSION) {
-                    error("Could not determine version from last build '${prevBuild}'")
-                }
-                echo("Using version ${NEW_VERSION} from latest openshift package ${prevBuild}")
-            }
-
-            if (! NEW_VERSION.startsWith("${params.BUILD_VERSION}.")) {
-                // The version we came up with somehow doesn't match what we expect to build; abort
-                error("Determined a version, '${NEW_VERSION}', that does not begin with ${params.BUILD_VERSION}!")
-            }
-
-            NEW_RELEASE = new Date().format("yyyyMMddHHmm")
-            NEW_DOCKERFILE_RELEASE = NEW_RELEASE
-
-            currentBuild.displayName = "#${currentBuild.number} - ${NEW_VERSION}-${NEW_RELEASE}"
-            if (!params.BUILD_CONTAINER_IMAGES) { currentBuild.displayName += " (RPM ONLY)" }
-            if (params.DRY_RUN) { currentBuild.displayName += " (DRY RUN)" }
-        }
+        stage("initialize") { build.initialize() }
 
         sshagent(["openshift-bot"]) {
-            // To work on private repos, buildlib operations must run with the permissions of openshift-bot
-
-            stage("doozer build rpms") {
-                def cmd =
-"""
---working-dir ${DOOZER_WORKING} --group 'openshift-${params.BUILD_VERSION}'
-rpms:build --version v${NEW_VERSION}
---release ${NEW_RELEASE}
-"""
-
-                parallel "remove previous workspace(s)": { ->
-                    // this can take a while, given NFS. do while building RPMs.
-                    sh script: "rm -rf ${DOOZER_WORKING}.*", returnStatus: true
-                },
-                "build RPMs": { ->
-                    params.DRY_RUN ? echo("doozer ${cmd}") : buildlib.doozer(cmd)
-                }
-
-
-            }
-
-            stage("puddle: ose 'building'") {
-                if(params.DRY_RUN) {
-                    echo "Build puddle with conf ${puddleConf}"
-                    return
-                }
-                OCP_PUDDLE = buildlib.build_puddle(
-                    puddleConf,    // The puddle configuration file to use
-                    null,   // signing key
-                    "-b",   // do not fail if we are missing dependencies
-                    "-d",   // print debug information
-                    "-n",   // do not send an email for this puddle
-                    "-s",   // do not create a "latest" link since this puddle is for building images
-                    "--label=building"   // create a symlink named "building" for the puddle
-                )
-            }
-
-            stage("update dist-git") {
-                if (!params.BUILD_CONTAINER_IMAGES) {
-                    return
-                }
-                def cmd =
-"""
---working-dir ${DOOZER_WORKING} --group 'openshift-${params.BUILD_VERSION}'
-images:rebase --version v${NEW_VERSION}
---release ${NEW_DOCKERFILE_RELEASE}
---message 'Updating Dockerfile version and release v${NEW_VERSION}-${NEW_DOCKERFILE_RELEASE}' --push
-"""
-                if(params.DRY_RUN) {
-                    echo "doozer ${cmd}"
-                    return
-                }
-                buildlib.doozer cmd
-                buildlib.notify_dockerfile_reconciliations(DOOZER_WORKING, params.BUILD_VERSION)
-            }
-
-            stage("build images") {
-                if (params.BUILD_CONTAINER_IMAGES) {
-                    try {
-                        exclude = ""
-                        if (BUILD_EXCLUSIONS != "") {
-                            exclude = "-x ${BUILD_EXCLUSIONS} --ignore-missing-base"
-                        }
-                        def cmd =
-"""
---working-dir ${DOOZER_WORKING} --group openshift-${params.BUILD_VERSION}
-${exclude}
-images:build
---push-to-defaults --repo-type unsigned
-"""
-                        if(params.DRY_RUN) {
-                            echo "doozer ${cmd}"
-                            return
-                        }
-                        buildlib.doozer cmd
-                    }
-                    catch (err) {
-                        record_log = buildlib.parse_record_log(DOOZER_WORKING)
-                        def failed_map = buildlib.get_failed_builds(record_log, true)
-                        if (!failed_map) { throw err }  // failed so badly we don't know what failed; assume all
-
-                        BUILD_FAILURES = failed_map.keySet().join(",")  // will make email show PARTIAL
-                        currentBuild.result = "UNSTABLE"
-                        currentBuild.description = "Failed images: ${BUILD_FAILURES}"
-
-                        def r = buildlib.determine_build_failure_ratio(record_log)
-                        if (r.total > 10 && r.ratio > 0.25 || r.total > 1 && r.failed == r.total) {
-                            echo "${r.failed} of ${r.total} image builds failed; probably not the owners' fault, will not spam"
-                        } else {
-                            buildlib.mail_build_failure_owners(failed_map, "aos-team-art@redhat.com", params.MAIL_LIST_FAILURE)
-                        }
-                    }
-                }
-            }
-
-            stage("mirror RPMs") {
-                if(params.DRY_RUN) {
-                    return
-                }
-
-                NEW_FULL_VERSION = "${NEW_VERSION}-${NEW_RELEASE}"
-
-                SYMLINK_NAME = "latest"
-                if (!params.BUILD_CONTAINER_IMAGES) {
-                    SYMLINK_NAME = "no-image-latest"
-                }
-
-                // Push the building puddle out to the correct directory on the mirrors (e.g. online-int, online-stg, or enterprise-X.Y)
-                buildlib.invoke_on_rcm_guest("push-to-mirrors.sh", SYMLINK_NAME, NEW_FULL_VERSION, BUILD_MODE)
-
-                // push-to-mirrors.sh sets up a different puddle name on rcm-guest and the mirrors
-                OCP_PUDDLE = "v${NEW_FULL_VERSION}_${OCP_PUDDLE}"
-                final mirror_url = get_mirror_url(BUILD_MODE, params.BUILD_VERSION)
-
-                buildlib.invoke_on_rcm_guest("publish-oc-binary.sh", params.BUILD_VERSION, NEW_FULL_VERSION, "openshift")
-
-                echo "Finished building OCP ${NEW_FULL_VERSION}"
-                mail_success(NEW_FULL_VERSION, mirror_url, record_log, commonlib)
-
-            }
-
-            stage('sync images') {
-                if (params.DRY_RUN || !params.BUILD_CONTAINER_IMAGES) {
-                    return
-                }
-                buildlib.sync_images(
-                    BUILD_VERSION_MAJOR,
-                    BUILD_VERSION_MINOR,
-                    "aos-team-art@redhat.com",
-                    currentBuild.number
-                )
-            }
+            // To work on private repos, buildlib operations must run
+            // with the permissions of openshift-bot
+            stage("build RPMs") { build.stageBuildRpms() }
+            stage("build compose") { build.stageBuildCompose() }
+            stage("update dist-git") { build.stageUpdateDistgit() }
+            stage("build images") { build.stageBuildImages() }
+            stage("mirror RPMs") { build.stageMirrorRpms() }
+            stage("sync images") { build.stageSyncImages() }
         }
+        stage("report success") { build.stageReportSuccess() }
     } catch (err) {
-
-        commonlib.email(
-            to: "${params.MAIL_LIST_FAILURE}",
-            from: "aos-cicd@redhat.com",
-            subject: "Error building OSE: ${params.BUILD_VERSION}",
-            body: """Encountered an error while running OCP pipeline: ${err}
-
-Jenkins job: ${env.BUILD_URL}
-        """);
-        currentBuild.description = "Error while running OCP pipeline:\n${err}"
+        currentBuild.description += "${err}"
         currentBuild.result = "FAILURE"
-        throw err
+
+        if (params.MAIL_LIST_FAILURE.trim()) {
+            commonlib.email(
+                to: params.MAIL_LIST_FAILURE,
+                from: "aos-team-art@redhat.com",
+                subject: "Error building OCP ${params.BUILD_VERSION}",
+                body:
+"""\
+Pipeline build "${currentBuild.displayName}" encountered an error:
+${currentBuild.description}
+
+
+View the build artifacts and console output on Jenkins:
+    - Jenkins job: ${env.BUILD_URL}
+    - Console output: ${env.BUILD_URL}console
+
+"""
+            )
+        }
+        throw err  // gets us a stack trace FWIW
     } finally {
         commonlib.safeArchiveArtifacts([
             "doozer_working/*.log",

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -1,0 +1,604 @@
+#!/usr/bin/env groovy
+
+buildlib = load("pipeline-scripts/buildlib.groovy")
+commonlib = buildlib.commonlib
+
+// Properties that should be initialized and not updated
+version = [
+    stream: "",     // "X.Y" e.g. "4.0"
+    full: "",       // e.g. "4.0.0"
+    release: "",    // e.g. "201901011200"
+    major: 0,       // X in X.Y, e.g. 4
+    minor: 0,       // Y in X.Y, e.g. 0
+]
+doozerWorking = "${env.WORKSPACE}/doozer_working" // must be in WORKSPACE to archive artifacts
+doozerOpts = "--working-dir ${doozerWorking}"
+
+// this plan is to be initialized but then adjusted for incremental builds
+buildPlan = [
+    dryRun: false, // report build plan without performing it
+    forceBuild: false, // build regardless of whether source has changed
+    buildRpms: false,
+    rpmsIncluded: "", // comma-separated list
+    rpmsExcluded: "", // comma-separated list
+    puddleConf: "",  // URL to download the puddle conf
+    buildImages: false,
+    imagesIncluded: "", // comma-separated list
+    imagesExcluded: "", // comma-separated list
+]
+// initialized but composeDir only filled in when puddle creates a compose
+rpmMirror = [       // where to mirror RPM compose
+    composeDir: "", // e.g. "YYYY-MM-DD.1"
+    url: "",
+]
+
+// some state to record and preserve between stages
+finalRpmVersionRelease = ""  // set before building a compose
+
+/**
+ * Initialize properties from Jenkins parameters.
+ * @return map which is the buildPlan property of this build.
+*/
+def initialize() {
+    GITHUB_BASE = "git@github.com:openshift"  // buildlib uses this :eyeroll:
+
+    currentBuild.displayName = "#${currentBuild.number} - ${params.BUILD_VERSION}.??"
+    echo "Initializing build: ${currentBuild.displayName}"
+
+    version.stream = params.BUILD_VERSION.trim()
+    version << determineBuildVersion(version.stream)
+    doozerOpts += " --group 'openshift-${version.stream}'"
+
+    buildPlan << [
+        dryRun: params.DRY_RUN,
+        forceBuild: params.FORCE_BUILD,
+        buildRpms: params.BUILD_RPMS != "none",
+        buildImages: params.BUILD_IMAGES != "none",
+    ]
+
+    // determine whether the user wanted to specify includes or excludes
+    rpmList = [only: "rpmsIncluded", except: "rpmsExcluded"][params.BUILD_RPMS]
+    if (rpmList) {
+        buildPlan[rpmList] = commonlib.cleanCommaList(params.RPM_LIST)
+    } else if (params.RPM_LIST.trim()) {
+        error("aborting because a list of RPMs was specified; you probably want to specify only/except.")
+    }
+
+    imageList = [only: "imagesIncluded", except: "imagesExcluded"][params.BUILD_IMAGES]
+    if (imageList) {
+        buildPlan[imageList] = commonlib.cleanCommaList(params.IMAGE_LIST)
+    } else if (params.IMAGE_LIST.trim()) {
+        error("aborting because a list of images was specified; you probably want to specify only/except.")
+    }
+
+    echo "Initial build plan: ${buildPlan}"
+
+    // figure out the puddle configuration
+    aosCdJobsCommitSha = commonlib.shell(script: "git rev-parse HEAD", returnStdout: true).trim()
+    def puddleConfBase = "https://raw.githubusercontent.com/openshift/aos-cd-jobs/" +
+                         "${aosCdJobsCommitSha}/build-scripts/puddle-conf"
+    buildPlan.puddleConf = "${puddleConfBase}/atomic_openshift-${version.stream}.conf"
+    // and where to mirror the compose when it's done
+    rpmMirror.url = "https://mirror.openshift.com/enterprise/enterprise-${version.stream}"
+
+    // adjust the build "title"
+    currentBuild.displayName = "#${currentBuild.number} - ${version.full}-${version.release}"
+    if (buildPlan.dryRun) { currentBuild.displayName += " [DRY RUN]" }
+    if (buildPlan.forceBuild) { currentBuild.displayName += " [force build]" }
+    if (!buildPlan.buildRpms) { currentBuild.displayName += " [no RPMs]" }
+    if (!buildPlan.buildImages) { currentBuild.displayName += " [no images]" }
+
+    // get a fresh doozerWorking; removing the old one is left in the background.
+    // NOTE: this waits for the background process if wrapped in commonlib.shell;
+    // as this is designed to run instantly and never fail, just run it in a normal shell.
+    sh """
+        mkdir -p ${doozerWorking}
+        mv ${doozerWorking} ${doozerWorking}.rm.${currentBuild.number}
+        mkdir -p ${doozerWorking}
+        # see discussion at https://stackoverflow.com/a/37161006 re:
+        JENKINS_NODE_COOKIE=dontKill BUILD_ID=dontKill nohup bash -c 'rm -rf ${doozerWorking}.rm.*' &
+    """
+    return planBuilds()
+}
+
+def latestOpenshiftRpmBuild(stream) {
+    retry(3) {
+        commonlib.shell(
+            script: "brew latest-build --quiet rhaos-${stream}-rhel-7-candidate openshift | awk '{print \$1}'",
+            returnStdout: true,
+        ).trim()
+    }
+}
+
+// From a brew NVR of openshift, return just the V part.
+@NonCPS
+def extractBuildVersion(build) {
+    // closure also keeps regex away from pipeline steps (error|echo)
+    def match = build =~ /(?x) ^openshift- (  \d+  ( \. \d+ )+  )-/
+    return match ? match[0][1] : "" // first group in the regex
+}
+
+/**
+ * From the minor version (stream) and parameters, determine which version to build.
+ * @param stream: OCP minor version "X.Y"
+ * @return a map to merge into the "version" property representing the determined version
+ */
+def determineBuildVersion(stream) {
+    def full = "${stream}.0"  // default
+    def release = new Date().format("yyyyMMddHHmm")
+
+    def prevBuild = latestOpenshiftRpmBuild(stream)
+    if(params.NEW_VERSION.trim() == "+") {
+        // increment previous build version
+        full = extractBuildVersion(prevBuild)
+        if (!full) { error("Could not determine version from last build '${prevBuild}'") }
+
+        def segments = full.tokenize(".").collect { it.toInteger() }
+        segments[-1]++
+        full = segments.join(".")
+        echo("Using version ${full} incremented from latest openshift package ${prevBuild}")
+    } else if(params.NEW_VERSION) {
+        // explicit version given
+        full = commonlib.standardVersion(params.NEW_VERSION, false)
+        echo("Using NEW_VERSION parameter for version: ${full}")
+    } else if (prevBuild) {
+        // use version from previous build
+        full = extractBuildVersion(prevBuild)
+        if (!full) { error("Could not determine version from last build '${prevBuild}'") }
+        echo("Using version ${full} from latest openshift package ${prevBuild}")
+    }
+
+    if (! full.startsWith("${stream}.")) {
+        // The version we came up with somehow doesn't match what we expect to build; abort
+        error("Determined a version, '${full}', that does not begin with '${stream}.'")
+    }
+
+    stream = stream.tokenize('.').collect { it.toInteger() }
+    return [
+        major: stream[0],
+        minor: stream[1],
+        full: full,
+        release: release,
+    ]
+}
+
+/**
+ * Plan what will be built.
+ * Figure out whether we're building RPMs and/or images, and which ones, based on
+ * the parameters and which sources have changed (if relevant).
+ * Fills in the "buildPlan" property for later stages to use.
+ * @return map which is the buildPlan property of this build.
+ */
+def planBuilds() {
+    if (buildPlan.forceBuild) {
+        echo "Building all as requested regardless of whether source has changed."
+        currentBuild.description = "Force building (whether source changed or not).\n"
+        if (!buildPlan.buildRpms) {
+            currentBuild.description += "RPMs: not building.\n"
+        }
+        currentBuild.description += "Will create RPM compose.\n"
+        if (!buildPlan.buildImages) {
+            currentBuild.description += "Images: not building.\n"
+        }
+        return buildPlan
+    }
+
+    // otherwise we need to scan sources.
+    echo "Building only where source has changed."
+    currentBuild.description = "Building sources that have changed.\n"
+
+    def changed = [:]
+    try {
+        def yamlData = readYaml text: buildlib.doozer(
+            """
+            ${doozerOpts}
+            ${includeExclude "rpms", buildPlan.rpmsIncluded, buildPlan.rpmsExcluded}
+            ${includeExclude "images", buildPlan.imagesIncluded, buildPlan.imagesExcluded}
+            config:scan-sources --yaml
+            """, [capture: true]
+        )
+        changed = getChanges(yamlData)
+
+        def report = { msg ->
+            echo msg
+            currentBuild.description += "${msg}\n"
+        }
+        if (!buildPlan.buildRpms) {
+            report "RPMs: not building."
+            report "Will not create RPM compose."
+        } else if (changed.rpms) {
+            report "RPMs: building " + changed.rpms.join(", ")
+            report "Will create RPM compose."
+            buildPlan.rpmsIncluded = changed.rpms.join(",")
+            buildPlan.rpmsExcluded = ""
+        } else {
+            buildPlan.buildRpms = false
+            report "RPMs: none changed."
+            report "Will not create RPM compose."
+        }
+
+        if (!buildPlan.buildImages) {
+            report "Images: not building."
+            return buildPlan
+        } else if (!changed.images) {
+            report "Images: none changed."
+            buildPlan.buildImages = false
+            currentBuild.displayName += " [no changes]"
+            return buildPlan
+        }
+        report "Found ${changed.images.size()} image(s) with changes:\n  " + changed.images.join("\n  ")
+
+        // also determine child images of changed
+        yamlData = readYaml text: buildlib.doozer(
+            """
+            ${doozerOpts}
+            ${includeExclude "images", buildPlan.imagesIncluded, buildPlan.imagesExcluded}
+            images:show-tree --yml
+            """, [capture: true]
+        )
+
+        // scan the image tree for changed and their children using recursive closure
+        Closure gather_children  // needs to be defined separately to self-call
+        gather_children = { all, data, initial, gather ->
+            // all(list): all images gathered so far while traversing tree
+            // data(map): the part of the yaml image tree we're looking at
+            // initial(list): all images initially found to have changed
+            // gather(bool): whether this is a subtree of an image with changed source
+            data.each { image, children ->
+                def gather_this = gather || image in initial
+                if (gather_this) {  // this or an ancestor was a changed image
+                    all.add(image)
+                }
+                // scan children recursively
+                all = gather_children(all, children, initial, gather_this)
+            }
+            return all
+        }
+        def images = gather_children([], yamlData, changed.images, false)
+        children = images - changed.images
+        if (children) {
+            report "Images: also building ${children.size()} child(ren):\n  " + children.join("\n  ")
+        }
+        buildPlan.imagesIncluded = images.join(",")
+        buildPlan.imagesExcluded = ""
+
+        // NOTE: it might be nice not to rebase child images where the source hasn't changed.
+        // However we would still need to update dockerfile for those images; but running doozer
+        // separately for rebase and update-dockerfile would mess up parent-child relationships,
+        // and it isn't worth the trouble to make that work.
+    } catch (err) {
+        currentBuild.description += "error during plan builds step:\n${err.getMessage()}\n"
+        throw err
+    }
+    return buildPlan
+}
+
+// extract the list of changed items of each kind
+@NonCPS
+def getChanges(yamlData) {
+    def changed = ["rpms": [], "images": []]
+    changed.each { kind, list ->
+        yamlData[kind].each { 
+            if (it["changed"]) {
+                list.add(it["name"])
+            }
+        }
+    }
+    return changed
+}
+
+// determine what doozer parameter (if any) to use for includes/excludes
+def includeExclude(kind, includes, excludes) {
+    // --latest-parent-version only applies for images but won't hurt for RPMs
+    if (includes) { return "--latest-parent-version --${kind} ${includes}" }
+    if (excludes) { return "--latest-parent-version --${kind} '' --exclude ${excludes}" }
+    return "--${kind} ''"
+}
+
+def stageBuildRpms() {
+    if (!buildPlan.buildRpms) {
+        echo "Not building RPMs."
+        return
+    }
+    def cmd =
+        """
+        ${doozerOpts}
+        ${includeExclude "rpms", buildPlan.rpmsIncluded, buildPlan.rpmsExcluded}
+        rpms:build --version v${version.full}
+        --release ${version.release}
+        """
+
+    buildPlan.dryRun ? echo("doozer ${cmd}") : buildlib.doozer(cmd)
+}
+
+/**
+ * If necessary, puddle a new compose from our candidate tag.
+ * Set the new puddle directory (e.g. "YYYY-MM-DD.1")
+ */
+def stageBuildCompose() {
+
+    // we may or may not have (successfully) built the openshift RPM in this run.
+    // in order to script the correct version to publish later, determine what's there now.
+    finalRpmVersionRelease = latestOpenshiftRpmBuild(version.stream).replace("openshift-", "")
+
+    if (!buildPlan.buildRpms && !buildPlan.forceBuild) {
+        // a force build of just images is likely to want to pick up new dependencies,
+        // so in that case still create the compose.
+        echo "No RPMs built, not a force build; no need to create a compose"
+        return
+    }
+    if(buildPlan.dryRun) {
+        echo "Build puddle with conf ${buildPlan.puddleConf}"
+        rpmMirror.composeDir = "YYYY-MM-DD.1"
+        return
+    }
+
+    rpmMirror.composeDir = buildlib.build_puddle(
+        buildPlan.puddleConf,    // The puddle configuration file to use
+        null,   // signing key
+        "-b",   // do not fail if we are missing dependencies
+        "-d",   // print debug information
+        "-n",   // do not send an email for this puddle
+        "-s",   // do not create a "latest" link since this puddle is for building images
+        "--label=building"   // create a symlink named "building" for the puddle
+    )
+}
+
+def stageUpdateDistgit() {
+    if (!buildPlan.buildImages) {
+        echo "Not rebasing images."
+        return
+    }
+    def cmd =
+        """
+        ${doozerOpts}
+        ${includeExclude "images", buildPlan.imagesIncluded, buildPlan.imagesExcluded}
+        images:rebase --version v${version.full} --release ${version.release}
+        --message 'Updating Dockerfile version and release v${version.full}-${version.release}' --push
+        """
+    if(buildPlan.dryRun) {
+        echo "doozer ${cmd}"
+        return
+    }
+    buildlib.doozer(cmd)
+    // TODO: if rebase fails for required images, notify image owners, and still notify on other reconciliations
+    buildlib.notify_dockerfile_reconciliations(doozerWorking, version.stream)
+    // TODO: if a non-required rebase fails, notify ART and the image owners
+}
+
+/**
+ * Build the images according to plan.
+ */
+def stageBuildImages() {
+    if (!buildPlan.buildImages) {
+        echo "Not building images."
+        return
+    }
+    try {
+        def cmd =
+            """
+            ${doozerOpts}
+            ${includeExclude "images", buildPlan.imagesIncluded, buildPlan.imagesExcluded}
+            images:build
+            --push-to-defaults --repo-type unsigned
+            """
+        if(buildPlan.dryRun) {
+            echo "doozer ${cmd}"
+            return
+        }
+        buildlib.doozer(cmd)
+    }
+    catch (err) {
+        recordLog = buildlib.parse_record_log(doozerWorking)
+        def failed_map = buildlib.get_failed_builds(recordLog, true)
+        if (!failed_map) { throw err }  // failed so badly we don't know what failed; give up
+
+        failed_images = failed_map.keySet()
+        currentBuild.result = "UNSTABLE"
+        currentBuild.description += "Failed images: ${failed_images.join(', ')}\n"
+
+        def r = buildlib.determine_build_failure_ratio(recordLog)
+        if (r.total > 10 && r.ratio > 0.25 || r.total > 1 && r.failed == r.total) {
+            echo "${r.failed} of ${r.total} image builds failed; probably not the owners' fault, will not spam"
+        } else {
+            buildlib.mail_build_failure_owners(failed_map, "aos-team-art@redhat.com", params.MAIL_LIST_FAILURE)
+        }
+    }
+}
+
+def stageMirrorRpms() {
+    if (!buildPlan.buildRpms && !buildPlan.forceBuild) {
+        echo "No updated RPMs to mirror."
+        return
+    }
+
+    def versionRelease = "${version.full}-${version.release}"
+
+    // Push the building puddle out to the mirrors
+    def symlinkName = "latest"
+
+    if(buildPlan.dryRun) {
+        // this is silly, but we can't use *args to DRY -- see https://issues.jenkins-ci.org/browse/JENKINS-46163
+        echo("invoke_on_rcm_guest push-to-mirrors.sh ${symlinkName} ${versionRelease} pre-release")
+    } else {
+        buildlib.invoke_on_rcm_guest("push-to-mirrors.sh", symlinkName, versionRelease, "pre-release")
+    }
+
+    def binaryPkgName = "openshift"
+    if(buildPlan.dryRun) {
+        echo("invoke_on_rcm_guest publish-oc-binary.sh ${version.stream} ${finalRpmVersionRelease} ${binaryPkgName}")
+    } else {
+        buildlib.invoke_on_rcm_guest("publish-oc-binary.sh", version.stream, finalRpmVersionRelease, binaryPkgName)
+    }
+
+    echo "Finished building OCP ${versionRelease}"
+}
+
+def stageSyncImages() {
+    if (!buildPlan.buildImages) {
+        echo "No built images to sync."
+        return
+    }
+    if(buildPlan.dryRun) {
+        echo "Not syncing images in a dry run."
+        return
+    }
+    buildlib.sync_images(
+        version.major,
+        version.minor,
+        "aos-team-art@redhat.com",
+        currentBuild.number
+    )
+}
+
+def stageReportSuccess() {
+    def builtNothing = buildPlan.dryRun || !(buildPlan.buildRpms || buildPlan.buildImages)
+    def recordLog = builtNothing ? [:] : buildlib.parse_record_log(doozerWorking)
+    def timingReport = getBuildTimingReport(recordLog)
+    currentBuild.description += timingReport
+
+    def stateYaml = builtNothing ? [:] : readYaml(file: "${doozerWorking}/state.yaml")
+    messageSuccess(rpmMirror.url)
+    emailSuccess(rpmMirror.url, timingReport, getImageBuildReport(recordLog), stateYaml)
+}
+
+def messageSuccess(mirrorURL) {
+    if (!buildPlan.buildImages) {
+        echo "No images built so no need for UMB message."
+        return
+    }
+    try {
+        timeout(3) {
+            sendCIMessage(
+                messageContent: "New build for OpenShift: ${version.full}",
+                messageProperties:
+                    """build_mode=pre-release
+                    puddle_url=${rpmMirror.url}/${rpmMirror.composeDir}
+                    image_registry_root=registry.reg-aws.openshift.com:443
+                    product=OpenShift Container Platform
+                    """,
+                messageType: 'ProductBuildDone',
+                overrides: [topic: 'VirtualTopic.qe.ci.jenkins'],
+                providerName: 'Red Hat UMB'
+            )
+        }
+    } catch (mex) {
+        echo "Error while sending CI message: ${mex.getMessage()}"
+    }
+}
+
+def emailSuccess(mirrorURL, timingReport, imageList, stateYaml) {
+    def mailList = params.MAIL_LIST_SUCCESS.trim()
+    // note: the default for the parameter is empty.
+    // normally this would probably only be set for full builds, if then.
+    // but it's there in case you want to notify someone, perhaps yourself.
+    if (!mailList) { return }
+
+    def subjectTags = ""
+    if (buildPlan.dryRun) { subjectTags += " [DRY RUN]" }
+
+    if (buildPlan.buildImages) {
+        if (buildPlan.imagesIncluded || buildPlan.imagesExcluded) {
+            subjectTags += " [partial]"
+        }
+        def result = stateYaml.get("images:rebase", [:])
+        if (result['success'] != result['total']) {
+            currentBuild.displayName += " [rebase failure]"
+            subjectTags += " [rebase failure]"
+        }
+        result = stateYaml.get("images:build", [:])
+        if (result['success'] != result['total']) {
+            currentBuild.displayName += " [image failure]"
+            subjectTags += " [image failure]"
+        }
+    } else if (buildPlan.buildRpms) {
+        subjectTags += " [RPM only]"
+    } else {
+        // no builds attempted; could only happen if incremental build found no changes
+        subjectTags += " [no changes]"
+    }
+
+    def injectNotes = (params.SPECIAL_NOTES.trim() == "") ? "" :
+"""
+Special notes associated with this build:
+*****************************************
+${params.SPECIAL_NOTES.trim()}
+*****************************************
+"""
+
+    def composeDetails = (!buildPlan.buildRpms && !buildPlan.forceBuild) ? "" :
+"""\
+RPMs:
+    RPM Compose (internal): http://download-node-02.eng.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift/${version.stream}/${rpmMirror.composeDir}
+    External Mirror: ${mirrorURL}/${rpmMirror.composeDir}
+"""
+
+    def imageDetails = (!buildPlan.buildImages) ? "" :
+"""\
+${timingReport}
+Images:
+  - Images have been pushed to registry.reg-aws.openshift.com:443     (Get pull access [1])
+    [1] https://github.com/openshift/ops-sop/blob/master/services/opsregistry.asciidoc#using-the-registry-manually-using-rh-sso-user
+${imageList}
+"""
+
+    commonlib.email(
+        to: mailList,
+        from: "aos-team-art@redhat.com",
+        subject: "[ART] New build for OCP: ${version.full}${subjectTags}",
+        body:
+"""\
+Pipeline build "${currentBuild.displayName}" finished successfully.
+${injectNotes}
+The build description it finished with is:
+******************************************
+${currentBuild.description}\
+******************************************
+
+${composeDetails}\
+${imageDetails}\
+View the build artifacts and console output on Jenkins:
+    - Jenkins job: ${env.BUILD_URL}
+    - Console output: ${env.BUILD_URL}console
+""");
+}
+
+// extract timing information from the recordLog and write a report string
+// the timing record log entry has this form:
+// image_build_metrics|elapsed_total_minutes={d}|task_count={d}|elapsed_wait_minutes={d}|
+def getBuildTimingReport(recordLog) {
+    metrics = recordLog['image_build_metrics']
+
+    if (metrics == null || metrics.size() == 0) {
+        return ""
+    }
+
+    return """
+Images built: ${metrics[0]['task_count']}
+Elapsed image build time: ${metrics[0]['elapsed_total_minutes']} minutes
+Time spent waiting for OSBS capacity: ${metrics[0]['elapsed_wait_minutes']} minutes
+"""
+}
+
+// get the list of images built
+def getImageBuildReport(recordLog) {
+    builds = recordLog['build']
+
+    if ( builds == null ) {
+        return ""
+    }
+
+    Set imageSet = []
+    for (i = 0; i < builds.size(); i++) {
+        bld = builds[i]
+        if (bld['status'] == "0" && bld['push_status'] == "0") {
+            imageSet << "${bld['image']}:${bld['version']}-${bld['release']}"
+        }
+    }
+
+    return "\nImages included in build:\n    " +
+        imageSet.toSorted().join("\n    ")
+}
+
+return this
+

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -1076,4 +1076,15 @@ def watch_brew_task_and_retry(name, taskId, brewUrl) {
     }
 }
 
+def getGroupBranch(doozerOpts) {
+    // for given doozer options determine the distgit branch from the group.yml file
+    def branch = doozer("${doozerOpts} config:read-group branch", [capture: true]).trim()
+    if (branch == "" ) {
+        error("failed to read branch from group.yml")
+    } else if (branch.contains("\n")) {
+        error("reading branch from group.yml got multiple lines:\n${branch}")
+    }
+    return branch
+}
+
 return this

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -85,7 +85,7 @@ def suppressEmailParam() {
         name: 'SUPPRESS_EMAIL',
         description: 'Do not actually send email, just archive it',
         $class: 'BooleanParameterDefinition',
-        defaultValue: false
+        defaultValue: !env.JOB_NAME.startsWith("aos-cd-builds/"),
     ]
 }
 


### PR DESCRIPTION
For 4.x this builds anything from one component to changed components to all components. My plan is to schedule it as frequently as possible with the default, which is to build changed. Then schedule it once a week or so with a force build so everything is built (this might include a version bump for releases).

This also demos what I hope become standards for designing our jobs (in particular, the Jenkinsfile that is largely just structure calling out to a module; the reduction of global variables down to a few well-known Jenkins-related ones plus module state; adding info to build description/displayName as the build progresses...).

@tbielawa @adammhaile @smunilla @shiywang @joeldavis84 @vikaslaad 