### PR TITLE
buildlib: wait before re-submitting brew tasks

### DIFF
--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -1066,6 +1066,7 @@ def watch_brew_task_and_retry(name, taskId, brewUrl) {
         echo msg
         try {
             retry(2) {
+		sleep(120)  // brew state takes time to settle, so wait to retry
                 commonlib.shell "brew resubmit ${taskId}"
             }
         } catch (err2) {


### PR DESCRIPTION
On immediate re-submit, brew seems to either do nothing and return success, or complain that the task is still open. Wait for it to get sorted out before re-submitting.