### PR TITLE
[ART-1376] Fix sandbox error in scheduled-jobs/reposync

### DIFF
--- a/scheduled-jobs/build/reposync/Jenkinsfile
+++ b/scheduled-jobs/build/reposync/Jenkinsfile
@@ -18,12 +18,16 @@ def runFor(sync_version, arch="x86_64") {
     failed |= (b.result != "SUCCESS")
 }
 
+@NonCPS
+def sortedVersions() {
+  return commonlib.ocp4Versions.sort(false)
+}
+
 node() {
     checkout scm
     buildlib = load("pipeline-scripts/buildlib.groovy")
     commonlib = buildlib.commonlib
-    def versions = commonlib.ocp4Versions.sort(false)
-    for ( String version : versions ) {
+    for ( String version : sortedVersions() ) {
         def arches = buildlib.branch_arches("openshift-${version}")
         for ( String arch : arches ) {
             runFor(version, arch)


### PR DESCRIPTION
error:
```
Scripts not permitted to use staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sort java.util.Collection boolean.
```

[First occurrance](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/scheduled-builds/job/reposync/2620/): Build #2620 (Jan 17, 2020 10:30:13 PM)

[Likely cause](https://github.com/openshift/aos-cd-jobs/commit/c8ec3d2e2b0bbb824732bd6c34c936a17cdb8faa)