### PR TITLE
[ART-1258] scope mirror pushes to client dir

### DIFF
--- a/build-scripts/rcm-guest/publish-oc-v4-binary.sh
+++ b/build-scripts/rcm-guest/publish-oc-v4-binary.sh
@@ -63,6 +63,22 @@ rsync \
     -e "ssh -l jenkins_aos_cd_bot -o StrictHostKeyChecking=no" \
     "${OUTDIR}" ${OSE_VERSION} latest \
     use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/x86_64/clients/oc/
-ssh -l jenkins_aos_cd_bot -o StrictHostKeychecking=no \
+
+retry() {
+  local count exit_code
+  count=0
+  until "$@"; do
+    exit_code="$?"
+    count=$((count + 1))
+    if [[ $count -lt 4 ]]; then
+      sleep 5
+    else
+      return "$exit_code"
+    fi
+  done
+}
+
+# kick off mirror push
+retry ssh -l jenkins_aos_cd_bot -o StrictHostKeychecking=no \
     use-mirror-upload.ops.rhcloud.com \
-    timeout 15m /usr/local/bin/push.pub.sh openshift-v4 -v || timeout 5m /usr/local/bin/push.pub.sh openshift-v4 -v || timeout 5m /usr/local/bin/push.pub.sh openshift-v4 -v
+    timeout 15m /usr/local/bin/push.pub.sh openshift-v4/clients/oc -v

--- a/build-scripts/rcm-guest/publish-odo-binary.sh
+++ b/build-scripts/rcm-guest/publish-odo-binary.sh
@@ -48,5 +48,20 @@ rsync \
     "${OUTDIR}" latest \
     use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/clients/odo/
 
-#kick off full mirror push
-ssh ${SSH_OPTS} timeout 15m /usr/local/bin/push.pub.sh openshift-v4 -v || timeout 5m /usr/local/bin/push.pub.sh openshift-v4 -v || timeout 5m /usr/local/bin/push.pub.sh openshift-v4 -v
+
+retry() {
+  local count exit_code
+  count=0
+  until "$@"; do
+    exit_code="$?"
+    count=$((count + 1))
+    if [[ $count -lt 4 ]]; then
+      sleep 5
+    else
+      return "$exit_code"
+    fi
+  done
+}
+
+# kick off mirror push
+retry ssh ${SSH_OPTS} timeout 15m /usr/local/bin/push.pub.sh openshift-v4/clients/odo -v

--- a/jobs/build/crc/build.groovy
+++ b/jobs/build/crc/build.groovy
@@ -48,10 +48,10 @@ def crcRsyncRelease() {
 
 def crcPushPub() {
     if ( params.DRY_RUN ) {
-        echo("[DRY-RUN] Would have ran 'push.pub.sh openshift-v4 -v' on use-mirror-upload")
+        echo("[DRY-RUN] Would have run 'push.pub.sh openshift-v4/clients/crc -v' on use-mirror-upload")
     } else {
-        echo("Running 'push.pub.sh openshift-v4 -v' on use-mirror-upload. This might take a little while.")
-        mirror_result = buildlib.invoke_on_use_mirror("push.pub.sh", "openshift-v4", '-v')
+        echo("Running 'push.pub.sh openshift-v4/clients/crc -v' on use-mirror-upload. This might take a little while.")
+        mirror_result = buildlib.invoke_on_use_mirror("push.pub.sh", "openshift-v4/clients/crc", '-v')
         if (mirror_result.contains("[FAILURE]")) {
             echo(mirror_result)
             error("Error running signed artifact sync push.pub.sh:\n${mirror_result}")

--- a/jobs/build/crc/build.groovy
+++ b/jobs/build/crc/build.groovy
@@ -7,7 +7,7 @@ releaseVer = ''
 def initialize() {
     buildlib.cleanWorkdir(workdir)
     if ( !params.RELEASE_URL.contains(sourceDomain) ) {
-	error("RELEASE_URL is not the expected host: ${sourceDomain}")
+        error("RELEASE_URL is not the expected host: ${sourceDomain}")
     }
 
     releaseVer = params.RELEASE_URL.split('/')[-1]
@@ -24,11 +24,11 @@ def crcDownloadRelease() {
     // --cut-dirs=4 => Don't make the 4 extra parent directories on the file system
     def cmd = "wget -r --level=1 --no-parent --cut-dirs=4 ${params.RELEASE_URL}"
     dir ( workdir ) {
-	def result = commonlib.shell(script: cmd)
-	// Rename it from the domain name to the actual version
-	commonlib.shell(script: "mv ${sourceDomain} ${releaseVer}")
-	// And update 'latest' symlink, of course
-	commonlib.shell(script: "ln -s ${releaseVer} latest")
+        def result = commonlib.shell(script: cmd)
+        // Rename it from the domain name to the actual version
+        commonlib.shell(script: "mv ${sourceDomain} ${releaseVer}")
+        // And update 'latest' symlink, of course
+        commonlib.shell(script: "ln -s ${releaseVer} latest")
     }
 }
 
@@ -41,21 +41,21 @@ def crcRsyncRelease() {
     // the index.html files from the files to be transferred
     cmd = "rsync ${dry} -av --delete-after --exclude='shell' --exclude='index*' --progress --no-g --omit-dir-times --chmod=Dug=rwX -e 'ssh -l jenkins_aos_cd_bot -o StrictHostKeyChecking=no' ${workdir}/${releaseVer} ${workdir}/latest ${dest}/"
     commonlib.shell(
-	script: cmd,
-	returnAll: true
+        script: cmd,
+        returnAll: true
     )
 }
 
 def crcPushPub() {
     if ( params.DRY_RUN ) {
-	echo("[DRY-RUN] Would have ran 'push.pub.sh openshift-v4 -v' on use-mirror-upload")
+        echo("[DRY-RUN] Would have ran 'push.pub.sh openshift-v4 -v' on use-mirror-upload")
     } else {
-	echo("Running 'push.pub.sh openshift-v4 -v' on use-mirror-upload. This might take a little while.")
-	mirror_result = buildlib.invoke_on_use_mirror("push.pub.sh", "openshift-v4", '-v')
-	if (mirror_result.contains("[FAILURE]")) {
-	    echo(mirror_result)
-	    error("Error running signed artifact sync push.pub.sh:\n${mirror_result}")
-	}
+        echo("Running 'push.pub.sh openshift-v4 -v' on use-mirror-upload. This might take a little while.")
+        mirror_result = buildlib.invoke_on_use_mirror("push.pub.sh", "openshift-v4", '-v')
+        if (mirror_result.contains("[FAILURE]")) {
+            echo(mirror_result)
+            error("Error running signed artifact sync push.pub.sh:\n${mirror_result}")
+        }
     }
 }
 


### PR DESCRIPTION
Pushing all of openshift-v4 on use-mirrors risks pushing unintended content. It's also needlessly checking the entire directory structure for updates.

This change scopes pushes as narrowly as possible to what needs to be updated. It also corrects some bad patterns that got repeated.
