### PR TITLE
appregistry: don't sync for 4.2 yet

### DIFF
--- a/jobs/build/appregistry/Jenkinsfile
+++ b/jobs/build/appregistry/Jenkinsfile
@@ -93,11 +93,14 @@ node {
 
     buildlib.initialize(false)
 
-    workDir = "${env.WORKSPACE}/workDir"
+    def workDir = "${env.WORKSPACE}/workDir"
     buildlib.cleanWorkdir(workDir)
 
     currentBuild.description = "Collecting appregistry images for ${params.BUILD_VERSION}"
     currentBuild.displayName += " - ${params.BUILD_VERSION}"
+
+    // temporarily disable 4.2 pushes until we have figured out what we need to do for them
+    def skipPush = (params.BUILD_VERSION == '4.2') ? true : params.SKIP_PUSH
 
     try {
         def operatorData = []
@@ -120,7 +123,7 @@ node {
                 currentBuild.description = "appregistry images collected for ${params.BUILD_VERSION}."
             }
             stage("push metadata") {
-                if (params.SKIP_PUSH) {
+                if (skipPush) {
                     currentBuild.description += "\nskipping metadata push."
                     return
                 }


### PR DESCRIPTION
We will need this whenever we actually start building 4.2 because we don't want to import 4.2 images over 4.1 images.

```
<jwforres>
the bundle we push always needs to contain the latest off all our z-streams
which means for any given operator like template-service-broker-operator, we need to pull the manifests out of the 4.1.z image the 4.2.z image, and glom them together

<sosiouxme>
to answer the question, i can make 4.2 sync a no-op until we have it sorted.

<jwforres>
yeah can you do the stopgap when you guys need to start running 4.2 builds
lets reconvene next week once 4.1.0 is out the door, and put our heads together