### PR TITLE
build/oc_sync: Accept version next to stream

### DIFF
--- a/jobs/build/oc_sync/Jenkinsfile
+++ b/jobs/build/oc_sync/Jenkinsfile
@@ -22,19 +22,13 @@ node {
                         description: 'Build stream to sync client from',
                         $class: 'hudson.model.ChoiceParameterDefinition',
                         choices: [
-                            "4-stable",
+                            "4.1-stable",
+                            "4.2-stable",
                             "4.1.0-0.nightly",
                             "4.2.0-0.nightly",
                             "4.3.0-0.nightly",
-                            "none",
                         ].join("\n"),
                         defaultValue: "4-stable"
-                    ],
-                    [
-                        name: 'VERSION',
-                        description: 'Build specific version, e.g. 4.1.20. Requires "none" for STREAM.',
-                        $class: 'hudson.model.StringParameterDefinition',
-                        defaultValue: ""
                     ],
                     [
                         name: 'OC_MIRROR_DIR',
@@ -71,7 +65,7 @@ node {
             stage("sync ocp clients") {
 		// must be able to access remote registry to extract image contents
 		buildlib.registry_quay_dev_login()
-                sh "./publish-clients-from-payload.sh ${env.WORKSPACE} ${STREAM} ${OC_MIRROR_DIR} ${VERSION}"
+                sh "./publish-clients-from-payload.sh ${env.WORKSPACE} ${STREAM} ${OC_MIRROR_DIR}"
             }
         }
     } catch (err) {

--- a/jobs/build/oc_sync/Jenkinsfile
+++ b/jobs/build/oc_sync/Jenkinsfile
@@ -26,8 +26,15 @@ node {
                             "4.1.0-0.nightly",
                             "4.2.0-0.nightly",
                             "4.3.0-0.nightly",
+                            "none",
                         ].join("\n"),
                         defaultValue: "4-stable"
+                    ],
+                    [
+                        name: 'VERSION',
+                        description: 'Build specific version, e.g. 4.1.20. Requires "none" for STREAM.',
+                        $class: 'hudson.model.StringParameterDefinition',
+                        defaultValue: ""
                     ],
                     [
                         name: 'OC_MIRROR_DIR',
@@ -64,7 +71,7 @@ node {
             stage("sync ocp clients") {
 		// must be able to access remote registry to extract image contents
 		buildlib.registry_quay_dev_login()
-                sh "./publish-clients-from-payload.sh ${env.WORKSPACE} ${STREAM} ${OC_MIRROR_DIR}"
+                sh "./publish-clients-from-payload.sh ${env.WORKSPACE} ${STREAM} ${OC_MIRROR_DIR} ${VERSION}"
             }
         }
     } catch (err) {

--- a/jobs/build/release/Jenkinsfile
+++ b/jobs/build/release/Jenkinsfile
@@ -95,6 +95,7 @@ node {
             previous = "${params.PREVIOUS}"
             String errata_url
             Map release_obj
+            (major, minor, tiny) = name.split("\\.")
 
             // must be able to access remote registry for verification
             buildlib.registry_quay_dev_login()
@@ -110,7 +111,7 @@ node {
             stage("get release info") {
                 release_info = release.stageGetReleaseInfo(quay_url, name)
             }
-            stage("client sync") { release.stageClientSync('4-stable', 'ocp') }
+            stage("client sync") { release.stageClientSync("${major}.${minor}-stable", 'ocp') }
             stage("advisory update") { release.stageAdvisoryUpdate() }
             stage("cross ref check") { release.stageCrossRef() }
             stage("send release message") { release.sendReleaseCompleteMessage(release_obj, advisory, errata_url) }


### PR DESCRIPTION
Currently, when running build/oc_sync, one can specify the stream (e.g. stable-4). The job figures out automatically what the latest build is doing.

With multiply Y-streams in support, this mechanism does not support setting e.g. a 4.1.Z ocp release out when a newer 4.2.Z exists. This has been a stop-gap solution to fix an immediate problem. With ART-1117, a better design is sought and implemented.