### PR TITLE
[ART-1351] Separate release image tag from name so name is not arch-specific

### DIFF
--- a/jobs/build/oc_sync/Jenkinsfile
+++ b/jobs/build/oc_sync/Jenkinsfile
@@ -4,6 +4,7 @@ node {
     checkout scm
     def buildlib = load("pipeline-scripts/buildlib.groovy")
     def commonlib = buildlib.commonlib
+    def release = load("pipeline-scripts/release.groovy")
 
     // Expose properties for a parameterized build
     properties(
@@ -18,8 +19,8 @@ node {
                 $class: 'ParametersDefinitionProperty',
                 parameterDefinitions: [
                     [
-                        name: 'FROM_RELEASE_TAG',
-                        description: 'Release tag to pull tools from (e.g. 4.2.6 or 4.3.0-0.nightly-2019-11-13-233341)',
+                        name: 'RELEASE_NAME',
+                        description: 'e.g. 4.2.6 or 4.3.0-0.nightly-2019-11-13-233341',
                         $class: 'hudson.model.StringParameterDefinition',
                         defaultValue: ""
                     ],
@@ -54,22 +55,25 @@ node {
 
 
     try {
-        currentBuild.displayName = "#${currentBuild.number} - ${FROM_RELEASE_TAG} - ${CLIENT_TYPE}"
+        currentBuild.displayName = "#${currentBuild.number} - ${RELEASE_NAME} - ${CLIENT_TYPE}"
+
+        def arch = commonlib.extractArchFromReleaseName(params.RELEASE_NAME)
+        def releaseTag = release.destReleaseTag(params.RELEASE_NAME, arch)
 
         if (params.CLIENT_TYPE == 'ocp') {
-            if (params.FROM_RELEASE_TAG.contains('nightly')) {
+            if (params.RELEASE_NAME.contains('nightly')) {
                 error("I'm not sure you want to publish a nightly out as the ocp client type")
             }
-            pull_spec = "quay.io/openshift-release-dev/ocp-release:${params.FROM_RELEASE_TAG}"
+            pull_spec = "quay.io/openshift-release-dev/ocp-release:${releaseTag}"
         } else {
-            pull_spec = "quay.io/openshift-release-dev/ocp-release-nightly:${params.FROM_RELEASE_TAG}"
+            pull_spec = "quay.io/openshift-release-dev/ocp-release-nightly:${releaseTag}"
         }
 
         sshagent(['aos-cd-test']) {
             stage("sync ocp clients") {
                 // must be able to access remote registry to extract image contents
                 buildlib.registry_quay_dev_login()
-                commonlib.shell "./publish-clients-from-payload.sh ${env.WORKSPACE} ${FROM_RELEASE_TAG} ${CLIENT_TYPE} '${pull_spec}'"
+                commonlib.shell "./publish-clients-from-payload.sh ${env.WORKSPACE} ${RELEASE_NAME} ${CLIENT_TYPE} '${pull_spec}'"
             }
         }
     } catch (err) {

--- a/jobs/build/oc_sync/Jenkinsfile
+++ b/jobs/build/oc_sync/Jenkinsfile
@@ -25,6 +25,12 @@ node {
                         defaultValue: ""
                     ],
                     [
+                        name: 'ARCH',
+                        description: 'architecture being synced',
+                        $class: 'hudson.model.ChoiceParameterDefinition',
+                        choices: ['x86_64', 's390x', 'ppc64le'].join('\n'),
+                    ],
+                    [
                         name: 'CLIENT_TYPE',
                         description: 'artifacts path under https://mirror.openshift.com',
                         $class: 'hudson.model.ChoiceParameterDefinition',
@@ -32,7 +38,6 @@ node {
                             "ocp",
                             "ocp-dev-preview",
                         ].join("\n"),
-                        defaultValue: "ocp"
                     ],
                     [
                         name: 'MAIL_LIST_FAILURE',
@@ -57,7 +62,7 @@ node {
     try {
         currentBuild.displayName = "#${currentBuild.number} - ${RELEASE_NAME} - ${CLIENT_TYPE}"
 
-        def arch = commonlib.extractArchFromReleaseName(params.RELEASE_NAME)
+        def arch = params.ARCH
         def releaseTag = release.destReleaseTag(params.RELEASE_NAME, arch)
 
         if (params.CLIENT_TYPE == 'ocp') {

--- a/jobs/build/pre-release/Jenkinsfile
+++ b/jobs/build/pre-release/Jenkinsfile
@@ -115,7 +115,7 @@ node {
 
             def dest_release_tag = from_release_tag
             if ( params.NEW_NAME_OVERRIDE.trim() != "" ) {
-                dest_release_tag = params.NEW_NAME_OVERRIDE
+                dest_release_tag = params.NEW_NAME_OVERRIDE.trim()
             }
 
             stage("versions") { release.stageVersions() }
@@ -129,12 +129,12 @@ node {
             }
 
             stage("build payload") {
-                release.stageGenPayload(quay_url, dest_release_tag, from_release_tag, "", "", "")
+                release.stageGenPayload(quay_url, dest_release_tag, dest_release_tag, from_release_tag, "", "", "")
             }
 
             stage("mirror tools") {
                 if ( params.MIRROR ) {
-                    release.stagePublishClient(quay_url, dest_release_tag, arch, CLIENT_TYPE)
+                    release.stagePublishClient(quay_url, dest_release_tag, dest_release_tag, arch, CLIENT_TYPE)
                 }
             }
 

--- a/jobs/build/release/Jenkinsfile
+++ b/jobs/build/release/Jenkinsfile
@@ -88,16 +88,17 @@ node {
     try {
         sshagent(['aos-cd-test']) {
             release_info = ""
-            def dest_release_tag = "${params.NAME}"
-            arch = release.getReleaseTagArch(params.FROM_RELEASE_TAG)
+            release_name = params.NAME.trim()
+            from_release_tag = params.FROM_RELEASE_TAG.trim()
+            arch = release.getReleaseTagArch(from_release_tag)
             archSuffix = release.getArchSuffix(arch)
             RELEASE_STREAM_NAME = "4-stable${archSuffix}"
+            dest_release_tag = release.destReleaseTag(release_name, arch)
 
 
-            from_release_tag = "${params.FROM_RELEASE_TAG}"
-            description = "${params.DESCRIPTION}"
-            advisory = params.ADVISORY? Integer.parseInt(params.ADVISORY.toString()) : 0
-            previous = "${params.PREVIOUS}"
+            description = params.DESCRIPTION
+            advisory = params.ADVISORY ? Integer.parseInt(params.ADVISORY.toString()) : 0
+            previous = params.PREVIOUS
             String errata_url
             Map release_obj
             def CLIENT_TYPE = 'ocp'
@@ -118,14 +119,14 @@ node {
                 advisory = advisory?:retval.advisoryInfo.id
                 errata_url = retval.errataUrl
             }
-            stage("build payload") { release.stageGenPayload(quay_url, dest_release_tag, from_release_tag, description, previous, errata_url) }
-            stage("tag stable") { release.stageTagRelease(quay_url, dest_release_tag, arch) }
-            stage("wait for stable") { release_obj = release.stageWaitForStable(RELEASE_STREAM_NAME, dest_release_tag) }
+            stage("build payload") { release.stageGenPayload(quay_url, release_name, dest_release_tag, from_release_tag, description, previous, errata_url) }
+            stage("tag stable") { release.stageTagRelease(quay_url, release_name, dest_release_tag, arch) }
+            stage("wait for stable") { release_obj = release.stageWaitForStable(RELEASE_STREAM_NAME, release_name) }
             stage("get release info") {
                 release_info = release.stageGetReleaseInfo(quay_url, dest_release_tag)
             }
             stage("advisory image list") {
-                filename = "${params.NAME}-image-list.txt"
+                filename = "${dest_release_tag}-image-list.txt"
                 retry (3) {
                     commonlib.shell(script: "elliott advisory-images -a ${advisory} > ${filename}")
                 }
@@ -134,15 +135,15 @@ node {
                     to: "openshift-ccs@redhat.com",
                     cc: "aos-team-art@redhat.com",
                     replyTo: "aos-team-art@redhat.com",
-                    subject: "OCP ${params.NAME} Image List",
+                    subject: "OCP ${release_name} (${arch}) Image List",
                     body: readFile(filename)
                 )
             }
             buildlib.registry_quay_dev_login()  // chances are, earlier auth has expired
-            stage("mirror tools") { release.stagePublishClient(quay_url, dest_release_tag, arch, CLIENT_TYPE) }
+            stage("mirror tools") { release.stagePublishClient(quay_url, dest_release_tag, release_name, arch, CLIENT_TYPE) }
             stage("advisory update") { release.stageAdvisoryUpdate() }
             stage("cross ref check") { release.stageCrossRef() }
-            stage("send release message") { release.sendReleaseCompleteMessage(release_obj, advisory, errata_url) }
+            stage("send release message") { release.sendReleaseCompleteMessage(release_obj, advisory, errata_url, arch) }
             stage("sign artifacts") {
                 release.signArtifacts(
                     name: name,
@@ -164,11 +165,11 @@ node {
             to: "${params.MAIL_LIST_SUCCESS}",
             replyTo: "aos-team-art@redhat.com",
             from: "aos-art-automation@redhat.com",
-            subject: "${dry_subject}Success building release payload: ${params.NAME}",
+            subject: "${dry_subject}Success building release payload: ${release_name} (${arch})",
             body: """
 Jenkins Job: ${env.BUILD_URL}
-Release Page: https://openshift-release${archSuffix}.svc.ci.openshift.org/releasestream/4-stable${archSuffix}/release/${params.NAME}
-Quay PullSpec: quay.io/openshift-release-dev/ocp-release:${params.NAME}
+Release Page: https://openshift-release${archSuffix}.svc.ci.openshift.org/releasestream/4-stable${archSuffix}/release/${release_name}
+Quay PullSpec: quay.io/openshift-release-dev/ocp-release:${dest_release_tag}
 
 ${release_info}
         """);

--- a/jobs/signing/sign-artifacts/umb_producer.py
+++ b/jobs/signing/sign-artifacts/umb_producer.py
@@ -60,6 +60,18 @@ SIGN_REQUEST_MESSAGE_FIELDS = [
 ART_CONSUMER = 'Consumer.openshift-art-signatory.{env}.VirtualTopic.eng.robosignatory.art.sign'
 
 
+def get_release_tag(release_name, arch):
+    """Determine the quay destination tag where a release image lives, based on the
+    release name and arch (since we can now have multiple arches for each release name)
+    - make sure it includes the arch in the tag to distinguish from any other releases of same name.
+
+    e.g.:
+    (4.2.0-0.nightly-s390x-2019-12-10-202536, s390x) remains 4.2.0-0.nightly-s390x-2019-12-10-202536
+    (4.3.0-0.nightly-2019-12-07-121211, x86_64) becomes 4.3.0-0.nightly-2019-12-07-121211-x86_64
+    """
+    return release_name if arch in release_name else "{}-{}".format(release_name, arch)
+
+
 ######################################################################
 # Click stuff! Define these here and reuse them later because having
 # 'required' options in the global context creates a poor user
@@ -344,7 +356,8 @@ thus allowing the signature to be looked up programmatically.
     }
 
     release_stage = "ocp-release-nightly" if "nightly" in release_name else "ocp-release"
-    pullspec = "quay.io/openshift-release-dev/{}:{}".format(release_stage, release_name)
+    release_tag = get_release_tag(release_name, arch)
+    pullspec = "quay.io/openshift-release-dev/{}:{}".format(release_stage, release_tag)
     json_claim['critical']['identity']['docker-reference'] = pullspec
 
     if not digest:

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -23,6 +23,7 @@ def stageVersions() {
  * e.g.:
  *   (4.2.0-0.nightly-s390x-2019-12-10-202536, s390x) remains 4.2.0-0.nightly-s390x-2019-12-10-202536
  *   (4.3.0-0.nightly-2019-12-07-121211, x86_64) becomes 4.3.0-0.nightly-2019-12-07-121211-x86_64
+ */
 def destReleaseTag(String releaseName, String arch) {
     return releaseName.contains(arch) ? releaseName : "${releaseName}-${arch}"
 }
@@ -136,7 +137,7 @@ def stageGenPayload(dest_repo, release_name, dest_release_tag, from_release_tag,
     if (previous != "") {
         cmd += "--previous \"${previous}\" "
     }
-    cmd += "--name ${dest_release_tag} "
+    cmd += "--name ${release_name} "
     cmd += "--metadata '${metadata}' "
     cmd += "--to-image=${dest_repo}:${dest_release_tag} "
 

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -15,6 +15,19 @@ def stageVersions() {
 }
 
 /**
+ * Determine the quay destination tag where a release image lives, based on the
+ * the release name and arch (since we can now have multiple arches for each
+ * release name) - make sure it includes the arch in the tag to distinguish
+ * from any other releases of same name.
+ *
+ * e.g.:
+ *   (4.2.0-0.nightly-s390x-2019-12-10-202536, s390x) remains 4.2.0-0.nightly-s390x-2019-12-10-202536
+ *   (4.3.0-0.nightly-2019-12-07-121211, x86_64) becomes 4.3.0-0.nightly-2019-12-07-121211-x86_64
+def destReleaseTag(String releaseName, String arch) {
+    return releaseName.contains(arch) ? releaseName : "${releaseName}-${arch}"
+}
+
+/**
  * Validate that we have not released the same thing already, and that
  * we have a valid advisory if needed.
  * quay_url: quay repo location for nightly images
@@ -101,7 +114,7 @@ def getArchSuffix(arch) {
     return arch == "x86_64" ? "" : "-${arch}"
 }
 
-def stageGenPayload(dest_repo, dest_release_tag, from_release_tag, description, previous, errata_url) {
+def stageGenPayload(dest_repo, release_name, dest_release_tag, from_release_tag, description, previous, errata_url) {
     // build metadata blob
     def metadata = "{\"description\": \"${description}\""
     if (errata_url) {
@@ -167,9 +180,9 @@ def stageSetClientLatest(from_release_tag, arch, client_type) {
 
 }
 
-def stageTagRelease(quay_url, release_tag, arch) {
+def stageTagRelease(quay_url, release_name, release_tag, arch) {
     def archSuffix = getArchSuffix(arch)
-    def cmd = "GOTRACEBACK=all ${oc_cmd} tag ${quay_url}:${release_tag} ocp${archSuffix}/release${archSuffix}:${release_tag}"
+    def cmd = "GOTRACEBACK=all ${oc_cmd} tag ${quay_url}:${release_name} ocp${archSuffix}/release${archSuffix}:${release_tag}"
 
     if (params.DRY_RUN) {
         echo "Would have run \n ${cmd}"
@@ -271,7 +284,7 @@ def stageCrossRef() {
     echo "Empty Stage"
 }
 
-def stagePublishClient(quay_url, from_release_tag, arch, client_type) {
+def stagePublishClient(quay_url, from_release_tag, release_name, arch, client_type) {
     def MIRROR_HOST = "use-mirror-upload.ops.rhcloud.com"
     def MIRROR_V4_BASE_DIR = "/srv/pub/openshift-v4"
 
@@ -281,7 +294,7 @@ def stagePublishClient(quay_url, from_release_tag, arch, client_type) {
 
     // From the newly built release, extract the client tools into the workspace following the directory structure
     // we expect to publish to on the use-mirror system.
-    def CLIENT_MIRROR_DIR="${BASE_TO_MIRROR_DIR}/${arch}/clients/${client_type}/${from_release_tag}"
+    def CLIENT_MIRROR_DIR="${BASE_TO_MIRROR_DIR}/${arch}/clients/${client_type}/${release_name}"
     sh "mkdir -p ${CLIENT_MIRROR_DIR}"
     def tools_extract_cmd = "MOBY_DISABLE_PIGZ=true GOTRACEBACK=all oc adm release extract --tools --command-os='*' -n ocp " +
                                 " --to=${CLIENT_MIRROR_DIR} --from ${quay_url}:${from_release_tag}"
@@ -324,7 +337,7 @@ def getReleaseTagArch(from_release_tag) {
     return arch
 }
 
-def void sendReleaseCompleteMessage(Map release, int advisoryNumber, String advisoryLiveUrl, String releaseStreamName='4-stable', String providerName = 'Red Hat UMB') {
+def void sendReleaseCompleteMessage(Map release, int advisoryNumber, String advisoryLiveUrl, String releaseStreamName='4-stable', String providerName = 'Red Hat UMB', String arch = 'x86_64') {
 
     if (params.DRY_RUN) {
         echo "Would have sent release complete message"
@@ -348,7 +361,7 @@ def void sendReleaseCompleteMessage(Map release, int advisoryNumber, String advi
             "type": "ocp-release",
             "name": "ocp-release",
             "version": releaseName,
-            "nvr": "ocp-release-${releaseName}",
+            "nvr": "ocp-release-${destReleaseTag(releaseName, arch)}",
             "release_stream": releaseStreamName,
             "release": release,
             "advisory": [

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -183,7 +183,7 @@ def stageSetClientLatest(from_release_tag, arch, client_type) {
 
 def stageTagRelease(quay_url, release_name, release_tag, arch) {
     def archSuffix = getArchSuffix(arch)
-    def cmd = "GOTRACEBACK=all ${oc_cmd} tag ${quay_url}:${release_name} ocp${archSuffix}/release${archSuffix}:${release_tag}"
+    def cmd = "GOTRACEBACK=all ${oc_cmd} tag ${quay_url}:${release_tag} ocp${archSuffix}/release${archSuffix}:${release_name}"
 
     if (params.DRY_RUN) {
         echo "Would have run \n ${cmd}"

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -362,7 +362,8 @@ def void sendReleaseCompleteMessage(Map release, int advisoryNumber, String advi
             "type": "ocp-release",
             "name": "ocp-release",
             "version": releaseName,
-            "nvr": "ocp-release-${destReleaseTag(releaseName, arch)}",
+            "nvr": "ocp-release-${releaseName}",
+            "architecture": arch,
             "release_stream": releaseStreamName,
             "release": release,
             "advisory": [


### PR DESCRIPTION
Remove assumption that **release-name** == **quay-tag** on release job.
<https://jira.coreos.com/browse/ART-1351>