### PR TITLE
make signedComposeStateQE retry 3 times

### DIFF
--- a/jobs/build/signed-compose/build.groovy
+++ b/jobs/build/signed-compose/build.groovy
@@ -103,7 +103,12 @@ def signedComposeRpmdiffsResolved(advisory) {
 // you're having trouble getting a build to get signed in a reasonable
 // amount of time (10 minutes).
 def signedComposeStateQE() {
-    buildlib.elliott("${elliottOpts} change-state --state QE ${advisoryOpt}")
+    def seconds = 0
+    retry(3) {
+        sleep seconds
+        seconds = seconds + 30
+        buildlib.elliott("${elliottOpts} change-state --state QE ${advisoryOpt}")
+    }
 }
 
 // Poll the 'signed' status of all builds attached to the advisory. We


### PR DESCRIPTION
Here's the interesting thing I found today when the singed-compose first attempt to move QE, elliott throw errors I guess from errata:

```
Running shell script via commonlib.shell:
elliott --group=openshift-3.10 change-state --state QE --use-default-advisory rpm
[Pipeline] sh
+ set +x
2019-10-24 02:34:00,782 INFO Cloning config data from https://github.com/openshift/ocp-build-data.git
2019-10-24 02:34:01,604 INFO Using branch from group.yml: rhaos-3.10-rhel-7
Default advisory detected: 47576
Erratum 47576: base: Validation failed: Errata Must complete RPMDiff
```

But the previous step RPM diffs resolved (which means rpmdiff.py pass). I don't have enough env to reproduce this problem... so adding a retry logic here hopefully could migrate the problems a little bit.
<img width="1073" alt="Screen Shot 2019-10-24 at 15 02 26" src="https://user-images.githubusercontent.com/6284003/67464131-66558d00-f675-11e9-9de7-1622027bced0.png">

https://localhost:8888/job/aos-cd-builds/job/build%252Fsigned-compose/83/console

