### PR TITLE
[ART-617] improve appregistry

### DIFF
--- a/jobs/build/appregistry/Jenkinsfile
+++ b/jobs/build/appregistry/Jenkinsfile
@@ -62,7 +62,6 @@ node {
                     commonlib.mockParam(),
                 ]
             ],
-            disableConcurrentBuilds()
         ]
     )
 
@@ -88,7 +87,9 @@ node {
                 currentBuild.description = "appregistry images collected for ${appregistry.buildVersion}."
             }
             stage("build metadata container") {
-                appregistry.stageBuildMetadata(operatorBuilds)
+                lock("appregistry-build-${params.STREAM}") {
+                    appregistry.stageBuildMetadata(operatorBuilds)
+                }
             }
             stage("push metadata") {
                 if (skipPush) {
@@ -107,7 +108,9 @@ node {
                         usernameVariable: 'QUAY_USERNAME',
                         passwordVariable: 'QUAY_PASSWORD',
                     )]) {
-                        appregistry.stagePushDevMetadata(operatorBuilds)
+                        lock("appregistry-push-dev") {
+                            appregistry.stagePushDevMetadata(operatorBuilds)
+                        }
                     }
                 }
             }
@@ -116,7 +119,9 @@ node {
                     currentBuild.description += "\nskipping attach to advisory."
                     return
                 }
-                appregistry.stageAttachMetadata(operatorBuilds)
+                lock("appregistry-attach-${appregistry.buildVersion}") {
+                    appregistry.stageAttachMetadata(operatorBuilds)
+                }
             }
         }
     } catch (err) {

--- a/jobs/build/appregistry/Jenkinsfile
+++ b/jobs/build/appregistry/Jenkinsfile
@@ -1,57 +1,8 @@
-@NonCPS
-def parseAndFilterOperators(lines) {
-    def data = []
-    lines.split().each { line ->
-        // label, name, nvr, version, component
-        def fields = line.split(',')
-        if (fields[0]) {
-            data.add([
-                name: fields[1],
-                nvr: fields[2],
-                version: fields[3].replace("v", ""),
-                component: fields[4],
-            ])
-        }
-    }
-    return data
-}
-
-
-def retrieveBotToken() {
-    def token = ""
-    withCredentials([usernamePassword(credentialsId: 'quay_appregistry_omps_bot', usernameVariable: 'QUAY_USERNAME', passwordVariable: 'QUAY_PASSWORD')]) {
-        def requestJson = """
-        {
-            "user": {
-                "username": "${QUAY_USERNAME}",
-                "password": "${QUAY_PASSWORD}"
-            }
-        }
-        """
-        retry(3) {
-            def response = httpRequest(
-                url: "https://quay.io/cnr/api/v1/users/login",
-                httpMode: 'POST',
-                contentType: 'APPLICATION_JSON',
-                requestBody: requestJson,
-                timeout: 60,
-                validResponseCodes: "200:599",
-            )
-            if (response.status != 200) {
-                sleep(5)
-                error "Quay token request failed: ${response.status} ${response.content}"
-            }
-            token = readJSON(text: response.content).token
-        }
-    }
-    return token
-}
-
 
 node {
     checkout scm
-    def buildlib = load("pipeline-scripts/buildlib.groovy")
-    def commonlib = buildlib.commonlib
+    def appregistry = load("appregistry.groovy")
+    def commonlib = appregistry.commonlib
 
     // Expose properties for a parameterized build
     properties(
@@ -114,135 +65,29 @@ node {
         ]
     )
 
-    buildlib.initialize(false)
-
     def workDir = "${env.WORKSPACE}/workDir"
-    buildlib.cleanWorkdir(workDir)
+    appregistry.initialize(workDir)
 
-    def buildVersion = params.BUILD_VERSION
-
-    currentBuild.description = "Collecting appregistry images for ${buildVersion} (${params.STREAM} stream)"
-    currentBuild.displayName += " - ${buildVersion} (${params.STREAM})"
+    currentBuild.description = "Collecting appregistry images for ${appregistry.buildVersion} (${params.STREAM} stream)"
+    currentBuild.displayName += " - ${appregistry.buildVersion} (${params.STREAM})"
 
     def skipPush = params.SKIP_PUSH
-
-    def validate = { params ->
-        if (params.STREAM in ["stage", "prod"]) {
-            if (!params.OLM_OPERATOR_ADVISORIES || !params.METADATA_ADVISORY) {
-                currentBuild.description += """\n
-                ERROR: OLM_OPERATOR_ADVISORIES and METADATA_ADVISORY parameters are required for selected STREAM.
-                """
-                return false
-            }
-        }
-        return true
-    }
-
-    def doozer = { cmd ->
-        buildlib.doozer("--working-dir ${workDir} -g openshift-${buildVersion} ${cmd}", [capture: true])
-    }
-
-    def elliott = { cmd ->
-        buildlib.elliott("-g openshift-${buildVersion} ${cmd}", [capture: true])
-    }
-
-    def getImagesData = { include ->
-        if (include) {
-            include = "--images " + commonlib.cleanCommaList(include)
-        }
-        doozer """
-            ${include}
-            images:print
-            --label 'com.redhat.delivery.appregistry'
-            --short '{label},{name},{build},{version},{component}'
-        """
-    }
-
-    def fetchNVRsFromAdvisories = { advisories ->
-        commonlib.cleanCommaList(advisories).split(",").collect { advisory ->
-            readJSON(text: elliott("get --json - ${advisory}")).errata_builds.values().flatten()
-        }.flatten()
-    }
-
-    def findImageNVRsInAdvisories = { images, advisoriesNVRs ->
-        images.collect {
-            image -> [
-                name: image.name,
-                nvr: advisoriesNVRs.find { it.startsWith(image.component) }
-            ]
-        }
-    }
-
-    def pushToOMPS = { token, metadata_nvr ->
-        httpRequest(
-            url: "https://omps-prod.cloud.paas.psi.redhat.com/v2/redhat-operators-art/koji/${metadata_nvr}",
-            httpMode: 'POST',
-            customHeaders: [[name: 'Authorization', value: token]],
-            timeout: 60,
-            validResponseCodes: "200:599",
-        )
-    }
-
-    def getMetadataNVRs = { operatorNVRs, stream ->
-        def nvrFlags = operatorNVRs.collect { "--nvr ${it}" }.join(" ")
-        doozer("operator-metadata:latest-build --stream ${stream} ${nvrFlags}")
-    }
-
-    def attachToAdvisory = { advisory, metadata_nvrs ->
-        def elliott_build_flags = []
-        metadata_nvrs.split().each { nvr -> elliott_build_flags.add("--build ${nvr}") }
-
-        elliott """
-            find-builds -k image
-            ${elliott_build_flags.join(" ")}
-            --attach ${advisory}
-        """
-    }
 
     try {
         def operatorData = []
         sshagent(["openshift-bot"]) {
             stage("validate params") {
-                if (!validate(params)) {
+                if (!appregistry.validate(params)) {
                     error "Parameter validation failed"
                 }
             }
             stage("fetch appregistry images") {
-                def lines = getImagesData(params.IMAGES.trim())
-                operatorData = parseAndFilterOperators(lines)
-
-                if (params.STREAM in ["stage", "prod"]) {
-                    def advisoriesNVRs = fetchNVRsFromAdvisories(params.OLM_OPERATOR_ADVISORIES)
-                    operatorData = findImageNVRsInAdvisories(operatorData, advisoriesNVRs)
-
-                    if (operatorData.any { it.nvr == null }) {
-                        currentBuild.description += """\n
-                        Advisories missing operators ${operatorData.findAll { it.nvr }.collect { it.name }.join(",")}
-                        """
-                        echo """
-                        ERROR: The following operators were not found in provided advisories.
-                        ${operatorData.findAll { !it.nvr }.collect { it.name }.join(",")}
-
-                        Possible solutions:
-                        1. Add more advisories in OLM_OPERATOR_ADVISORIES parameter, that have the missing operators attached
-                        2. Attach missing operators to at least one of the provided advisories: ${params.OLM_OPERATOR_ADVISORIES}
-                        3. Limit the expected operators in IMAGES parameter: ${operatorData.findAll { it.nvr }.collect { it.name }.join(",")}
-                        """
-                        error "operators not found"
-                    }
-                }
-
+                operatorData = appregistry.stageFetchOperatorImages()
                 writeYaml file: "${workDir}/appreg.yaml", data: operatorData
-                currentBuild.description = "appregistry images collected for ${buildVersion}."
+                currentBuild.description = "appregistry images collected for ${appregistry.buildVersion}."
             }
             stage("build metadata container") {
-                def nvrs = operatorData.collect { item -> item.nvr }
-
-                doozer """
-                    operator-metadata:build ${nvrs.join(' ')}
-                    ${params.FORCE_METADATA_BUILD ? "-f" : ""}
-                    --stream ${params.STREAM}
-                """
+                appregistry.stageBuildMetadata(operatorData)
             }
             stage("push metadata") {
                 if (skipPush) {
@@ -256,69 +101,21 @@ node {
 
                 if (params.STREAM == 'dev') {
                     currentBuild.description += "\npushing operator metadata."
-                    withCredentials([usernamePassword(credentialsId: 'quay_appregistry_omps_bot', usernameVariable: 'QUAY_USERNAME', passwordVariable: 'QUAY_PASSWORD')]) {
-                        def errors = []
-                        def token = retrieveBotToken()
-                        for (def i = 0; i < operatorData.size(); i++) {
-                            def build = operatorData[i]
-                            def metadata_nvr = getMetadataNVRs([build.nvr], params.STREAM)
-
-                            def response = [:]
-                            try {
-                                retry(errors ? 3 : 60) { // retry the first failing pkg for 30m; after that, give up after 1m30s
-                                    response = [:] // ensure we aren't looking at a previous response
-                                    response = pushToOMPS(token, metadata_nvr)
-                                    if (response.status != 200) {
-                                        sleep(30)
-                                        error "${[metadata_nvr: metadata_nvr, response_content: response.content]}"
-                                    }
-                                }
-                            } catch (err) {
-                                if (response.status != 200) {
-                                    errors.add([
-                                        metadata_nvr: metadata_nvr,
-                                        response_status: response.status,
-                                        response_content: response.content
-                                    ])
-                                } else {
-                                    // failed because of something other than bad request; note that instead
-                                    errors.add(err)
-                                }
-                                continue // without claiming any success
-                            }
-                            currentBuild.description += "\n  ${metadata_nvr}"
-                        }
-                        if (!errors.isEmpty()) {
-                            error "${errors}"
-                        }
+                    withCredentials([usernamePassword(
+                        credentialsId: 'quay_appregistry_omps_bot',
+                        usernameVariable: 'QUAY_USERNAME',
+                        passwordVariable: 'QUAY_PASSWORD',
+                    )]) {
+                        appregistry.stagePushDevMetadata(operatorData)
                     }
                 }
             }
             stage("attach metadata to advisory") {
-                    if (!params.METADATA_ADVISORY) {
-                        currentBuild.description += "\nskipping attach to advisory."
-                        return
-                    }
-
-                    def metadata_nvrs = getMetadataNVRs(operatorData.collect { it.nvr }, params.STREAM)
-
-                    elliott """
-                        change-state -s NEW_FILES
-                        -a ${params.METADATA_ADVISORY}
-                        ${params.DRY_RUN ? "--noop" : ""}
-                    """
-
-                    attachToAdvisory(params.METADATA_ADVISORY, metadata_nvrs)
-
-                    /*
-                    // this would be convenient, except that we don't have a way
-                    // to set the CDN repos first, and can't move to QE without that.
-                    elliott """
-                        change-state -s QE
-                        -a ${params.METADATA_ADVISORY}
-                        ${params.DRY_RUN ? "--noop" : ""}
-                    """
-                    */
+                if (!params.METADATA_ADVISORY) {
+                    currentBuild.description += "\nskipping attach to advisory."
+                    return
+                }
+                appregistry.stageAttachMetadata(operatorData)
             }
         }
     } catch (err) {

--- a/jobs/build/appregistry/Jenkinsfile
+++ b/jobs/build/appregistry/Jenkinsfile
@@ -1,3 +1,4 @@
+// This will likely only make sense once you understand https://mojo.redhat.com/docs/DOC-1203429
 
 node {
     checkout scm
@@ -74,7 +75,7 @@ node {
     def skipPush = params.SKIP_PUSH
 
     try {
-        def operatorData = []
+        def operatorBuilds = []
         sshagent(["openshift-bot"]) {
             stage("validate params") {
                 if (!appregistry.validate(params)) {
@@ -82,19 +83,19 @@ node {
                 }
             }
             stage("fetch appregistry images") {
-                operatorData = appregistry.stageFetchOperatorImages()
-                writeYaml file: "${workDir}/appreg.yaml", data: operatorData
+                operatorBuilds = appregistry.stageFetchOperatorImages()
+                writeYaml file: "${workDir}/appreg.yaml", data: operatorBuilds
                 currentBuild.description = "appregistry images collected for ${appregistry.buildVersion}."
             }
             stage("build metadata container") {
-                appregistry.stageBuildMetadata(operatorData)
+                appregistry.stageBuildMetadata(operatorBuilds)
             }
             stage("push metadata") {
                 if (skipPush) {
                     currentBuild.description += "\nskipping metadata push."
                     return
                 }
-                if (!operatorData) {
+                if (!operatorBuilds) {
                     currentBuild.description += "\nno operator metadata to push."
                     return
                 }
@@ -106,7 +107,7 @@ node {
                         usernameVariable: 'QUAY_USERNAME',
                         passwordVariable: 'QUAY_PASSWORD',
                     )]) {
-                        appregistry.stagePushDevMetadata(operatorData)
+                        appregistry.stagePushDevMetadata(operatorBuilds)
                     }
                 }
             }
@@ -115,7 +116,7 @@ node {
                     currentBuild.description += "\nskipping attach to advisory."
                     return
                 }
-                appregistry.stageAttachMetadata(operatorData)
+                appregistry.stageAttachMetadata(operatorBuilds)
             }
         }
     } catch (err) {

--- a/jobs/build/appregistry/appregistry.groovy
+++ b/jobs/build/appregistry/appregistry.groovy
@@ -303,15 +303,17 @@ def stageAttachMetadata(operatorBuilds) {
 
     attachToAdvisory(params.METADATA_ADVISORY, metadata_nvrs)
 
-    /*
-    // this would be convenient, except that we don't have a way
-    // to set the CDN repos first, and can't move to QE without that.
-    elliott """
-        change-state -s QE
-        -a ${params.METADATA_ADVISORY}
-        ${params.DRY_RUN ? "--noop" : ""}
-    """
-    */
+    try {
+        elliott """
+            change-state -s QE
+            -a ${params.METADATA_ADVISORY}
+            ${params.DRY_RUN ? "--noop" : ""}
+        """
+    } catch(e) {
+        // the first time we do this for an advisory, we don't have a way to set the CDN repos first, so move to QE will fail.
+        echo "failed to move metadata advisory to QE state; check CDN repos and script output"
+        currentBuild.description += "\nFailed to move metadata advisory to QE state; check CDN repos and script output"
+    }
 }
 
 return this

--- a/jobs/build/appregistry/appregistry.groovy
+++ b/jobs/build/appregistry/appregistry.groovy
@@ -1,0 +1,229 @@
+buildlib = load("pipeline-scripts/buildlib.groovy")
+commonlib = buildlib.commonlib
+workDir = null
+buildVersion = null
+
+def initialize(workDir) {
+    this.workDir = workDir
+    this.buildVersion = params.BUILD_VERSION
+    buildlib.initialize(false)
+    buildlib.cleanWorkdir(workDir)
+}
+
+@NonCPS
+def parseAndFilterOperators(lines) {
+    def data = []
+    lines.split().each { line ->
+        // label, name, nvr, version, component
+        def fields = line.split(',')
+        if (fields[0]) {
+            data.add([
+                name: fields[1],
+                nvr: fields[2],
+                version: fields[3].replace("v", ""),
+                component: fields[4],
+            ])
+        }
+    }
+    return data
+}
+
+def retrieveBotToken() {
+    def token = ""
+    withCredentials([usernamePassword(credentialsId: 'quay_appregistry_omps_bot', usernameVariable: 'QUAY_USERNAME', passwordVariable: 'QUAY_PASSWORD')]) {
+        def requestJson = """
+        {
+            "user": {
+                "username": "${QUAY_USERNAME}",
+                "password": "${QUAY_PASSWORD}"
+            }
+        }
+        """
+        retry(3) {
+            def response = httpRequest(
+                url: "https://quay.io/cnr/api/v1/users/login",
+                httpMode: 'POST',
+                contentType: 'APPLICATION_JSON',
+                requestBody: requestJson,
+                timeout: 60,
+                validResponseCodes: "200:599",
+            )
+            if (response.status != 200) {
+                sleep(5)
+                error "Quay token request failed: ${response.status} ${response.content}"
+            }
+            token = readJSON(text: response.content).token
+        }
+    }
+    return token
+}
+
+def validate(params) {
+    if (params.STREAM in ["stage", "prod"]) {
+        if (!params.OLM_OPERATOR_ADVISORIES || !params.METADATA_ADVISORY) {
+            currentBuild.description += """\n
+            ERROR: OLM_OPERATOR_ADVISORIES and METADATA_ADVISORY parameters are required for selected STREAM.
+            """
+            return false
+        }
+    }
+    return true
+}
+
+def doozer(cmd) {
+    buildlib.doozer("--working-dir ${workDir} -g openshift-${buildVersion} ${cmd}", [capture: true])
+}
+
+def elliott(cmd) {
+    buildlib.elliott("-g openshift-${buildVersion} ${cmd}", [capture: true])
+}
+
+def getImagesData(include) {
+    if (include) {
+        include = "--images " + commonlib.cleanCommaList(include)
+    }
+    doozer """
+        ${include}
+        images:print
+        --label 'com.redhat.delivery.appregistry'
+        --short '{label},{name},{build},{version},{component}'
+    """
+}
+
+def fetchNVRsFromAdvisories(advisories) {
+    commonlib.cleanCommaList(advisories).split(",").collect { advisory ->
+        readJSON(text: elliott("get --json - ${advisory}")).errata_builds.values().flatten()
+    }.flatten()
+}
+
+def findImageNVRsInAdvisories(images, advisoriesNVRs) {
+    images.collect {
+        image -> [
+            name: image.name,
+            nvr: advisoriesNVRs.find { it.startsWith(image.component) }
+        ]
+    }
+}
+
+def pushToOMPS(token, metadata_nvr) {
+    httpRequest(
+        url: "https://omps-prod.cloud.paas.psi.redhat.com/v2/redhat-operators-art/koji/${metadata_nvr}",
+        httpMode: 'POST',
+        customHeaders: [[name: 'Authorization', value: token]],
+        timeout: 60,
+        validResponseCodes: "200:599",
+    )
+}
+
+def getMetadataNVRs(operatorNVRs, stream) {
+    def nvrFlags = operatorNVRs.collect { "--nvr ${it}" }.join(" ")
+    doozer("operator-metadata:latest-build --stream ${stream} ${nvrFlags}")
+}
+
+def attachToAdvisory(advisory, metadata_nvrs) {
+    def elliott_build_flags = []
+    metadata_nvrs.split().each { nvr -> elliott_build_flags.add("--build ${nvr}") }
+
+    elliott """
+        find-builds -k image
+        ${elliott_build_flags.join(" ")}
+        --attach ${advisory}
+    """
+}
+
+def stageFetchOperatorImages() {
+    operatorData = parseAndFilterOperators(getImagesData(params.IMAGES.trim()))
+
+    if (params.STREAM in ["stage", "prod"]) {
+        def advisoriesNVRs = fetchNVRsFromAdvisories(params.OLM_OPERATOR_ADVISORIES)
+        operatorData = findImageNVRsInAdvisories(operatorData, advisoriesNVRs)
+
+        if (operatorData.any { it.nvr == null }) {
+            currentBuild.description += """\n
+            Advisories missing operators ${operatorData.findAll { it.nvr }.collect { it.name }.join(",")}
+            """
+            echo """
+            ERROR: The following operators were not found in provided advisories.
+            ${operatorData.findAll { !it.nvr }.collect { it.name }.join(",")}
+
+            Possible solutions:
+            1. Add more advisories in OLM_OPERATOR_ADVISORIES parameter, that have the missing operators attached
+            2. Attach missing operators to at least one of the provided advisories: ${params.OLM_OPERATOR_ADVISORIES}
+            3. Limit the expected operators in IMAGES parameter: ${operatorData.findAll { it.nvr }.collect { it.name }.join(",")}
+            """
+            error "operators not found"
+        }
+    }
+    return operatorData
+}
+
+def stageBuildMetadata(operatorData) {
+    def nvrs = operatorData.collect { item -> item.nvr }
+
+    doozer """
+        operator-metadata:build ${nvrs.join(' ')}
+        ${params.FORCE_METADATA_BUILD ? "-f" : ""}
+        --stream ${params.STREAM}
+    """
+}
+
+def stagePushDevMetadata(operatorData) {
+    def errors = []
+    def token = retrieveBotToken()
+    for (def i = 0; i < operatorData.size(); i++) {
+        def build = operatorData[i]
+        def metadata_nvr = getMetadataNVRs([build.nvr], params.STREAM)
+
+        def response = [:]
+        try {
+            retry(errors ? 3 : 60) { // retry the first failing pkg for 30m; after that, give up after 1m30s
+                response = [:] // ensure we aren't looking at a previous response
+                response = pushToOMPS(token, metadata_nvr)
+                if (response.status != 200) {
+                    sleep(30)
+                    error "${[metadata_nvr: metadata_nvr, response_content: response.content]}"
+                }
+            }
+        } catch (err) {
+            if (response.status != 200) {
+                errors.add([
+                    metadata_nvr: metadata_nvr,
+                    response_status: response.status,
+                    response_content: response.content
+                ])
+            } else {
+                // failed because of something other than bad request; note that instead
+                errors.add(err)
+            }
+            continue // without claiming any success
+        }
+        currentBuild.description += "\n  ${metadata_nvr}"
+    }
+    if (!errors.isEmpty()) {
+        error "${errors}"
+    }
+}
+
+def stageAttachMetadata(operatorData) {
+    def metadata_nvrs = getMetadataNVRs(operatorData.collect { it.nvr }, params.STREAM)
+
+    elliott """
+        change-state -s NEW_FILES
+        -a ${params.METADATA_ADVISORY}
+        ${params.DRY_RUN ? "--noop" : ""}
+    """
+
+    attachToAdvisory(params.METADATA_ADVISORY, metadata_nvrs)
+
+    /*
+    // this would be convenient, except that we don't have a way
+    // to set the CDN repos first, and can't move to QE without that.
+    elliott """
+        change-state -s QE
+        -a ${params.METADATA_ADVISORY}
+        ${params.DRY_RUN ? "--noop" : ""}
+    """
+    */
+}
+
+return this


### PR DESCRIPTION
I've made quite distinct commits so you can easily review each logical advance.

Main improvements:
1. use locks so jobs may run concurrently
1. when individual OMPS requests fail, still run the others
2. run OMPS requests in parallel (formerly serial HTTP REST call)
3. retry "CVP not finished" errors for an hour, others 3 times (more or less addresses ART-1103)
4. for stage/prod, attempt to change the advisory to QE state afterward (but ignore if it fails)