### PR TITLE
cri-o: force a checkout

### DIFF
--- a/sjb/config/test_cases/test_pull_request_crio_critest_rhel.yml
+++ b/sjb/config/test_cases/test_pull_request_crio_critest_rhel.yml
@@ -17,7 +17,7 @@ extensions:
     script: |-
       cd /go/src/github.com/cri-o/cri-o
       git fetch origin
-      git checkout master
+      git checkout -f master
       git branch -D target || true
       git branch -D pr || true
       git branch target "${PULL_BASE_SHA}"

--- a/sjb/config/test_cases/test_pull_request_crio_e2e_features_rhel.yml
+++ b/sjb/config/test_cases/test_pull_request_crio_e2e_features_rhel.yml
@@ -17,7 +17,7 @@ extensions:
     script: |-
       cd /go/src/github.com/cri-o/cri-o
       git fetch origin
-      git checkout master
+      git checkout -f master
       git branch -D target || true
       git branch -D pr || true
       git branch target "${PULL_BASE_SHA}"

--- a/sjb/config/test_cases/test_pull_request_crio_e2e_rhel.yml
+++ b/sjb/config/test_cases/test_pull_request_crio_e2e_rhel.yml
@@ -17,7 +17,7 @@ extensions:
     script: |-
       cd /go/src/github.com/cri-o/cri-o
       git fetch origin
-      git checkout master
+      git checkout -f master
       git branch -D target || true
       git branch -D pr || true
       git branch target "${PULL_BASE_SHA}"

--- a/sjb/config/test_cases/test_pull_request_crio_integration_rhel.yml
+++ b/sjb/config/test_cases/test_pull_request_crio_integration_rhel.yml
@@ -17,7 +17,7 @@ extensions:
     script: |-
       cd /go/src/github.com/cri-o/cri-o
       git fetch origin
-      git checkout master
+      git checkout -f master
       git branch -D target || true
       git branch -D pr || true
       git branch target "${PULL_BASE_SHA}"


### PR DESCRIPTION
this will prevent situations like: https://openshift-gce-devel.appspot.com/build/origin-federated-results/pr-logs/pull/cri-o_cri-o/3001/test_pull_request_crio_e2e_features_fedora/6122 where the tree is dirty from a previous step, but we don't need these changes to checkout the target pr
Signed-off-by: Peter Hunt <pehunt@redhat.com>