### PR TITLE
work around push.enterprise.sh not setting rc

### DIFF
--- a/build-scripts/use-mirror/push.enterprise.sh
+++ b/build-scripts/use-mirror/push.enterprise.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+set -o xtrace
+
+location="${1:-}"
+log=$(mktemp)  # push.enterprise.sh does not indicate errors with rc so check output
+
+timeout 2h /usr/local/bin/push.enterprise.sh reposync -v $location |& tee -a \$log
+
+grep -q '\[FAILURE\]' $log && rc=1 || rc=0
+rm -f $log
+exit $rc

--- a/jobs/build/reposync/Jenkinsfile
+++ b/jobs/build/reposync/Jenkinsfile
@@ -114,7 +114,7 @@ node {
                     sh "rsync -avzh --chmod=a+rwx,g-w,o-w --delete -e \"ssh -o StrictHostKeyChecking=no\" ${LOCAL_SYNC_DIR}/ ${MIRROR_TARGET}:${MIRROR_SYNC_DIR} "
 
                     timeout(time: 2, unit: 'HOURS') {
-                        sh "ssh -o StrictHostKeyChecking=no ${MIRROR_TARGET} -- push.enterprise.sh -v ${MIRROR_RELATIVE_REPOSYNC}"
+                        buildlib.invoke_on_use_mirror("push.enterprise.sh", MIRROR_RELATIVE_REPOSYNC)
                     }
                 }
             }


### PR DESCRIPTION
push.enterprise.sh script that we do not control does not give an error rc when it actually fails. In order to detect failure, check the output.

reposync was doing this already, but this generalizes it to other uses ART depends on.