### PR TITLE
Fix up RHCOS sync handling of arches

### DIFF
--- a/build-scripts/use-mirror/rhcossync.sh
+++ b/build-scripts/use-mirror/rhcossync.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 set -exo pipefail
 
-# RHCOS version, like 42.80.20190828.2
-VERSION=
-# Where to put this on the mirror, such as'4.2' or 'pre-release'
+# Where to put this on the mirror, such as '4.2' or 'pre-release':
 RHCOS_MIRROR_PREFIX=
+ARCH=x86_64
+# RHCOS version, like 42.80.20190828.2:
+BUILDID=
+# release version, like 4.2.0:
+VERSION=
 FORCE=0
 TEST=0
 BASEDIR=
@@ -62,8 +65,12 @@ function checkDestDir() {
 
 function downloadImages() {
     for img in $(<${SYNCLIST}); do
-	curl -L --retry 5 -O $img
+	curl -L --fail --retry 5 -O $img
     done
+    # rename files to indicate the release they match (including arch suffix)
+    release="$VERSION"
+    [[ $release == *${ARCH}* ]] || release="$release-$ARCH"
+    rename "$BUILDID" "$release" *
 }
 
 function genSha256() {
@@ -96,12 +103,18 @@ fi
 
 while [ $1 ]; do
     case "$1" in
-	"--version")
-	    shift
-	    VERSION=$1;;
 	"--prefix")
 	    shift
 	    RHCOS_MIRROR_PREFIX=$1;;
+	"--arch")
+	    shift
+	    ARCH=$1;;
+	"--buildid")
+	    shift
+	    BUILDID=$1;;
+	"--version")
+	    shift
+	    VERSION=$1;;
 	"--synclist")
 	    shift
 	    SYNCLIST=$1;;

--- a/jobs/build/rhcos_sync/Jenkinsfile
+++ b/jobs/build/rhcos_sync/Jenkinsfile
@@ -27,8 +27,14 @@ node {
                         defaultValue: "",
                     ],
                     [
+                        name: 'ARCH',
+                        description: 'Which architecture of RHCOS build to look for',
+                        $class: 'hudson.model.ChoiceParameterDefinition',
+                        choices: (['x86_64', 's390x', 'ppc64le', 'aarch64']),
+                    ],
+                    [
                         name: 'RHCOS_MIRROR_PREFIX',
-                        description: 'Where to place this release under https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/',
+                        description: 'Where to place this release under https://mirror.openshift.com/pub/openshift-v4/ARCH/dependencies/rhcos/',
                         $class: 'hudson.model.ChoiceParameterDefinition',
                         choices: (['pre-release', 'test'] + commonlib.ocp4Versions),
                     ],
@@ -37,12 +43,6 @@ node {
                         description: 'ID of the RHCOS build to sync. e.g.: 42.80.20190828.2',
                         $class: 'hudson.model.StringParameterDefinition',
                         defaultValue: "",
-                    ],
-                    [
-                        name: 'ARCH',
-                        description: 'architecture being synced',
-                        $class: 'hudson.model.ChoiceParameterDefinition',
-                        choices: ['x86_64', 's390x', 'ppc64le'].join('\n'),
                     ],
                     [
                         name: 'NOOP',

--- a/jobs/build/rhcos_sync/Jenkinsfile
+++ b/jobs/build/rhcos_sync/Jenkinsfile
@@ -70,7 +70,7 @@ node {
                     ],
                     [
                         name: 'NO_MIRROR',
-                        description: 'Do not run the push.pub script after downloading"',
+                        description: 'Do not run the push.pub script after downloading',
                         $class: 'BooleanParameterDefinition',
                         defaultValue: false,
                     ],

--- a/jobs/build/rhcos_sync/build.groovy
+++ b/jobs/build/rhcos_sync/build.groovy
@@ -60,16 +60,16 @@ def rhcosSyncMirrorArtifacts() {
     sh("scp -o StrictHostKeychecking=no ${syncList} use-mirror-upload.ops.rhcloud.com:/tmp/")
     def invokeOpts = "-- --prefix ${params.RHCOS_MIRROR_PREFIX} --version ${params.NAME} --synclist /tmp/${syncList} --basedir ${baseDir}"
     if ( params.FORCE ) {
-    	invokeOpts += " --force"
+            invokeOpts += " --force"
     }
     if ( params.NOOP ) {
-	    invokeOpts += " --test"
+            invokeOpts += " --test"
     }
     if ( params.NO_LATEST ) {
-	    invokeOpts += " --nolatest"
+            invokeOpts += " --nolatest"
     }
     if ( params.NO_MIRROR ) {
-	    invokeOpts += " --nomirror"
+            invokeOpts += " --nomirror"
     }
 
     buildlib.invoke_on_use_mirror("rhcossync.sh", invokeOpts)
@@ -77,7 +77,8 @@ def rhcosSyncMirrorArtifacts() {
 
 def rhcosSyncGenDocs() {
     dir( rhcosWorking ) {
-	    sh("sh ../gen-docs.sh < meta.json > rhcos-${params.RHCOS_BUILD}.adoc")
+        // TODO
+        // sh("sh ../gen-docs.sh < meta.json > rhcos-${params.RHCOS_BUILD}.adoc")
     }
     artifacts.add("rhcos_working/rhcos-${params.RHCOS_BUILD}.adoc")
 }

--- a/jobs/build/rhcos_sync/build.groovy
+++ b/jobs/build/rhcos_sync/build.groovy
@@ -4,20 +4,24 @@ rhcosWorking = "${env.WORKSPACE}/rhcos_working"
 logLevel = ""
 dryRun = ""
 artifacts = []
-baseUrl = "https://art-rhcos-ci.s3.amazonaws.com/releases/rhcos-%OCPVERSION%%ARCHSUFFIX%/%RHCOSBUILD%%ARCHDIR%"
+baseUrl = ""
 metaUrl = ""
-baseDir = "/srv/pub/openshift-v4/%ARCH%/dependencies/rhcos"
+baseDir = ""
 syncList = "rhcos-synclist-${currentBuild.number}.txt"
 
 def initialize() {
     buildlib.cleanWorkdir(rhcosWorking)
-    // Sub in those vars
-    baseUrl = baseUrl.replace("%OCPVERSION%", params.BUILD_VERSION)
-    baseUrl = baseUrl.replace("%RHCOSBUILD%", params.RHCOS_BUILD)
-    // baseUrl layout changed between 4.2 and 4.3; with 4.3 it began to include an arch subdir.
-    baseUrl = baseUrl.replace("%ARCHDIR%", buildlib.cmp_version(params.BUILD_VERSION, "4.2") == 1 ? "/${params.ARCH}" : "")
-    baseUrl = baseUrl.replace("%ARCHSUFFIX%", (params.ARCH == "x86_64") ? "" : "-${params.ARCH}")
-    baseDir = baseDir.replace("%ARCH%", params.ARCH)
+    // Sub in some vars according to params
+    def ocpVersion = params.BUILD_VERSION
+    def rhcosBuild = params.RHCOS_BUILD
+    def arch = params.ARCH
+    def archSuffix = arch == "x86_64" ? "" : "-${arch}"
+      // we do not plan to release a new 4.1 bootimage ever
+      // 4.2 is grandfathered in without the archDir in the path
+      // 4.3+ include archDir - ref. rhcos release browser
+    def archDir = ocpVersion == "4.2" ? "" : "/${arch}"
+    baseUrl = "https://art-rhcos-ci.s3.amazonaws.com/releases/rhcos-${ocpVersion}${archSuffix}${archDir}/${rhcosBuild}"
+    baseDir = "/srv/pub/openshift-v4/${arch}/dependencies/rhcos"
     // Actual meta.json
     metaUrl = baseUrl + "/meta.json"
 

--- a/jobs/build/rhcos_sync/build.groovy
+++ b/jobs/build/rhcos_sync/build.groovy
@@ -62,7 +62,13 @@ def rhcosSyncPrintArtifacts() {
 
 def rhcosSyncMirrorArtifacts() {
     sh("scp -o StrictHostKeychecking=no ${syncList} use-mirror-upload.ops.rhcloud.com:/tmp/")
-    def invokeOpts = "-- --prefix ${params.RHCOS_MIRROR_PREFIX} --version ${params.NAME} --synclist /tmp/${syncList} --basedir ${baseDir}"
+    def invokeOpts = "--" +
+        " --prefix ${params.RHCOS_MIRROR_PREFIX}" +
+        " --arch ${params.ARCH}" +
+        " --buildid ${params.RHCOS_BUILD}" +
+        " --version ${params.NAME}" +
+        " --synclist /tmp/${syncList}" +
+        " --basedir ${baseDir}"
     if ( params.FORCE ) {
             invokeOpts += " --force"
     }


### PR DESCRIPTION
Number of issues.

1. release browser dir structure changed in 4.3+
2. destination on mirror needs to be arch-specific
3. files need to be renamed to include name and arch instead of rhcos build id

This does that.
https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/lmeyer/job/lmeyer-dev/job/dev-build%252Frhcos_sync/9/