### PR TITLE
Add 4.1 RHEL8 puddle conf

### DIFF
--- a/build-scripts/puddle-conf/atomic_openshift-4.1.el8.conf
+++ b/build-scripts/puddle-conf/atomic_openshift-4.1.el8.conf
@@ -1,0 +1,17 @@
+[puddle]
+type = simple
+rootdir = /mnt/rcm-guest/puddles/RHAOS
+mashroot = /mnt/rcm-guest/puddles/RHAOS/mash
+brewroot = file:///mnt/redhat/brewroot
+topurl = http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/
+name = AtomicOpenShift.el8
+version = 4.1
+emails = aos-devel@redhat.com,aos-qe@redhat.com
+announcer = openshift-puddle <aos-devel@redhat.com>
+publish = no
+external = /mnt/redhat/brewroot/repos/rhel-8-build/latest/$arch/
+tag = rhaos-4.1-rhel-8-candidate
+arches = x86_64,ppc64le,aarch64,s390x
+keys = fd431d51,f21541eb
+variant = Server-RH8-RHOSE-4.1
+blacklist = thrift-glib, thrift-qt, v8-python

--- a/scheduled-jobs/build/rhcos-puddle/Jenkinsfile
+++ b/scheduled-jobs/build/rhcos-puddle/Jenkinsfile
@@ -1,0 +1,34 @@
+#!/usr/bin/env groovy
+
+node {
+    checkout scm
+    def buildlib = load("pipeline-scripts/buildlib.groovy")
+
+    properties(
+        [
+            buildDiscarder(
+                logRotator(
+                    artifactDaysToKeepStr: '',
+                    artifactNumToKeepStr: '',
+                    daysToKeepStr: '',
+                    numToKeepStr: '360'
+                )
+            ),
+            disableConcurrentBuilds(),
+        ]
+    )
+
+    echo "Initializing puddle build #${currentBuild.number}"
+
+    def puddleConf = "https://raw.githubusercontent.com/openshift/aos-cd-jobs/master/build-scripts/puddle-conf/atomic_openshift-4.1.el8.conf"
+
+    puddle = buildlib.build_puddle(
+	$puddleConf,
+        "-b",   // do not fail if we are missing dependencies
+        "-d",   // print debug information
+        "-n"    // do not send an email for this puddle
+    )
+
+    echo "View the package list here: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift.el8/4.1/latest/x86_64/os/Packages/"
+
+}

--- a/scheduled-jobs/build/rhcos-puddle/README.md
+++ b/scheduled-jobs/build/rhcos-puddle/README.md
@@ -1,0 +1,1 @@
+Builds 4.1 puddles frequently for RHCOS on RHEL8


### PR DESCRIPTION
Enables RHCOS to build using 4.1 content built in RHEL8 buildroots