### PR TITLE
[ART-1345] backup: ensure destination directory exists

### DIFF
--- a/jobs/maintenance/buildvm_backup/build.groovy
+++ b/jobs/maintenance/buildvm_backup/build.groovy
@@ -48,6 +48,9 @@ backupPlan = [
         '/mnt/nfs/jenkins_home/update-center-rootCAs',
         '/mnt/nfs/jenkins_home/jobs/*/jobs/*/config.xml',
         '/mnt/nfs/jenkins_home/jobs/*/config.xml',
+
+        // firewall rules
+        '/root/network',
     ],
 ]
 
@@ -96,7 +99,10 @@ def stageRunBackup() {
 
     scpRes = commonlib.shell(
             returnAll: true,
-            script: "scp ${tarballPath} root@${backupPlan.destHost}:${tarballPath}"
+            script: """
+              ssh -l root ${backupPlan.destHost} mkdir -p ${backupPlan.backupPath}
+              scp ${tarballPath} root@${backupPlan.destHost}:${tarballPath}
+            """
     )
 
     if (scpRes.returnStatus != 0) {


### PR DESCRIPTION
...and include firewall configuration in backup.
- Addressess [failure](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/maintenance/job/maintenance%252Fbuildvm_backup/93/console) `scp: /mnt/workspace/backups/buildvm/buildvm.openshift.eng.bos.redhat.com.week-49.tgz: No such file or directory`
- [Test run](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/jdelft-maintenance/job/maintenance%252Fbuildvm_backup/3/console)