### PR TITLE
Force no depth limit on clone

### DIFF
--- a/jobs/build/merge_ocp/Jenkinsfile
+++ b/jobs/build/merge_ocp/Jenkinsfile
@@ -40,7 +40,7 @@ node {
                         $class: 'hudson.model.StringParameterDefinition',
                         defaultValue: [
                             'aos-art-automation+failed-ocp-merge@redhat.com',
-                        ]
+                        ].join(',')
                     ],
                     commonlib.mockParam(),
                 ]

--- a/jobs/build/ocp3/Jenkinsfile
+++ b/jobs/build/ocp3/Jenkinsfile
@@ -274,7 +274,7 @@ node {
                             'aos-cicd@redhat.com',
                             'aos-qe@redhat.com',
                             'aos-art-automation+new-ocp3-build@redhat.com',
-                        ]
+                        ].join(',')
                     ],
                     [
                         name: 'MAIL_LIST_FAILURE',
@@ -282,7 +282,7 @@ node {
                         $class: 'hudson.model.StringParameterDefinition',
                         defaultValue: [
                             'aos-art-automation+failed-ocp3-build@redhat.com'
-                        ]
+                        ].join(',')
                     ],
                     [
                         name: 'BUILD_MODE',

--- a/jobs/build/odo_sync/Jenkinsfile
+++ b/jobs/build/odo_sync/Jenkinsfile
@@ -24,7 +24,7 @@ node {
                         defaultValue: [
                             'aos-art-automation+failed-odo-sync@redhat.com',
                             'moahmed@redhat.com'
-                        ]
+                        ].join(',')
                     ],
                     commonlib.mockParam(),
                 ]

--- a/scheduled-jobs/build/merge/Jenkinsfile
+++ b/scheduled-jobs/build/merge/Jenkinsfile
@@ -7,7 +7,7 @@ properties( [
 description = ""
 failed = false
 
-b = build job: '../aos-cd-builds/build%2Fmerge_ocp', propagate: false
+b = build job: '../aos-cd-builds/build%2Fmerge_ocp',  parameters: [string(name: 'COMMIT_DEPTH', value: '0')], propagate: false
 description += "${b.displayName} - ${b.result}\n"
 
 currentBuild.description = description.trim()


### PR DESCRIPTION
It doesn't look like Jenkins multibranch pipeline is picking up the change in default for clone depth. Forcing it with this PR in the scheduled job.