### PR TITLE
update-base-images: fail faster on missing rpms

### DIFF
--- a/jobs/build/update-base-images/build.sh
+++ b/jobs/build/update-base-images/build.sh
@@ -26,10 +26,13 @@ build_common() {
 
     cd ${TARGET_DIR}
     echo "$img" > additional-tags
-    echo """FROM $from
+    echo """
+    FROM $from
 
     USER root
-    RUN yum update -y $@ && yum clean all
+    RUN echo 'skip_missing_names_on_install=0' >> /etc/yum.conf \\
+     && yum update -y $@ \\
+     && yum clean all
     USER $user
 
     LABEL \\


### PR DESCRIPTION
configure all of our base images to fail yum installs that are only
partially satisfied. we already check for this after the build finishes,
but it would be better for the install logs to show the failure.