### PR TITLE
Fix broken signing on pre-release job

### DIFF
--- a/jobs/build/pre-release/Jenkinsfile
+++ b/jobs/build/pre-release/Jenkinsfile
@@ -147,6 +147,7 @@ node {
 			env: "prod",
 			key_name: "beta2",
 			arch: arch,
+			digest: payloadDigest,
 			client_type: 'ocp-dev-preview',
 		    )
                 }


### PR DESCRIPTION
[pre-release job](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/signing-jobs/job/signing%252Fsign-artifacts/120/console) was failing with the following msg:
```
java.lang.IllegalArgumentException: Null value not allowed as an
environment variable: DIGEST
at hudson.EnvVars.put(EnvVars.java:378)
at
hudson.model.StringParameterValue.buildEnvironment(StringParameterValue.java:59)
at
hudson.model.ParametersAction.buildEnvironment(ParametersAction.java:145)
at hudson.model.Run.getEnvironment(Run.java:2383)
at
org.jenkinsci.plugins.workflow.job.WorkflowRun.getEnvironment(WorkflowRun.java:471)
at
hudson.plugins.git.GitSCM.checkout(GitSCM.java:1185)
at
org.jenkinsci.plugins.workflow.steps.scm.SCMStep.checkout(SCMStep.java:124)
at
org.jenkinsci.plugins.workflow.steps.scm.SCMStep$StepExecutionImpl.run(SCMStep.java:93)
at
org.jenkinsci.plugins.workflow.steps.scm.SCMStep$StepExecutionImpl.run(SCMStep.java:80)
at
org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:47)
at
java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
at
java.util.concurrent.FutureTask.run(FutureTask.java:266)
at
java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
at
java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
at
java.lang.Thread.run(Thread.java:748)
Finished:
FAILURE
```

That is because a new build parameter `DIGEST` was introduced in https://github.com/openshift/aos-cd-jobs/pull/2068

Solution is the same as present in the `release` job: https://github.com/openshift/aos-cd-jobs/blob/96a1bb26592cfc033b23d8bcc5b108ebc7a45fc2/jobs/build/release/Jenkinsfile#L158

`payloadDigest` is apparently globaly defined here: https://github.com/openshift/aos-cd-jobs/blob/96a1bb26592cfc033b23d8bcc5b108ebc7a45fc2/pipeline-scripts/release.groovy#L139