### PR TITLE
ocp3/Jenkinsfile: fix auto_mode version comparison

### DIFF
--- a/jobs/build/ocp3/Jenkinsfile
+++ b/jobs/build/ocp3/Jenkinsfile
@@ -422,7 +422,7 @@ node {
                     releases = buildlib.get_releases(GITHUB_URLS['ose'])
                     echo "AUTO-MODE: release repo: ${GITHUB_URLS['ose']}"
                     echo "AUTO-MODE: releases: ${releases}"
-                    BUILD_MODE = buildlib.auto_mode(params.BUILD_VERSION, '4.x', releases)
+                    BUILD_MODE = buildlib.auto_mode(params.BUILD_VERSION, '4.0', releases)
                     echo "BUILD_MODE = ${BUILD_MODE}"
                 }
             }


### PR DESCRIPTION
`auto_mode` logic ends up trying to compare this bogus version and complaining that it's not made up of ints.
So, make it out of ints (but still just as bogus).