### PR TITLE
rhcos-puddle: add puddle for 4.2 builds

### DIFF
--- a/scheduled-jobs/build/rhcos-puddle/Jenkinsfile
+++ b/scheduled-jobs/build/rhcos-puddle/Jenkinsfile
@@ -19,57 +19,60 @@ node {
     )
 
     def buildException = null
-    try {
-        buildlib.kinit()
-        stage("openshift rpm") {
-            buildlib.commonlib.shell(
-                '''
-                set -exuo pipefail
-                tmpdir=$(mktemp -d XXXXXXXXXX.distgit)
-                pushd $tmpdir
-                export REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
-                rhpkg --user ocp-build clone rpms/openshift --branch rhaos-4.1-rhel-8
-                cd openshift
-                git checkout origin/rhaos-4.1-rhel-7 -- *
-                rc=0
-                if git commit -m "Automated copy from RHEL7 branch"; then
-                    # we have changes to build
-                    for i in 1 2 3; do
-                        if rhpkg push && rhpkg build; then
-                            rc=0
-                            break
-                        fi
-                        rc=1
-                        sleep 60
-                    done
-                fi
-                popd
-                rm -rf $tmpdir
-                exit $rc
-                '''
-            )
+    def puddleVersions = ["4.1", "4.2"]
+    puddleVersions.each { version ->
+        try {
+            buildlib.kinit()
+            stage("openshift rpm for ${version}") {
+                buildlib.commonlib.shell(
+                    '''
+                    set -exuo pipefail
+                    tmpdir=$(mktemp -d XXXXXXXXXX.distgit)
+                    pushd $tmpdir
+                    export REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
+                    rhpkg --user ocp-build clone rpms/openshift --branch rhaos-''' + version + '''-rhel-8
+                    cd openshift
+                    git checkout origin/rhaos-''' + version + '''-rhel-7 -- *
+                    rc=0
+                    if git commit -m "Automated copy from RHEL7 branch"; then
+                        # we have changes to build
+                        for i in 1 2 3; do
+                            if rhpkg push && rhpkg build; then
+                                rc=0
+                                break
+                            fi
+                            rc=1
+                            sleep 60
+                        done
+                    fi
+                    popd
+                    rm -rf $tmpdir
+                    exit $rc
+                    '''
+                )
+            }
+        } catch(e) {
+            // still run puddle when the rpm build fails
+            echo "Package build failed:\n${e}"
+            buildException = e
         }
-    } catch(e) {
-        // still run puddle when the rpm build fails
-        echo "Package build failed:\n${e}"
-        buildException = e
-    }
 
-    stage("run puddle") {
-        echo "Initializing puddle build #${currentBuild.number}"
+        stage("run puddle for ${version}") {
+            echo "Initializing puddle build #${currentBuild.number} for Openshift version ${version}"
 
-        def puddleConf = "https://raw.githubusercontent.com/openshift/aos-cd-jobs/master/build-scripts/puddle-conf/atomic_openshift-4.1.el8.conf"
+            def puddleConf = "https://raw.githubusercontent.com/openshift/aos-cd-jobs/master/build-scripts/puddle-conf/atomic_openshift-${version}.el8.conf"
 
-        puddle = buildlib.build_puddle(
-        puddleConf,
-        null,
-            "-b",   // do not fail if we are missing dependencies
-            "-d",   // print debug information
-            "-n"    // do not send an email for this puddle
-        )
+            puddle = buildlib.build_puddle(
+            puddleConf,
+            null,
+                "-b",   // do not fail if we are missing dependencies
+                "-d",   // print debug information
+                "-n"    // do not send an email for this puddle
+            )
 
-        echo "View the package list here: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift.el8/4.1/latest/x86_64/os/Packages/"
+            echo "View the package list here: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift/${version}-el8/latest/x86_64/os/Packages/"
 
+        }
     }
 
     if(buildException) {

--- a/scheduled-jobs/build/rhcos-puddle/README.md
+++ b/scheduled-jobs/build/rhcos-puddle/README.md
@@ -1,1 +1,1 @@
-Builds 4.1 openshift package and puddles frequently for RHCOS on RHEL8
+Builds 4.x openshift package and puddles frequently for RHCOS on RHEL8


### PR DESCRIPTION
Modify puddle job to also output 4.2-el8 builds as a separate stage.

Note: I based this off the conf here: https://github.com/openshift/aos-cd-jobs/blob/master/build-scripts/puddle-conf/atomic_openshift-4.2.el8.conf. This also does not affect the el7 based RPMS, and only intendeds to create a 4.2 puddle for RHCOS specific el8 packages.