### PR TITLE
Use an absolute path instead

### DIFF
--- a/jobs/build/send-umb-messages/Jenkinsfile
+++ b/jobs/build/send-umb-messages/Jenkinsfile
@@ -9,7 +9,7 @@ node {
     releases = ["4-stable", "4.2.0-0.nightly"]
 
     stage("send UMB messages for new releases") {
-        dir ("~/.cache/releases") {
+        dir ("/mnt/nfs/home/jenkins/.cache/releases") {
             for (String release : releases) {
                 latestRelease = sh(
                     returnStdout: true,


### PR DESCRIPTION
```
java.nio.file.NoSuchFileException: /mnt/workspace/jenkins/working/d-builds_build_send-umb-messages/~/.cache/releases/4-stable.current
```