### PR TITLE
Use capital Custom type

### DIFF
--- a/jobs/build/send-umb-messages/Jenkinsfile
+++ b/jobs/build/send-umb-messages/Jenkinsfile
@@ -20,7 +20,7 @@ node {
                     sendCIMessage(
                         messageContent: "New release payload for OpenShift ${release}",
                         messageProperties: "${latestRelease}",
-                        messageType: 'custom',
+                        messageType: 'Custom',
                         overrides: [topic: 'VirtualTopic.qe.ci.jenkins'],
                         providerName: 'Red Hat UMB'
                     )


### PR DESCRIPTION
Guess `sendCIMessage` doesn't like lower case letters
```
java.lang.IllegalArgumentException: No enum constant com.redhat.utils.MessageUtils.MESSAGE_TYPE.custom
```