### PR TITLE
Job for building signed EL7/EL8 composes

### DIFF
--- a/build-scripts/puddle-conf/errata-puddle-4.2-signed.el8.conf
+++ b/build-scripts/puddle-conf/errata-puddle-4.2-signed.el8.conf
@@ -1,0 +1,18 @@
+[puddle]
+type = simple
+rootdir = /mnt/rcm-guest/puddles/RHAOS
+mashroot = /mnt/rcm-guest/puddles/RHAOS/mash
+brewroot = file:///mnt/redhat/brewroot
+topurl = http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/
+name = AtomicOpenShift-signed
+version = 4.2-el8
+emails = aos-team-art@redhat.com
+announcer = openshift-puddle <aos-team-art@redhat.com>
+publish = no
+external = /mnt/redhat/brewroot/repos/rhel-8-build/latest/$arch/
+arches = x86_64,ppc64le,aarch64,s390x
+keys = fd431d51,f21541eb
+signed = yes
+blacklist = thrift-glib, thrift-qt, v8-python
+tag = rhaos-4.2-rhel-8-image-build
+variant = RHOSE-4.2

--- a/build-scripts/rcm-guest/call_puddle_advisory_el8.sh
+++ b/build-scripts/rcm-guest/call_puddle_advisory_el8.sh
@@ -4,15 +4,11 @@ set -euxo pipefail
 # Download conf file from URL and call puddle with given advisories
 
 VERSION=$1
-ERRATA=$2
 CONF=`mktemp`
-echo "Making new signed compose for OCP ${VERSION} using Errata Whitelist: '${ERRATA}'"
+echo "Making new signed compose for OCP ${VERSION}-el8"
 
 echo "Fetching default errata-puddle config file for ${VERSION}"
-wget https://raw.githubusercontent.com/openshift/aos-cd-jobs/master/build-scripts/puddle-conf/errata-puddle-${VERSION}-signed.conf -O $CONF
-
-echo "Substituting in errata_whitelist with provided value: ${ERRATA}"
-sed -i -r "s|errata_whitelist.*|errata_whitelist = ${ERRATA}|" $CONF
+wget https://raw.githubusercontent.com/openshift/aos-cd-jobs/master/build-scripts/puddle-conf/errata-puddle-${VERSION}-signed.el8.conf -O $CONF
 
 echo "Running puddle command"
 puddle $CONF -b -d -n

--- a/jobs/build/signed-compose/build.groovy
+++ b/jobs/build/signed-compose/build.groovy
@@ -4,96 +4,406 @@ commonlib = buildlib.commonlib
 // We'll update this later
 elliottOpts = ""
 advisoryOpt = "--use-default-advisory rpm"
+errataList = ""
+puddleURL = "http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift-signed/${params.BUILD_VERSION}"
+workdir = "puddleWorking"
+// Substitute the advisory ID in later
+rpmDiffsUrl = "https://errata.devel.redhat.com/advisory/ID/rpmdiff_runs"
 
 def initialize(advisory) {
+    buildlib.cleanWorkdir(workdir)
     elliottOpts += "--group=openshift-${params.BUILD_VERSION}"
-    echo "${currentBuild.DisplayName}: https://errata.devel.redhat.com/advisory/${advisory}"
+    echo("${currentBuild.displayName}: https://errata.devel.redhat.com/advisory/${advisory}")
+    rpmDiffsUrl = rpmDiffsUrl.replace("ID", advisory)
+    errataList += buildlib.elliott("${elliottOpts} puddle-advisories", [capture: true]).trim().replace(' ', '')
+    currentBuild.description = "Signed puddle for advisory https://errata.devel.redhat.com/advisory/${advisory}"
+    currentBuild.description += "\nErrata whitelist: ${errataList}"
 }
 
+// Set the advisory to the NEW_FILES state (allows builds to be added)
 def signedComposeStateNewFiles() {
-    buildlib.elliott "${elliottOpts} change-state --state NEW_FILES ${advisoryOpt}"
+    buildlib.elliott("${elliottOpts} change-state --state NEW_FILES ${advisoryOpt}")
 }
 
+// Search brew for, and then attach, any viable builds. Do this for
+// EL7 and EL8.
 def signedComposeAttachBuilds() {
-    buildlib.elliott "${elliottOpts} find-builds --kind rpm ${advisoryOpt}"
+    // Don't actually attach builds if this is just a dry run
+    def advs = (params.DRY_RUN == true) ? advisoryOpt : ''
+    def cmd = "${elliottOpts} find-builds --kind rpm ${advs}"
+    def cmdEl8 = "${elliottOpts} --branch rhaos-${params.BUILD_VERSION}-rhel-8 find-builds --kind rpm ${advs}"
+
+    try {
+        def attachResult = buildlib.elliott(cmd, [capture: true]).trim().split('\n')[-1]
+        def attachResultEl8 = buildlib.elliott(cmdEl8, [capture: true]).trim().split('\n')[-1]
+    } catch (err) {
+        echo("Problem running elliott")
+        currentBuild.description += """
+----------------------------------------
+${err}
+----------------------------------------"""
+        error("Could not process a find-builds command")
+    }
 }
 
+// Monitor and wait for all of the RPM diffs to run.
+//
+// @param <String> advisory: The ID of the advisory to watch
 def signedComposeRpmdiffsRan(advisory) {
     commonlib.shell(
-	// script auto-waits 60 seconds and re-retries until completed
-	script: "./rpmdiff.py check-ran ${advisory}",
+        // script auto-waits 60 seconds and re-retries until completed
+        script: "./rpmdiff.py check-ran ${advisory}",
     )
 }
 
+// Check that each of the RPM Diffs for the given advisory have been
+// resolved (waived/passed). RPM Diffs that require human intervention
+// will be collected and then later emailed out to the team.
+//
+// The job will block here until the diffs are resolved and someone
+// presses the `CONTINUE` button.
+//
+// @param <String> advisory: The ID of the advisory to check
 def signedComposeRpmdiffsResolved(advisory) {
     echo "Action may be required: Complete any pending RPM Diff waivers to continue. Pending diffs will be printed."
 
-    def stderr, stdout, res = commonlib.shell(
-	script: "./rpmdiff.py check-resolved {$advisory}", returnAll: true
+    def result = commonlib.shell(
+        script: "./rpmdiff.py check-resolved ${advisory}",
+        returnAll: true
     )
 
-    if (res != 0) {
-	mailForResolution(stdout)
-	// email people to have somebody take care of business
-	def resp = input message: "Action required: Complete any pending RPM Diff waivers to continue",
+    if (result.returnStatus != 0) {
+        currentBuild.description += "\nRPM Diff resolution required"
+        mailForResolution(result.stdout)
+        // email people to have somebody take care of business
+        def resp = input message: "Action required: Complete any pending RPM Diff waivers to continue",
         parameters: [
-	    [
+            [
                 $class: 'hudson.model.ChoiceParameterDefinition',
                 choices: "CONTINUE\nABORT",
                 name: 'action',
                 description: 'CONTINUE if all RPM diffs have been waived. ABORT (terminate the pipeline) to stop this job.'
-	    ]
+            ]
         ]
 
         switch (resp) {
-	    case "CONTINUE":
-                echo "RPM Diffs are resolved. Continuing to make signed puddle"
+            case "CONTINUE":
+                echo("RPM Diffs are resolved. Continuing to make signed puddle")
                 return true
-	    default:
+            default:
                 error("User chose to abort pipeline after reviewing RPM Diff waivers")
         }
     }
 }
 
+// Put the advisory into the QE state. This will trigger the
+// build-signing mechanism. You might call this more than once if
+// you're having trouble getting a build to get signed in a reasonable
+// amount of time (10 minutes).
 def signedComposeStateQE() {
-    buildlib.elliott "${elliottOpts} change-state --state QE ${advisoryOpt}"
+    buildlib.elliott("${elliottOpts} change-state --state QE ${advisoryOpt}")
 }
 
+// Poll the 'signed' status of all builds attached to the advisory. We
+// wrap this in a retry() because some times the builds won't get
+// signed in a reasonable amount of time (10 minutes). To account for
+// that possible condition we frob the state between NEW_FILES and
+// QE. Re-entering the QE state triggers the signing mechanism again.
 def signedComposeRpmsSigned() {
-    buildlib.elliott "${elliottOpts} poll-signed ${adisoryOpt}"
+    def signed = false
+    retry(3) {
+        try {
+            buildlib.elliott("${elliottOpts} poll-signed --minutes=10 ${advisoryOpt}")
+            signed = true
+        } catch (err) {
+            signedComposeStateNewFiles()
+            // Give it a chance to catch up. ET can be slow
+            sleep 5
+            signedComposeStateQE()
+        } finally {
+            if ( !signed ) {
+                error("Failed to get all builds to 'signed' status after 3 retries")
+            }
+        }
+    }
 }
 
-def signedComposeNewCompose() {
-    echo "Puddle a signed compose including the errata"
+// Create a new RHEL7 compose. Take note of the following:
+//
+// The `puddle` command (which this step invokes) *REQUIRES* that the
+// user running it (ocp-build, in this case) has a valid kerberos
+// ticket. To ensure that this is ready and available for our use case
+// we must ensure a few things happen:
+//
+// * The `jenkins` user has enabled kerberos `ticket forwarding`
+//   option. When running `kinit` we *MUST* include the `-f` option
+//   flag. This requests a `forwardable` ticket for the user.
+//
+// * Additionally, ensure that the `jenkins` user has the:
+//
+//     `GSSAPIDelegateCredentials yes`
+//
+//  option set in their ~/.ssh/config file like this:
+//
+//     Host rcm-guest rcm-guest.app.eng.bos.redhat.com
+//     Hostname                   rcm-guest.app.eng.bos.redhat.com
+//     User                       ocp-build
+//     GSSAPIDelegateCredentials  yes
+//
+// That last line there, will tell the `ssh` command to try to
+// authenticate using GSSAPI (kerberos, in our case) credentials.
+//
+// FINALLY, the user on the remote end (`ocp-build`) *MUST* have their
+// `~/.k5login` file configured to include the principal we're
+// authenticating with.
+def signedComposeNewComposeEl7() {
+    if ( params.DRY_RUN ) {
+        currentBuild.description += "\nDry-run: EL7 Compose not actually built"
+        echo("Skipping running puddle. Would have used whitelist: ${errataList}")
+    } else {
+        def cmd = "ssh ocp-build@rcm-guest.app.eng.bos.redhat.com sh -s ${buildlib.args_to_string(params.BUILD_VERSION, errataList)} < ${env.WORKSPACE}/build-scripts/rcm-guest/call_puddle_advisory.sh"
+        def result = commonlib.shell(
+            script: cmd,
+            returnAll: true,
+        )
 
-    def errataList = buildlib.getErrataWhitelist(params.BUILD_VERSION)
-    buildlib.invoke_on_rcm_guest("call_puddle_advisory.sh", params.BUILD_VERSION, errataList)
-
-    echo "View the package list here: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift/${params.BUILD_VERSION}/latest/x86_64/os/Packages/"
+        if ( result.returnStatus != 0 ) {
+            mailForFailure(result.combined)
+            error("Error running puddle command")
+        }
+    }
 }
 
+// Create a new signed RHEL8 puddle. This is a work-around of sorts.
+//
+// Due to limitations in 'puddle' (which is deprecated) we have to
+// assemble a RHEL8 brew tag with signed packages MANUALLY. This
+// script (ocp-tag-signed-errata-builds.py) was provided by Ryan
+// Hartman from RCM. This replaces our former process (pre September
+// 2019) wherein we would have to submit a ticket to RCM to have
+// packages assembled into a constantly changing brew tag.
+//
+// Now, using this new process, we skip making a ticket. Instead, our
+// build account (kerberos principal:
+// ocp-build/buildvm.openshift.eng.bos.redhat.com@REDHAT.COM) has been
+// given permission to add packages into the new tags for RHEL8.
+def signedComposeNewComposeEl8() {
+    def tagCmd = "./ocp-tag-signed-errata-builds.py --errata-group RHOSE-${params.BUILD_VERSION} --errata-group 'RHOSE ASYNC' --errata-product RHOSE --errata-product-version OSE-${params.BUILD_VERSION}-RHEL-8 --brew-pending-tag rhaos-${params.BUILD_VERSION}-rhel-8-image-build --verbose"
+
+    if ( params.DRY_RUN ) {
+        currentBuild.description += "\nDry-run: EL8 Compose not actually built"
+        echo("Packages which would have been added to rhaos-${params.BUILD_VERSION}-rhel-8-image-build tag:")
+        def testTagCmd = cmd + " --test"
+        def tagResult = commonlib.shell(
+            script: testTagCmd,
+            returnAll: true,
+        )
+
+        echo("Sleeping 10 seconds to give brew some time to catch up")
+        sleep 10
+
+        if ( tagResult.returnStatus == 0 ) {
+            echo(tagResult.stdout)
+        } else {
+            echo()
+            error("""Error running test tag assembly:
+----------------------------------------
+${tagResult.combined}
+----------------------------------------
+""")
+        }
+    } else {
+        echo("Updating RHEL8 brew tag")
+        def tagResult = commonlib.shell(
+            script: tagCmd,
+            returnAll: true,
+        )
+
+        echo("Sleeping 10 seconds to give brew some time to catch up")
+        sleep 10
+
+        if ( tagResult.returnStatus == 0 ) {
+            def newPkgs = []
+            def untaggedPkgs = []
+            for ( line in tagResult.stdout.split('\n') ) {
+                if ( line.contains('tag_builds') ) {
+                    newPkgs.add(line.split(' ')[3])
+                } else if ( line.contains('untag_builds') ) {
+                    untaggedPkgs.add(line.split(' ')[3])
+                }
+            }
+
+            if ( newPkgs.size() > 0 ) {
+                currentBuild.description += "\n${newPkgs.size()} packages added to RHEL8 tag"
+                currentBuild.description += "\n${untaggedPkgs.size()} packages removed from RHEL8 tag"
+                currentBuild.displayName += " [+${newPkgs.size()}/-${untaggedPkgs.size()} EL8]"
+            }
+        } else {
+            mailForFailure(tagResult.combined)
+            error("""Error running tag assembly:
+----------------------------------------
+${tagResult.combined}
+----------------------------------------
+""")
+        }
+
+        echo("Building RHEL8 puddle")
+        def puddleCmd = "ssh ocp-build@rcm-guest.app.eng.bos.redhat.com sh -s ${buildlib.args_to_string(params.BUILD_VERSION)} < ${env.WORKSPACE}/build-scripts/rcm-guest/call_puddle_advisory_el8.sh"
+        def puddleResult = commonlib.shell(
+            script: puddleCmd,
+            returnAll: true,
+        )
+
+        if ( puddleResult.returnStatus == 0 ) {
+            echo("View the package list here: ${puddleURL}-el8")
+        } else {
+            mailForFailure(puddleResult.combined)
+            error("Error running puddle command")
+        }
+    }
+}
+
+// We did it! This grabs puddle logs to give us data required to
+// format a useful email.
+def mailForSuccess() {
+    def puddleMetaEl7 = analyzePuddleLogs()
+    def puddleMetaEl8 = analyzePuddleLogs('-el8')
+    def successMessage = """New signed composes created for OpenShift ${params.BUILD_VERSION}
+
+  Errata Whitelist included advisories: ${errataList}
+  EL7 Puddle URL: ${puddleMetaEl7.newPuddle}
+  EL8 Puddle URL: ${puddleMetaEl8.newPuddle}
+  Jenkins Console Log: ${commonlib.buildURL('console')}
+
+Puddle Changelog EL7:
+######################################################################
+${puddleMetaEl7.changeLog}
+######################################################################
+
+Puddle Changelog EL8:
+######################################################################
+${puddleMetaEl8.changeLog}
+######################################################################
+
+"""
+
+    echo("Mailing success message: ")
+    echo(successMessage)
+
+    commonlib.email(
+        // to: "aos-art-automation@redhat.com",
+        to: params.MAIL_LIST_SUCCESS,
+        from: "aos-art-automation+new-signed-compose@redhat.com",
+        replyTo: "aos-team-art@redhat.com",
+        subject: "New signed compose for OpenShift ${params.BUILD_VERSION} job #${currentBuild.number}",
+        body: successMessage,
+    )
+}
+
+// @param <String> err: Error message from failed command
+def mailForFailure(String err) {
+    def failureMessage = """Error creating new signed compose OpenShift ${params.BUILD_VERSION}
+
+  Errata Whitelist included advisories: ${errataList}
+  Jenkins Console Log: ${commonlib.buildURL('console')}
+
+######################################################################
+${err}
+######################################################################
+
+"""
+
+    echo("Mailing failure message: ")
+    echo(failureMessage)
+
+    commonlib.email(
+        // to: "aos-art-automation@redhat.com",
+        to: params.MAIL_LIST_FAILURE,
+        from: "aos-art-automation+failed-signed-compose@redhat.com",
+        replyTo: "aos-team-art@redhat.com",
+        subject: "Error creating new signed compose for OpenShift ${params.BUILD_VERSION} job #${currentBuild.number}",
+        body: failureMessage,
+    )
+}
+
+// RPM Diffs have ran, however, they are not all resolved/waived. Send
+// out a notice to the team so someone can complete the remaining
+// diffs.
+//
+// @param <String> diffs: A string with the status of EACH remaining
+// diff, what RPM is being diffed, and the URL to resolve the diff
 def mailForResolution(diffs) {
-    def buildURL = env.BUILD_URL.replace('https://buildvm.openshift.eng.bos.redhat.com:8443', 'https://localhost:8888')
     def diffMessage = """
 Manual RPM Diff resolution is required for the generation of an
 ongoing signed-compose. Please review the RPM Diffs below and resolve
 them as soon as possible.
 
+View all RPM Diffs: ${rpmDiffsUrl}
+----------------------------------------
 ${diffs}
+----------------------------------------
 
 After the RPM Diffs have been resolved please return to the
 in-progress compose job and choose the CONTINUE option.
 
-    - Jenkins job: ${buildURL}
+    - Jenkins job: ${commonlib.buildURL('input')}
 """
 
     commonlib.email(
-        to: "aos-art-automation@redhat.com",
+        // to: "aos-art-automation@redhat.com",
+        to: params.MAIL_LIST_FAILURE,
         from: "aos-art-automation+rpmdiff-resolution@redhat.com",
         replyTo: "aos-team-art@redhat.com",
-	subject: "RPM Diffs require resolution for signed compose: ${currentBuild.number}",
-	body: diffMessage
+        subject: "RPM Diffs require resolution for signed compose: ${currentBuild.number}",
+        body: diffMessage,
     )
 }
+
+// ######################################################################
+// Some utility functions
+// ######################################################################
+
+// Get data from the logs of the newly created puddle. Will download
+// the puddle.log and changelog.log files for archiving. Uses the
+// global `puddleURL` variable to get the initial log. This log is
+// parsed to identify the unique tag (`latestTag`) of the new puddle.
+//
+// @params <String> dist: Prefixed with a hyphen '-', a short
+// distribution name. For example: '-el8'. Absent (default) will pull
+// standard puddle logs, which are el7.
+//
+// @return <Object> (map) with keys:
+// - String changeLog: The full changelog
+// - String puddleLog: The full build log
+// - String latestTag: The YYYY-MM-DD.i tag of the puddle, where 'i'
+//   is a monotonically increasing integer
+// - String newPuddle: Full URL to the new puddle base directory
+def analyzePuddleLogs(String dist='') {
+    dir(workdir) {
+        // Get the generic 'latest', it will tell us the actual name of this new puddle
+        commonlib.shell("wget ${puddleURL}${dist}/latest/logs/puddle.log -O puddle${dist}.log")
+        // This the tag of our newly created puddle
+        def latestTag = commonlib.shell(
+            script: "awk -n '/now points to/{print \$NF}' puddle${dist}.log",
+            returnStdout: true,
+        ).trim()
+
+        currentBuild.description += "\nTag${dist}: ${latestTag}"
+        // Form the canonical URL to our new puddle
+        def newPuddle = "${puddleURL}${dist}/${latestTag}"
+
+        currentBuild.description += "Puddle: ${newPuddle}"
+        // Save the changelog for emailing out
+        commonlib.shell("wget ${newPuddle}/logs/changelog.log -O changelog${dist}.log")
+
+        return [
+            changeLog: readFile("changelog${dist}.log"),
+            puddleLog: readFile("puddle${dist}.log"),
+            latestTag: latestTag,
+            newPuddle: newPuddle,
+        ]
+    }
+}
+
 
 return this

--- a/jobs/build/signed-compose/ocp-tag-signed-errata-builds.py
+++ b/jobs/build/signed-compose/ocp-tag-signed-errata-builds.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python
+
+"""
+PURPOSE
+ * This script only tags builds into pending
+ * Builds get into builroot via buildroot-push tag (rcm-common/bin/push_to_buildroot)
+ * Builds get into released/main tag via move-pushed-erratum in errata tool in post push tasks
+ * Original/legacy script is still available as sync_brew_with_errata (lot of redundancy and slow)
+"""
+import optparse
+import urllib3
+import koji
+import xmlrpclib
+import logging
+import sys
+from kobo.rpmlib import compare_nvr
+
+def get_logger_name():
+    try:
+        return __file__
+    except NameError:
+        return sys.argv[0]
+
+#: This is our log object, clients of this library can use this
+#: object to define their own logging needs
+
+BREW_URL = "https://brewhub.engineering.redhat.com/brewhub"
+ERRATA_URL = "http://errata-xmlrpc.devel.redhat.com/errata/errata_service"
+ERRATA_API_URL = "https://errata.engineering.redhat.com/api/v1/"
+
+DROPPED_STATES = ["DROPPED"]
+SHIPPED_STATES = ["SHIPPED_LIVE"]
+
+BREW_EMBARGOED_TAG = "embargoed"
+
+def tag_builds(koji_proxy, tag, nvrs, tagged_builds, test=False):
+    """
+    tag_builds from nvrs into tag, skip already tagged ones
+    Args:
+        koji_proxy
+        tag: buildroot push tag
+        nvrs: list of nvrs
+        tagged_builds: dict {nvr: build_info_hash}
+        test=False
+    """
+    for nvr in sorted(nvrs):
+        if not nvr in tagged_builds:
+            logging.debug("tag_builds: %s is not tagged.", nvr)
+            if not test:
+                logging.info("tag_builds: Tagging build: %s", nvr)
+                koji_proxy.tagBuild(tag, nvr) # non-blocking
+            else:
+                logging.info("tag_builds: Would tag %s into %s", nvr, tag)
+        else:
+            logging.debug("tag_builds: Build %s is already tagged.", nvr)
+
+def untag_builds(koji_proxy, tag, nvrs, tagged_builds, test=False):
+    """
+    untag builds from tagged_builds if the buildroot push flag is removed
+    otherwise just keep on tagging on top of each other
+    Args:
+        koji_proxy
+        tag: buildroot push tag
+        nvrs: list of nvrs
+        tagged_builds: dict {nvr: build_info_hash}
+        test=False
+    """
+    # let's iterate over builds which are actually tagged (less)
+    #
+    # untag only builds which are in errata and buildroot-push is not set.
+    # Which implies that somebody cancelled the flag. 
+    for nvr in sorted(tagged_builds):
+        if nvr in nvrs:
+            logging.debug("untag_builds: %s is tagged", nvr)
+            if not test:
+                logging.info("untag_builds: Untagging build: %s", nvr)
+                koji_proxy.untagBuild(tag, nvr) # non-blocking
+            else:
+                logging.info("untag_builds: Would untag %s from %s", nvr, tag)
+
+def _diff_me(a_builds, b_builds):
+    """
+    Returns set of nvrs which are in a but not in b
+    Args:
+        a_builds list or set of nvrs
+        b_builds list or set of nvrs
+    """
+    logging.debug("a_builds: %s" % a_builds)
+    logging.debug("b_builds: %s" % b_builds)
+
+    return set(b_builds).difference(set(a_builds))
+
+def get_missing_builds(errata, tagged):
+    """
+    Returns dict nvr: build_info  for builds which are in errata but not in pending
+    """
+    return _diff_me(tagged, errata)
+
+def get_extra_builds(errata, tagged):
+    """
+    Returns dict nvr: build_info  for builds which are in pending but not in errata
+    """
+    return _diff_me(errata, tagged)
+
+def get_errata_builds(errata_proxy, errata_group,
+                      errata_product, module_builds=False, errata_product_version=None):
+    """
+    returs dict {nvr: build_info} doesn't actually fetch build info from koji
+        to get result faster
+    Args:
+        errata_proxy
+        errata_group
+        errata_product
+        errata_product_version
+    """
+
+    errata_builds = {}
+
+
+    for advisory in errata_proxy.get_advisory_list(dict(group=errata_group,
+        product=errata_product)):
+        logging.debug("Checking advisory %s", advisory["errata_id"])
+
+        if advisory["status"] in DROPPED_STATES:
+            logging.debug("Skipping because it is DROPPED")
+            continue
+
+        if advisory["status"] in SHIPPED_STATES:
+            logging.debug("Skipping advisory as it is SHIPPED and it's already in released tag.")
+            continue
+        
+        if advisory["status"] == "NEW FILES":
+            logging.debug("Skipping advisory as it is in New Files thus it doesn't contain signed builds")
+            continue
+
+        logging.debug("Getting builds from advisory: %s", advisory["errata_id"])
+        for build in errata_proxy.getErrataBrewBuilds(advisory["errata_id"]):
+            nvr = build["brew_build_nvr"]
+            logging.debug("Checking NVR %s", nvr)
+            if errata_product_version:
+                product_version = build["product_version"]["name"]
+                if product_version != errata_product_version:
+                    logging.debug("skipping build it's not in specified product version: %s",
+                        nvr, product_version, ', '.join(errata_product_version))
+                    continue
+            is_module = build["is_module"]
+            if module_builds and not is_module:
+                   continue
+            if not module_builds and is_module:
+                   continue
+            build_info = {}
+            build_info["build_flags"] = build["build_flags"]
+            errata_builds[nvr] = build_info
+            logging.debug("NVR %s added", nvr)
+
+    return errata_builds
+
+
+def get_brew_builds(koji_proxy, brew_tags, latest=False, inherit=False):
+    """
+    """
+    brew_builds_by_name = {}
+    brew_builds = set()
+
+    if not brew_tags:
+        brew_tags = []
+    if isinstance(brew_tags, basestring):
+        brew_tags = [brew_tags]
+
+    for brew_tag in brew_tags:
+        for build in koji_proxy.listTagged(brew_tag, latest=latest, inherit=inherit):
+            if latest:
+                previous_build = brew_builds_by_name.get(build["name"])
+                if not previous_build or compare_nvr(previous_build, build) == 1:
+                    brew_builds_by_name[build["name"]] = build
+                    brew_builds.remove(previous_build)
+                    brew_builds.add(build["nvr"])
+            else:
+                brew_builds.add(build["nvr"])
+    return brew_builds
+
+def main():
+    parser = optparse.OptionParser("%prog --errata-group=NAME" \
+            "--errata-product=NAME --brew-pending-tag=NAME")
+    parser.add_option(
+        "--brew-pending-tag",
+        metavar="NAME",
+        help="Required. Main Brew tag. Example: rhel-7.0",
+    )
+
+    parser.add_option(
+        "--errata-product",
+        metavar="NAME",
+        help="Required. Name of Product in Errata Tool.",
+    )
+    parser.add_option(
+        "--errata-product-version",
+        dest="errata_product_version",
+        metavar="VERSION",
+        help="Example: RHEL-7.5",
+    )
+    parser.add_option(
+        "--errata-group",
+        metavar="NAME",
+        action="append",
+        default=[],
+        help="Required. Errata release. May be specified multiple times. Example: RHEL-7.0.0",
+    )
+    parser.add_option(
+        "--brew-url",
+        default=BREW_URL,
+        help="Brew hub URL, default: %s" % BREW_URL
+    )
+    parser.add_option(
+        "--errata-xmlrpc-url",
+        default=ERRATA_URL,
+        help="Errata Tool XMLRPC URL, default: %s" % ERRATA_URL
+    )
+    parser.add_option(
+        "--errata-api-url",
+        default=ERRATA_API_URL,
+        help="Errata Tool REST API URL, default: %s" % ERRATA_API_URL
+    )
+    parser.add_option(
+        "--test",
+        action="store_true",
+        help="Do not execute any tagging operation."
+    )
+    parser.add_option(
+        "--brew-source-tag",
+        action="append",
+        help=optparse.SUPPRESS_HELP
+    )
+    parser.add_option(
+        "--brew-ignore-embargoed-tag",
+        action="store_true",
+        help=("Allow builds into destination tag even if tagged into the Brew 'embargoed' tag.")
+    )
+    parser.add_option(
+        "--brew-embargoed-tag-name",
+        default=BREW_EMBARGOED_TAG,
+        help=("Name of Brew tag to check for embargoed builds. Default: '%s'" % BREW_EMBARGOED_TAG)
+    )
+    parser.add_option(
+        "--module-builds",
+        action="store_true",
+        help="to distinguish between module & non-module builds."
+    )
+    parser.add_option(
+        "--quiet",
+        action="store_true",
+        help="Suppress most logs except critical ones"
+    )
+    parser.add_option(
+        "--verbose",
+        action="store_true",
+        help="Output VERBOSE lines"
+    )
+    parser.add_option(
+        "--debug",
+        action="store_true",
+        help="Show debug output"
+    )
+
+    opts, _ = parser.parse_args()
+
+    log_level = logging.WARNING # Default logging level
+    if opts.quiet:
+        log_level = logging.ERROR
+    elif opts.verbose:
+        log_level = logging.INFO
+    elif opts.debug:
+        log_level = logging.DEBUG
+
+    logging.basicConfig(level=log_level)
+    
+
+        
+
+    # Disabling all urllib3 warnings to hide all noise caused by old python version
+    # on RHEL 6.9 (lack of SNI support and an outdated ssl module).
+    # It is not possible to hide specific warnings due to import issues on the server.
+    # Refer to JIRA: RCMWORK-5834 for more details
+    urllib3.disable_warnings()
+
+    # Checking for valid brew_tag
+    koji_proxy = koji.ClientSession(opts.brew_url, opts={'krbservice': 'brewhub'})
+    koji_proxy.krb_login()
+    multicall = xmlrpclib.MultiCall(koji_proxy)
+    errata_proxy = xmlrpclib.ServerProxy(opts.errata_xmlrpc_url)
+
+    test_tags = []
+
+    embargoed_builds = set()
+    if not opts.brew_ignore_embargoed_tag:
+        multicall.getTag(opts.brew_embargoed_tag_name)
+        logging.debug("Getting embargoed builds")
+        embargoed_builds = get_brew_builds(koji_proxy, opts.brew_embargoed_tag_name,
+                                           latest=False, inherit=False)
+
+    if not opts.brew_pending_tag:
+        parser.error("specify brew tag")
+
+    multicall.getTag(opts.brew_pending_tag)
+    test_tags.append(opts.brew_pending_tag)
+
+    if not opts.errata_product:
+        parser.error("specify errata product")
+
+    if not (opts.errata_group or opts.errata_product_version):
+        parser.error("specify errata group (release) or errata product version")
+
+    logging.debug("Getting all builds from tag: %s",
+        opts.brew_pending_tag)
+
+    # these are currently in pending
+    tagged_builds = get_brew_builds(koji_proxy, opts.brew_pending_tag,
+                                    latest=False, inherit=False)
+
+    logging.debug("product: %s release_group: %s product_version: %s",
+        opts.errata_product, opts.errata_group, opts.errata_product_version)
+    # all of these should be in pending
+    all_et_builds = get_errata_builds(errata_proxy, opts.errata_group, opts.errata_product, opts.module_builds,
+                    opts.errata_product_version)
+
+    et_builds = set(all_et_builds.keys())
+
+    # Ignore ET builds that don't come from specified source tag(s)
+    if opts.brew_source_tag:
+        # builds in tags specified via --brew-source-tag opts
+        source_tag_builds = set()
+        for source_tag in opts.brew_source_tag:
+            builds = get_brew_builds(koji_proxy, source_tag,
+                                        latest=False, inherit=False)
+            source_tag_builds |= set(builds)
+
+        # keep only builds we care about
+        et_builds &= source_tag_builds
+
+    # Remove builds that are also in the embargoed build list
+    logging.debug("Removing builds which are also in the '%s' tag", opts.brew_embargoed_tag_name)
+    et_builds -= set(embargoed_builds)
+
+    logging.debug("Getting builds which are in Errata but not in tag: %s",
+        opts.brew_pending_tag)
+    missing = get_missing_builds(et_builds, tagged_builds)
+    logging.debug("Found %d builds which are not tagged. %s" % (len(missing), missing))
+
+    logging.debug("Getting builds which are in tag: %s but not in Errata",
+        opts.brew_pending_tag)
+    extra = get_extra_builds(et_builds, tagged_builds)
+    logging.debug("Found %d builds which are tagged and shouldn't be. %s" % (len(extra), extra))
+
+
+
+    # to be removed from -pending
+    tag_builds(koji_proxy, opts.brew_pending_tag, missing, tagged_builds, test=opts.test)
+    untag_builds(koji_proxy, opts.brew_pending_tag, extra, tagged_builds, test=opts.test)
+
+if __name__ == "__main__":
+    main()

--- a/jobs/build/signed-compose/rpmdiff.py
+++ b/jobs/build/signed-compose/rpmdiff.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from pprint import pprint as pp
 import os
 import time
 import sys
@@ -12,6 +13,8 @@ def rpmdiffs_ran(advisory):
     rpmdiffs = advisory.externalTests(test_type='rpmdiff')
 
     print("Checking to see if RPM diffs have finished running")
+    print("Current RPM Diff status data:")
+    pp(rpmdiffs)
     not_finished_diffs = []
     for diff in rpmdiffs:
         if diff['attributes']['status'] in ['QUEUED_FOR_TEST', 'RUNNING']:
@@ -30,6 +33,9 @@ def rpmdiffs_resolved(advisory):
     rpmdiffs = advisory.externalTests(test_type='rpmdiff')
     completed_diffs = []
     incomplete_diffs = []
+
+    print("Current RPM Diff status data:")
+    pp(rpmdiffs)
 
     for diff in rpmdiffs:
         if diff['attributes']['status'] in ['INFO', 'WAIVED']:

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -37,7 +37,11 @@ def kinit() {
     echo "Initializing ocp-build kerberos credentials"
     // Keytab for old os1 build machine
     // sh "kinit -k -t /home/jenkins/ocp-build.keytab ocp-build/atomic-e2e-jenkins.rhev-ci-vms.eng.rdu2.redhat.com@REDHAT.COM"
-    sh "kinit -k -t /home/jenkins/ocp-build-buildvm.openshift.eng.bos.redhat.com.keytab ocp-build/buildvm.openshift.eng.bos.redhat.com@REDHAT.COM"
+    //
+    // The '-f' ensures that the ticket is forwarded to remote hosts
+    // when using SSH. This is required for when we build signed
+    // puddles.
+    sh "kinit -f -k -t /home/jenkins/ocp-build-buildvm.openshift.eng.bos.redhat.com.keytab ocp-build/buildvm.openshift.eng.bos.redhat.com@REDHAT.COM"
 }
 
 def registry_login() {
@@ -111,25 +115,6 @@ def oc(cmd, opts=[:]){
         returnStdout: opts.capture ?: false,
         script: "GOTRACEBACK=all /usr/bin/oc ${cleanWhitespace(cmd)}"
     )
-}
-
-def getDefaultAdvisoryID(version, type) {
-    // Get the ID of the default advisory for the given version of the
-    // specified type (rpm/image/security)
-    //
-    // @param version: The openshift version param, e.g. '4.2'
-    // @param type: The kind of advisory to look up, e.g. rpm/image/security
-    def result = this.elliott "--group=openshift-${version} get --use-default-advisory ${type} --id-only", [capture: true]
-    return result.stdout
-}
-
-def getErrataWhitelist(version) {
-    // Get the advisories that should go into an errata_whitelist
-    // puddle config
-    //
-    // @param version: The openshift version param, e.g. '4.2'
-    def result = this.elliott "--group=openshift-${version} puddle-advisories", [capture: true]
-    return result.stdout
 }
 
 def initialize_ose_dir() {


### PR DESCRIPTION
Supports https://jira.coreos.com/browse/ART-308 - "Always build
(images) ONCE"

Introduces a new job, 'signed-compose'. Automatically Handles most of
the business required to get new RPMs added to the correct advisory,
RPM Diffs resolved, RPMs signed, and new generating a new compose.

* RPM Diffs are reviewed for completeness. A notice is emailed if
  action is required
* Monitors 'signed' status. Will retry 3 times to get RPMs signed if
  the robo-signer is hanging
* Updates a RHEL8 brew tag with new signed builds

----

Note some removals of code that was originally in buildlib. Most of that was moved, or just removed because it wasn't being used.