### PR TITLE
[ART-675] Usage instructions for release DESCRIPTION param

### DIFF
--- a/jobs/build/release/Jenkinsfile
+++ b/jobs/build/release/Jenkinsfile
@@ -36,7 +36,7 @@ node {
                     ],
                     [
                         name: 'DESCRIPTION',
-                        description: '[deprecated] Release description for metadata',
+                        description: 'Should be empty unless you know otherwise',
                         $class: 'hudson.model.StringParameterDefinition',
                         defaultValue: ""
                     ],


### PR DESCRIPTION
Item 4 of [ART-675](https://jira.coreos.com/browse/ART-675): Usage instructions for release `DESCRIPTION` param.