### PR TITLE
ART-1196: scope "release" job to look at "latest" for the same version

### DIFF
--- a/jobs/build/release/Jenkinsfile
+++ b/jobs/build/release/Jenkinsfile
@@ -1,4 +1,7 @@
 #!/usr/bin/env groovy
+import groovy.transform.Field
+
+@Field final RELEASE_STREAM_NAME = "4-stable"
 
 node {
     checkout scm
@@ -106,11 +109,11 @@ node {
             }
             stage("payload") { release.stageGenPayload(quay_url, name, from_release_tag, description, previous, errata_url) }
             stage("tag stable") { release.stageTagRelease(quay_url, name) }
-            stage("wait for stable") { release_obj = release.stageWaitForStable() }
+            stage("wait for stable") { release_obj = release.stageWaitForStable(RELEASE_STREAM_NAME, name) }
             stage("get release info") {
                 release_info = release.stageGetReleaseInfo(quay_url, name)
             }
-            stage("client sync") { release.stageClientSync('4-stable', 'ocp') }
+            stage("client sync") { release.stageClientSync(RELEASE_STREAM_NAME, 'ocp') }
             stage("advisory update") { release.stageAdvisoryUpdate() }
             stage("cross ref check") { release.stageCrossRef() }
             stage("send release message") { release.sendReleaseCompleteMessage(release_obj, advisory, errata_url) }

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -324,6 +324,15 @@ String extractMajorMinorVersion(String version) {
 }
 
 /**
+ * Returns the major and minor version numbers for a given version string.
+ * e.g. "4.1.0-rc.9" => [4, 1]
+ */
+def extractMajorMinorVersionNumbers(String version) {
+    return (version =~ /^(\d+)\.(\d+)/)[0].subList(1,3).collect { it as int }
+}
+
+
+/**
  * Attempts, for a specified duration, to claim a Jenkins lock. If claimed, the
  * lock is released before returning. Callers should be aware this leaves
  * a race condition and there is no guarantee they will get the lock themselves. Thus, this


### PR DESCRIPTION
Currently the release job creates a new release stream in 4-stable, then waits for it to be accepted by looking for "latest". It needs to scope that "latest" search down to things with the same version; otherwise when we add 4.1.22, with 4.2.z in the stream it will never be considered latest. We can scope the current query.:

```
curl -X GET -G https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/4-stable/latest --data-urlencode 'in=>4.1.0-0 <4.2.0-0' --data-urlencode format=pullSpec
```

This PR works by constructing the URL with correct filtering query string,
where the version range is calculated from the `major.minor` portion of `NAME` build parameter.

Test runs (commented all stages except `wait for stable`):
- 4.2.2 https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/yuxzhu-aos-cd-jobs/job/build%252Frelease/59/
- 4.1.22 https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/yuxzhu-aos-cd-jobs/job/build%252Frelease/58/
- emulating retries by giving a fake URL:  https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/yuxzhu-aos-cd-jobs/job/build%252Frelease/57/