### PR TITLE
Make scheduled reposync job multi-arch aware

### DIFF
--- a/scheduled-jobs/build/reposync/Jenkinsfile
+++ b/scheduled-jobs/build/reposync/Jenkinsfile
@@ -1,3 +1,4 @@
+buildlib = load("pipeline-scripts/buildlib.groovy")
 
 properties( [
         buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '100')),
@@ -19,11 +20,13 @@ def runFor(sync_version, arch="x86_64") {
     failed |= (b.result != "SUCCESS")
 }
 
-runFor("4.1")
-runFor("4.2")
-runFor("4.3")
-runFor("4.4")
+def versions = ['4.1', '4.2', '4.3', '4.4']
+for ( String version : versions ) {
+    def arches = buildlib.branch_arches("openshift-${version}")
+    for ( String arch : arches ) {
+	runFor(version, arch)
+    }
+}
 
 currentBuild.description = description.trim()
 currentBuild.result = failed ? "FAILURE" : "SUCCESS"
-


### PR DESCRIPTION
Loop over arches for each version we are reposyncing.

RE: https://jira.coreos.com/browse/ART-1186
Enable multi-arch 4.2/4.3 builds
