### PR TITLE
Change advisory state to attach metadata build on appregistry job

### DIFF
--- a/jobs/build/appregistry/Jenkinsfile
+++ b/jobs/build/appregistry/Jenkinsfile
@@ -173,12 +173,16 @@ node {
                     }
                 } else {
                     if (params.ADVISORY) {
+                        buildlib.elliott("change-state -s NEW_FILES -a ${params.ADVISORY} ${params.DRY_RUN ? "--noop" : ""}")
+
                         cmd = """--group openshift-${params.BUILD_VERSION}
                             find-builds -k image
                             --build ${build.metadata_nvr}
                             --attach ${params.ADVISORY}
                         """
                         buildlib.elliott(cmd)
+
+                        buildlib.elliott("change-state -s QE -a ${params.ADVISORY} ${params.DRY_RUN ? "--noop" : ""}")
                     }
                 }
             }


### PR DESCRIPTION
Related to: https://jira.coreos.com/browse/ART-877

Temporarily change the state of provided advisory to `NEW_FILES`, to be able to attach the new build, then sets it back to `QE`.