### PR TITLE
minimally need 4.1 option for bump core jenkins version rpm job

### DIFF
--- a/jobs/devex/jenkins-bump-version/Jenkinsfile
+++ b/jobs/devex/jenkins-bump-version/Jenkinsfile
@@ -12,8 +12,8 @@ properties(
                     name: 'OCP_RELEASE',
                     description: 'OCP target release',
                     $class: 'hudson.model.ChoiceParameterDefinition',
-                    choices: ['4.0', '3.15', '3.14', '3.13', '3.12', '3.11', '3.10', '3.9', '3.8', '3.7', '3.6'].join('\n'),
-                    defaultValue: '4.0'
+                    choices: ['4.5', '4.4', '4.3', '4.2', '4.1', '4.0', '3.15', '3.14', '3.13', '3.12', '3.11', '3.10', '3.9', '3.8', '3.7', '3.6'].join('\n'),
+                    defaultValue: '4.1'
                 ],
                 [
                     name: 'MAIL_LIST_SUCCESS',


### PR DESCRIPTION
/assign @adammhaile 

our updates using `4.0` do not appear to be getting picked up in the 4.1 builds