### PR TITLE
Start using the new aos-art-automation address

### DIFF
--- a/jobs/build/appregistry/Jenkinsfile
+++ b/jobs/build/appregistry/Jenkinsfile
@@ -81,7 +81,7 @@ node {
                         name: 'MAIL_LIST_FAILURE',
                         description: 'Failure Mailing List',
                         defaultValue: [
-                            'aos-team-art@redhat.com',
+                            'aos-art-automation+failed-appregistry@redhat.com',
                         ].join(',')
                     ),
                     commonlib.mockParam(),
@@ -160,7 +160,8 @@ node {
         if (skipPush) { return }  // don't spam on failures we don't care about
         commonlib.email(
             to: "${params.MAIL_LIST_FAILURE}",
-            from: "aos-team-art@redhat.com",
+            from: "aos-art-automation@redhat.com",
+            replyTo: "aos-team-art@redhat.com",
             subject: "Unexpected error during appregistry job",
             body: "Console output: ${env.BUILD_URL}console\n${currentBuild.description}",
         )

--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -192,7 +192,7 @@ node {
                     buildlib.sync_images(
                         majorVersion,
                         minorVersion,
-                        "aos-team-art@redhat.com",
+                        "aos-team-art@redhat.com", // "reply to"
                         currentBuild.number
                     )
                 }

--- a/jobs/build/ocp3/Jenkinsfile
+++ b/jobs/build/ocp3/Jenkinsfile
@@ -272,7 +272,7 @@ node {
                         defaultValue: [
                             'aos-cicd@redhat.com',
                             'aos-qe@redhat.com',
-                            'aos-team-art@redhat.com',
+                            'aos-art-automation+new-ocp3-build@redhat.com',
                         ].join(',')
                     ],
                     [
@@ -280,7 +280,7 @@ node {
                         description: 'Failure Mailing List',
                         $class: 'hudson.model.StringParameterDefinition',
                         defaultValue: [
-                            'aos-team-art@redhat.com'
+                            'aos-art-automation+failed-ocp3-build@redhat.com'
                         ].join(',')
                     ],
                     [

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -85,7 +85,7 @@ node {
                         description: 'Failure Mailing List',
                         $class: 'hudson.model.StringParameterDefinition',
                         defaultValue: [
-                            'aos-team-art@redhat.com'
+                            'aos-art-automation+failed-ocp4-build@redhat.com'
                         ].join(',')
                     ],
                     [

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -514,7 +514,8 @@ ${imageList}
 
     commonlib.email(
         to: mailList,
-        from: "aos-team-art@redhat.com",
+        from: "aos-art-automation@redhat.com",
+        replyTo: "aos-team-art@redhat.com",
         subject: "[ART] New build for OCP: ${version.full}${subjectTags}",
         body:
 """\
@@ -571,4 +572,3 @@ def getImageBuildReport(recordLog) {
 }
 
 return this
-

--- a/jobs/build/release/Jenkinsfile
+++ b/jobs/build/release/Jenkinsfile
@@ -68,6 +68,7 @@ node {
                             'aos-cicd@redhat.com',
                             'aos-qe@redhat.com',
                             'aos-team-art@redhat.com',
+                            'aos-art-automation+new-release@redhat.com',
                         ].join(',')
                     ],
                     [
@@ -75,7 +76,7 @@ node {
                         description: 'Failure Mailing List',
                         $class: 'hudson.model.StringParameterDefinition',
                         defaultValue: [
-                            'aos-team-art@redhat.com'
+                            'aos-art-automation+failed-release@redhat.com'
                         ].join(',')
                     ],
                     commonlib.mockParam(),
@@ -112,7 +113,8 @@ node {
 
         commonlib.email(
             to: "${params.MAIL_LIST_SUCCESS}",
-            from: "aos-cicd@redhat.com",
+            replyTo: "aos-team-art@redhat.com",
+            from: "aos-art-automation@redhat.com",
             subject: "${dry_subject}Success building release payload: ${params.NAME}",
             body: """
 Jenkins Job: ${env.BUILD_URL}
@@ -124,7 +126,8 @@ ${release_info}
     } catch (err) {
         commonlib.email(
             to: "${params.MAIL_LIST_FAILURE}",
-            from: "aos-cicd@redhat.com",
+            replyTo: "aos-team-art@redhat.com",
+            from: "aos-art-automation@redhat.com",
             subject: "Error running OCP Release",
             body: "Encountered an error while running OCP release: ${err}");
         currentBuild.description = "Error while running OCP release:\n${err}"

--- a/jobs/build/reposync/Jenkinsfile
+++ b/jobs/build/reposync/Jenkinsfile
@@ -28,7 +28,7 @@ node {
                         description: 'Failure Mailing List',
                         $class: 'hudson.model.StringParameterDefinition',
                         defaultValue: [
-                            'aos-team-art@redhat.com',
+                            'aos-art-automation+failed-reposync@redhat.com',
                         ].join(',')
                     ],
                     commonlib.mockParam(),
@@ -74,7 +74,8 @@ node {
     } catch (err) {
         commonlib.email(
             to: "${MAIL_LIST_FAILURE}",
-            from: "aos-team-art@redhat.com",
+            replyTo: "aos-team-art@redhat.com",
+            from: "aos-art-automation@redhat.com",
             subject: "Error syncing v${SYNC_VERSION} repos",
             body: """Encountered an error while running OCP pipeline: ${err}
 

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -743,8 +743,9 @@ def sync_images(major, minor, mail_list, build_number) {
     }
     if ( results.any { it.result != 'SUCCESS' } ) {
         commonlib.email(
-            to: mail_list,
-            from: "aos-team-art@redhat.com",
+            replyTo: mail_list,
+            to: "aos-art-automation+failed-image-sync@redhat.com",
+            from: "aos-art-automation@redhat.com",
             subject: "Problem syncing images after ${currentBuild.displayName}",
             body: "Jenkins console: ${env.BUILD_URL}/console",
         )
@@ -962,7 +963,7 @@ presto:
     task_url: https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=20415814
     message: "Exception occurred: ;;; Traceback (most recent call last): [...]"
 
- * param returnAddress: email will come "from" this
+ * param returnAddress: replies to the email will go to this
  * param defaultOwner: if no owner is listed, send build failure email to this
 **/
 def mail_build_failure_owners(failed_builds, returnAddress, defaultOwner) {
@@ -984,8 +985,9 @@ The following logs are just the container build portion of the OSBS build:
                 container_log = ""
             }
             commonlib.email(
-                from: returnAddress,
-                to: "${returnAddress},${failure.owners ?: defaultOwner}",
+                replyTo: returnAddress,
+                from: "aos-art-automation@redhat.com",
+                to: "aos-art-automation+failed-ocp-build@redhat.com,${failure.owners ?: defaultOwner}",
                 subject: "Failed OCP build of ${failure.image}:${failure.version}",
                 body: """
 ART's brew/OSBS build of OCP image ${failure.image}:${failure.version} has failed.


### PR DESCRIPTION
In general this change makes it such that automated emails don't go
directly to the team email address. This hits most of the big
spammers. Changes follow this format.

* 'to' field is aos-art-automation+SOME_TOPIC@, OTHER_PEOPLE@
* 'replyTo' field is always the team email address
* 'from' will include aos-art-automation@