### PR TITLE
crio: remove oct provision calls

### DIFF
--- a/sjb/config/test_cases/test_pull_request_crio_ami_rhel.yml
+++ b/sjb/config/test_cases/test_pull_request_crio_ami_rhel.yml
@@ -12,11 +12,6 @@ extensions:
       script: |-
         oct prepare user
         sed -i 's/User ec2-user/User origin/g' ./.config/origin-ci-tool/inventory/.ssh_config
-    - type: "host_script"
-      title: "bootstrap remote host"
-      script: |-
-        oct bootstrap host
-        oct bootstrap node
     - type: "script"
       title: "install git"
       script: |-


### PR DESCRIPTION
origin-ci-tool is effectively deprecated, and crio is trying to switch to rhel8. because the package names are different, we are currently failing test_ami* calls. Fix this by not installing ansible on ami test (i.e. not calling the deprecated oct tool at this stage), but instead expect the ami creator to have installed ansible already.

Signed-off-by: Peter Hunt <pehunt@redhat.com>