### PR TITLE
Fix 'Required context class hudson.FilePath is missing'

### DIFF
--- a/scheduled-jobs/build/reposync/Jenkinsfile
+++ b/scheduled-jobs/build/reposync/Jenkinsfile
@@ -1,5 +1,3 @@
-buildlib = load("pipeline-scripts/buildlib.groovy")
-
 properties( [
         buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '100')),
         disableConcurrentBuilds(),
@@ -20,11 +18,14 @@ def runFor(sync_version, arch="x86_64") {
     failed |= (b.result != "SUCCESS")
 }
 
-def versions = ['4.1', '4.2', '4.3', '4.4']
-for ( String version : versions ) {
-    def arches = buildlib.branch_arches("openshift-${version}")
-    for ( String arch : arches ) {
-	runFor(version, arch)
+node() {
+    buildlib = load("pipeline-scripts/buildlib.groovy")
+    def versions = ['4.1', '4.2', '4.3', '4.4']
+    for ( String version : versions ) {
+	def arches = buildlib.branch_arches("openshift-${version}")
+	for ( String arch : arches ) {
+	    runFor(version, arch)
+	}
     }
 }
 


### PR DESCRIPTION
```
org.jenkinsci.plugins.workflow.steps.MissingContextVariableException: Required context class hudson.FilePath is missing
Perhaps you forgot to surround the code with a step that provides this, such as: node
```