### PR TITLE
appregistry: ignore 4.2 failures until we get it sorted

### DIFF
--- a/jobs/build/appregistry/Jenkinsfile
+++ b/jobs/build/appregistry/Jenkinsfile
@@ -157,6 +157,7 @@ node {
         }
     } catch (err) {
         currentBuild.description = "Job failed: ${err}\n-----------------\n${currentBuild.description}"
+        if (skipPush) { return }  // don't spam on failures we don't care about
         commonlib.email(
             to: "${params.MAIL_LIST_FAILURE}",
             from: "aos-team-art@redhat.com",


### PR DESCRIPTION
For now, 4.2 errors are just noise. Turn them off and plan to reinstate once we have 4.2 app registry pushes working.