### PR TITLE
build/ocp: fix python-style comments in groovy

### DIFF
--- a/jobs/build/ocp/Jenkinsfile
+++ b/jobs/build/ocp/Jenkinsfile
@@ -811,8 +811,8 @@ node {
                     echo "openshift-ansible rpm brew task: ${OA_BREW_URL}"
                 }
 
-                # [lmeyer 2019-04-01] (not a joke) this would be nice in parallel except that
-                # commonlib.shell turns out not to be safe for concurrency. Keep it serial for now.
+                // [lmeyer Apr 2019] this would be nice in parallel except that
+                // commonlib.shell turns out not to be safe for concurrency. Keep it serial for now.
                 buildlib.watch_brew_task_and_retry("atomic-openshift RPM", oseTaskId, OSE_BREW_URL)
                 buildlib.watch_brew_task_and_retry("openshift-ansible RPM", oaTaskId, OA_BREW_URL)
             }


### PR DESCRIPTION
April Fools! I broke 3.x builds for a week!