### PR TITLE
[ART-1301] signing/sign-artifacts: Accept Digest parameter

### DIFF
--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -92,8 +92,8 @@ def initialize_openshift_dir() {
 
 def cleanWhitespace(cmd) {
     return (cmd
-        .replaceAll( '\\\n', ' ' ) // If caller included line continuation characters, remove them
-        .replaceAll( '\n', ' ' ) // Allow newlines in command for readability, but don't let them flow into the sh
+        .replaceAll( ' *\\\n *', ' ' ) // If caller included line continuation characters, remove them
+        .replaceAll( ' *\n *', ' ' ) // Allow newlines in command for readability, but don't let them flow into the sh
         .trim()
     )
 }


### PR DESCRIPTION
This is part 1 of [ART-1301](https://jira.coreos.com/browse/ART-1301). The signing job should accept a digest, rather than query it from a 3rd party to ensure that this is not tampered with.

This has been tested:
- [with DIGEST](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/jdelft-signing-jobs/job/signing%252Fsign-artifacts/3/console) in the job parameters
- [without DIGEST](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/jdelft-signing-jobs/job/signing%252Fsign-artifacts/4/console in the job parameters)