### PR TITLE
Switch back to JSON for QE new payload messages

### DIFF
--- a/jobs/build/send-umb-messages/Jenkinsfile
+++ b/jobs/build/send-umb-messages/Jenkinsfile
@@ -39,15 +39,12 @@ node {
                 if ( latestRelease != previousRelease ) {
 		    currentBuild.displayName += "🆕: ${release} "
 		    currentBuild.description += "\n🆕: ${release}"
-		    def msgJson = readJSON file: '', text: latestRelease
-		    def messageProperties = """name=${msgJson.name}
-pullSpec=${msgJson.pullSpec}
-downloadURL=${msgJson.downloadURL}
-"""
+
                     sendCIMessage(
-                        messageContent: "New release payload for OpenShift ${release}",
-                        messageProperties: "${messageProperties}",
+                        messageProperties: "release=${release}",
+			messageContent: latestRelease,
                         messageType: 'Custom',
+			failOnError: true,
                         overrides: [topic: 'VirtualTopic.qe.ci.jenkins'],
                         providerName: 'Red Hat UMB'
                     )


### PR DESCRIPTION
Include the release as a message property for easy differentiating
Set message body as json blob from release API