### PR TITLE
build/release: refresh quay auth before client sync

### DIFF
--- a/jobs/build/release/Jenkinsfile
+++ b/jobs/build/release/Jenkinsfile
@@ -116,6 +116,7 @@ node {
             stage("get release info") {
                 release_info = release.stageGetReleaseInfo(quay_url, dest_release_tag)
             }
+            buildlib.registry_quay_dev_login()  // chances are, earlier auth has expired
             stage("mirror tools") { release.stagePublishClient(quay_url, dest_release_tag, arch, CLIENT_TYPE) }
             stage("advisory update") { release.stageAdvisoryUpdate() }
             stage("cross ref check") { release.stageCrossRef() }


### PR DESCRIPTION
Fixes problem where quay auth expires while waiting for the release to be accepted, so client extraction fails.