### PR TITLE
[ART-675] trigger signing after release job

### DIFF
--- a/jobs/build/release/Jenkinsfile
+++ b/jobs/build/release/Jenkinsfile
@@ -120,7 +120,15 @@ node {
             stage("advisory update") { release.stageAdvisoryUpdate() }
             stage("cross ref check") { release.stageCrossRef() }
             stage("send release message") { release.sendReleaseCompleteMessage(release_obj, advisory, errata_url) }
-
+            stage("sign artifacts") {
+                release.signArtifacts(
+                    name: name,
+                    signature_name: "signature-1",
+                    dry_run: params.DRY_RUN,
+                    env: "prod",
+                    key_name: "redhatrelease2",
+                )
+            }
         }
 
         dry_subject = ""

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -357,4 +357,18 @@ def void sendReleaseCompleteMessage(Map release, int advisoryNumber, String advi
     }
 }
 
+def signArtifacts(Map signingParams) {
+    build(
+        job: "signing%2Fsign-artifacts",
+        propagate: false,
+        parameters: [
+            param("String", "NAME", signingParams.name),
+            param("String", "SIGNATURE_NAME", signingParams.signature_name),
+            param("Boolean", "DRY_RUN", signingParams.dry_run),
+            param("String", "ENV", signingParams.env),
+            param("String", "KEY_NAME", signingParams.key_name),
+        ]
+    )
+}
+
 return this


### PR DESCRIPTION
Item 6 of [ART-675](https://jira.coreos.com/browse/ART-675): Run the signing job at the end (we've determined there's no reason to wait).