### PR TITLE
Enable multi-arch signing, and RHCOS signing

### DIFF
--- a/jobs/signing/sign-artifacts/Jenkinsfile
+++ b/jobs/signing/sign-artifacts/Jenkinsfile
@@ -34,10 +34,13 @@ node {
                         defaultValue: "signature-1"
                     ],
                     [
-                        name: 'DRY_RUN',
-                        description: 'Only do dry run test and exit.',
-                        $class: 'BooleanParameterDefinition',
-                        defaultValue: false
+                        name: 'PRODUCT',
+                        description: 'Which product to sign',
+                        $class: 'hudson.model.ChoiceParameterDefinition',
+                        choices: [
+                            "openshift",
+                            "rhcos",
+                        ].join("\n"),
                     ],
                     [
                         name: 'ENV',
@@ -63,6 +66,12 @@ node {
                         description: 'The digest of the release. Example value: "sha256=f28cbabd1227352fe704a00df796a4511880174042dece96233036a10ac61639"\nCan be taken from the Release job.',
                         $class: 'hudson.model.StringParameterDefinition',
                         defaultValue: ""
+		    ],
+		    [
+                        name: 'DRY_RUN',
+                        description: 'Only do dry run test and exit\nDoes not send anything over the bus',
+                        $class: 'BooleanParameterDefinition',
+                        defaultValue: false
                     ],
                     commonlib.mockParam(),
                 ]
@@ -88,6 +97,12 @@ node {
             currentBuild.description += "[DRY RUN]"
         }
 
+	if ( !env.JOB_NAME.startsWith("signing-jobs/") ) {
+	    requestIdSuffix = "-test"
+	} else {
+	    requestIdSuffix = ""
+	}
+
         wrap([$class: 'BuildUser']) {
             echo "Submitting signing requests as user: ${env.BUILD_USER_ID}"
 
@@ -95,11 +110,6 @@ node {
 
                 withCredentials([file(credentialsId: 'msg-openshift-art-signatory-prod.crt', variable: 'busCertificate'),
                                  file(credentialsId: 'msg-openshift-art-signatory-prod.key', variable: 'busKey')]) {
-                    echo "Authenticating with bus cert/key at: ${busCertificate}/${busKey}"
-                    // Following line is for debugging when we're
-                    // initially testing this
-                    sh 'ls -l ${busCertificate} ${busKey}'
-
                     // ######################################################################
                     def baseUmbParams = buildlib.cleanWhitespace("""
                                 --requestor "${env.BUILD_USER_ID}" --sig-keyname ${params.KEY_NAME}
@@ -107,45 +117,42 @@ node {
                                 --client-key ${busKey} --env ${params.ENV}
                             """)
 
-                    // ######################################################################
-                    def openshiftJsonSignParams = buildlib.cleanWhitespace("""
-                        ${baseUmbParams} --product openshift
-                        --request-id 'openshift-json-digest-${env.BUILD_ID}' ${digest} ${noop}
-                            """)
+                    if ( params.PRODUCT == 'openshift' ) {
+                        // ######################################################################
+                        def openshiftJsonSignParams = buildlib.cleanWhitespace("""
+                             ${baseUmbParams} --product openshift
+                             --request-id 'openshift-json-digest-${env.BUILD_ID}${requestIdSuffix}' ${digest} ${noop}
+                         """)
 
-                    echo "Submitting OpenShift Payload JSON claim signature request"
-                    commonlib.shell(
-                        script: "../umb_producer.py json-digest ${openshiftJsonSignParams}"
-                    )
+                        echo "Submitting OpenShift Payload JSON claim signature request"
+                        commonlib.shell(
+                            script: "../umb_producer.py json-digest ${openshiftJsonSignParams}"
+                        )
 
-                    // ######################################################################
-                    
-                    def openshiftSha256SignParams = buildlib.cleanWhitespace("""
-                                ${baseUmbParams} --product openshift
-                                --request-id 'openshift-message-digest-${env.BUILD_ID}' ${noop}
-                            """)
+                        // ######################################################################
 
-                    echo "Submitting OpenShift sha256 message-digest signature request"
-                    commonlib.shell(
-                        script: "../umb_producer.py message-digest ${openshiftSha256SignParams}"
-                    )
+                        def openshiftSha256SignParams = buildlib.cleanWhitespace("""
+                            ${baseUmbParams} --product openshift --arch ${params.ARCH}
+                            --request-id 'openshift-message-digest-${env.BUILD_ID}${requestIdSuffix}' ${noop}
+                        """)
 
-                    // Comment this out for now. I don't think we even
-                    // have a sha256sum.txt file on the rhcos mirror
-                    // endpoint right now. Also, that url structure isn't
-                    // what we're going for when we hit GA.
-                    //
-                    // ######################################################################
-                    // def rhcosSha256SignParams = buildlib.cleanWhitespace("""
-                            //     ${baseUmbParams} --product rhcos
-                            //     --request-id 'rhcos-message-digest-${env.BUILD_ID} ${noop}'
-                            // """)
+                        echo "Submitting OpenShift sha256 message-digest signature request"
+                        commonlib.shell(
+                            script: "../umb_producer.py message-digest ${openshiftSha256SignParams}"
+                        )
 
-                    // echo "Submitting RHCOS sha256 message-digest signature request"
-                    // res = commonlib.shell(
-                    //     returnAll: true,
-                    //     script: "../umb_producer.py message-digest ${rhcosSha256SignParams}"
-                    // )
+                    } else if ( params.PRODUCT == 'rhcos' ) {
+                        def rhcosSha256SignParams = buildlib.cleanWhitespace("""
+                            ${baseUmbParams} --product rhcos ${noop} --arch ${params.ARCH}
+                            --request-id 'rhcos-message-digest-${env.BUILD_ID}${requestIdSuffix}'
+                        """)
+
+                        echo "Submitting RHCOS sha256 message-digest signature request"
+                        res = commonlib.shell(
+                            returnAll: true,
+                            script: "../umb_producer.py message-digest ${rhcosSha256SignParams}"
+                        )
+                    }
                 }
             }
         }
@@ -159,37 +166,7 @@ node {
         //
         // 2) Message digests, they are sha256sum.txt files which have
         // sha digests for a directory of contents
-
         // ######################################################################
-
-        // Old comment preserved for context. Feel free to remove once
-        // implemented:
-        //
-        // <OLD-COMMENT>
-        // How do you differentiate between the responses? Once you
-        // have the response object you will examine the
-        // 'artifact_meta' object. For reference, we SEND that object
-        // when we submit the signing request. For example:
-        //
-        // * Request to sign a JSON digest, 'artifact_meta' could look
-        // like this:
-        //
-        //     "artifact_meta": {
-        //	     "product": "openshift",
-        //	     "release_name": "4.1.0-rc.5",
-        //	     "type": "json-digest",
-        //	     "name": "sha256=dc67ad5edd91ca48402309fe0629593e5ae3333435ef8d0bc52c2b62ca725021"
-        //     }
-        //
-        // We receive that same object back in the signing
-        // response. Look at .artifact_meta.type and see it says
-        // 'json-digest'. This means it falls under mirroring location
-        // (1) from above. We can fill in the mirroring location using
-        // the information from the response object.
-        //
-        // signatures/openshift/release/`.artifact_meta.name`/signature-1
-        //
-        // </OLD-COMMENT>
 
         mirrorTarget = "use-mirror-upload.ops.rhcloud.com"
         if (params.DRY_RUN) {
@@ -201,44 +178,45 @@ node {
 
             dir(workDir) {
                 try {
-                    // ######################################################################
+                    if ( params.PRODUCT == 'openshift' ) {
+                        // ######################################################################
 
-                    // the umb producer script should have generated two
-                    // files. One is a 'sha26=.......' and one is
-                    // 'sha256sum.txt.sig'
+                        // the umb producer script should have generated two
+                        // files. One is a 'sha26=.......' and one is
+                        // 'sha256sum.txt.sig'
 
-                    // sha256=...........
-                    //
-                    // 1) JSON digest claims. They get mirrored to
-                    // mirror.openshift.com/pub/openshift-v4/ using this directory
-                    // structure:
-                    //
-                    // signatures/openshift/release/
-                    //   -> sha256=<IMAGE-DIGEST>/signature-1
-                    //
-                    // where <IMAGE-DIGEST> is the digest of the payload image and
-                    // the signed artifact is 'signature-1'
-                    //
-                    // 2) A message digest (sha256sum.txt) is mirrored to
-                    // https://mirror.openshift.com/pub/openshift-v4/clients/
-                    // using this directory structure:
-                    //
-                    // ocp/
-                    //  -> <RELEASE-NAME>/sha256sum.txt.sig
-                    //
-                    // where <RELEASE-NAME> is something like '4.1.0-rc.5'
+                        // sha256=...........
+                        //
+                        // 1) JSON digest claims. They get mirrored to
+                        // mirror.openshift.com/pub/openshift-v4/ using this directory
+                        // structure:
+                        //
+                        // signatures/openshift/release/
+                        //   -> sha256=<IMAGE-DIGEST>/signature-1
+                        //
+                        // where <IMAGE-DIGEST> is the digest of the payload image and
+                        // the signed artifact is 'signature-1'
+                        //
+                        // 2) A message digest (sha256sum.txt) is mirrored to
+                        // https://mirror.openshift.com/pub/openshift-v4/clients/
+                        // using this directory structure:
+                        //
+                        // ocp/
+                        //  -> <RELEASE-NAME>/sha256sum.txt.sig
+                        //
+                        // where <RELEASE-NAME> is something like '4.1.0-rc.5'
 
-                    // transform the file into a directory containing the
-                    // file, mirror to google.
-		            //
-		            // Notes on gsutil options:
-		            // -n - no clobber/overwrite
-		            // -v - print url of item
-		            // -L - write to log for auto re-processing
-		            // -r - recursive
-                    def googleStoragePath = (params.ENV == 'stage') ? 'test-1' : 'official'
-                    def gsutil = '/mnt/nfs/home/jenkins/google-cloud-sdk/bin/gsutil'  // doesn't seem to be in path
-                    commonlib.shell("""
+                        // transform the file into a directory containing the
+                        // file, mirror to google.
+                        //
+                        // Notes on gsutil options:
+                        // -n - no clobber/overwrite
+                        // -v - print url of item
+                        // -L - write to log for auto re-processing
+                        // -r - recursive
+                        def googleStoragePath = (params.ENV == 'stage') ? 'test-1' : 'official'
+                        def gsutil = '/mnt/nfs/home/jenkins/google-cloud-sdk/bin/gsutil'  // doesn't seem to be in path
+                        commonlib.shell("""
                         for file in sha256=*; do
                             mv \$file ${params.SIGNATURE_NAME}
                             mkdir \$file
@@ -250,55 +228,67 @@ node {
                                 if [ \$i -eq 10 ]; then echo "Failed to mirror to google after 10 attempts. Giving up."; exit 1; fi
                             done
                         done
-                    """)
-                    sshagent(["openshift-bot"]) {
-                        def mirrorReleasePath = "openshift-v4/signatures/openshift/${(params.ENV == 'stage') ? 'test' : 'release'}"
-                        sh "rsync -avzh -e \"ssh -o StrictHostKeyChecking=no\" sha256=* ${mirrorTarget}:/srv/pub/${mirrorReleasePath}/"
-                        mirror_result = buildlib.invoke_on_use_mirror("push.pub.sh", mirrorReleasePath)
-                        if (mirror_result.contains("[FAILURE]")) {
-                            echo mirror_result
-                            error("Error running signed artifact sync push.pub.sh:\n${mirror_result}")
+                        """)
+                        sshagent(["openshift-bot"]) {
+                            def mirrorReleasePath = "openshift-v4/signatures/openshift/${(params.ENV == 'stage') ? 'test' : 'release'}"
+                            sh "rsync -avzh -e \"ssh -o StrictHostKeyChecking=no\" sha256=* ${mirrorTarget}:/srv/pub/${mirrorReleasePath}/"
+                            mirror_result = buildlib.invoke_on_use_mirror("push.pub.sh", mirrorReleasePath)
+                            if (mirror_result.contains("[FAILURE]")) {
+                                echo mirror_result
+                                error("Error running signed artifact sync push.pub.sh:\n${mirror_result}")
+                            }
                         }
-                    }
 
-                    // ######################################################################
+                        // ######################################################################
 
-                    // sha256sum.txt.sig
-                    //
-                    // For message digests (mirroring type 2) we'll see instead
-                    // that .artifact_meta.type says 'message-digest'. Take this
-                    // for example (request to sign the sha256sum.txt file from
-                    // 4.1.0-rc.5):
-                    //
-                    //     "artifact_meta": {
-                    //         "product": "openshift",
-                    //         "release_name": "4.1.0-rc.5",
-                    //         "type": "message-digest",
-                    //         "name": "sha256sum.txt.sig"
-                    //     }
-                    //
-                    // Note that the 'product' key WILL become important when we
-                    // are sending RHCOS bare metal message-digests in the
-                    // future. From the .artifact_meta above we know that we have
-                    // just received the sha256sum.txt.sig file for openshift
-                    // release 4.1.0-rc.5. We will mirror this file to:
-                    //
-                    // https://mirror.openshift.com/pub/openshift-v4/clients/
-                    //  --> ocp/
-                    //  ----> `.artifacts.name`/
-                    //  ------> sha256sum.txt.sig
-                    //  ==> https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.1.0-rc.5/sha256sum.txt.sig
+                        // sha256sum.txt.sig
+                        //
+                        // For message digests (mirroring type 2) we'll see instead
+                        // that .artifact_meta.type says 'message-digest'. Take this
+                        // for example (request to sign the sha256sum.txt file from
+                        // 4.1.0-rc.5):
+                        //
+                        //     "artifact_meta": {
+                        //         "product": "openshift",
+                        //         "release_name": "4.1.0-rc.5",
+                        //         "type": "message-digest",
+                        //         "name": "sha256sum.txt.sig"
+                        //     }
+                        //
+                        // Note that the 'product' key WILL become important when we
+                        // are sending RHCOS bare metal message-digests in the
+                        // future. From the .artifact_meta above we know that we have
+                        // just received the sha256sum.txt.sig file for openshift
+                        // release 4.1.0-rc.5. We will mirror this file to:
+                        //
+                        // https://mirror.openshift.com/pub/openshift-v4/clients/
+                        //  --> ocp/
+                        //  ----> `.artifacts.name`/
+                        //  ------> sha256sum.txt.sig
+                        //  ==> https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.1.0-rc.5/sha256sum.txt.sig
 
-                    sshagent(["openshift-bot"]) {
-                        def mirrorReleasePath = "openshift-v4/${params.ARCH}/clients/ocp/${params.NAME}"
-                        def sigFileName = (params.ENV == 'stage') ? 'sha256sum.txt.sig.test' : 'sha256sum.txt.sig'
-                        sh "rsync -avzh -e \"ssh -o StrictHostKeyChecking=no\" sha256sum.txt.sig ${mirrorTarget}:/srv/pub/${mirrorReleasePath}/${sigFileName}"
-                        mirror_result = buildlib.invoke_on_use_mirror("push.pub.sh", mirrorReleasePath)
-                        if (mirror_result.contains("[FAILURE]")) {
-                            echo mirror_result
-                            error("Error running signed artifact sync push.pub.sh:\n${mirror_result}")
+                        sshagent(["openshift-bot"]) {
+                            def mirrorReleasePath = "openshift-v4/${params.ARCH}/clients/ocp/${params.NAME}"
+                            sh "rsync -avzh -e \"ssh -o StrictHostKeyChecking=no\" sha256sum.txt.sig ${mirrorTarget}:/srv/pub/${mirrorReleasePath}/sha256sum.txt.sig"
+                            mirror_result = buildlib.invoke_on_use_mirror("push.pub.sh", mirrorReleasePath)
+                            if (mirror_result.contains("[FAILURE]")) {
+                                echo mirror_result
+                                error("Error running signed artifact sync push.pub.sh:\n${mirror_result}")
+                            }
                         }
-                    }
+                    } else if ( params.PRODUCT == 'rhcos') {
+			sshagent(["openshift-bot"]) {
+			    def name_parts = params.NAME.split('.')
+			    def nameXY = "${name_parts[0]}.${name_parts[1]}"
+                            def mirrorReleasePath = "openshift-v4/${params.ARCH}/dependencies/rhcos/${nameXY}/${params.NAME}"
+                            sh "rsync -avzh -e \"ssh -o StrictHostKeyChecking=no\" sha256sum.txt.sig ${mirrorTarget}:/srv/pub/${mirrorReleasePath}/sha256sum.txt.sig"
+                            mirror_result = buildlib.invoke_on_use_mirror("push.pub.sh", mirrorReleasePath)
+                            if (mirror_result.contains("[FAILURE]")) {
+                                echo mirror_result
+                                error("Error running signed artifact sync push.pub.sh:\n${mirror_result}")
+                            }
+                        }
+		    }
                 } finally {
                     echo "Archiving artifacts in jenkins:"
                     commonlib.safeArchiveArtifacts([
@@ -313,13 +303,12 @@ node {
     }
 
     stage('log sync'){
-        buildArtifactPath = env.WORKSPACE.replaceFirst('/working/', '/builds/')
-        dirName = buildArtifactPath.split('/')[-1]
-        def cmd =  "/bin/rsync --inplace -avzh ${buildArtifactPath}/[0-9]* /mnt/art-build-artifacts/signing-jobs/${dirName}"
-        if (params.DRY_RUN) {
-            echo "Would have run: ${cmd}"
-        } else {
-            sh cmd
-        }
+	if ( !params.DRY_RUN ) {
+            buildArtifactPath = env.WORKSPACE.replaceFirst('/working/', '/builds/')
+            dirName = buildArtifactPath.split('/')[-1]
+            sh "/bin/rsync --inplace -avzh ${buildArtifactPath}/[0-9]* /mnt/art-build-artifacts/signing-jobs/${dirName}"
+	} else {
+	    echo("DRY-RUN, not syncing logs")
+	}
     }
 }


### PR DESCRIPTION
RE: ART-678 - Include RHCOS bootimages in 4.x signing job

This enables the sign-artifacts job to sign RHCOS, as well as non-x86
OpenShift sha256sum artifacts.