### PR TITLE
Fix oc_sync makes 'latest' symlinks and registry auth

### DIFF
--- a/jobs/build/oc_sync/Jenkinsfile
+++ b/jobs/build/oc_sync/Jenkinsfile
@@ -40,9 +40,13 @@ node {
 
     commonlib.checkMock()
 
+    buildlib.cleanWorkdir("${env.WORKSPACE}")
+
     try {
         sshagent(['aos-cd-test']) {
             stage("sync ocp clients") {
+		// must be able to access remote registry to extract image contents
+		buildlib.registry_quay_dev_login()
                 sh "./publish-clients-from-payload.sh ${env.WORKSPACE} ${STREAM}"
             }
         }

--- a/jobs/build/oc_sync/publish-clients-from-payload.sh
+++ b/jobs/build/oc_sync/publish-clients-from-payload.sh
@@ -23,7 +23,7 @@ else
 fi
 
 
-TMPDIR=${WORKSPACE}/tools/
+TMPDIR=${WORKSPACE}/tools
 mkdir -p "${TMPDIR}"
 cd ${TMPDIR}
 
@@ -32,11 +32,12 @@ mkdir -p ${OUTDIR}
 pushd ${OUTDIR}
 
 #extract all release assests
+oc version
 oc adm release extract --tools --command-os=* ${PULL_SPEC} --to=${OUTDIR}
 popd
 
 # create latest symlink
-ln -sf ${VERSION} latest
+ln -svf ${VERSION} latest
 
 #sync to use-mirror-upload
 rsync \


### PR DESCRIPTION
* Clean workdir before starting
* Run auth login before starting
* Make shell script commands more verbose
* Remove excessive '/' in path so logs print sane
* Dump `oc` version