### PR TITLE
scheduled-jobs/build/ocp-4.1-full: auto-bump version

### DIFF
--- a/scheduled-jobs/build/ocp-4.1-full/Jenkinsfile
+++ b/scheduled-jobs/build/ocp-4.1-full/Jenkinsfile
@@ -9,7 +9,7 @@ def b = build(
     job: '../aos-cd-builds/build%2Fose4.1',
     propagate: false,
     parameters: [
-        // we might consider: string(name: 'NEW_VERSION', value: '+'),
+        string(name: 'NEW_VERSION', value: '+'),
         booleanParam(name: 'FORCE_BUILD', value: true),
     ],
 )


### PR DESCRIPTION
Use our scheduled once-per-release full rebuild to bump the version we are building. That way we can't forget to do it.