### PR TITLE
fix broken ocp3 job: No such property: GITHUB_BASE

### DIFF
--- a/jobs/build/ocp3/Jenkinsfile
+++ b/jobs/build/ocp3/Jenkinsfile
@@ -228,6 +228,8 @@ def get_rpm_specfile_path(record_log, package_name) {
 
 node {
     checkout scm
+    GITHUB_BASE = "git@github.com:openshift" // buildlib uses this global var
+
     def buildlib = load("pipeline-scripts/buildlib.groovy")
     def commonlib = buildlib.commonlib
 


### PR DESCRIPTION
https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp3/167/:
groovy.lang.MissingPropertyException: No such property: GITHUB_BASE for class: Script1

This is because buildlib requires `GITHUB_BASE` global variable to be present.