### PR TITLE
[ART-722] Sweep builds and bugs after incremental and custom builds

### DIFF
--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -64,6 +64,12 @@ node {
                         $class: 'hudson.model.BooleanParameterDefinition',
                         defaultValue: true
                     ],
+                    [
+                        name: 'SWEEP_BUILDS',
+                        description: 'Sweep and attach builds to advisories',
+                        $class: 'hudson.model.BooleanParameterDefinition',
+                        defaultValue: true
+                    ],
                     commonlib.suppressEmailParam(),
                     [
                         name: 'MAIL_LIST_SUCCESS',
@@ -242,6 +248,12 @@ node {
                     --kind rpm
                     ${attach}
                     """
+                }
+            }
+
+            stage('sweep') {
+                if (params.SWEEP_BUILDS) {
+                    buildlib.sweep(params.BUILD_VERSION, true)
                 }
             }
 

--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -65,10 +65,10 @@ node {
                         defaultValue: true
                     ],
                     [
-                        name: 'SWEEP_BUILDS',
-                        description: 'Sweep and attach builds to advisories',
+                        name: 'SWEEP_BUGS',
+                        description: 'Sweep and attach bugs to advisories',
                         $class: 'hudson.model.BooleanParameterDefinition',
-                        defaultValue: true
+                        defaultValue: false
                     ],
                     commonlib.suppressEmailParam(),
                     [
@@ -252,8 +252,8 @@ node {
             }
 
             stage('sweep') {
-                if (params.SWEEP_BUILDS) {
-                    buildlib.sweep(params.BUILD_VERSION, true)
+                if (params.SWEEP_BUGS) {
+                    buildlib.sweep(params.BUILD_VERSION, false)
                 }
             }
 

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -116,6 +116,7 @@ node {
                 stage("build images") { build.stageBuildImages() }
                 stage("mirror RPMs") { build.stageMirrorRpms() }
                 stage("sync images") { build.stageSyncImages() }
+                stage("sweep") { buildlib.sweep(params.BUILD_VERSION, true) }
             }
         }
         stage("report success") { build.stageReportSuccess() }

--- a/jobs/build/signed-compose/Jenkinsfile
+++ b/jobs/build/signed-compose/Jenkinsfile
@@ -66,7 +66,6 @@ node {
 
     try {
         sshagent(["openshift-bot"]) {
-            stage("Advisory is NEW_FILES") { build.signedComposeStateNewFiles() }
             stage("Attach builds") { build.signedComposeAttachBuilds() }
             stage("RPM diffs ran") { build.signedComposeRpmdiffsRan(advisory) }
             stage("RPM diffs resolved") { build.signedComposeRpmdiffsResolved(advisory) }

--- a/jobs/build/signed-compose/build.groovy
+++ b/jobs/build/signed-compose/build.groovy
@@ -27,7 +27,11 @@ def signedComposeAttachBuilds() {
         echo("Job configured not to attach builds; continuing using builds already attached")
         return
     }
-    buildlib.attachBuildsToAdvisory(["rpm"])
+    if (!params.DRY_RUN) {
+        echo("Skipping attach builds to advisory for dry run")
+        return
+    }
+    buildlib.attachBuildsToAdvisory(["rpm"], params.BUILD_VERSION)
 }
 
 // Monitor and wait for all of the RPM diffs to run.

--- a/jobs/build/signed-compose/build.groovy
+++ b/jobs/build/signed-compose/build.groovy
@@ -20,16 +20,6 @@ def initialize(advisory) {
     currentBuild.description += "\nErrata whitelist: ${errataList}"
 }
 
-// Set the advisory to the NEW_FILES state (allows builds to be added)
-def signedComposeStateNewFiles() {
-    if (params.DRY_RUN) {
-        echo("Skipping advisory state change for dry run.")
-        echo("would have run: ${elliottOpts} change-state --state NEW_FILES ${advisoryOpt}")
-        return
-    }
-    buildlib.elliott("${elliottOpts} change-state --state NEW_FILES ${advisoryOpt}")
-}
-
 // Search brew for, and then attach, any viable builds. Do this for
 // EL7 and EL8.
 def signedComposeAttachBuilds() {
@@ -37,24 +27,7 @@ def signedComposeAttachBuilds() {
         echo("Job configured not to attach builds; continuing using builds already attached")
         return
     }
-    // Don't actually attach builds if this is just a dry run
-    def advs = params.DRY_RUN ? '' : advisoryOpt
-    def cmd = "${elliottOpts} find-builds --kind rpm ${advs}"
-    def cmdEl8 = "${elliottOpts} --branch rhaos-${params.BUILD_VERSION}-rhel-8 find-builds --kind rpm ${advs}"
-
-    try {
-        buildlib.elliott(cmd, [capture: true]).trim().split('\n')[-1]
-        if (requiresRhel8()) {
-            buildlib.elliott(cmdEl8, [capture: true]).trim().split('\n')[-1]
-        }
-    } catch (err) {
-        echo("Problem running elliott")
-        currentBuild.description += """
-----------------------------------------
-${err}
-----------------------------------------"""
-        error("Could not process a find-builds command")
-    }
+    buildlib.attachBuildsToAdvisory(["rpm"])
 }
 
 // Monitor and wait for all of the RPM diffs to run.

--- a/jobs/build/sweep/Jenkinsfile
+++ b/jobs/build/sweep/Jenkinsfile
@@ -74,17 +74,7 @@ node {
             currentBuild.description += "* Not sweeping builds\n"
             return
         }
-        try {
-            currentBuild.description += "* Searching for and attaching new builds...\n"
-            buildlib.elliott "-g openshift-${version} find-builds -k rpm --use-default-advisory rpm"
-            if (major == '4') {
-                buildlib.elliott "-g openshift-${version} --branch rhaos-${version}-rhel-8 find-builds -k rpm --use-default-advisory rpm"
-            }
-            buildlib.elliott "-g openshift-${version} find-builds -k image --use-default-advisory image"
-        } catch (elliottErr) {
-            currentBuild.description += "Error sweeping builds:\n${elliottErr}"
-            throw elliottErr
-        }
+        buildlib.attachBuildsToAdvisory(["rpm", "image"])
     }
     currentBuild.description = "Ran without errors\n---------------\n" + currentBuild.description
 }

--- a/jobs/build/sweep/Jenkinsfile
+++ b/jobs/build/sweep/Jenkinsfile
@@ -76,7 +76,11 @@ node {
         }
         try {
             currentBuild.description += "* Searching for and attaching new builds...\n"
-            buildlib.elliott "-g openshift-${version} find-builds -k ${kind} --use-default-advisory ${kind}"
+            buildlib.elliott "-g openshift-${version} find-builds -k rpm --use-default-advisory rpm"
+            if (major == '4') {
+                buildlib.elliott "-g openshift-${version} --branch rhaos-${version}-rhel-8 find-builds -k rpm --use-default-advisory rpm"
+            }
+            buildlib.elliott "-g openshift-${version} find-builds -k image --use-default-advisory image"
         } catch (elliottErr) {
             currentBuild.description += "Error sweeping builds:\n${elliottErr}"
             throw elliottErr

--- a/jobs/build/sweep/Jenkinsfile
+++ b/jobs/build/sweep/Jenkinsfile
@@ -74,7 +74,11 @@ node {
             currentBuild.description += "* Not sweeping builds\n"
             return
         }
-        buildlib.attachBuildsToAdvisory(["rpm", "image"])
+        if (params.DRY_RUN) {
+            echo("Skipping attach builds to advisory for dry run")
+            return
+        }
+        buildlib.attachBuildsToAdvisory(["rpm", "image"], params.BUILD_VERSION)
     }
     currentBuild.description = "Ran without errors\n---------------\n" + currentBuild.description
 }

--- a/jobs/build/sweep/Jenkinsfile
+++ b/jobs/build/sweep/Jenkinsfile
@@ -20,6 +20,11 @@ node {
                 parameterDefinitions: [
                     commonlib.ocpVersionParam('BUILD_VERSION'),
                     commonlib.mockParam(),
+                    booleanParam(
+                        name: 'SWEEP_BUILDS',
+                        defaultValue: true,
+                        description: 'Sweep and attach builds to advisories',
+                    ),
                 ],
             ],
         ]
@@ -60,7 +65,20 @@ node {
             currentBuild.description += "* Searching for and attaching new bugs in MODIFIED state...\n"
             buildlib.elliott "--group=openshift-${version} find-bugs --mode sweep --use-default-advisory ${kind}"
         } catch (elliottErr) {
-            currentBuild.description = "Error sweeping:\n${elliottErr}"
+            currentBuild.description += "Error sweeping bugs:\n${elliottErr}"
+            throw elliottErr
+        }
+    }
+    stage("Sweep builds") {
+        if (!params.SWEEP_BUILDS) {
+            currentBuild.description += "* Not sweeping builds\n"
+            return
+        }
+        try {
+            currentBuild.description += "* Searching for and attaching new builds...\n"
+            buildlib.elliott "-g openshift-${version} find-builds -k ${kind} --use-default-advisory ${kind}"
+        } catch (elliottErr) {
+            currentBuild.description += "Error sweeping builds:\n${elliottErr}"
             throw elliottErr
         }
     }

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -724,7 +724,13 @@ def build_ami(major, minor, version, release, yum_base_url, ansible_branch, mail
     }
 }
 
-def sweep(buildVersion, sweepBuilds) {
+/**
+ * Trigger sweep job.
+ *
+ * @param String buildVersion: OCP build version (e.g. 4.2, 4.1, 3.11)
+ * @param Boolean sweepBuilds: Enable/disable build sweeping
+ */
+def sweep(String buildVersion, Boolean sweepBuilds) {
     def sweepJob = build(
         job: 'build%2Fsweep',
         propagate: false,

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -724,6 +724,27 @@ def build_ami(major, minor, version, release, yum_base_url, ansible_branch, mail
     }
 }
 
+def sweep(build_version, sweep_builds) {
+    def sweep_job = build(
+        job: 'build%2Fsweep',
+        prapagate: false,
+        parameters: [
+            param('String', 'BUILD_VERSION', build_version),
+            param('Boolean', 'SWEEP_BUILDS', sweep_builds),
+        ]
+    )
+    if (sweep_job.result != 'SUCCESS') {
+        commonlib.email(
+            replyTo: mail_list,
+            to: 'aos-art-automation+failed-sweep@redhat.com',
+            from: 'aos-art-automation@redhat.com',
+            subject: "Problem sweeping after ${currentBuild.displayName}",
+            body: "Jenkins console: ${commonlib.buildURL('console')}",
+        )
+        currentBuild.result = 'UNSTABLE'
+    }
+}
+
 def sync_images(major, minor, mail_list, build_number) {
     // Run an image sync after a build. This will mirror content from
     // internal registries to quay. After a successful sync an image

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -729,8 +729,8 @@ def sweep(build_version, sweep_builds) {
         job: 'build%2Fsweep',
         propagate: false,
         parameters: [
-            param('String', 'BUILD_VERSION', build_version),
-            param('Boolean', 'SWEEP_BUILDS', sweep_builds),
+            string(name: 'BUILD_VERSION', value: build_version),
+            booleanParam(name: 'SWEEP_BUILDS', value: sweep_builds),
         ]
     )
     if (sweep_job.result != 'SUCCESS') {

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -1276,7 +1276,7 @@ def assertBuildPermitted(doozerOpts) {
 }
 
 /**
- * Run elliott find-builds and attach to given advisory, if not running a DRY_RUN.
+ * Run elliott find-builds and attach to given advisory.
  * It looks for builds twice (rhel-7 and rhel-8) for OCP 4.y
  * Side-effect: Advisory states are changed to "NEW FILES" in order to attach builds.
  *

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -727,7 +727,7 @@ def build_ami(major, minor, version, release, yum_base_url, ansible_branch, mail
 def sweep(build_version, sweep_builds) {
     def sweep_job = build(
         job: 'build%2Fsweep',
-        prapagate: false,
+        propagate: false,
         parameters: [
             param('String', 'BUILD_VERSION', build_version),
             param('Boolean', 'SWEEP_BUILDS', sweep_builds),
@@ -735,7 +735,7 @@ def sweep(build_version, sweep_builds) {
     )
     if (sweep_job.result != 'SUCCESS') {
         commonlib.email(
-            replyTo: mail_list,
+            replyTo: 'aos-art-team@redhat.com',
             to: 'aos-art-automation+failed-sweep@redhat.com',
             from: 'aos-art-automation@redhat.com',
             subject: "Problem sweeping after ${currentBuild.displayName}",

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -1289,21 +1289,21 @@ def assertBuildPermitted(doozerOpts) {
  * @param String[] kinds: List of build kinds you want to find (e.g. ["rpm", "image"])
  * @param String buildVersion: OCP build version (e.g. 4.2, 4.1, 3.11)
  */
-def attachBuildsToAdvisory(String[] kinds, String buildVersion) {
+def attachBuildsToAdvisory(kinds, buildVersion) {
     def groupOpt = "-g openshift-${buildVersion}"
     def isOCP4 = buildVersion.startsWith("4.")
     def rhel8branchOpt = "--branch rhaos-${buildVersion}-rhel-8"
 
     try {
         if ("rpm" in kinds) {
-            elliott("${groupOpt} change-stage -s NEW_FILES --use-default-advisory rpm")
+            elliott("${groupOpt} change-state -s NEW_FILES --use-default-advisory rpm")
             elliott("${groupOpt} find-builds -k rpm --use-default-advisory rpm")
             if (isOCP4) {
-                elliott("${groupOpt} find-builds -k rpm --use-default-advisory rpm ${rhel8branchOpt}")
+                elliott("${groupOpt} ${rhel8branchOpt} find-builds -k rpm --use-default-advisory rpm")
             }
         }
         if ("image" in kinds) {
-            elliott("${groupOpt} change-stage -s NEW_FILES --use-default-advisory image")
+            elliott("${groupOpt} change-state -s NEW_FILES --use-default-advisory image")
             elliott("${groupOpt} find-builds -k image --use-default-advisory image")
         }
     } catch (err) {

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -724,16 +724,16 @@ def build_ami(major, minor, version, release, yum_base_url, ansible_branch, mail
     }
 }
 
-def sweep(build_version, sweep_builds) {
-    def sweep_job = build(
+def sweep(buildVersion, sweepBuilds) {
+    def sweepJob = build(
         job: 'build%2Fsweep',
         propagate: false,
         parameters: [
-            string(name: 'BUILD_VERSION', value: build_version),
-            booleanParam(name: 'SWEEP_BUILDS', value: sweep_builds),
+            string(name: 'BUILD_VERSION', value: buildVersion),
+            booleanParam(name: 'SWEEP_BUILDS', value: sweepBuilds),
         ]
     )
-    if (sweep_job.result != 'SUCCESS') {
+    if (sweepJob.result != 'SUCCESS') {
         commonlib.email(
             replyTo: 'aos-art-team@redhat.com',
             to: 'aos-art-automation+failed-sweep@redhat.com',
@@ -1281,12 +1281,12 @@ def assertBuildPermitted(doozerOpts) {
  * Side-effect: Advisory states are changed to "NEW FILES" in order to attach builds.
  *
  * @param String[] kinds: List of build kinds you want to find (e.g. ["rpm", "image"])
- * @param String build_version: OCP build version (e.g. 4.2, 4.1, 3.11)
+ * @param String buildVersion: OCP build version (e.g. 4.2, 4.1, 3.11)
  */
-def attachBuildsToAdvisory(String[] kinds, String build_version) {
-    def groupOpt = "-g openshift-${build_version}"
-    def isOCP4 = build_version.startsWith("4.")
-    def rhel8branchOpt = "--branch rhaos-${build_version}-rhel-8"
+def attachBuildsToAdvisory(String[] kinds, String buildVersion) {
+    def groupOpt = "-g openshift-${buildVersion}"
+    def isOCP4 = buildVersion.startsWith("4.")
+    def rhel8branchOpt = "--branch rhaos-${buildVersion}-rhel-8"
 
     try {
         if ("rpm" in kinds) {

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -1281,15 +1281,12 @@ def assertBuildPermitted(doozerOpts) {
  * Side-effect: Advisory states are changed to "NEW FILES" in order to attach builds.
  *
  * @param String[] kinds: List of build kinds you want to find (e.g. ["rpm", "image"])
+ * @param String build_version: OCP build version (e.g. 4.2, 4.1, 3.11)
  */
-def attachBuildsToAdvisory(String[] kinds) {
-    if (params.DRY_RUN) {
-        echo("Skipping attach builds to advisory for dry run")
-        return
-    }
-    def groupOpt = "-g openshift-${params.BUILD_VERSION}"
-    def isOCP4 = params.BUILD_VERSION.startsWith("4.")
-    def rhel8branchOpt = "--branch rhaos-${params.BUILD_VERSION}-rhel-8"
+def attachBuildsToAdvisory(String[] kinds, String build_version) {
+    def groupOpt = "-g openshift-${build_version}"
+    def isOCP4 = build_version.startsWith("4.")
+    def rhel8branchOpt = "--branch rhaos-${build_version}-rhel-8"
 
     try {
         if ("rpm" in kinds) {


### PR DESCRIPTION
## [ART-722](https://jira.coreos.com/browse/ART-722) Acceptance Criteria

1. Expand the sweep job to also sweep builds into the default advisories.
2. Make sweeping optional for bugs and builds (both default to true).
3. After a 4.x build (always when incremental ocp4, optionally when custom job), run the sweep job.
4. After a refresh-images build (3.x signed imgs), run the sweep job for builds only.

## What is introduced by this PR

* New option `SWEEP_BUILDS` for `builds/sweep`, defaulting to `true`, that, if enabled, will run `elliott find-builds` and attach to default advisory: **(acceptance criteria 1 and 2)**
![Screenshot from 2019-11-12 11-54-53](https://user-images.githubusercontent.com/190616/68671972-e1151800-0550-11ea-9eb5-25931385457a.png)

* New `buildlib` function `sweep`, to programatically call sweep jobs.

* New option `SWEEP_BUILDS` for `builds/custom`, defaulting to `true`, that, if enabled, will trigger a `build/sweep` job at the end of its execution: **(part of acceptance criteria 3)**
![Screenshot from 2019-11-12 11-55-51](https://user-images.githubusercontent.com/190616/68671981-e4100880-0550-11ea-85a1-a16e7bbfeb1f.png)

* New stage `"sweep builds"` at the end of `build/ocp4`. **(part of acceptance criteria 3)**

**Acceptance criteria 4** seems to be already fulfilled: https://github.com/openshift/aos-cd-jobs/blob/master/jobs/build/refresh-images/Jenkinsfile#L320-L325

## Note for reviewers

I'd suggest we test them during a release before merging: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/talessio-aos-cd-jobs/