### PR TITLE
build-sync: Parameterize selecting base image stream file

### DIFF
--- a/jobs/build/build-sync/Jenkinsfile
+++ b/jobs/build/build-sync/Jenkinsfile
@@ -35,7 +35,7 @@ node {
     // Location of the image stream to apply
     def ocIsObject = "${mirrorWorking}/release-is.yaml"
     // Locally stored image stream stub
-    def baseImageStream = "/home/jenkins/base-art-latest-imagestream.yaml"
+    def baseImageStream = "/home/jenkins/base-art-latest-imagestream-${params.BUILD_VERSION}.yaml"
     // Kubeconfig allowing ART to interact with api.ci.openshift.org
     def ciKubeconfig = "/home/jenkins/kubeconfigs/art-publish.kubeconfig"
 


### PR DESCRIPTION
Instead of using a hard-coded path to a base image stream, substitute
in the build version parameter for selection.

Now we'll be able to push to the 4.0 and 4.1 image streams separately.

On the buildvm there is now a new base image stream. In a future PR we should do something to remove that dependency and generate them from inputs.