### PR TITLE
Fix oc push to find older rpm

### DIFF
--- a/build-scripts/rcm-guest/publish-oc-v4-binary.sh
+++ b/build-scripts/rcm-guest/publish-oc-v4-binary.sh
@@ -4,7 +4,7 @@ set -eux
 rpm_name() {
     printf "${RPM}" "${arch}"
     [[ "${arch}" == x86_64 ]] && printf %s -redistributable
-    printf %s "-${VERSION}"
+    printf %s "-*.git."
 }
 
 extract() {


### PR DESCRIPTION
Fix for https://localhost:8888/job/aos-cd-builds/job/build%252Focp4/1040/console
```
+ mkdir macosx windows
+ for arch in x86_64 '${ARCH}'
+++ rpm_name x86_64
+++ printf /mnt/rcm-guest/puddles/RHAOS/AtomicOpenShift/4.2/building/%s/os/Packages/openshift-clients x86_64
+++ [[ x86_64 == x86_64 ]]
+++ printf %s -redistributable
+++ printf %s -4.2.0-201909050219.git.0.9bd7c55.el7
++ echo '/mnt/rcm-guest/puddles/RHAOS/AtomicOpenShift/4.2/building/x86_64/os/Packages/openshift-clients-redistributable-4.2.0-201909050219.git.0.9bd7c55.el7*'
+ rpm='/mnt/rcm-guest/puddles/RHAOS/AtomicOpenShift/4.2/building/x86_64/os/Packages/openshift-clients-redistributable-4.2.0-201909050219.git.0.9bd7c55.el7*'
+ [[ x86_64 != x86_64 ]]
+ mkdir x86_64
+ [[ x86_64 != x86_64 ]]
+ rpm2cpio '/mnt/rcm-guest/puddles/RHAOS/AtomicOpenShift/4.2/building/x86_64/os/Packages/openshift-clients-redistributable-4.2.0-201909050219.git.0.9bd7c55.el7*'
+ cpio -idm --quiet ./usr/share/openshift/linux/oc ./usr/share/openshift/macosx/oc ./usr/share/openshift/windows/oc.exe
rpm2cpio: /mnt/rcm-guest/puddles/RHAOS/AtomicOpenShift/4.2/building/x86_64/os/Packages/openshift-clients-redistributable-4.2.0-201909050219.git.0.9bd7c55.el7*: No such file or directory
cpio: premature end of archive
+ rm -rf /tmp/ocbinary.lgDPkDxRZ0
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
$ ssh-agent -k
```