### PR TITLE
Factory2 msg

### DIFF
--- a/jobs/build/send-umb-messages/Jenkinsfile
+++ b/jobs/build/send-umb-messages/Jenkinsfile
@@ -25,33 +25,33 @@ node {
                     returnStdout: true,
                     script: "curl -s https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/${release}/latest",
                 ).trim()
-		try {
+                try {
                     previousRelease = readFile("${release}.current")
-		} catch (readex) {
-		    // The first time this job is ran and the first
-		    // time any new release is added the 'readFile'
-		    // won't find the file and will raise a
-		    // NoSuchFileException exception.
-		    touch file: "${release}.current"
-		    previousRelease = ""
-		}
+                } catch (readex) {
+                    // The first time this job is ran and the first
+                    // time any new release is added the 'readFile'
+                    // won't find the file and will raise a
+                    // NoSuchFileException exception.
+                    touch file: "${release}.current"
+                    previousRelease = ""
+                }
 
                 if ( latestRelease != previousRelease ) {
-		    currentBuild.displayName += "🆕: ${release} "
-		    currentBuild.description += "\n🆕: ${release}"
+                    currentBuild.displayName += "🆕: ${release} "
+                    currentBuild.description += "\n🆕: ${release}"
 
                     sendCIMessage(
                         messageProperties: "release=${release}",
-			messageContent: latestRelease,
+                        messageContent: latestRelease,
                         messageType: 'Custom',
-			failOnError: true,
+                        failOnError: true,
                         overrides: [topic: 'VirtualTopic.qe.ci.jenkins'],
                         providerName: 'Red Hat UMB'
                     )
                     writeFile file: "${release}.current", text: "${latestRelease}"
                 } else {
-		    currentBuild.description += "\nUnchanged: ${release}"
-		}
+                    currentBuild.description += "\nUnchanged: ${release}"
+                }
             }
         }
     }

--- a/jobs/build/send-umb-messages/Jenkinsfile
+++ b/jobs/build/send-umb-messages/Jenkinsfile
@@ -40,9 +40,52 @@ node {
                     currentBuild.displayName += "🆕: ${release} "
                     currentBuild.description += "\n🆕: ${release}"
 
+                    def object = readJSON text: latestRelease
+
+                    def downloadURL = object.downloadURL
+                    def version = object.name
+                    def pullRef = object.pullSpec
+                    def digest = "MISSING_DIGEST_FIX_PLEASE"
+                    string repo = "somerepo"
+
+                    def ts = sh (
+                        returnStdout: true,
+                        script: 'date "+%Y-%m-%d\'T\'%H:%M:%S.%N\'Z\'"',
+                    ).trim()
+
+                    def msg = [
+                            artifact: [
+                                type: "container-image",
+                                repository: "${repo}",
+                                digest: "${digest}",
+                                issuer: "OpenShift Automated Release Team",
+                                pull_ref: "${pullRef}",
+                                scratch: false,
+                                id: "${repo}@${digest}",
+                            ],
+                            contact: [
+                                name: "Nightly-pipeline for OCP 4.x",
+                                team: "AOS QE",
+                                docs: "https://somewhere.com/user-documentation",
+                                email: "aos-qe@redhat.com",
+                                irc: "#aos-qe"
+                            ],
+                            decision: [
+                                result: "go",
+                                summary: "1 of 1 required tests passed",
+                                url: "https://datagrepper.somewhere.com/id?id=2018-21cc85d6"
+                            ],
+                            generated_at: "${ts}",
+                            version: "${version}",
+                            downloadURL: "${downloadURL}"
+                        ]
+
+                    def json = groovy.json.JsonOutput.toJson(msg)
+                    json = groovy.json.JsonOutput.prettyPrint(json)
+
                     sendCIMessage(
                         messageProperties: "release=${release}",
-                        messageContent: latestRelease,
+                        messageContent: json,
                         messageType: 'Custom',
                         failOnError: true,
                         overrides: [topic: 'VirtualTopic.qe.ci.jenkins'],


### PR DESCRIPTION
Hello,

1st commit replaces tabs by spaces - both tabs and spaces were used in the same file => problems with indentation.

2nd commit changes the format of UMB message to be more is accordance with Factory 2.0 standard. I'm not sure how I can test this exact job. Any hints are welcome. However I did test the code in my own job - it's output can be seen [here](https://openshift-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/tmp_preichl/15/artifact/UMB_message.json).

There's also problem with missing digest of the build.