### PR TITLE
Job result status is not determined by SRC=DEST filtering

### DIFF
--- a/jobs/build/build-sync/Jenkinsfile
+++ b/jobs/build/build-sync/Jenkinsfile
@@ -112,17 +112,6 @@ release:gen-payload
                 error(currentBuild.description)
             }
         }
-
-        def stateYaml = readYaml(file: "${mirrorWorking}/state.yaml")
-        def result = stateYaml.get("release:gen-payload", [:])
-        if (result['success'] != result['total']) {
-            if (result['success'] == 0) {
-                currentBuild.result = "FAILURE"
-            }
-            else {
-                currentBuild.result = "UNSTABLE"
-            }
-        }
     } finally {
         commonlib.safeArchiveArtifacts([
                 "MIRROR_working/oc_mirror_input",


### PR DESCRIPTION
Old result status was eagerly marking jobs as UNSTABLE. In fact, the
conditions that made that decision were too aggressive. Don't the
exclusion of images as 'unstable', that incorrectly reflects the
status the job.

Now the result status is pass/fail. Did the job work or not?