### PR TITLE
Adding new ocp sync job

### DIFF
--- a/jobs/build/oc_sync/Jenkinsfile
+++ b/jobs/build/oc_sync/Jenkinsfile
@@ -1,0 +1,57 @@
+#!/usr/bin/env groovy
+
+node {
+    checkout scm
+    def buildlib = load("pipeline-scripts/buildlib.groovy")
+    def commonlib = buildlib.commonlib
+
+    // Expose properties for a parameterized build
+    properties(
+        [
+            buildDiscarder(
+                logRotator(
+                    artifactDaysToKeepStr: '',
+                    artifactNumToKeepStr: '',
+                    daysToKeepStr: '',
+                    numToKeepStr: '8')),
+            [
+                $class: 'ParametersDefinitionProperty',
+                parameterDefinitions: [
+                    [
+                        name: 'STREAM',
+                        description: 'Build stream to sync client from',
+                        $class: 'hudson.model.StringParameterDefinition',
+                        defaultValue: "4.1.0-0.ci"
+                    ],
+                    [
+                        name: 'MAIL_LIST_FAILURE',
+                        description: 'Failure Mailing List',
+                        $class: 'hudson.model.StringParameterDefinition',
+                        defaultValue: [
+                            'aos-team-art@redhat.com'
+                        ].join(',')
+                    ],
+                    commonlib.mockParam(),
+                ]
+            ],
+            disableConcurrentBuilds()
+        ]
+    )
+
+    try {
+        sshagent(['aos-cd-test']) {
+            stage("sync ocp clients") {
+                sh "./publish-clients-from-payload.sh ${env.WORKSPACE} ${STREAM}"
+            }
+        }
+    } catch (err) {
+        commonlib.email(
+            to: "${params.MAIL_LIST_FAILURE}",
+            from: "aos-cicd@redhat.com",
+            subject: "Error syncing ocp client from payload",
+            body: "Encountered an error while syncing ocp client from payload: ${err}");
+        currentBuild.description = "Error while syncing ocp client from payload:\n${err}"
+        currentBuild.result = "FAILURE"
+        throw err
+    }
+}

--- a/jobs/build/oc_sync/publish-clients-from-payload.sh
+++ b/jobs/build/oc_sync/publish-clients-from-payload.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -eux
+
+WORKSPACE=$1
+STREAM=$2
+
+SSH_OPTS="-l jenkins_aos_cd_bot -o StrictHostKeychecking=no use-mirror-upload.ops.rhcloud.com"
+
+# get latest release from GitHub API
+wget https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/${STREAM}/latest
+#extract pull_spec
+PULL_SPEC=`jq -r '.pullSpec' latest`
+#extract name
+VERSION=`jq -r '.name' latest`
+
+#check if already exists
+if ssh ${SSH_OPTS} "[ -d /srv/pub/openshift-v4/clients/ocp/${VERSION} ]";
+then
+    echo "Already have latest version"
+    exit 0
+else
+    echo "Fetching OCP clients from payload ${VERSION}"
+fi
+
+
+TMPDIR=${WORKSPACE}/tools/
+mkdir -p "${TMPDIR}"
+cd ${TMPDIR}
+
+OUTDIR=${TMPDIR}/${VERSION}
+mkdir -p ${OUTDIR}
+pushd ${OUTDIR}
+
+#extract all release assests
+oc adm release extract --tools --command-os=* ${PULL_SPEC} --to=${OUTDIR}
+popd
+
+# create latest symlink
+ln -sf ${VERSION} latest
+
+#sync to use-mirror-upload
+rsync \
+    -av --delete-after --progress --no-g --omit-dir-times --chmod=Dug=rwX \
+    -e "ssh -l jenkins_aos_cd_bot -o StrictHostKeyChecking=no" \
+    "${OUTDIR}" latest \
+    use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/clients/ocp/
+
+# kick off full mirror push
+ssh ${SSH_OPTS} timeout 15m /usr/local/bin/push.pub.sh openshift-v4 -v || timeout 5m /usr/local/bin/push.pub.sh openshift-v4 -v || timeout 5m /usr/local/bin/push.pub.sh openshift-v4 -v


### PR DESCRIPTION
@tbielawa @vikaslaad @sosiouxme 
Results of sync can be seen here -> https://mirror.openshift.com/pub/openshift-v4/clients/ocp/
Put in separate folder for now, especially because not just the oc client, now includes installer. `ocp` seemed like a valid name. 