### PR TITLE
Scripts to help find which rpms are not being used by containers

### DIFF
--- a/hacks/refine-candidate/download-logs.sh
+++ b/hacks/refine-candidate/download-logs.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+TAG="$1"
+
+if [[ -z "$TAG" ]]; then
+    echo "Specify a tag to download logs for"
+    echo "e.g. $0 rhaos-4.2-rhel-7-candidate"
+    exit 1
+fi
+
+for build in $(brew list-tagged --quiet --latest $TAG | awk '{print $1}' | grep -E '(apb|container)-v?[0-9]'); do
+	task=$(brew buildinfo $build | grep Extra: | sed -n  's/.*container_koji_task_id...\([0-9]\+\).*/\1/p')
+	if [ -z "$task" ]; then
+		echo "Could not find task for: $build"
+	else
+		brew download-logs -r $task
+	fi
+done
+
+

--- a/hacks/refine-candidate/findit.sh
+++ b/hacks/refine-candidate/findit.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#set -o xtrace
+
+TAG=$1
+
+if [[ -z "$TAG" ]]; then
+    echo "Run only after running download-logs.sh. Specify a the same tag to find RPMs being used by container builds."
+    echo "e.g. $0 rhaos-4.2-rhel-7-candidate"
+    exit 1
+fi
+
+
+parse_rpm() {
+	# Extract NVRA components from rpm filename
+	RPM=$1;B=${RPM##*/};B=${B%.rpm};A=${B##*.};B=${B%.*};R=${B##*-};B=${B%-*};V=${B##*-};B=${B%-*};N=$B
+}
+
+brew list-tagged --quiet --latest $TAG | awk '{print $1}' | grep -vE '(apb|container)-v?[0-9]' > rpm-builds
+
+KEEP="cri-o cri-tools openshift-clients openshift-hyperkube"
+
+# retrieve a list of all the non-source RPMs in those builds
+rm -f rpm-report
+rm -f rpm-names
+for build in $(cat rpm-builds); do
+	rpms=$(brew buildinfo $build | grep -oE '[^/]+\.(noarch|x86_64|ppc64le)\.rpm')
+	found=0
+	bases=""
+	for rpm in $rpms; do
+		echo "Found $rpm in $build" >> rpm-report
+		parse_rpm $rpm
+		base=$(basename --suffix=.rpm $rpm)
+
+		if [[ "$KEEP" == *"$N"* ]]; then
+			found=1
+			break
+		fi
+
+		bases="$base $bases"
+		grep "Installing :.*$N" kojilogs/*/*.log  > /dev/null
+		if [[ "$?" == "0" ]]; then
+			found=1
+			break
+	  	fi
+	done
+
+	if [[ "$found" == "0" ]]; then
+		echo "Unable to find any rpm from $build : $bases"
+	fi
+done
+
+


### PR DESCRIPTION
$ ./download-logs.sh
Then
$ ./findit.sh

```
Unable to find any rpm from ansible-operator-0.0.1-2.git.59.4beb3d2.el7 : ansible-operator-container-scripts-0.0.1-2.git.59.4beb3d2.el7.noarch ansible-operator-devel-0.0.1-2.git.59.4beb3d2.el7.noarch ansible-operator-0.0.1-2.git.59.4beb3d2.el7.x86_64 ansible-operator-0.0.1-2.git.59.4beb3d2.el7.ppc64le 
Unable to find any rpm from ansible-service-broker-1.4.4-1.el7 : ansible-service-broker-container-scripts-1.4.4-1.el7.noarch ansible-service-broker-selinux-1.4.4-1.el7.noarch ansible-service-broker-devel-1.4.4-1.el7.noarch automation-broker-apb-role-1.4.4-1.el7.noarch ansible-service-broker-1.4.4-1.el7.x86_64 ansible-service-broker-1.4.4-1.el7.ppc64le 
Unable to find any rpm from bubblewrap-0.1.7-1.el7 : bubblewrap-debuginfo-0.1.7-1.el7.x86_64 bubblewrap-0.1.7-1.el7.x86_64 bubblewrap-debuginfo-0.1.7-1.el7.ppc64le bubblewrap-0.1.7-1.el7.ppc64le 
Unable to find any rpm from csi-attacher-0.2.0-3.git27299be.el7 : csi-attacher-0.2.0-3.git27299be.el7.x86_64 csi-attacher-debuginfo-0.2.0-3.git27299be.el7.x86_64 csi-attacher-0.2.0-3.git27299be.el7.ppc64le csi-attacher-debuginfo-0.2.0-3.git27299be.el7.ppc64le 
Unable to find any rpm from csi-driver-registrar-0.2.0-1.el7 : csi-driver-registrar-debuginfo-0.2.0-1.el7.x86_64 csi-driver-registrar-0.2.0-1.el7.x86_64 csi-driver-registrar-debuginfo-0.2.0-1.el7.ppc64le csi-driver-registrar-0.2.0-1.el7.ppc64le 
Unable to find any rpm from csi-livenessprobe-0.0.1-1.gitff5b6a0.el7 : csi-livenessprobe-debuginfo-0.0.1-1.gitff5b6a0.el7.x86_64 csi-livenessprobe-0.0.1-1.gitff5b6a0.el7.x86_64 csi-livenessprobe-debuginfo-0.0.1-1.gitff5b6a0.el7.ppc64le csi-livenessprobe-0.0.1-1.gitff5b6a0.el7.ppc64le 
Unable to find any rpm from csi-provisioner-0.2.0-2.el7 : csi-provisioner-0.2.0-2.el7.x86_64 csi-provisioner-debuginfo-0.2.0-2.el7.x86_64 csi-provisioner-0.2.0-2.el7.ppc64le csi-provisioner-debuginfo-0.2.0-2.el7.ppc64le 
Unable to find any rpm from golang-github-openshift-prometheus-alert-buffer-0-3.gitceca8c1.el7 : golang-github-openshift-prometheus-alert-buffer-0-3.gitceca8c1.el7.x86_64 golang-github-openshift-prometheus-alert-buffer-0-3.gitceca8c1.el7.ppc64le 
Unable to find any rpm from google-cloud-sdk-183.0.0-3.el7 : google-cloud-sdk-183.0.0-3.el7.x86_64 
Unable to find any rpm from kubefed-client-4.2.0-201909151311.git.1.250827e.el7 : kubefed-client-4.2.0-201909151311.git.1.250827e.el7.x86_64 kubefed-client-4.2.0-201909151311.git.1.250827e.el7.ppc64le 
Unable to find any rpm from openshift-ansible-4.2.0-201909151311.git.193.f3aa1ab.el7 : openshift-ansible-4.2.0-201909151311.git.193.f3aa1ab.el7.noarch openshift-ansible-test-4.2.0-201909151311.git.193.f3aa1ab.el7.noarch 
Unable to find any rpm from openshift-enterprise-autoheal-4.2.0-201909151311.git.1.c4b45ce.el7 : openshift-enterprise-autoheal-4.2.0-201909151311.git.1.c4b45ce.el7.x86_64 openshift-enterprise-autoheal-4.2.0-201909151311.git.1.c4b45ce.el7.ppc64le 
Unable to find any rpm from python-adal-0.5.0-1.el7 : python2-adal-0.5.0-1.el7.noarch 
Unable to find any rpm from python-docker-2.4.2-2.el7 : python-docker-2.4.2-2.el7.noarch 
Unable to find any rpm from python-futures-3.0.3-2.el7 : python-futures-3.0.3-2.el7.noarch 
Unable to find any rpm from python-greenlet-0.4.2-4.el7 : python-greenlet-0.4.2-4.el7.x86_64 python-greenlet-devel-0.4.2-4.el7.x86_64 python-greenlet-debuginfo-0.4.2-4.el7.x86_64 python-greenlet-devel-0.4.2-4.el7.ppc64le python-greenlet-debuginfo-0.4.2-4.el7.ppc64le python-greenlet-0.4.2-4.el7.ppc64le 
Unable to find any rpm from python-jwt-1.4.0-2.1.el7 : python-jwt-1.4.0-2.1.el7.noarch 
Unable to find any rpm from python-nose-xcover-1.0.10-1.el7 : python-nose-xcover-1.0.10-1.el7.noarch 
Unable to find any rpm from python-oauthlib-0.6.0-2.el7 : python-oauthlib-0.6.0-2.el7.noarch 
Unable to find any rpm from python-requests-oauthlib-0.4.0-7.el7 : python-requests-oauthlib-0.4.0-7.el7.noarch 

```