### PR TITLE
Add GOTRACEBACK env var for full trace

### DIFF
--- a/jobs/build/oc_sync/publish-clients-from-payload.sh
+++ b/jobs/build/oc_sync/publish-clients-from-payload.sh
@@ -32,8 +32,8 @@ mkdir -p ${OUTDIR}
 pushd ${OUTDIR}
 
 #extract all release assests
-oc version
-oc adm release extract --tools --command-os=* ${PULL_SPEC} --to=${OUTDIR}
+GOTRACEBACK=all oc version
+GOTRACEBACK=all oc adm release extract --tools --command-os=* ${PULL_SPEC} --to=${OUTDIR}
 popd
 
 #sync to use-mirror-upload

--- a/jobs/build/release/release.groovy
+++ b/jobs/build/release/release.groovy
@@ -14,7 +14,7 @@ def stageValidation() {
     echo "Verifying payload does not already exist"
     res = commonlib.shell(
         returnAll: true,
-        script: "${oc_cmd} adm release info quay.io/openshift-release-dev/ocp-release:${params.NAME}"
+        script: "GOTRACEBACK=all ${oc_cmd} adm release info quay.io/openshift-release-dev/ocp-release:${params.NAME}"
     )
 
     if(res.returnStatus == 0){
@@ -44,7 +44,7 @@ def stageGenPayload() {
     metadata += "}"
 
     // build oc command
-    def cmd = "${oc_cmd} adm release new "
+    def cmd = "GOTRACEBACK=all ${oc_cmd} adm release new "
     cmd += "--from-release=registry.svc.ci.openshift.org/ocp/release:${params.FROM_RELEASE_TAG} "
     if (params.PREVIOUS != "") {
         cmd += "--previous \"${params.PREVIOUS}\" "
@@ -64,7 +64,7 @@ def stageGenPayload() {
 
 def stageTagStable() {
     def name = params.NAME
-    def cmd = "${oc_cmd} tag quay.io/openshift-release-dev/ocp-release:${name} ocp/release:${name}"
+    def cmd = "GOTRACEBACK=all ${oc_cmd} tag quay.io/openshift-release-dev/ocp-release:${name} ocp/release:${name}"
 
     if (params.DRY_RUN) {
         echo "Would have run \n ${cmd}"
@@ -115,7 +115,7 @@ def stageWaitForStable() {
 }
 
 def stageGetReleaseInfo(){
-    def cmd = "${oc_cmd} adm release info --pullspecs quay.io/openshift-release-dev/ocp-release:${params.NAME}"
+    def cmd = "GOTRACEBACK=all ${oc_cmd} adm release info --pullspecs quay.io/openshift-release-dev/ocp-release:${params.NAME}"
 
     if (params.DRY_RUN) {
         echo "Would have run \n ${cmd}"

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -109,7 +109,7 @@ def elliott(cmd, opts=[:]){
 def oc(cmd, opts=[:]){
     return commonlib.shell(
         returnStdout: opts.capture ?: false,
-        script: "/usr/bin/oc ${cleanWhitespace(cmd)}"
+        script: "GOTRACEBACK=all /usr/bin/oc ${cleanWhitespace(cmd)}"
     )
 }
 


### PR DESCRIPTION
We had an `oc` error running the release job today but we didn't get the full trace. This forces full tracebacks if errors happen

https://buildvm.openshift.eng.bos.redhat.com:8443/job/aos-cd-builds/job/build%252Foc_sync/14/console
