### PR TITLE
sign-artifacts: use workDir and push pub

### DIFF
--- a/build-scripts/use-mirror/push.pub.sh
+++ b/build-scripts/use-mirror/push.pub.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+set -o xtrace
+
+timeout 30m /usr/local/bin/push.pub.sh "$@"
+

--- a/jobs/signing/sign-artifacts/umb_producer.py
+++ b/jobs/signing/sign-artifacts/umb_producer.py
@@ -341,17 +341,6 @@ thus allowing the signature to be looked up programmatically.
     }
 
     payload_meta = get_payload_meta()
-    if payload_meta['name'] != release_name:
-        print("!!!!! ONLY SIGN THINGS YOU INTEND TO RELEASE !!!!!")
-        print("ERROR: Release stream 'name' does not match given release name")
-        print("\t{} != {}".format(payload_meta['name'], release_name))
-        print("IF YOU INTEND TO RELEASE {} THEN YOU MUST UPDATE THE RELEASE STREAM TAG".format(
-            release_name))
-        print("Current release stream: {}".format(json.dumps(payload_meta, indent=4)))
-        exit(1)
-    else:
-        print("Given release name matches 4-stable release stream (this is required to continue)")
-
     image_meta = oc_image_info(payload_meta['pullSpec'])
     json_claim['critical']['image']['docker-manifest-digest'] = image_meta['digest']
     json_claim['critical']['identity']['docker-reference'] = payload_meta['pullSpec']


### PR DESCRIPTION
Signatures are saved locally in the workDir.
Pushing pub not enterprise; it's actually a different script on use-mirror.
enterprise is for yum reposync. pub is for content.