### PR TITLE
Remove Gabe from devex jenkins email lists

### DIFF
--- a/jobs/devex/jenkins-bump-version/Jenkinsfile
+++ b/jobs/devex/jenkins-bump-version/Jenkinsfile
@@ -19,13 +19,13 @@ properties(
                     name: 'MAIL_LIST_SUCCESS',
                     description: 'Success Mailing List',
                     $class: 'hudson.model.StringParameterDefinition',
-                    defaultValue: 'aos-art-automation+passed-jenkins-bump-version@redhat.com,gmontero@redhat.com,abenaiss@redhat.com,vbobade@redhat.com'
+                    defaultValue: 'aos-art-automation+passed-jenkins-bump-version@redhat.com,openshift-dev-services+jenkins@redhat.com'
                 ],
                 [
                     name: 'MAIL_LIST_FAILURE',
                     description: 'Failure Mailing List',
                     $class: 'hudson.model.StringParameterDefinition',
-                    defaultValue: 'aos-art-automation+failed-jenkins-bump-version@redhat.com,gmontero@redhat.com,abenaiss@redhat.com,vbobade@redhat.com'
+                    defaultValue: 'aos-art-automation+failed-jenkins-bump-version@redhat.com,openshift-dev-services+jenkins@redhat.com'
                 ],
                 [
                     name: 'TARGET_NODE',

--- a/jobs/devex/jenkins-plugins/Jenkinsfile
+++ b/jobs/devex/jenkins-plugins/Jenkinsfile
@@ -25,13 +25,13 @@ properties(
                     name: 'MAIL_LIST_SUCCESS',
                     description: 'Success Mailing List',
                     $class: 'hudson.model.StringParameterDefinition',
-                    defaultValue: 'aos-art-automation+passed-jenkins-plugins-update@redhat.com,gmontero@redhat.com,abenaiss@redhat.com,vbobade@redhat.com'
+                    defaultValue: 'aos-art-automation+passed-jenkins-plugins-update@redhat.com,openshift-dev-services+jenkins@redhat.com'
                 ],
                 [
                     name: 'MAIL_LIST_FAILURE',
                     description: 'Failure Mailing List',
                     $class: 'hudson.model.StringParameterDefinition',
-                    defaultValue: 'aos-art-automation+failed-jenkins-plugins-update@redhat.com,gmontero@redhat.com,abenaiss@redhat.com,vbobade@redhat.com'
+                    defaultValue: 'aos-art-automation+failed-jenkins-plugins-update@redhat.com,openshift-dev-services+jenkins@redhat.com'
                 ],
                 [
                     name: 'TARGET_NODE',


### PR DESCRIPTION
@gabemontero @akram 

This is a follow up to the MR against ocp-build-data which removed Gabe and Adam from the maintainers lists. Adam wasn't present, so nothing to do for removing him here.