### PR TITLE
DRY, elliottest=>elliott

### DIFF
--- a/jobs/build/sweep/Jenkinsfile
+++ b/jobs/build/sweep/Jenkinsfile
@@ -29,7 +29,7 @@ node {
 	echo "Initializing bug sweep for ${params.BUILD_VERSION}. Sync: #${currentBuild.number}"
 	currentBuild.displayName = "${params.BUILD_VERSION} bug sweep"
 
-        buildlib.elliotttest "--version"
+        buildlib.elliott "--version"
         sh "which elliott"
 
 	buildlib.kinit()
@@ -38,7 +38,7 @@ node {
     try {
 	stage("Sweep bugs") {
 	    currentBuild.description = "Searching for and attaching bugs"
-	    buildlib.elliotttest "--group=openshift-${params.BUILD_VERSION} find-bugs --auto --use-default-advisory rpm"
+	    buildlib.elliott "--group=openshift-${params.BUILD_VERSION} find-bugs --auto --use-default-advisory rpm"
 	    currentBuild.description = "Ran bug attaching command without errors"
 	}
     } catch (findBugsError) {

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -86,36 +86,30 @@ def initialize_openshift_dir() {
     echo "Initialized env.OPENSHIFT_DIR: ${env.OPENSHIFT_DIR}"
 }
 
+def cleanWhitespace(cmd) {
+    return (cmd
+        .replaceAll( '\\\n', ' ' ) // If caller included line continuation characters, remove them
+        .replaceAll( '\n', ' ' ) // Allow newlines in command for readability, but don't let them flow into the sh
+        .trim()
+    )
+}
+
 def doozer(cmd, opts=[:]){
-    cmd = cmd.replaceAll( '\n', ' ' ) // Allow newlines in command for readability, but don't let them flow into the sh
-    cmd = cmd.replaceAll( ' \\ ', ' ' ) // If caller included line continuation characters, remove them
     return commonlib.shell(
         returnStdout: opts.capture ?: false,
-        script: "doozer ${cmd.trim()}")
+        script: "doozer ${cleanWhitespace(cmd)}")
 }
 
 def elliott(cmd, opts=[:]){
-    cmd = cmd.replaceAll( '\n', ' ' ) // Allow newlines in command for readability, but don't let them flow into the sh
-    cmd = cmd.replaceAll( ' \\ ', ' ' ) // If caller included line continuation characters, remove them
     return commonlib.shell(
         returnStdout: opts.capture ?: false,
-        script: "${env.ENTERPRISE_IMAGES_DIR}/tools/bin/elliott --user=ocp-build ${cmd.trim()}")
-}
-
-def elliotttest(cmd, opts=[:]){
-    cmd = cmd.replaceAll( '\n', ' ' ) // Allow newlines in command for readability, but don't let them flow into the sh
-    cmd = cmd.replaceAll( ' \\ ', ' ' ) // If caller included line continuation characters, remove them
-    return commonlib.shell(
-        returnStdout: opts.capture ?: false,
-        script: "elliott ${cmd.trim()}")
+        script: "elliott ${cleanWhitespace(cmd)}")
 }
 
 def oc(cmd, opts=[:]){
-    cmd = cmd.replaceAll( '\n', ' ' ) // Allow newlines in command for readability, but don't let them flow into the sh
-    cmd = cmd.replaceAll( ' \\ ', ' ' ) // If caller included line continuation characters, remove them
     return commonlib.shell(
         returnStdout: opts.capture ?: false,
-        script: "/usr/bin/oc ${cmd.trim()}"
+        script: "/usr/bin/oc ${cleanWhitespace(cmd)}"
     )
 }
 


### PR DESCRIPTION
DRY some repeat whitespace handling.
Looks like the path-less and user-less elliott works fine, let's make
that the norm.
