### PR TITLE
No more unlabeled src_dest files in build-sync

### DIFF
--- a/jobs/build/build-sync/build.groovy
+++ b/jobs/build/build-sync/build.groovy
@@ -88,7 +88,6 @@ release:gen-multiarch-payload
 """
 	echo("Generated files:")
 	echo("######################################################################")
-	sh("cat src_dest")
 	for ( String a: arches ) {
 	    echo("######################################################################")
 	    echo("src_dest.${a}")


### PR DESCRIPTION
Job was failing because it was trying to dump out a file that isn't created anymore