### PR TITLE
update-base-images: Lock ansible-runner version

### DIFF
--- a/jobs/build/update-base-images/build.sh
+++ b/jobs/build/update-base-images/build.sh
@@ -66,7 +66,7 @@ $z - s390x
 img=$1; shift
 case "$img" in
         ansible.runner)
-            build_common $img ansible-runner:latest 0 $@
+            build_common $img ansible-runner:1.2.0-1.1571949727 0 $@
             ;;
 
         elasticsearch)


### PR DESCRIPTION
latest should not be used anymore, as that now points to newer versions.
This will have to be updated periodically upon new freshmaker builds.

CC: @joepvd 