### PR TITLE
signed-compose: 3.x do not use rhel8 compose

### DIFF
--- a/jobs/build/signed-compose/Jenkinsfile
+++ b/jobs/build/signed-compose/Jenkinsfile
@@ -67,7 +67,9 @@ node {
             stage("New el7 compose") { build.signedComposeNewComposeEl7() }
             // Ensure the rhel8 tag script can read the required cert
             withEnv(['REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt']) {
-                stage("New el8 compose") { build.signedComposeNewComposeEl8() }
+                if (build.requiresRhel8()) {
+                    stage("New el8 compose") { build.signedComposeNewComposeEl8() }
+                }
             }
         }
         build.mailForSuccess()


### PR DESCRIPTION
Seems like this would work fine for 3.x if we just didn't try to look for el8 builds and make a compose out of them.