### PR TITLE
[ART-1301] release: Use digest for signing job

### DIFF
--- a/jobs/build/release/Jenkinsfile
+++ b/jobs/build/release/Jenkinsfile
@@ -155,6 +155,7 @@ node {
                     env: "prod",
                     key_name: "redhatrelease2",
                     arch: arch,
+                    digest: payloadDigest,
                 )
             }
         }

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -130,9 +130,16 @@ def stageGenPayload(dest_repo, dest_release_tag, from_release_tag, description, 
         cmd += "--dry-run=true "
     }
 
-    commonlib.shell(
-        script: cmd
+    def output = commonlib.shell(
+        script: cmd,
+        returnStdout: true
     )
+    output.eachLine {
+        if (it =~ /^sha256:/) {
+            payloadDigest = it.split(' ')[0]
+            currentBuild.description += " ${payloadDigest}"
+        }
+    }
 }
 
 def stageSetClientLatest(from_release_tag, arch, client_type) {
@@ -375,6 +382,7 @@ def signArtifacts(Map signingParams) {
             string(name: "ENV", value: signingParams.env),
             string(name: "KEY_NAME", value: signingParams.key_name),
             string(name: "ARCH", value: signingParams.arch),
+            string(name: "DIGEST", value: signingParams.digest),
         ]
     )
 }


### PR DESCRIPTION
This is part 2 of [ART-1301](https://jira.coreos.com/browse/ART-1301). Collect the digest of the release from the oc command, in order to pass it along to the `signing/sign-artifacts` job.

Needs https://github.com/openshift/aos-cd-jobs/pull/2067 to be merged.