### PR TITLE
Fix kustomize version

### DIFF
--- a/sjb/config/test_cases/pull-ci-openshift-cluster-api-actuator-pkg-master-e2e.yml
+++ b/sjb/config/test_cases/pull-ci-openshift-cluster-api-actuator-pkg-master-e2e.yml
@@ -43,13 +43,9 @@ extensions:
     - type: "script"
       title: "Install kustomize"
       script: |-
-        curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases/latest |\
-          grep browser_download |\
-          grep linux |\
-          cut -d '"' -f 4 |\
-          xargs curl -O -L
-        chmod u+x kustomize_*_linux_amd64
-        sudo mv kustomize_*_linux_amd64 /usr/bin/kustomize
+        curl -Lo kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v2.1.0/kustomize_2.1.0_linux_amd64
+        chmod u+x kustomize
+        sudo mv kustomize /usr/bin/kustomize
     - type: "script"
       title: "Install imagebuilder"
       script: |-

--- a/sjb/config/test_cases/pull-ci-openshift-cluster-api-provider-kubemark-master-e2e.yml
+++ b/sjb/config/test_cases/pull-ci-openshift-cluster-api-provider-kubemark-master-e2e.yml
@@ -35,13 +35,9 @@ extensions:
     - type: "script"
       title: "Install kustomize"
       script: |-
-        curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases/latest |\
-          grep browser_download |\
-          grep linux |\
-          cut -d '"' -f 4 |\
-          xargs curl -O -L
-        chmod u+x kustomize_*_linux_amd64
-        sudo mv kustomize_*_linux_amd64 /usr/bin/kustomize
+        curl -Lo kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v2.1.0/kustomize_2.1.0_linux_amd64
+        chmod u+x kustomize
+        sudo mv kustomize /usr/bin/kustomize
     - type: "script"
       title: "Install imagebuilder"
       script: |-

--- a/sjb/config/test_cases/pull-ci-openshift-cluster-autoscaler-operator-master-e2e.yml
+++ b/sjb/config/test_cases/pull-ci-openshift-cluster-autoscaler-operator-master-e2e.yml
@@ -35,13 +35,9 @@ extensions:
     - type: "script"
       title: "Install kustomize"
       script: |-
-        curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases/latest |\
-          grep browser_download |\
-          grep linux |\
-          cut -d '"' -f 4 |\
-          xargs curl -O -L
-        chmod u+x kustomize_*_linux_amd64
-        sudo mv kustomize_*_linux_amd64 /usr/bin/kustomize
+        curl -Lo kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v2.1.0/kustomize_2.1.0_linux_amd64
+        chmod u+x kustomize
+        sudo mv kustomize /usr/bin/kustomize
     - type: "script"
       title: "Install imagebuilder"
       script: |-

--- a/sjb/config/test_cases/pull-ci-openshift-kubernetes-autoscaler-master-e2e.yml
+++ b/sjb/config/test_cases/pull-ci-openshift-kubernetes-autoscaler-master-e2e.yml
@@ -36,13 +36,9 @@ extensions:
     - type: "script"
       title: "Install kustomize"
       script: |-
-        curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases/latest |\
-          grep browser_download |\
-          grep linux |\
-          cut -d '"' -f 4 |\
-          xargs curl -O -L
-        chmod u+x kustomize_*_linux_amd64
-        sudo mv kustomize_*_linux_amd64 /usr/bin/kustomize
+        curl -Lo kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v2.1.0/kustomize_2.1.0_linux_amd64
+        chmod u+x kustomize
+        sudo mv kustomize /usr/bin/kustomize
     - type: "script"
       title: "Install imagebuilder"
       script: |-

--- a/sjb/config/test_cases/pull-ci-openshift-machine-api-operator-master-e2e.yml
+++ b/sjb/config/test_cases/pull-ci-openshift-machine-api-operator-master-e2e.yml
@@ -35,13 +35,9 @@ extensions:
     - type: "script"
       title: "Install kustomize"
       script: |-
-        curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases/latest |\
-          grep browser_download |\
-          grep linux |\
-          cut -d '"' -f 4 |\
-          xargs curl -O -L
-        chmod u+x kustomize_*_linux_amd64
-        sudo mv kustomize_*_linux_amd64 /usr/bin/kustomize
+        curl -Lo kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v2.1.0/kustomize_2.1.0_linux_amd64
+        chmod u+x kustomize
+        sudo mv kustomize /usr/bin/kustomize
     - type: "script"
       title: "Install imagebuilder"
       script: |-

--- a/sjb/generated/pull-ci-openshift-cluster-api-actuator-pkg-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-cluster-api-actuator-pkg-master-e2e.xml
@@ -245,13 +245,9 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
-curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases/latest |\
-  grep browser_download |\
-  grep linux |\
-  cut -d &#39;&#34;&#39; -f 4 |\
-  xargs curl -O -L
-chmod u+x kustomize_*_linux_amd64
-sudo mv kustomize_*_linux_amd64 /usr/bin/kustomize
+curl -Lo kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v2.1.0/kustomize_2.1.0_linux_amd64
+chmod u+x kustomize
+sudo mv kustomize /usr/bin/kustomize
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/pull-ci-openshift-cluster-api-provider-kubemark-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-cluster-api-provider-kubemark-master-e2e.xml
@@ -237,13 +237,9 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
-curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases/latest |\
-  grep browser_download |\
-  grep linux |\
-  cut -d &#39;&#34;&#39; -f 4 |\
-  xargs curl -O -L
-chmod u+x kustomize_*_linux_amd64
-sudo mv kustomize_*_linux_amd64 /usr/bin/kustomize
+curl -Lo kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v2.1.0/kustomize_2.1.0_linux_amd64
+chmod u+x kustomize
+sudo mv kustomize /usr/bin/kustomize
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/pull-ci-openshift-cluster-autoscaler-operator-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-cluster-autoscaler-operator-master-e2e.xml
@@ -237,13 +237,9 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
-curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases/latest |\
-  grep browser_download |\
-  grep linux |\
-  cut -d &#39;&#34;&#39; -f 4 |\
-  xargs curl -O -L
-chmod u+x kustomize_*_linux_amd64
-sudo mv kustomize_*_linux_amd64 /usr/bin/kustomize
+curl -Lo kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v2.1.0/kustomize_2.1.0_linux_amd64
+chmod u+x kustomize
+sudo mv kustomize /usr/bin/kustomize
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/pull-ci-openshift-kubernetes-autoscaler-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-kubernetes-autoscaler-master-e2e.xml
@@ -237,13 +237,9 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
-curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases/latest |\
-  grep browser_download |\
-  grep linux |\
-  cut -d &#39;&#34;&#39; -f 4 |\
-  xargs curl -O -L
-chmod u+x kustomize_*_linux_amd64
-sudo mv kustomize_*_linux_amd64 /usr/bin/kustomize
+curl -Lo kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v2.1.0/kustomize_2.1.0_linux_amd64
+chmod u+x kustomize
+sudo mv kustomize /usr/bin/kustomize
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/pull-ci-openshift-machine-api-operator-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-machine-api-operator-master-e2e.xml
@@ -237,13 +237,9 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
-curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases/latest |\
-  grep browser_download |\
-  grep linux |\
-  cut -d &#39;&#34;&#39; -f 4 |\
-  xargs curl -O -L
-chmod u+x kustomize_*_linux_amd64
-sudo mv kustomize_*_linux_amd64 /usr/bin/kustomize
+curl -Lo kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v2.1.0/kustomize_2.1.0_linux_amd64
+chmod u+x kustomize
+sudo mv kustomize /usr/bin/kustomize
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;


### PR DESCRIPTION
Information provided by https://api.github.com/repos/kubernetes-sigs/kustomize/releases/latest
no longer provides sufficient information to download the latest linux binary.
Also, the latest version is v3 which we have not tested properly yet.