### PR TITLE
Build MAO and CAO images locally instead of pulling them from the payload

### DIFF
--- a/sjb/config/test_cases/pull-ci-openshift-cluster-api-actuator-pkg-master-e2e.yml
+++ b/sjb/config/test_cases/pull-ci-openshift-cluster-api-actuator-pkg-master-e2e.yml
@@ -53,13 +53,10 @@ extensions:
       title: "Deploy machine API operator"
       script: |-
         export GOPATH=/data
-        cd $GOPATH/src/github.com/openshift/machine-api-operator/
-
-        MAO_IMAGE=$(docker run registry.svc.ci.openshift.org/openshift/origin-release:v4.0 image machine-api-operator)
-        docker pull $MAO_IMAGE
-        docker tag $MAO_IMAGE docker.io/openshift/origin-machine-api-operator:v4.0.0
-
-        # deploy expected cluster and machineset objects
+        cd $GOPATH/src/github.com/openshift/machine-api-operator
+        go get -u github.com/openshift/imagebuilder/cmd/imagebuilder
+        sudo mv /data/bin/imagebuilder /usr/bin
+        sudo imagebuilder -t "docker.io/openshift/origin-machine-api-operator:v4.0.0" .
         sudo make deploy-kubemark
     - type: "script"
       title: "Deploy cluster autoscaler operator"
@@ -67,10 +64,7 @@ extensions:
         export GOPATH=/data
         cd $GOPATH/src/github.com/openshift/cluster-autoscaler-operator/
 
-        CAO_IMAGE=$(docker run registry.svc.ci.openshift.org/openshift/origin-release:v4.0 image cluster-autoscaler-operator)
-        docker pull $CAO_IMAGE
-        docker tag $CAO_IMAGE docker.io/openshift/origin-cluster-autoscaler-operator:v4.0
-
+        sudo imagebuilder -t "quay.io/openshift/origin-cluster-autoscaler-operator:v4.0" .
         kustomize build | sudo kubectl apply -f -
     - type: "script"
       title: "Deploy cluster resources"

--- a/sjb/config/test_cases/pull-ci-openshift-cluster-api-provider-kubemark-master-e2e.yml
+++ b/sjb/config/test_cases/pull-ci-openshift-cluster-api-provider-kubemark-master-e2e.yml
@@ -53,20 +53,19 @@ extensions:
       title: "Deploy machine API operator"
       script: |-
         export GOPATH=/data
-        cd $GOPATH/src/github.com/openshift/machine-api-operator/
-
-        MAO_IMAGE=$(docker run registry.svc.ci.openshift.org/openshift/origin-release:v4.0 image machine-api-operator)
-        docker pull $MAO_IMAGE
-        docker tag $MAO_IMAGE docker.io/openshift/origin-machine-api-operator:v4.0.0
-
-        # deploy expected cluster and machineset objects
+        cd $GOPATH/src/github.com/openshift/machine-api-operator
+        make build
+        go get -u github.com/openshift/imagebuilder/cmd/imagebuilder
+        sudo mv /data/bin/imagebuilder /usr/bin
+        sudo imagebuilder -t "docker.io/openshift/origin-machine-api-operator:v4.0.0" .
         sudo make deploy-kubemark
     - type: "script"
       title: "Deploy cluster autoscaler operator"
       script: |-
         export GOPATH=/data
         cd $GOPATH/src/github.com/openshift/cluster-autoscaler-operator/
-        sed -i  "s/image: docker\.io\/openshift\/origin-cluster-autoscaler-operator:v4\.0/image: quay\.io\/openshift\/origin-cluster-autoscaler-operator:v4\.0/" install/04_deployment.yaml
+
+        sudo imagebuilder -t "quay.io/openshift/origin-cluster-autoscaler-operator:v4.0" .
         kustomize build | sudo kubectl apply -f -
     - type: "script"
       title: "Deploy cluster resources"

--- a/sjb/config/test_cases/pull-ci-openshift-cluster-autoscaler-operator-master-e2e.yml
+++ b/sjb/config/test_cases/pull-ci-openshift-cluster-autoscaler-operator-master-e2e.yml
@@ -45,21 +45,16 @@ extensions:
       title: "Deploy machine API operator"
       script: |-
         export GOPATH=/data
-        cd $GOPATH/src/github.com/openshift/machine-api-operator/
-
-        MAO_IMAGE=$(docker run registry.svc.ci.openshift.org/openshift/origin-release:v4.0 image machine-api-operator)
-        docker pull $MAO_IMAGE
-        docker tag $MAO_IMAGE docker.io/openshift/origin-machine-api-operator:v4.0.0
-
-        # deploy expected cluster and machineset objects
+        cd $GOPATH/src/github.com/openshift/machine-api-operator
+        go get -u github.com/openshift/imagebuilder/cmd/imagebuilder
+        sudo mv /data/bin/imagebuilder /usr/bin
+        sudo imagebuilder -t "docker.io/openshift/origin-machine-api-operator:v4.0.0" .
         sudo make deploy-kubemark
     - type: "script"
       title: "Deploy cluster autoscaler operator"
       script: |-
         export GOPATH=/data
         cd $GOPATH/src/github.com/openshift/cluster-autoscaler-operator/
-        go get -u github.com/openshift/imagebuilder/cmd/imagebuilder
-        sudo mv /data/bin/imagebuilder /usr/bin
         sudo imagebuilder -t "quay.io/openshift/origin-cluster-autoscaler-operator:v4.0" .
         kustomize build | sudo kubectl apply -f -
     - type: "script"

--- a/sjb/config/test_cases/pull-ci-openshift-machine-api-operator-master-e2e.yml
+++ b/sjb/config/test_cases/pull-ci-openshift-machine-api-operator-master-e2e.yml
@@ -57,10 +57,7 @@ extensions:
         export GOPATH=/data
         cd $GOPATH/src/github.com/openshift/cluster-autoscaler-operator/
 
-        CAO_IMAGE=$(docker run registry.svc.ci.openshift.org/openshift/origin-release:v4.0 image cluster-autoscaler-operator)
-        docker pull $CAO_IMAGE
-        docker tag $CAO_IMAGE quay.io/openshift/origin-cluster-autoscaler-operator:v4.0
-
+        sudo imagebuilder -t "quay.io/openshift/origin-cluster-autoscaler-operator:v4.0" .
         kustomize build | sudo kubectl apply -f -
     - type: "script"
       title: "Deploy cluster resources"

--- a/sjb/generated/pull-ci-openshift-cluster-api-actuator-pkg-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-cluster-api-actuator-pkg-master-e2e.xml
@@ -266,13 +266,10 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 export GOPATH=/data
-cd \$GOPATH/src/github.com/openshift/machine-api-operator/
-
-MAO_IMAGE=\$(docker run registry.svc.ci.openshift.org/openshift/origin-release:v4.0 image machine-api-operator)
-docker pull \$MAO_IMAGE
-docker tag \$MAO_IMAGE docker.io/openshift/origin-machine-api-operator:v4.0.0
-
-# deploy expected cluster and machineset objects
+cd \$GOPATH/src/github.com/openshift/machine-api-operator
+go get -u github.com/openshift/imagebuilder/cmd/imagebuilder
+sudo mv /data/bin/imagebuilder /usr/bin
+sudo imagebuilder -t &#34;docker.io/openshift/origin-machine-api-operator:v4.0.0&#34; .
 sudo make deploy-kubemark
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -290,10 +287,7 @@ cd &#34;\${HOME}&#34;
 export GOPATH=/data
 cd \$GOPATH/src/github.com/openshift/cluster-autoscaler-operator/
 
-CAO_IMAGE=\$(docker run registry.svc.ci.openshift.org/openshift/origin-release:v4.0 image cluster-autoscaler-operator)
-docker pull \$CAO_IMAGE
-docker tag \$CAO_IMAGE docker.io/openshift/origin-cluster-autoscaler-operator:v4.0
-
+sudo imagebuilder -t &#34;quay.io/openshift/origin-cluster-autoscaler-operator:v4.0&#34; .
 kustomize build | sudo kubectl apply -f -
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/pull-ci-openshift-cluster-api-provider-kubemark-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-cluster-api-provider-kubemark-master-e2e.xml
@@ -276,13 +276,11 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 export GOPATH=/data
-cd \$GOPATH/src/github.com/openshift/machine-api-operator/
-
-MAO_IMAGE=\$(docker run registry.svc.ci.openshift.org/openshift/origin-release:v4.0 image machine-api-operator)
-docker pull \$MAO_IMAGE
-docker tag \$MAO_IMAGE docker.io/openshift/origin-machine-api-operator:v4.0.0
-
-# deploy expected cluster and machineset objects
+cd \$GOPATH/src/github.com/openshift/machine-api-operator
+make build
+go get -u github.com/openshift/imagebuilder/cmd/imagebuilder
+sudo mv /data/bin/imagebuilder /usr/bin
+sudo imagebuilder -t &#34;docker.io/openshift/origin-machine-api-operator:v4.0.0&#34; .
 sudo make deploy-kubemark
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -299,7 +297,8 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 export GOPATH=/data
 cd \$GOPATH/src/github.com/openshift/cluster-autoscaler-operator/
-sed -i  &#34;s/image: docker\.io\/openshift\/origin-cluster-autoscaler-operator:v4\.0/image: quay\.io\/openshift\/origin-cluster-autoscaler-operator:v4\.0/&#34; install/04_deployment.yaml
+
+sudo imagebuilder -t &#34;quay.io/openshift/origin-cluster-autoscaler-operator:v4.0&#34; .
 kustomize build | sudo kubectl apply -f -
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/pull-ci-openshift-cluster-autoscaler-operator-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-cluster-autoscaler-operator-master-e2e.xml
@@ -258,13 +258,10 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 export GOPATH=/data
-cd \$GOPATH/src/github.com/openshift/machine-api-operator/
-
-MAO_IMAGE=\$(docker run registry.svc.ci.openshift.org/openshift/origin-release:v4.0 image machine-api-operator)
-docker pull \$MAO_IMAGE
-docker tag \$MAO_IMAGE docker.io/openshift/origin-machine-api-operator:v4.0.0
-
-# deploy expected cluster and machineset objects
+cd \$GOPATH/src/github.com/openshift/machine-api-operator
+go get -u github.com/openshift/imagebuilder/cmd/imagebuilder
+sudo mv /data/bin/imagebuilder /usr/bin
+sudo imagebuilder -t &#34;docker.io/openshift/origin-machine-api-operator:v4.0.0&#34; .
 sudo make deploy-kubemark
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -281,8 +278,6 @@ set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 export GOPATH=/data
 cd \$GOPATH/src/github.com/openshift/cluster-autoscaler-operator/
-go get -u github.com/openshift/imagebuilder/cmd/imagebuilder
-sudo mv /data/bin/imagebuilder /usr/bin
 sudo imagebuilder -t &#34;quay.io/openshift/origin-cluster-autoscaler-operator:v4.0&#34; .
 kustomize build | sudo kubectl apply -f -
 SCRIPT

--- a/sjb/generated/pull-ci-openshift-machine-api-operator-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-machine-api-operator-master-e2e.xml
@@ -280,10 +280,7 @@ cd &#34;\${HOME}&#34;
 export GOPATH=/data
 cd \$GOPATH/src/github.com/openshift/cluster-autoscaler-operator/
 
-CAO_IMAGE=\$(docker run registry.svc.ci.openshift.org/openshift/origin-release:v4.0 image cluster-autoscaler-operator)
-docker pull \$CAO_IMAGE
-docker tag \$CAO_IMAGE quay.io/openshift/origin-cluster-autoscaler-operator:v4.0
-
+sudo imagebuilder -t &#34;quay.io/openshift/origin-cluster-autoscaler-operator:v4.0&#34; .
 kustomize build | sudo kubectl apply -f -
 SCRIPT
 chmod +x &#34;${script}&#34;


### PR DESCRIPTION
Openshift release payload is not always up-to-date with the latest docker images.
Thus, building all required images locally so we have always the latest ones.