### PR TITLE
chore(sjb/**): change aos-auth-team emails to aos-apiserver

### DIFF
--- a/sjb/config/test_cases/test_branch_origin_extended_gssapi.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_gssapi.yml
@@ -3,7 +3,7 @@ parent: 'common/test_cases/origin_release_with_ecosystem.yml'
 overrides:
   junit_analysis: False
   email:
-    - aos-auth-team@redhat.com
+    - aos-apiserver@redhat.com
   sync:
     - "openshift,origin=master"
 extensions:

--- a/sjb/config/test_cases/test_branch_origin_extended_gssapi_310.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_gssapi_310.yml
@@ -3,7 +3,7 @@ parent: 'common/test_cases/origin_release_with_ecosystem_310.yml'
 overrides:
   junit_analysis: False
   email:
-    - aos-auth-team@redhat.com
+    - aos-apiserver@redhat.com
   sync:
     - "openshift,origin=release-3.10"
 extensions:

--- a/sjb/config/test_cases/test_branch_origin_extended_ldap_groups.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_ldap_groups.yml
@@ -3,7 +3,7 @@ parent: 'common/test_cases/origin_release_with_ecosystem.yml'
 overrides:
   junit_analysis: False
   email:
-    - aos-auth-team@redhat.com
+    - aos-apiserver@redhat.com
   sync:
     - "openshift,origin=master"
 extensions:

--- a/sjb/config/test_cases/test_branch_origin_extended_ldap_groups_310.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_ldap_groups_310.yml
@@ -3,7 +3,7 @@ parent: 'common/test_cases/origin_release_with_ecosystem_310.yml'
 overrides:
   junit_analysis: False
   email:
-    - aos-auth-team@redhat.com
+    - aos-apiserver@redhat.com
   sync:
     - "openshift,origin=release-3.10"
 extensions:

--- a/sjb/generated/test_branch_origin_extended_gssapi.xml
+++ b/sjb/generated/test_branch_origin_extended_gssapi.xml
@@ -613,7 +613,7 @@ oct deprovision</command>
       <userMetadata/>
     </hudson.plugins.s3.S3BucketPublisher>
     <hudson.tasks.Mailer plugin="mailer@1.16">
-      <recipients>aos-auth-team@redhat.com</recipients>
+      <recipients>aos-apiserver@redhat.com</recipients>
       <dontNotifyEveryUnstableBuild>false</dontNotifyEveryUnstableBuild>
       <sendToIndividuals>false</sendToIndividuals>
     </hudson.tasks.Mailer>

--- a/sjb/generated/test_branch_origin_extended_gssapi_310.xml
+++ b/sjb/generated/test_branch_origin_extended_gssapi_310.xml
@@ -676,7 +676,7 @@ oct deprovision</command>
       <userMetadata/>
     </hudson.plugins.s3.S3BucketPublisher>
     <hudson.tasks.Mailer plugin="mailer@1.16">
-      <recipients>aos-auth-team@redhat.com</recipients>
+      <recipients>aos-apiserver@redhat.com</recipients>
       <dontNotifyEveryUnstableBuild>false</dontNotifyEveryUnstableBuild>
       <sendToIndividuals>false</sendToIndividuals>
     </hudson.tasks.Mailer>

--- a/sjb/generated/test_branch_origin_extended_ldap_groups.xml
+++ b/sjb/generated/test_branch_origin_extended_ldap_groups.xml
@@ -613,7 +613,7 @@ oct deprovision</command>
       <userMetadata/>
     </hudson.plugins.s3.S3BucketPublisher>
     <hudson.tasks.Mailer plugin="mailer@1.16">
-      <recipients>aos-auth-team@redhat.com</recipients>
+      <recipients>aos-apiserver@redhat.com</recipients>
       <dontNotifyEveryUnstableBuild>false</dontNotifyEveryUnstableBuild>
       <sendToIndividuals>false</sendToIndividuals>
     </hudson.tasks.Mailer>

--- a/sjb/generated/test_branch_origin_extended_ldap_groups_310.xml
+++ b/sjb/generated/test_branch_origin_extended_ldap_groups_310.xml
@@ -676,7 +676,7 @@ oct deprovision</command>
       <userMetadata/>
     </hudson.plugins.s3.S3BucketPublisher>
     <hudson.tasks.Mailer plugin="mailer@1.16">
-      <recipients>aos-auth-team@redhat.com</recipients>
+      <recipients>aos-apiserver@redhat.com</recipients>
       <dontNotifyEveryUnstableBuild>false</dontNotifyEveryUnstableBuild>
       <sendToIndividuals>false</sendToIndividuals>
     </hudson.tasks.Mailer>


### PR DESCRIPTION
Update email address for auth jobs from aos-auth-team@redhat.com
to aos-apiserver@redhat.com to reflect team changes from group-b
re-org.

✏️ Updated to use new name, `aos-apiserver` (prev `aos-master`) @sttts

cc @mfojtik 