### PR TITLE
ART-947: fix release job ADVISORY parameter and remove ERRATA_URL par…

### DIFF
--- a/jobs/build/pre-release/Jenkinsfile
+++ b/jobs/build/pre-release/Jenkinsfile
@@ -71,7 +71,7 @@ node {
 
             stage("versions") { prerelease.stageVersions() }
 
-            stage("validation") { prerelease.stageValidation(quay_url, from_release_tag, "") }
+            stage("validation") { prerelease.stageValidation(quay_url, from_release_tag) }
 
             stage("payload") { prerelease.stageGenPayload(quay_url, from_release_tag, from_release_tag, "", "", "") }
 

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -313,4 +313,13 @@ def array_to_list(array) {
     return l
 }
 
+/**
+ * Given a version string x.y.z,
+ * returns the x.y part.
+ * e.g. "4.1.0-rc.9" => "4.1"
+ */
+String extractMajorMinorVersion(String version) {
+    return (version =~ /^(\d+\.\d+)/)[0][1]
+}
+
 return this


### PR DESCRIPTION
…ameter

1. If `ADVISORY` is not given, the value will be retrieved from `ocp_build_data` with `elliott`.
2. Verify the advisory exists and is in `QE` state and a live ID is associated.
3. `ERRATA_URL` parameter is removed. The live URL is constructed from the advisory information.
4. Print console logs with fancy emojis.