### PR TITLE
[ART-675] Add release name to release and signing jobs

### DIFF
--- a/jobs/build/release/Jenkinsfile
+++ b/jobs/build/release/Jenkinsfile
@@ -110,6 +110,7 @@ node {
             currentBuild.displayName += "- ${name}"
             if (params.DRY_RUN) {
                 currentBuild.displayName += " (dry-run)"
+                currentBuild.description += "[DRY RUN]"
             }
 
 

--- a/jobs/build/release/Jenkinsfile
+++ b/jobs/build/release/Jenkinsfile
@@ -107,6 +107,12 @@ node {
             def CLIENT_TYPE = 'ocp'
 
 
+            currentBuild.displayName += "- ${name}"
+            if (params.DRY_RUN) {
+                currentBuild.displayName += " (dry-run)"
+            }
+
+
             // must be able to access remote registry for verification
             buildlib.registry_quay_dev_login()
             stage("versions") { release.stageVersions() }

--- a/jobs/signing/sign-artifacts/Jenkinsfile
+++ b/jobs/signing/sign-artifacts/Jenkinsfile
@@ -78,6 +78,7 @@ node {
         currentBuild.displayName += "- ${params.NAME}"
         if (noop) {
             currentBuild.displayName += " (dry-run)"
+            currentBuild.description += "[DRY RUN]"
         }
 
         wrap([$class: 'BuildUser']) {

--- a/jobs/signing/sign-artifacts/Jenkinsfile
+++ b/jobs/signing/sign-artifacts/Jenkinsfile
@@ -75,6 +75,11 @@ node {
     stage('sign-artifacts') {
         def noop = params.DRY_RUN ? " --noop" : " "
 
+        currentBuild.displayName += "- ${params.NAME}"
+        if (noop) {
+            currentBuild.displayName += " (dry-run)"
+        }
+
         wrap([$class: 'BuildUser']) {
             echo "Submitting signing requests as user: ${env.BUILD_USER_ID}"
 


### PR DESCRIPTION
Item 1 of [ART-675](https://jira.coreos.com/browse/ART-675): Adding release name to `build/release` and `signing/sign-artifacts` displayNames.
**Bonus:** Adding `(dry-run)` displayNames if is a dry-run run ;D