### PR TITLE
Add force checkout for target branches

### DIFF
--- a/sjb/config/test_cases/test_branch_crio_e2e_features_rhel.yml
+++ b/sjb/config/test_cases/test_branch_crio_e2e_features_rhel.yml
@@ -15,7 +15,7 @@ extensions:
     script: |-
       cd /go/src/github.com/cri-o/cri-o
       git fetch origin
-      git checkout "${PULL_BASE_SHA}"
+      git checkout -f "${PULL_BASE_SHA}"
   - type: "script"
     title: "run the cri-o e2e features tests"
     timeout: "21600"  # 6 hours.  Playbook has shorter timeout for the test-task.

--- a/sjb/config/test_cases/test_branch_crio_e2e_rhel.yml
+++ b/sjb/config/test_cases/test_branch_crio_e2e_rhel.yml
@@ -15,7 +15,7 @@ extensions:
     script: |-
       cd /go/src/github.com/cri-o/cri-o
       git fetch origin
-      git checkout "${PULL_BASE_SHA}"
+      git checkout -f "${PULL_BASE_SHA}"
   - type: "script"
     title: "run the cri-o e2e tests"
     timeout: "21600"  # 6 hours.  Playbook has shorter timeout for the test-task.

--- a/sjb/config/test_cases/test_pull_request_crio_critest_rhel.yml
+++ b/sjb/config/test_cases/test_pull_request_crio_critest_rhel.yml
@@ -21,7 +21,7 @@ extensions:
       git branch -D target || true
       git branch -D pr || true
       git branch target "${PULL_BASE_SHA}"
-      git checkout target
+      git checkout -f target
       git fetch origin "pull/${PULL_NUMBER}/head:pr"
       git merge "${PULL_PULL_SHA}"
   - type: "script"

--- a/sjb/config/test_cases/test_pull_request_crio_e2e_features_rhel.yml
+++ b/sjb/config/test_cases/test_pull_request_crio_e2e_features_rhel.yml
@@ -21,7 +21,7 @@ extensions:
       git branch -D target || true
       git branch -D pr || true
       git branch target "${PULL_BASE_SHA}"
-      git checkout target
+      git checkout -f target
       git fetch origin "pull/${PULL_NUMBER}/head:pr"
       git merge "${PULL_PULL_SHA}"
   - type: "script"

--- a/sjb/config/test_cases/test_pull_request_crio_e2e_rhel.yml
+++ b/sjb/config/test_cases/test_pull_request_crio_e2e_rhel.yml
@@ -21,7 +21,7 @@ extensions:
       git branch -D target || true
       git branch -D pr || true
       git branch target "${PULL_BASE_SHA}"
-      git checkout target
+      git checkout -f target
       git fetch origin "pull/${PULL_NUMBER}/head:pr"
       git merge "${PULL_PULL_SHA}"
   - type: "script"

--- a/sjb/config/test_cases/test_pull_request_crio_integration_rhel.yml
+++ b/sjb/config/test_cases/test_pull_request_crio_integration_rhel.yml
@@ -21,7 +21,7 @@ extensions:
       git branch -D target || true
       git branch -D pr || true
       git branch target "${PULL_BASE_SHA}"
-      git checkout target
+      git checkout -f target
       git fetch origin "pull/${PULL_NUMBER}/head:pr"
       git merge "${PULL_PULL_SHA}"
   - type: "script"


### PR DESCRIPTION
We're facing a CI issue related to go modules where the change cannot be
merged because the target branch has local changes:

https://storage.googleapis.com/origin-federated-results/pr-logs/pull/cri-o_cri-o/3005/test_pull_request_crio_e2e_fedora/8293/build-log.txt

We now use `checkout -f` to throw away the local changes before doing
the merge.
