### PR TITLE
Fixups for moving to cri-o/cri-o

### DIFF
--- a/sjb/config/common/test_cases/crio.yml
+++ b/sjb/config/common/test_cases/crio.yml
@@ -144,8 +144,8 @@ post_actions:
 artifacts:
   - /go/src/k8s.io/kubernetes/artifacts
   - /go/src/k8s.io/kubernetes/e2e.log
-  - /go/src/github.com/kubernetes-sigs/cri-o/testout.txt
-  - /go/src/github.com/kubernetes-sigs/cri-o/reports
+  - /go/src/github.com/cri-o/cri-o/testout.txt
+  - /go/src/github.com/cri-o/cri-o/reports
   - /tmp/artifacts/*
   - /tmp/kubelet.log
   - /tmp/kube-apiserver.log

--- a/sjb/config/test_cases/ami_build_origin_int_rhel_crio.yml
+++ b/sjb/config/test_cases/ami_build_origin_int_rhel_crio.yml
@@ -28,9 +28,9 @@ extensions:
         sudo chmod a+rwx /go
         sudo chmod o+rw /etc/environment
         sudo echo "GOPATH=/go" >> /etc/environment
-        mkdir -p /go/src/github.com/kubernetes-sigs
-        cd /go/src/github.com/kubernetes-sigs
-        git clone https://github.com/kubernetes-sigs/cri-o.git
+        mkdir -p /go/src/github.com/cri-o
+        cd /go/src/github.com/cri-o
+        git clone https://github.com/cri-o/cri-o.git
     - type: "script"
       title: "set up cri-o dependencies"
       script: |-
@@ -39,7 +39,7 @@ extensions:
                          --tags setup  \
                          --become-user root \
                          --connection local \
-                         /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                         /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml
     - type: "host_script"
       title: "package the AMI"
       script: |-

--- a/sjb/config/test_cases/test_branch_crio_e2e_features_rhel.yml
+++ b/sjb/config/test_cases/test_branch_crio_e2e_features_rhel.yml
@@ -13,7 +13,7 @@ extensions:
   - type: "script"
     title: "clone cri-o and check out the correct refs"
     script: |-
-      cd /go/src/github.com/kubernetes-sigs/cri-o
+      cd /go/src/github.com/cri-o/cri-o
       git fetch origin
       git checkout "${PULL_BASE_SHA}"
   - type: "script"
@@ -25,4 +25,4 @@ extensions:
                        --tags e2e-features    \
                        --become-user root \
                        --connection local \
-                       /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                       /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml

--- a/sjb/config/test_cases/test_branch_crio_e2e_rhel.yml
+++ b/sjb/config/test_cases/test_branch_crio_e2e_rhel.yml
@@ -13,7 +13,7 @@ extensions:
   - type: "script"
     title: "clone cri-o and check out the correct refs"
     script: |-
-      cd /go/src/github.com/kubernetes-sigs/cri-o
+      cd /go/src/github.com/cri-o/cri-o
       git fetch origin
       git checkout "${PULL_BASE_SHA}"
   - type: "script"
@@ -25,4 +25,4 @@ extensions:
                        --tags e2e    \
                        --become-user root \
                        --connection local \
-                       /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                       /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml

--- a/sjb/config/test_cases/test_pull_request_crio_ami_rhel.yml
+++ b/sjb/config/test_cases/test_pull_request_crio_ami_rhel.yml
@@ -32,9 +32,9 @@ extensions:
         sudo mkdir /go
         sudo chmod a+rwx /go
         sudo echo "GOPATH=/go" >> /etc/environment
-        mkdir -p /go/src/github.com/kubernetes-sigs
-        cd /go/src/github.com/kubernetes-sigs
-        git clone https://github.com/kubernetes-sigs/cri-o.git
+        mkdir -p /go/src/github.com/cri-o
+        cd /go/src/github.com/cri-o
+        git clone https://github.com/cri-o/cri-o.git
         cd cri-o
         git branch target "${PULL_BASE_SHA}"
         git checkout target
@@ -48,7 +48,7 @@ extensions:
                          --tags setup  \
                          --become-user root \
                          --connection local \
-                         /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                         /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml
     - type: "host_script"
       title: "package the AMI"
       script: |-
@@ -62,4 +62,4 @@ extensions:
                          --tags integration,critest,e2e,e2e-features \
                          --become-user root \
                          --connection local \
-                         /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                         /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml

--- a/sjb/config/test_cases/test_pull_request_crio_critest_rhel.yml
+++ b/sjb/config/test_cases/test_pull_request_crio_critest_rhel.yml
@@ -15,7 +15,7 @@ extensions:
   - type: "script"
     title: "clone cri-o and check out the correct refs"
     script: |-
-      cd /go/src/github.com/kubernetes-sigs/cri-o
+      cd /go/src/github.com/cri-o/cri-o
       git fetch origin
       git checkout master
       git branch -D target || true
@@ -32,4 +32,4 @@ extensions:
                        --tags critest    \
                        --become-user root \
                        --connection local \
-                       /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                       /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml

--- a/sjb/config/test_cases/test_pull_request_crio_e2e_features_rhel.yml
+++ b/sjb/config/test_cases/test_pull_request_crio_e2e_features_rhel.yml
@@ -15,7 +15,7 @@ extensions:
   - type: "script"
     title: "clone cri-o and check out the correct refs"
     script: |-
-      cd /go/src/github.com/kubernetes-sigs/cri-o
+      cd /go/src/github.com/cri-o/cri-o
       git fetch origin
       git checkout master
       git branch -D target || true
@@ -33,4 +33,4 @@ extensions:
                        --tags e2e-features    \
                        --become-user root \
                        --connection local \
-                       /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                       /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml

--- a/sjb/config/test_cases/test_pull_request_crio_e2e_rhel.yml
+++ b/sjb/config/test_cases/test_pull_request_crio_e2e_rhel.yml
@@ -15,7 +15,7 @@ extensions:
   - type: "script"
     title: "clone cri-o and check out the correct refs"
     script: |-
-      cd /go/src/github.com/kubernetes-sigs/cri-o
+      cd /go/src/github.com/cri-o/cri-o
       git fetch origin
       git checkout master
       git branch -D target || true
@@ -34,4 +34,4 @@ extensions:
                        --become-user root \
                        ${EXTRA_EVARS:-} \
                        --connection local \
-                       /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                       /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml

--- a/sjb/config/test_cases/test_pull_request_crio_integration_rhel.yml
+++ b/sjb/config/test_cases/test_pull_request_crio_integration_rhel.yml
@@ -15,7 +15,7 @@ extensions:
   - type: "script"
     title: "clone cri-o and check out the correct refs"
     script: |-
-      cd /go/src/github.com/kubernetes-sigs/cri-o
+      cd /go/src/github.com/cri-o/cri-o
       git fetch origin
       git checkout master
       git branch -D target || true
@@ -32,4 +32,4 @@ extensions:
                        --tags integration \
                        --become-user root \
                        --connection local \
-                       /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                       /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml

--- a/sjb/generated/ami_build_origin_int_fedora_crio.xml
+++ b/sjb/generated/ami_build_origin_int_fedora_crio.xml
@@ -227,9 +227,9 @@ sudo mkdir /go
 sudo chmod a+rwx /go
 sudo chmod o+rw /etc/environment
 sudo echo &#34;GOPATH=/go&#34; &gt;&gt; /etc/environment
-mkdir -p /go/src/github.com/kubernetes-sigs
-cd /go/src/github.com/kubernetes-sigs
-git clone https://github.com/kubernetes-sigs/cri-o.git
+mkdir -p /go/src/github.com/cri-o
+cd /go/src/github.com/cri-o
+git clone https://github.com/cri-o/cri-o.git
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -248,7 +248,7 @@ ansible-playbook -vv --become  \
                  --tags setup  \
                  --become-user root \
                  --connection local \
-                 /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                 /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -296,13 +296,13 @@ if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdev
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/k8s.io/kubernetes/e2e.log
     scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/k8s.io/kubernetes/e2e.log &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/testout.txt; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/testout.txt
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/testout.txt; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/testout.txt
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/reports; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/reports
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/reports; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/reports
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
 fi
 if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /tmp/artifacts/*; then
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /tmp/artifacts/*

--- a/sjb/generated/ami_build_origin_int_rhel_crio.xml
+++ b/sjb/generated/ami_build_origin_int_rhel_crio.xml
@@ -227,9 +227,9 @@ sudo mkdir /go
 sudo chmod a+rwx /go
 sudo chmod o+rw /etc/environment
 sudo echo &#34;GOPATH=/go&#34; &gt;&gt; /etc/environment
-mkdir -p /go/src/github.com/kubernetes-sigs
-cd /go/src/github.com/kubernetes-sigs
-git clone https://github.com/kubernetes-sigs/cri-o.git
+mkdir -p /go/src/github.com/cri-o
+cd /go/src/github.com/cri-o
+git clone https://github.com/cri-o/cri-o.git
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -248,7 +248,7 @@ ansible-playbook -vv --become  \
                  --tags setup  \
                  --become-user root \
                  --connection local \
-                 /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                 /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -296,13 +296,13 @@ if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdev
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/k8s.io/kubernetes/e2e.log
     scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/k8s.io/kubernetes/e2e.log &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/testout.txt; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/testout.txt
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/testout.txt; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/testout.txt
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/reports; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/reports
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/reports; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/reports
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
 fi
 if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /tmp/artifacts/*; then
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /tmp/artifacts/*

--- a/sjb/generated/test_branch_crio_e2e_features_fedora.xml
+++ b/sjb/generated/test_branch_crio_e2e_features_fedora.xml
@@ -204,7 +204,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
-cd /go/src/github.com/kubernetes-sigs/cri-o
+cd /go/src/github.com/cri-o/cri-o
 git fetch origin
 git checkout &#34;\${PULL_BASE_SHA}&#34;
 SCRIPT
@@ -225,7 +225,7 @@ ansible-playbook -vv --become  \
                  --tags e2e-features    \
                  --become-user root \
                  --connection local \
-                 /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                 /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -263,13 +263,13 @@ if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdev
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/k8s.io/kubernetes/e2e.log
     scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/k8s.io/kubernetes/e2e.log &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/testout.txt; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/testout.txt
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/testout.txt; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/testout.txt
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/reports; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/reports
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/reports; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/reports
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
 fi
 if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /tmp/artifacts/*; then
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /tmp/artifacts/*

--- a/sjb/generated/test_branch_crio_e2e_features_rhel.xml
+++ b/sjb/generated/test_branch_crio_e2e_features_rhel.xml
@@ -204,7 +204,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
-cd /go/src/github.com/kubernetes-sigs/cri-o
+cd /go/src/github.com/cri-o/cri-o
 git fetch origin
 git checkout &#34;\${PULL_BASE_SHA}&#34;
 SCRIPT
@@ -225,7 +225,7 @@ ansible-playbook -vv --become  \
                  --tags e2e-features    \
                  --become-user root \
                  --connection local \
-                 /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                 /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -263,13 +263,13 @@ if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdev
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/k8s.io/kubernetes/e2e.log
     scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/k8s.io/kubernetes/e2e.log &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/testout.txt; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/testout.txt
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/testout.txt; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/testout.txt
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/reports; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/reports
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/reports; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/reports
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
 fi
 if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /tmp/artifacts/*; then
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /tmp/artifacts/*

--- a/sjb/generated/test_branch_crio_e2e_fedora.xml
+++ b/sjb/generated/test_branch_crio_e2e_fedora.xml
@@ -204,7 +204,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
-cd /go/src/github.com/kubernetes-sigs/cri-o
+cd /go/src/github.com/cri-o/cri-o
 git fetch origin
 git checkout &#34;\${PULL_BASE_SHA}&#34;
 SCRIPT
@@ -225,7 +225,7 @@ ansible-playbook -vv --become  \
                  --tags e2e    \
                  --become-user root \
                  --connection local \
-                 /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                 /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -263,13 +263,13 @@ if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdev
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/k8s.io/kubernetes/e2e.log
     scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/k8s.io/kubernetes/e2e.log &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/testout.txt; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/testout.txt
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/testout.txt; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/testout.txt
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/reports; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/reports
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/reports; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/reports
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
 fi
 if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /tmp/artifacts/*; then
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /tmp/artifacts/*

--- a/sjb/generated/test_branch_crio_e2e_rhel.xml
+++ b/sjb/generated/test_branch_crio_e2e_rhel.xml
@@ -204,7 +204,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
-cd /go/src/github.com/kubernetes-sigs/cri-o
+cd /go/src/github.com/cri-o/cri-o
 git fetch origin
 git checkout &#34;\${PULL_BASE_SHA}&#34;
 SCRIPT
@@ -225,7 +225,7 @@ ansible-playbook -vv --become  \
                  --tags e2e    \
                  --become-user root \
                  --connection local \
-                 /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                 /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -263,13 +263,13 @@ if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdev
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/k8s.io/kubernetes/e2e.log
     scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/k8s.io/kubernetes/e2e.log &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/testout.txt; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/testout.txt
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/testout.txt; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/testout.txt
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/reports; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/reports
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/reports; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/reports
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
 fi
 if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /tmp/artifacts/*; then
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /tmp/artifacts/*

--- a/sjb/generated/test_branch_ovn_kubernetes_unit.xml
+++ b/sjb/generated/test_branch_ovn_kubernetes_unit.xml
@@ -266,13 +266,13 @@ if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdev
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/k8s.io/kubernetes/e2e.log
     scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/k8s.io/kubernetes/e2e.log &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/testout.txt; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/testout.txt
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/testout.txt; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/testout.txt
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/reports; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/reports
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/reports; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/reports
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
 fi
 if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /tmp/artifacts/*; then
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /tmp/artifacts/*

--- a/sjb/generated/test_pull_request_crio_ami_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_ami_fedora.xml
@@ -235,9 +235,9 @@ cd &#34;\${HOME}&#34;
 sudo mkdir /go
 sudo chmod a+rwx /go
 sudo echo &#34;GOPATH=/go&#34; &gt;&gt; /etc/environment
-mkdir -p /go/src/github.com/kubernetes-sigs
-cd /go/src/github.com/kubernetes-sigs
-git clone https://github.com/kubernetes-sigs/cri-o.git
+mkdir -p /go/src/github.com/cri-o
+cd /go/src/github.com/cri-o
+git clone https://github.com/cri-o/cri-o.git
 cd cri-o
 git branch target &#34;\${PULL_BASE_SHA}&#34;
 git checkout target
@@ -261,7 +261,7 @@ ansible-playbook -vv --become  \
                  --tags setup  \
                  --become-user root \
                  --connection local \
-                 /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                 /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -285,7 +285,7 @@ ansible-playbook -vv --become  \
                  --tags integration,critest,e2e,e2e-features \
                  --become-user root \
                  --connection local \
-                 /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                 /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -323,13 +323,13 @@ if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdev
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/k8s.io/kubernetes/e2e.log
     scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/k8s.io/kubernetes/e2e.log &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/testout.txt; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/testout.txt
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/testout.txt; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/testout.txt
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/reports; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/reports
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/reports; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/reports
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
 fi
 if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /tmp/artifacts/*; then
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /tmp/artifacts/*

--- a/sjb/generated/test_pull_request_crio_ami_rhel.xml
+++ b/sjb/generated/test_pull_request_crio_ami_rhel.xml
@@ -235,9 +235,9 @@ cd &#34;\${HOME}&#34;
 sudo mkdir /go
 sudo chmod a+rwx /go
 sudo echo &#34;GOPATH=/go&#34; &gt;&gt; /etc/environment
-mkdir -p /go/src/github.com/kubernetes-sigs
-cd /go/src/github.com/kubernetes-sigs
-git clone https://github.com/kubernetes-sigs/cri-o.git
+mkdir -p /go/src/github.com/cri-o
+cd /go/src/github.com/cri-o
+git clone https://github.com/cri-o/cri-o.git
 cd cri-o
 git branch target &#34;\${PULL_BASE_SHA}&#34;
 git checkout target
@@ -261,7 +261,7 @@ ansible-playbook -vv --become  \
                  --tags setup  \
                  --become-user root \
                  --connection local \
-                 /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                 /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -285,7 +285,7 @@ ansible-playbook -vv --become  \
                  --tags integration,critest,e2e,e2e-features \
                  --become-user root \
                  --connection local \
-                 /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                 /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -323,13 +323,13 @@ if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdev
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/k8s.io/kubernetes/e2e.log
     scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/k8s.io/kubernetes/e2e.log &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/testout.txt; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/testout.txt
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/testout.txt; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/testout.txt
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/reports; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/reports
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/reports; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/reports
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
 fi
 if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /tmp/artifacts/*; then
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /tmp/artifacts/*

--- a/sjb/generated/test_pull_request_crio_critest_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_critest_fedora.xml
@@ -206,7 +206,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
-cd /go/src/github.com/kubernetes-sigs/cri-o
+cd /go/src/github.com/cri-o/cri-o
 git fetch origin
 git checkout master
 git branch -D target || true
@@ -233,7 +233,7 @@ ansible-playbook -vv --become  \
                  --tags critest    \
                  --become-user root \
                  --connection local \
-                 /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                 /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -271,13 +271,13 @@ if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdev
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/k8s.io/kubernetes/e2e.log
     scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/k8s.io/kubernetes/e2e.log &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/testout.txt; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/testout.txt
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/testout.txt; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/testout.txt
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/reports; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/reports
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/reports; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/reports
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
 fi
 if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /tmp/artifacts/*; then
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /tmp/artifacts/*

--- a/sjb/generated/test_pull_request_crio_critest_rhel.xml
+++ b/sjb/generated/test_pull_request_crio_critest_rhel.xml
@@ -206,7 +206,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
-cd /go/src/github.com/kubernetes-sigs/cri-o
+cd /go/src/github.com/cri-o/cri-o
 git fetch origin
 git checkout master
 git branch -D target || true
@@ -233,7 +233,7 @@ ansible-playbook -vv --become  \
                  --tags critest    \
                  --become-user root \
                  --connection local \
-                 /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                 /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -271,13 +271,13 @@ if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdev
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/k8s.io/kubernetes/e2e.log
     scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/k8s.io/kubernetes/e2e.log &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/testout.txt; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/testout.txt
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/testout.txt; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/testout.txt
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/reports; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/reports
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/reports; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/reports
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
 fi
 if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /tmp/artifacts/*; then
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /tmp/artifacts/*

--- a/sjb/generated/test_pull_request_crio_e2e_features_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_e2e_features_fedora.xml
@@ -206,7 +206,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
-cd /go/src/github.com/kubernetes-sigs/cri-o
+cd /go/src/github.com/cri-o/cri-o
 git fetch origin
 git checkout master
 git branch -D target || true
@@ -233,7 +233,7 @@ ansible-playbook -vv --become  \
                  --tags e2e-features    \
                  --become-user root \
                  --connection local \
-                 /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                 /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -271,13 +271,13 @@ if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdev
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/k8s.io/kubernetes/e2e.log
     scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/k8s.io/kubernetes/e2e.log &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/testout.txt; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/testout.txt
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/testout.txt; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/testout.txt
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/reports; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/reports
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/reports; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/reports
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
 fi
 if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /tmp/artifacts/*; then
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /tmp/artifacts/*

--- a/sjb/generated/test_pull_request_crio_e2e_features_rhel.xml
+++ b/sjb/generated/test_pull_request_crio_e2e_features_rhel.xml
@@ -206,7 +206,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
-cd /go/src/github.com/kubernetes-sigs/cri-o
+cd /go/src/github.com/cri-o/cri-o
 git fetch origin
 git checkout master
 git branch -D target || true
@@ -233,7 +233,7 @@ ansible-playbook -vv --become  \
                  --tags e2e-features    \
                  --become-user root \
                  --connection local \
-                 /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                 /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -271,13 +271,13 @@ if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdev
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/k8s.io/kubernetes/e2e.log
     scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/k8s.io/kubernetes/e2e.log &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/testout.txt; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/testout.txt
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/testout.txt; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/testout.txt
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/reports; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/reports
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/reports; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/reports
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
 fi
 if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /tmp/artifacts/*; then
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /tmp/artifacts/*

--- a/sjb/generated/test_pull_request_crio_e2e_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_e2e_fedora.xml
@@ -206,7 +206,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
-cd /go/src/github.com/kubernetes-sigs/cri-o
+cd /go/src/github.com/cri-o/cri-o
 git fetch origin
 git checkout master
 git branch -D target || true
@@ -234,7 +234,7 @@ ansible-playbook -vv --become  \
                  --become-user root \
                  \${EXTRA_EVARS:-} \
                  --connection local \
-                 /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                 /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -272,13 +272,13 @@ if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdev
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/k8s.io/kubernetes/e2e.log
     scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/k8s.io/kubernetes/e2e.log &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/testout.txt; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/testout.txt
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/testout.txt; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/testout.txt
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/reports; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/reports
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/reports; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/reports
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
 fi
 if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /tmp/artifacts/*; then
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /tmp/artifacts/*

--- a/sjb/generated/test_pull_request_crio_e2e_rhel.xml
+++ b/sjb/generated/test_pull_request_crio_e2e_rhel.xml
@@ -206,7 +206,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
-cd /go/src/github.com/kubernetes-sigs/cri-o
+cd /go/src/github.com/cri-o/cri-o
 git fetch origin
 git checkout master
 git branch -D target || true
@@ -234,7 +234,7 @@ ansible-playbook -vv --become  \
                  --become-user root \
                  \${EXTRA_EVARS:-} \
                  --connection local \
-                 /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                 /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -272,13 +272,13 @@ if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdev
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/k8s.io/kubernetes/e2e.log
     scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/k8s.io/kubernetes/e2e.log &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/testout.txt; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/testout.txt
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/testout.txt; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/testout.txt
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/reports; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/reports
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/reports; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/reports
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
 fi
 if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /tmp/artifacts/*; then
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /tmp/artifacts/*

--- a/sjb/generated/test_pull_request_crio_integration_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_integration_fedora.xml
@@ -206,7 +206,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
-cd /go/src/github.com/kubernetes-sigs/cri-o
+cd /go/src/github.com/cri-o/cri-o
 git fetch origin
 git checkout master
 git branch -D target || true
@@ -233,7 +233,7 @@ ansible-playbook -vv --become  \
                  --tags integration \
                  --become-user root \
                  --connection local \
-                 /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                 /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -271,13 +271,13 @@ if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdev
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/k8s.io/kubernetes/e2e.log
     scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/k8s.io/kubernetes/e2e.log &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/testout.txt; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/testout.txt
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/testout.txt; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/testout.txt
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/reports; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/reports
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/reports; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/reports
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
 fi
 if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /tmp/artifacts/*; then
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /tmp/artifacts/*

--- a/sjb/generated/test_pull_request_crio_integration_rhel.xml
+++ b/sjb/generated/test_pull_request_crio_integration_rhel.xml
@@ -206,7 +206,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
-cd /go/src/github.com/kubernetes-sigs/cri-o
+cd /go/src/github.com/cri-o/cri-o
 git fetch origin
 git checkout master
 git branch -D target || true
@@ -233,7 +233,7 @@ ansible-playbook -vv --become  \
                  --tags integration \
                  --become-user root \
                  --connection local \
-                 /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                 /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -271,13 +271,13 @@ if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdev
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/k8s.io/kubernetes/e2e.log
     scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/k8s.io/kubernetes/e2e.log &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/testout.txt; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/testout.txt
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/testout.txt; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/testout.txt
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/reports; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/reports
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/reports; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/reports
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
 fi
 if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /tmp/artifacts/*; then
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /tmp/artifacts/*

--- a/sjb/generated/test_pull_request_crio_managed_net_ns_e2e_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_managed_net_ns_e2e_fedora.xml
@@ -221,7 +221,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
-cd /go/src/github.com/kubernetes-sigs/cri-o
+cd /go/src/github.com/cri-o/cri-o
 git fetch origin
 git checkout master
 git branch -D target || true
@@ -249,7 +249,7 @@ ansible-playbook -vv --become  \
                  --become-user root \
                  \${EXTRA_EVARS:-} \
                  --connection local \
-                 /go/src/github.com/kubernetes-sigs/cri-o/contrib/test/integration/main.yml
+                 /go/src/github.com/cri-o/cri-o/contrib/test/integration/main.yml
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -287,13 +287,13 @@ if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdev
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/k8s.io/kubernetes/e2e.log
     scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/k8s.io/kubernetes/e2e.log &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/testout.txt; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/testout.txt
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/testout.txt; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/testout.txt
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/testout.txt &#34;${ARTIFACT_DIR}&#34;
 fi
-if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/kubernetes-sigs/cri-o/reports; then
-    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/kubernetes-sigs/cri-o/reports
-    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/kubernetes-sigs/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
+if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /go/src/github.com/cri-o/cri-o/reports; then
+    ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /go/src/github.com/cri-o/cri-o/reports
+    scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel:/go/src/github.com/cri-o/cri-o/reports &#34;${ARTIFACT_DIR}&#34;
 fi
 if ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo stat /tmp/artifacts/*; then
     ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod -R o+rX /tmp/artifacts/*


### PR DESCRIPTION
CRI-O has moved homes, and now lives at github.com/cri-o/cri-o. 
Fixup this repo to reflect this change

Signed-off-by: Peter Hunt <pehunt@redhat.com>