### PR TITLE
Add a link to credentials section on sjb/push* 403

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ field on the repository as per [the spec](./sjb/syntax.md#sync_repos). Then, whe
 to merge in your pull request by entering in your pull request number in the appropriate parameter field in the Jenkins UI when
 starting the job.
 
+### Push Credentials
+
 Note: the `sjb/push-update{,-automatic}.sh` scripts expect `$USERNAME` and `$PASSWORD` to be set as envars when they are run.
 `$USERNAME` is your user with which you log in to the Jenkins master at [ci.openshift](http://ci.openshift.redhat.com/).
 `$PASSWORD` is a Jenkins API token you have to generate through the Jenkins UI. As a logged-in user, click your username in the upper right hand of the UI. After the account page loads, click "Configure" on the right hand side, and after the configuration page loads, you will see an option to generate a new token. Copy this to your password store, since it is only displayed for copy/pasting when you first generate it.

--- a/sjb/push-update.sh
+++ b/sjb/push-update.sh
@@ -38,6 +38,9 @@ function retry_post() {
 			tput setaf 1
 			tput bold
 			echo "[ERROR] Failed to POST ${url}: ${response}"
+			if [[ "${response}" == "403" ]]; then
+			    echo "Please see https://github.com/openshift/aos-cd-jobs/#push-credentials"
+			fi
 			tput sgr0
 			break
 		else


### PR DESCRIPTION
```
$ ./sjb/push-update.sh sjb/generated/push_wildfly_images.xml
[INFO] Checking for existence of push_wildfly_images...
[INFO] Updating push_wildfly_images...
[ERROR] Failed to POST job/push_wildfly_images/config.xml: 403
Please see https://github.com/openshift/aos-cd-jobs/#push-credentials
```