### PR TITLE
Stop 'Error building custom OCP: #XYZ' going to aos-team-art@redhat.com

### DIFF
--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -94,7 +94,7 @@ node {
                         description: 'Failure Mailing List',
                         $class: 'hudson.model.StringParameterDefinition',
                         defaultValue: [
-                            'aos-team-art@redhat.com',
+                            'aos-art-automation+failed-custom-build@redhat.com',
                         ].join(',')
                     ],
                     commonlib.mockParam(),


### PR DESCRIPTION
These should go to failure list instead.