### PR TITLE
Use UTC timestamp as OCP 4 release number

### DIFF
--- a/jobs/build/aws-ami/Jenkinsfile
+++ b/jobs/build/aws-ami/Jenkinsfile
@@ -88,7 +88,6 @@ node('openshift-build-1') {
     try {
         set_workspace()
         def buildlib = null
-        def build_date = new Date().format('yyyyMMddHHmm')
         stage('invoke') {
             currentBuild.displayName = "#${currentBuild.number} - ${OPENSHIFT_VERSION}-${OPENSHIFT_RELEASE}"
             echo "Sending payload:\n${FORM_PAYLOAD}"

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -1,4 +1,7 @@
 #!/usr/bin/groovy
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+import java.time.ZoneOffset
 
 commonlib = load("pipeline-scripts/commonlib.groovy")
 commonlib.initialize()
@@ -1150,7 +1153,7 @@ def latestOpenshiftRpmBuild(stream, branch) {
 }
 
 def defaultReleaseFor(stream) {
-    return stream.startsWith("3") ? "1" : new Date().format("yyyyMMddHHmm")
+    return stream.startsWith("3") ? "1" : DateTimeFormatter.ofPattern("yyyyMMddHHmm").withZone(ZoneOffset.UTC).format(Instant.now())
 }
 
 // From a brew NVR of openshift, return just the V part.


### PR DESCRIPTION
Currently the OCP 4 release number (e.g. `201912130945`) is based on a local timezone. Considering both Red Hat Bugzilla and Errata Tool are using UTC, our life would be easier if the release number uses UTC as well. With UTC timestamp, we can quickly determine if a bugfix is included in a build at first glance.