### PR TITLE
Sync oc from `.nightly` instead of `.ci` stream

### DIFF
--- a/jobs/build/oc_sync/Jenkinsfile
+++ b/jobs/build/oc_sync/Jenkinsfile
@@ -21,7 +21,7 @@ node {
                         name: 'STREAM',
                         description: 'Build stream to sync client from',
                         $class: 'hudson.model.StringParameterDefinition',
-                        defaultValue: "4.1.0-0.ci"
+                        defaultValue: "4.1.0-0.nightly"
                     ],
                     [
                         name: 'MAIL_LIST_FAILURE',


### PR DESCRIPTION
I noticed in https://buildvm.openshift.eng.bos.redhat.com:8443/job/aos-cd-builds/job/build%252Foc_sync/3/console that we synced from `registry.svc.ci.openshift.org/ocp/release:4.1.0-0.ci-2019-04-18-114217` we should be syncing from the `.nightly` one instead