### PR TITLE
ART-1006: Fetch OLM operators NVRs from advisories

### DIFF
--- a/jobs/build/appregistry/Jenkinsfile
+++ b/jobs/build/appregistry/Jenkinsfile
@@ -203,7 +203,7 @@ node {
         sshagent(["openshift-bot"]) {
             stage("validate params") {
                 if (!validate(params)) {
-                    sh "exit 1"
+                    error "Parameter validation failed"
                 }
             }
             stage("fetch appregistry images") {

--- a/jobs/build/appregistry/Jenkinsfile
+++ b/jobs/build/appregistry/Jenkinsfile
@@ -294,28 +294,30 @@ node {
                 }
             }
             stage("attach metadata to advisory") {
-                    if (params.METADATA_ADVISORY) {
-
-                        def metadata_nvrs = getMetadataNVRs(operatorData.collect { it.name })
-
-                        elliott """
-                            change-state -s NEW_FILES
-                            -a ${params.METADATA_ADVISORY}
-                            ${params.DRY_RUN ? "--noop" : ""}
-                        """
-
-                        attachToAdvisory(params.METADATA_ADVISORY, metadata_nvrs)
-
-                        /*
-                        // this would be convenient, except that we don't have a way
-                        // to set the CDN repos first, and can't move to QE without that.
-                        elliott """
-                            change-state -s QE
-                            -a ${params.METADATA_ADVISORY}
-                            ${params.DRY_RUN ? "--noop" : ""}
-                        """
-                        */
+                    if (!params.METADATA_ADVISORY) {
+                        currentBuild.description += "\nskipping attach to advisory."
+                        return
                     }
+
+                    def metadata_nvrs = getMetadataNVRs(operatorData.collect { it.name })
+
+                    elliott """
+                        change-state -s NEW_FILES
+                        -a ${params.METADATA_ADVISORY}
+                        ${params.DRY_RUN ? "--noop" : ""}
+                    """
+
+                    attachToAdvisory(params.METADATA_ADVISORY, metadata_nvrs)
+
+                    /*
+                    // this would be convenient, except that we don't have a way
+                    // to set the CDN repos first, and can't move to QE without that.
+                    elliott """
+                        change-state -s QE
+                        -a ${params.METADATA_ADVISORY}
+                        ${params.DRY_RUN ? "--noop" : ""}
+                    """
+                    */
             }
         }
     } catch (err) {

--- a/jobs/build/appregistry/Jenkinsfile
+++ b/jobs/build/appregistry/Jenkinsfile
@@ -1,5 +1,5 @@
 @NonCPS
-def processImages(lines) {
+def parseAndFilterOperators(lines) {
     def data = []
     lines.split().each { line ->
         // label, name, nvr, version, component
@@ -164,7 +164,7 @@ node {
         }.flatten()
     }
 
-    def replaceNVRsByFoundInAdvisories = { images, advisoriesNVRs ->
+    def findImageNVRsInAdvisories = { images, advisoriesNVRs ->
         images.collect {
             image -> [
                 name: image.name,
@@ -209,11 +209,11 @@ node {
             }
             stage("fetch appregistry images") {
                 def lines = getImagesData(params.IMAGES.trim())
-                operatorData = processImages(lines)
+                operatorData = parseAndFilterOperators(lines)
 
                 if (params.STREAM in ["stage", "prod"]) {
                     def advisoriesNVRs = fetchNVRsFromAdvisories(params.OLM_OPERATOR_ADVISORIES)
-                    operatorData = replaceNVRsByFoundInAdvisories(operatorData, advisoriesNVRs)
+                    operatorData = findImageNVRsInAdvisories(operatorData, advisoriesNVRs)
 
                     if (operatorData.any { it.nvr == null }) {
                         currentBuild.description += """\n
@@ -228,7 +228,7 @@ node {
                         2. Attach missing operators to at least one of the provided advisories: ${params.OLM_OPERATOR_ADVISORIES}
                         3. Limit the expected operators in IMAGES parameter: ${operatorData.findAll { it.nvr }.collect { it.name }.join(",")}
                         """
-                        sh "exit 1"
+                        error "operators not found"
                     }
                 }
 

--- a/jobs/build/appregistry/Jenkinsfile
+++ b/jobs/build/appregistry/Jenkinsfile
@@ -260,7 +260,7 @@ node {
                         def token = retrieveBotToken()
                         for (def i = 0; i < operatorData.size(); i++) {
                             def build = operatorData[i]
-                            def metadata_nvr = doozer("operator-metadata:latest-build ${build.name}")
+                            def metadata_nvr = getMetadataNVRs([build.name])
 
                             def response = [:]
                             try {

--- a/jobs/build/appregistry/Jenkinsfile
+++ b/jobs/build/appregistry/Jenkinsfile
@@ -129,7 +129,9 @@ node {
     def validate = { params ->
         if (params.STREAM in ["stage", "prod"]) {
             if (!params.SOURCE_ADVISORIES || !params.TARGET_ADVISORY) {
-                echo "ERROR: SOURCE_ADVISORIES and TARGET_ADVISORY parameters are required for selected STREAM."
+                currentBuild.description += """\n
+                ERROR: SOURCE_ADVISORIES and TARGET_ADVISORY parameters are required for selected STREAM.
+                """
                 return false
             }
         }

--- a/jobs/build/appregistry/Jenkinsfile
+++ b/jobs/build/appregistry/Jenkinsfile
@@ -80,12 +80,12 @@ node {
                         defaultValue: 'dev',
                     ],
                     string(
-                        name: 'SOURCE_ADVISORIES',
+                        name: 'OLM_OPERATOR_ADVISORIES',
                         description: 'One or more advisories where OLM operators are attached\n* Required for "stage" and "prod" STREAMs',
                         defaultValue: '',
                     ),
                     string(
-                        name: 'TARGET_ADVISORY',
+                        name: 'METADATA_ADVISORY',
                         description: 'Advisory to attach corresponding metadata builds\n* Required for "stage" and "prod" STREAMs',
                         defaultValue: '',
                     ),
@@ -128,9 +128,9 @@ node {
 
     def validate = { params ->
         if (params.STREAM in ["stage", "prod"]) {
-            if (!params.SOURCE_ADVISORIES || !params.TARGET_ADVISORY) {
+            if (!params.OLM_OPERATOR_ADVISORIES || !params.METADATA_ADVISORY) {
                 currentBuild.description += """\n
-                ERROR: SOURCE_ADVISORIES and TARGET_ADVISORY parameters are required for selected STREAM.
+                ERROR: OLM_OPERATOR_ADVISORIES and METADATA_ADVISORY parameters are required for selected STREAM.
                 """
                 return false
             }
@@ -211,7 +211,7 @@ node {
                 operatorData = processImages(lines)
 
                 if (params.STREAM in ["stage", "prod"]) {
-                    def advisoriesNVRs = fetchNVRsFromAdvisories(params.SOURCE_ADVISORIES)
+                    def advisoriesNVRs = fetchNVRsFromAdvisories(params.OLM_OPERATOR_ADVISORIES)
                     operatorData = replaceNVRsByFoundInAdvisories(operatorData, advisoriesNVRs)
 
                     if (operatorData.any { it.nvr == null }) {
@@ -223,8 +223,8 @@ node {
                         ${operatorData.findAll { !it.nvr }.collect { it.name }.join(",")}
 
                         Possible solutions:
-                        1. Add more advisories in SOURCE_ADVISORIES parameter, that have the missing operators attached
-                        2. Attach missing operators to at least one of the provided advisories: ${params.SOURCE_ADVISORIES}
+                        1. Add more advisories in OLM_OPERATOR_ADVISORIES parameter, that have the missing operators attached
+                        2. Attach missing operators to at least one of the provided advisories: ${params.OLM_OPERATOR_ADVISORIES}
                         3. Limit the expected operators in IMAGES parameter: ${operatorData.findAll { it.nvr }.collect { it.name }.join(",")}
                         """
                         sh "exit 1"
@@ -294,24 +294,24 @@ node {
                 }
             }
             stage("attach metadata to advisory") {
-                    if (params.TARGET_ADVISORY) {
+                    if (params.METADATA_ADVISORY) {
 
                         def metadata_nvrs = getMetadataNVRs(operatorData.collect { it.name })
 
                         elliott """
                             change-state -s NEW_FILES
-                            -a ${params.TARGET_ADVISORY}
+                            -a ${params.METADATA_ADVISORY}
                             ${params.DRY_RUN ? "--noop" : ""}
                         """
 
-                        attachToAdvisory(params.TARGET_ADVISORY, metadata_nvrs)
+                        attachToAdvisory(params.METADATA_ADVISORY, metadata_nvrs)
 
                         /*
                         // this would be convenient, except that we don't have a way
                         // to set the CDN repos first, and can't move to QE without that.
                         elliott """
                             change-state -s QE
-                            -a ${params.TARGET_ADVISORY}
+                            -a ${params.METADATA_ADVISORY}
                             ${params.DRY_RUN ? "--noop" : ""}
                         """
                         */

--- a/jobs/build/appregistry/Jenkinsfile
+++ b/jobs/build/appregistry/Jenkinsfile
@@ -183,8 +183,9 @@ node {
         )
     }
 
-    def getMetadataNVRs = { operatorNames ->
-        doozer("operator-metadata:latest-build ${operatorNames.join(" ")}")
+    def getMetadataNVRs = { operatorNVRs, stream ->
+        def nvrFlags = operatorNVRs.collect { "--nvr ${it.nvr}" }.join(" ")
+        doozer("operator-metadata:latest-build --stream ${stream} ${nvrFlags}")
     }
 
     def attachToAdvisory = { advisory, metadata_nvrs ->
@@ -260,7 +261,7 @@ node {
                         def token = retrieveBotToken()
                         for (def i = 0; i < operatorData.size(); i++) {
                             def build = operatorData[i]
-                            def metadata_nvr = getMetadataNVRs([build.name])
+                            def metadata_nvr = getMetadataNVRs([build.nvr], params.STREAM)
 
                             def response = [:]
                             try {
@@ -299,7 +300,7 @@ node {
                         return
                     }
 
-                    def metadata_nvrs = getMetadataNVRs(operatorData.collect { it.name })
+                    def metadata_nvrs = getMetadataNVRs(operatorData.collect { it.nvr }, params.STREAM)
 
                     elliott """
                         change-state -s NEW_FILES

--- a/jobs/build/appregistry/Jenkinsfile
+++ b/jobs/build/appregistry/Jenkinsfile
@@ -215,6 +215,9 @@ node {
                     operatorData = replaceNVRsByFoundInAdvisories(operatorData, advisoriesNVRs)
 
                     if (operatorData.any { it.nvr == null }) {
+                        currentBuild.description += """\n
+                        Advisories missing operators ${operatorData.findAll { it.nvr }.collect { it.name }.join(",")}
+                        """
                         echo """
                         ERROR: The following operators were not found in provided advisories.
                         ${operatorData.findAll { !it.nvr }.collect { it.name }.join(",")}

--- a/jobs/build/appregistry/Jenkinsfile
+++ b/jobs/build/appregistry/Jenkinsfile
@@ -121,8 +121,8 @@ node {
 
     def buildVersion = params.BUILD_VERSION
 
-    currentBuild.description = "Collecting appregistry images for ${buildVersion}"
-    currentBuild.displayName += " - ${buildVersion}"
+    currentBuild.description = "Collecting appregistry images for ${buildVersion} (${params.STREAM} stream)"
+    currentBuild.displayName += " - ${buildVersion} (${params.STREAM})"
 
     def skipPush = params.SKIP_PUSH
 


### PR DESCRIPTION
Related ticket: https://jira.coreos.com/browse/ART-1006

Currently our `build/appregistry` job only fetches the latest metadata build. With all those concurrent releases going on, we need to have the ability to pick precise NVRs to build metadata from.

I split this PR in 2 sections, "refactoring" and "new feature", and created explicit merges of each of those sections to make it easier for reviewers:
```
*   803fbfd9d Merge branch 'New-ART-1006-new-feature' into New-ART-1006
|\
| * 62aacf1a2 (new-feature) Fetch NVRs from advisories depending on STREAM
| * 14c546e27 Collect {component} name of images
| * c7040bbd8 Add "validate params" stage
| * ac385f1f0 Add new SOURCE_ADVISORIES parameters
|/
*   98e9d7b32 Merge branch 'New-ART-1006-refactoring' into New-ART-1006
|\
| * a53f3d7f5 (refactoring) Rename ADVISORY parameter to TARGET_ADVISORY
| * a6e7db932 Extract `attachToAdvisory` logic from stage
| * 03a9663a6 Extract `getMetadataNVRs` logic from stage
| * b72b04aa0 Move metadata advisory attachment to own stage
| * 93efa1bac Extract `pushToOMPS` logic from stage
| * 00f8190ff Extract `getImagesData` logic from stage
| * 48ab55859 Remove duplication of common elliott arguments
| * 1fef9ac99 Remove duplication of common doozer arguments
| * d24e8bd2e Access params.BUILD_VERSION through buildVersion
|/  
*
```

#### Refactoring

I needed to move some code around in order to make the addition of the new feature more intuitive. There is much more that could be refactored, but I needed to stop due to time constraints.

But the **TL;DR** is extracting some low-level details of certain operations out of the stage definition, to allow us to see "the big picture" when looking at stages.

#### New feature

Introduces a new build parameter: `SOURCE_ADVISORIES` that should be populated with advisories that contain OLM operators attached.

We read the builds attached to `SOURCE_ADVISORIES`, and filter out everything that is not an OLM operator. That way we have the exact NVRs of attached operators.

And those are the NVRs we pass to `doozer` to build metadata containers.

`SOURCE_ADVISORIES` and `TARGET_ADVISORY` only make sense if `STREAM` is either `"stage"` or `"prod"`, so there is a small validation stage right at the beginning.

#### ~~Still missing~~

~~Any `doozer` API changes introduced by https://jira.coreos.com/browse/ART-1005 will need to be added here.~~
Using changes introduced in doozer's ART-1005: https://github.com/openshift/aos-cd-jobs/pull/2001/commits/c3279967a29091b2e91e510a7b7cd1ede5e08e74