### PR TITLE
[ART-1293] Fix broken UMB messages job

### DIFF
--- a/jobs/build/send-umb-messages/Jenkinsfile
+++ b/jobs/build/send-umb-messages/Jenkinsfile
@@ -26,7 +26,7 @@ node {
         dir ("/mnt/nfs/home/jenkins/.cache/releases") {
             for (String release : releases) {
                 // There are different release controllers for OCP - one for each architecture.
-                RELEASE_CONTROLLER_URL = commonlib.getReleaseControllerURL(releaseStream)
+                RELEASE_CONTROLLER_URL = commonlib.getReleaseControllerURL(release)
                 latestRelease = sh(
                     returnStdout: true,
                     script: "curl -s ${RELEASE_CONTROLLER_URL}/api/v1/releasestream/${release}/latest",


### PR DESCRIPTION
[ART-1293](https://jira.coreos.com/browse/ART-1293) our `build/send-umb-messages` job was broken with the following error:
```
groovy.lang.MissingPropertyException: No such property: releaseStream for class: WorkflowScript
```