### PR TITLE
Add build/ose4.4 job + corresponding scheduled builds

### DIFF
--- a/jobs/build/ose4.4/Jenkinsfile
+++ b/jobs/build/ose4.4/Jenkinsfile
@@ -1,0 +1,48 @@
+#!/usr/bin/env groovy
+
+node {
+    checkout scm
+    def commonlib = load("pipeline-scripts/commonlib.groovy")
+    properties([
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '')),
+        disableConcurrentBuilds(),
+        [
+            $class: 'ParametersDefinitionProperty',
+            parameterDefinitions: [
+                [
+                    name: 'DRY_RUN',
+                    description: 'Take no action, just echo what the build would have done.',
+                    $class: 'BooleanParameterDefinition',
+                    defaultValue: false
+                ],
+                [
+                    name: 'NEW_VERSION',
+                    description: '(Optional) version for build instead of most recent\nor "+" to bump most recent version',
+                    $class: 'StringParameterDefinition',
+                    defaultValue: ""
+                ],
+                [
+                    name: 'FORCE_BUILD',
+                    description: 'Build regardless of whether source has changed',
+                    $class: 'BooleanParameterDefinition',
+                    defaultValue: false
+                ],
+                commonlib.mockParam(),
+            ]
+        ]
+    ])
+
+    commonlib.checkMock()
+    currentBuild.displayName = "ocp: [${params.NEW_VERSION ?: '4.4'}]"
+
+    b = build job: 'build%2Focp4', propagate: false,
+        parameters: [
+            string(name: 'BUILD_VERSION', value: '4.4'),
+            string(name: 'NEW_VERSION', value: params.NEW_VERSION),
+            booleanParam(name: 'FORCE_BUILD', value: params.FORCE_BUILD),
+            booleanParam(name: 'DRY_RUN', value: params.DRY_RUN),
+        ]
+
+    currentBuild.displayName = "ocp:${b.displayName}"
+    currentBuild.result = b.result
+}

--- a/scheduled-jobs/build/ocp-4.4-full/Jenkinsfile
+++ b/scheduled-jobs/build/ocp-4.4-full/Jenkinsfile
@@ -1,0 +1,19 @@
+
+properties([
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '60', numToKeepStr: '')),
+    disableConcurrentBuilds(),
+])
+
+currentBuild.displayName += " 4.4 full build"
+def b = build(
+    job: '../aos-cd-builds/build%2Fose4.4',
+    propagate: false,
+    parameters: [
+        // we might consider: string(name: 'NEW_VERSION', value: '+'),
+        booleanParam(name: 'FORCE_BUILD', value: true),
+    ],
+)
+
+currentBuild.result = (b.result == "SUCCESS") ? "SUCCESS" : "FAILURE"
+currentBuild.displayName = "[${b.result}] ${b.displayName}"
+currentBuild.description = b.description

--- a/scheduled-jobs/build/ocp-4.4-full/README.md
+++ b/scheduled-jobs/build/ocp-4.4-full/README.md
@@ -1,0 +1,1 @@
+Runs a full (force) OCP build of release-4.4 weekly.

--- a/scheduled-jobs/build/ocp-4.4-incremental/Jenkinsfile
+++ b/scheduled-jobs/build/ocp-4.4-incremental/Jenkinsfile
@@ -1,0 +1,12 @@
+
+properties([
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '60', numToKeepStr: '')),
+    disableConcurrentBuilds(),
+])
+
+currentBuild.displayName += " 4.4 incremental build"
+def b = build job: '../aos-cd-builds/build%2Fose4.4', propagate: false
+
+currentBuild.result = (b.result == "SUCCESS") ? "SUCCESS" : "FAILURE"
+currentBuild.displayName = "[${b.result}] ${b.displayName}"
+currentBuild.description = b.description

--- a/scheduled-jobs/build/ocp-4.4-incremental/README.md
+++ b/scheduled-jobs/build/ocp-4.4-incremental/README.md
@@ -1,0 +1,1 @@
+Runs an incremental OCP build of release-4.4 regularly.

--- a/scheduled-jobs/build/reposync/Jenkinsfile
+++ b/scheduled-jobs/build/reposync/Jenkinsfile
@@ -22,6 +22,7 @@ def runFor(sync_version, arch="x86_64") {
 runFor("4.1")
 runFor("4.2")
 runFor("4.3")
+runFor("4.4")
 
 currentBuild.description = description.trim()
 currentBuild.result = failed ? "FAILURE" : "SUCCESS"


### PR DESCRIPTION
List of Jenkins jobs introduced by this PR

* `aos-cd-builds > build/ose4.4`
* `scheduled-builds > ocp-4.4-full`
* `scheduled-builds > ocp-4.4-incremental`
* `scheduled-builds > reposync` for `4.4`

Related ticket: https://jira.coreos.com/browse/ART-1140