### PR TITLE
minor build tweaks

### DIFF
--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -51,7 +51,7 @@ node {
                     ],
                     [
                         name: 'RPM_LIST',
-                        description: '(Optional) Comma/space-separated list to include/exclude per BUILD_RPMS (e.g. openshift,openshift-kuryr.yml)',
+                        description: '(Optional) Comma/space-separated list to include/exclude per BUILD_RPMS (e.g. openshift,openshift-kuryr)',
                         $class: 'hudson.model.StringParameterDefinition',
                         defaultValue: ""
                     ],
@@ -117,7 +117,7 @@ node {
         }
         stage("report success") { build.stageReportSuccess() }
     } catch (err) {
-        currentBuild.description += "${err}"
+        currentBuild.description += "\n-----------------\n\n${err}"
         currentBuild.result = "FAILURE"
 
         if (params.MAIL_LIST_FAILURE.trim()) {

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -899,15 +899,15 @@ def notify_dockerfile_reconciliations(doozerWorking, buildVersion) {
     for (i = 0; i < distgit_notify.size(); i++) {
         distgit = distgit_notify[i][0]
         val = distgit_notify[i][1]
+        if (!val.owners) { continue }
 
         alias = val.source_alias
         url = dockerfile_url_for(alias.origin_url, alias.branch, val.source_dockerfile_subpath)
         dockerfile_url = url ? "Upstream source file: ${url}" : ""
 
-        // always mail team; val.owners will be comma delimited or empty
         commonlib.email(
-            to: "aos-team-art@redhat.com,${val.owners}",
-            from: "aos-cicd@redhat.com",
+            to: val.owners,
+            from: "aos-team-art@redhat.com",
             subject: "${val.image} Dockerfile reconciliation for OCP v${buildVersion}",
             body: """
 Why am I receiving this?
@@ -988,7 +988,7 @@ The following logs are just the container build portion of the OSBS build:
             }
             commonlib.email(
                 from: returnAddress,
-                to: failure.owners ?: defaultOwner,
+                to: "${returnAddress},${failure.owners ?: defaultOwner}",
                 subject: "Failed OCP build of ${failure.image}:${failure.version}",
                 body: """
 ART's brew/OSBS build of OCP image ${failure.image}:${failure.version} has failed.


### PR DESCRIPTION
build/ocp4: improve build descriptions
If there's just one RPM/image, show it by name.
Add a divider line between the build plan and the results.

buildlib: adjust notifications
Don't spam ART with reconciliation notifs.
Do include ART on build failures so we are more likely to notice them.
