### PR TITLE
Bump openshift-ansible version for gogitit

### DIFF
--- a/tower-scripts/bin/gogitit_online_int.yml
+++ b/tower-scripts/bin/gogitit_online_int.yml
@@ -35,7 +35,7 @@ repos:
     dst: roles/oso_console_extensions/
 - id: openshift-ansible
   url: https://github.com/openshift/openshift-ansible.git
-  version: openshift-ansible-3.10.0-0.50.0
+  version: openshift-ansible-3.11.153-2
   copy:
   - src: roles/lib_openshift/
     dst: roles/lib_openshift/

--- a/tower-scripts/bin/gogitit_online_prod.yml
+++ b/tower-scripts/bin/gogitit_online_prod.yml
@@ -35,7 +35,7 @@ repos:
     dst: roles/oso_console_extensions/
 - id: openshift-ansible
   url: https://github.com/openshift/openshift-ansible.git
-  version: openshift-ansible-3.10.0-0.50.0
+  version: openshift-ansible-3.11.153-2
   copy:
   - src: roles/lib_openshift/
     dst: roles/lib_openshift/

--- a/tower-scripts/bin/gogitit_online_stg.yml
+++ b/tower-scripts/bin/gogitit_online_stg.yml
@@ -35,7 +35,7 @@ repos:
     dst: roles/oso_console_extensions/
 - id: openshift-ansible
   url: https://github.com/openshift/openshift-ansible.git
-  version: openshift-ansible-3.10.0-0.50.0
+  version: openshift-ansible-3.11.153-2
   copy:
   - src: roles/lib_openshift/
     dst: roles/lib_openshift/


### PR DESCRIPTION
Bumping for storageclass.beta.kubernetes.io/is-default-class: vs storageclass.kubernetes.io/is-default-class: in lib_openshift oc_storageclass