### PR TITLE
Fix missing comma in send-umb-message

### DIFF
--- a/jobs/build/send-umb-messages/Jenkinsfile
+++ b/jobs/build/send-umb-messages/Jenkinsfile
@@ -24,7 +24,7 @@ node {
                         overrides: [topic: 'VirtualTopic.qe.ci.jenkins'],
                         providerName: 'Red Hat UMB'
                     )
-                    writeFile file: "${release}.current" text: "${latestRelease}"
+                    writeFile file: "${release}.current", text: "${latestRelease}"
                 }
             }
         }


### PR DESCRIPTION
```Running in Durability level: MAX_SURVIVABILITY
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
WorkflowScript: 27: expecting '}', found ':' @ line 27, column 62.
   ile: "${release}.current" text: "${lates
                                 ^

1 error
```