### PR TITLE
Fix build mailer footer

### DIFF
--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -160,6 +160,15 @@ emailIndex = 0
  * Wrapper to persist email as an artifact and enable suppressing actual email
  */
 def email(args) {
+    args.body += """
+------------------------------------------------------
+
+NOTE: These job links are only available to ART. Please contact us if
+you need to see something specific from the logs.
+
+Jenkins Job: ${buildURL()}
+Console Log: ${buildURL('console')}
+"""
     if (params.SUPPRESS_EMAIL) {
         def title = currentBuild.displayName ?: ""
         if (!title.contains("no email")) {
@@ -189,15 +198,6 @@ def email(args) {
 
         // this is a bit silly but writeYaml and writeFile lack finesse
         body = args.remove("body")  // unreadable when written as yaml
-	body += """
-------------------------------------------------------
-
-NOTE: These job links are only available to ART. Please contact us if
-you need to see something specific from the logs.
-
-Jenkins Job: ${buildURL()}
-Console Log: ${buildURL('console')}
-"""
         writeYaml file: filename, data: args
         yaml = readFile filename
         writeFile file: filename, text: yaml + "\n\n" + body


### PR DESCRIPTION
I had tried to implement a standard build mail footer before but accidentally put that code at the end of the function, it needs to happen earlier _before_ the actual `mail` function is called :smile: 