### PR TITLE
[ART-1191] New build/helm_sync job

### DIFF
--- a/jobs/build/helm_sync/Jenkinsfile
+++ b/jobs/build/helm_sync/Jenkinsfile
@@ -27,6 +27,7 @@ pipeline {
                 sh "rpm2cpio helm-redistributable.rpm | cpio -id"
                 sh "rm -rf ${VERSION} && mkdir ${VERSION}"
                 sh "mv ./usr/share/helm-redistributable/* ${VERSION}/"
+                sh "mv ${VERSION}/*/* ${VERSION}/ && /bin/ls -d ${VERSION}/*/ | xargs rmdir"
                 sh "tree ${VERSION}"
             }
         }

--- a/jobs/build/helm_sync/Jenkinsfile
+++ b/jobs/build/helm_sync/Jenkinsfile
@@ -1,0 +1,43 @@
+#!/usr/bin/env groovy
+
+pipeline {
+    agent any
+
+    parameters {
+        string(
+            name: "RPM_URL",
+            description: "Redistributable RPM URL. Example: http://download.eng.bos.redhat.com/brewroot/vol/rhel-7/packages/helm/3.0.1/4.el7/x86_64/helm-redistributable-3.0.1-4.el7.x86_64.rpm",
+            defaultValue: ""
+        )
+        string(
+            name: "VERSION",
+            description: "Desired version name. Example: v3.0.1",
+            defaultValue: ""
+        )
+    }
+
+    stages {
+        stage("Download RPM") {
+            steps {
+                sh "wget ${params.RPM_URL} -O helm-redistributable.rpm"
+            }
+        }
+        stage("Extract RPM contents") {
+            steps {
+                sh "rpm2cpio helm-redistributable.rpm | cpio -id"
+                sh "rm -rf ${VERSION} && mkdir ${VERSION}"
+                sh "mv ./usr/share/helm-redistributable/* ${VERSION}/"
+                sh "tree ${VERSION}"
+            }
+        }
+        stage("Sync to mirror") {
+            steps {
+                sshagent(['aos-cd-test']) {
+                    sh "scp -r ${VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/clients/helm/"
+                    sh "ssh -o StrictHostKeychecking=no use-mirror-upload.ops.rhcloud.com ln -sf ${VERSION} /srv/pub/openshift-v4/clients/helm/latest"
+                    sh "ssh -o StrictHostKeychecking=no use-mirror-upload.ops.rhcloud.com /usr/local/bin/push.pub.sh openshift-v4/clients/helm -v"
+                }
+            }
+        }
+    }
+}

--- a/jobs/build/helm_sync/Jenkinsfile
+++ b/jobs/build/helm_sync/Jenkinsfile
@@ -27,15 +27,15 @@ pipeline {
         }
         stage("Download RPM") {
             steps {
-                sh "wget -nv ${params.RPM_URL} -O helm-redistributable.rpm"
+                sh "wget --no-verbose ${params.RPM_URL} --output-document=helm-redistributable.rpm"
             }
         }
         stage("Extract RPM contents") {
             steps {
-                sh "rpm2cpio helm-redistributable.rpm | cpio -id"
-                sh "rm -rf ${params.VERSION} && mkdir ${params.VERSION}"
-                sh "mv -v ./usr/share/helm-redistributable/* ${params.VERSION}/"
-                sh "mv -v ${params.VERSION}/*/* ${params.VERSION}/ && /bin/ls -d ${params.VERSION}/*/ | xargs rmdir"
+                sh "rpm2cpio helm-redistributable.rpm | cpio --extract --make-directories"
+                sh "rm --recursive --force ${params.VERSION} && mkdir ${params.VERSION}"
+                sh "mv --verbose ./usr/share/helm-redistributable/* ${params.VERSION}/"
+                sh "mv --verbose ${params.VERSION}/*/* ${params.VERSION}/ && /bin/ls --directory ${params.VERSION}/*/ | xargs rmdir"
                 sh "tree ${params.VERSION}"
             }
         }
@@ -43,7 +43,7 @@ pipeline {
             steps {
                 sshagent(['aos-cd-test']) {
                     sh "scp -r ${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/clients/helm/"
-                    sh "ssh -o StrictHostKeychecking=no use-mirror-upload.ops.rhcloud.com ln -sf ${params.VERSION} /srv/pub/openshift-v4/clients/helm/latest"
+                    sh "ssh -o StrictHostKeychecking=no use-mirror-upload.ops.rhcloud.com ln --symbolic --force ${params.VERSION} /srv/pub/openshift-v4/clients/helm/latest"
                     sh "ssh -o StrictHostKeychecking=no use-mirror-upload.ops.rhcloud.com /usr/local/bin/push.pub.sh openshift-v4/clients/helm -v"
                 }
             }

--- a/jobs/build/helm_sync/Jenkinsfile
+++ b/jobs/build/helm_sync/Jenkinsfile
@@ -27,15 +27,15 @@ pipeline {
         }
         stage("Download RPM") {
             steps {
-                sh "wget ${params.RPM_URL} -O helm-redistributable.rpm"
+                sh "wget -nv ${params.RPM_URL} -O helm-redistributable.rpm"
             }
         }
         stage("Extract RPM contents") {
             steps {
                 sh "rpm2cpio helm-redistributable.rpm | cpio -id"
                 sh "rm -rf ${VERSION} && mkdir ${VERSION}"
-                sh "mv ./usr/share/helm-redistributable/* ${VERSION}/"
-                sh "mv ${VERSION}/*/* ${VERSION}/ && /bin/ls -d ${VERSION}/*/ | xargs rmdir"
+                sh "mv -v ./usr/share/helm-redistributable/* ${VERSION}/"
+                sh "mv -v ${VERSION}/*/* ${VERSION}/ && /bin/ls -d ${VERSION}/*/ | xargs rmdir"
                 sh "tree ${VERSION}"
             }
         }

--- a/jobs/build/helm_sync/Jenkinsfile
+++ b/jobs/build/helm_sync/Jenkinsfile
@@ -43,8 +43,8 @@ pipeline {
             steps {
                 sshagent(['aos-cd-test']) {
                     sh "scp -r ${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/clients/helm/"
-                    sh "ssh -o StrictHostKeychecking=no use-mirror-upload.ops.rhcloud.com ln --symbolic --force ${params.VERSION} /srv/pub/openshift-v4/clients/helm/latest"
-                    sh "ssh -o StrictHostKeychecking=no use-mirror-upload.ops.rhcloud.com /usr/local/bin/push.pub.sh openshift-v4/clients/helm -v"
+                    sh "ssh use-mirror-upload.ops.rhcloud.com ln --symbolic --force ${params.VERSION} /srv/pub/openshift-v4/clients/helm/latest"
+                    sh "ssh use-mirror-upload.ops.rhcloud.com /usr/local/bin/push.pub.sh openshift-v4/clients/helm -v"
                 }
             }
         }

--- a/jobs/build/helm_sync/Jenkinsfile
+++ b/jobs/build/helm_sync/Jenkinsfile
@@ -33,17 +33,17 @@ pipeline {
         stage("Extract RPM contents") {
             steps {
                 sh "rpm2cpio helm-redistributable.rpm | cpio -id"
-                sh "rm -rf ${VERSION} && mkdir ${VERSION}"
-                sh "mv -v ./usr/share/helm-redistributable/* ${VERSION}/"
-                sh "mv -v ${VERSION}/*/* ${VERSION}/ && /bin/ls -d ${VERSION}/*/ | xargs rmdir"
-                sh "tree ${VERSION}"
+                sh "rm -rf ${params.VERSION} && mkdir ${params.VERSION}"
+                sh "mv -v ./usr/share/helm-redistributable/* ${params.VERSION}/"
+                sh "mv -v ${params.VERSION}/*/* ${params.VERSION}/ && /bin/ls -d ${params.VERSION}/*/ | xargs rmdir"
+                sh "tree ${params.VERSION}"
             }
         }
         stage("Sync to mirror") {
             steps {
                 sshagent(['aos-cd-test']) {
-                    sh "scp -r ${VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/clients/helm/"
-                    sh "ssh -o StrictHostKeychecking=no use-mirror-upload.ops.rhcloud.com ln -sf ${VERSION} /srv/pub/openshift-v4/clients/helm/latest"
+                    sh "scp -r ${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/clients/helm/"
+                    sh "ssh -o StrictHostKeychecking=no use-mirror-upload.ops.rhcloud.com ln -sf ${params.VERSION} /srv/pub/openshift-v4/clients/helm/latest"
                     sh "ssh -o StrictHostKeychecking=no use-mirror-upload.ops.rhcloud.com /usr/local/bin/push.pub.sh openshift-v4/clients/helm -v"
                 }
             }

--- a/jobs/build/helm_sync/Jenkinsfile
+++ b/jobs/build/helm_sync/Jenkinsfile
@@ -27,6 +27,7 @@ pipeline {
         }
         stage("Download RPM") {
             steps {
+                sh "rm --force helm-redistributable.rpm"
                 sh "wget --no-verbose ${params.RPM_URL} --output-document=helm-redistributable.rpm"
             }
         }

--- a/jobs/build/helm_sync/Jenkinsfile
+++ b/jobs/build/helm_sync/Jenkinsfile
@@ -17,6 +17,14 @@ pipeline {
     }
 
     stages {
+        stage("Validate params") {
+            if (!params.RPM_URL) {
+                error "RPM_URL must be specified"
+            }
+            if (!params.VERSION) {
+                error "VERSION must be specified"
+            }
+        }
         stage("Download RPM") {
             steps {
                 sh "wget ${params.RPM_URL} -O helm-redistributable.rpm"


### PR DESCRIPTION
Extract contents of a given helm-redistributable RPM and places them in
https://mirror.openshift.com/pub/openshift-v4/clients/helm/

Example run at https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/talessio-aos-cd-jobs/job/build%252Fhelm_sync/2