### PR TITLE
scheduled-jobs/build/rhcos-puddle: export REQUESTS_CA_BUNDLE

### DIFF
--- a/scheduled-jobs/build/rhcos-puddle/Jenkinsfile
+++ b/scheduled-jobs/build/rhcos-puddle/Jenkinsfile
@@ -27,6 +27,7 @@ node {
                 set -exuo pipefail
                 tmpdir=$(mktemp -d XXXXXXXXXX.distgit)
                 pushd $tmpdir
+                export REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
                 rhpkg --user ocp-build clone rpms/openshift --branch rhaos-4.1-rhel-8
                 cd openshift
                 git checkout origin/rhaos-4.1-rhel-7 -- *


### PR DESCRIPTION
otherwise the job is broken and rhcos gets old version of openshift.