### PR TITLE
Reflect build/ocp4 result in scheduled builds

### DIFF
--- a/scheduled-jobs/build/ocp-4.1-full/Jenkinsfile
+++ b/scheduled-jobs/build/ocp-4.1-full/Jenkinsfile
@@ -14,6 +14,6 @@ def b = build(
     ],
 )
 
-currentBuild.result = (b.result == "SUCCESS") ? "SUCCESS" : "FAILURE"
+currentBuild.result = b.result
 currentBuild.displayName = "[${b.result}] ${b.displayName}"
 currentBuild.description = b.description

--- a/scheduled-jobs/build/ocp-4.1-incremental/Jenkinsfile
+++ b/scheduled-jobs/build/ocp-4.1-incremental/Jenkinsfile
@@ -7,6 +7,6 @@ properties([
 currentBuild.displayName += " 4.1 incremental build"
 def b = build job: '../aos-cd-builds/build%2Fose4.1', propagate: false
 
-currentBuild.result = (b.result == "SUCCESS") ? "SUCCESS" : "FAILURE"
+currentBuild.result = b.result
 currentBuild.displayName = "[${b.result}] ${b.displayName}"
 currentBuild.description = b.description

--- a/scheduled-jobs/build/ocp-4.2-full/Jenkinsfile
+++ b/scheduled-jobs/build/ocp-4.2-full/Jenkinsfile
@@ -14,6 +14,6 @@ def b = build(
     ],
 )
 
-currentBuild.result = (b.result == "SUCCESS") ? "SUCCESS" : "FAILURE"
+currentBuild.result = b.result
 currentBuild.displayName = "[${b.result}] ${b.displayName}"
 currentBuild.description = b.description

--- a/scheduled-jobs/build/ocp-4.2-incremental/Jenkinsfile
+++ b/scheduled-jobs/build/ocp-4.2-incremental/Jenkinsfile
@@ -7,6 +7,6 @@ properties([
 currentBuild.displayName += " 4.2 incremental build"
 def b = build job: '../aos-cd-builds/build%2Fose4.2', propagate: false
 
-currentBuild.result = (b.result == "SUCCESS") ? "SUCCESS" : "FAILURE"
+currentBuild.result = b.result
 currentBuild.displayName = "[${b.result}] ${b.displayName}"
 currentBuild.description = b.description

--- a/scheduled-jobs/build/ocp-4.3-full/Jenkinsfile
+++ b/scheduled-jobs/build/ocp-4.3-full/Jenkinsfile
@@ -14,6 +14,6 @@ def b = build(
     ],
 )
 
-currentBuild.result = (b.result == "SUCCESS") ? "SUCCESS" : "FAILURE"
+currentBuild.result = b.result
 currentBuild.displayName = "[${b.result}] ${b.displayName}"
 currentBuild.description = b.description

--- a/scheduled-jobs/build/ocp-4.3-incremental/Jenkinsfile
+++ b/scheduled-jobs/build/ocp-4.3-incremental/Jenkinsfile
@@ -7,6 +7,6 @@ properties([
 currentBuild.displayName += " 4.3 incremental build"
 def b = build job: '../aos-cd-builds/build%2Fose4.3', propagate: false
 
-currentBuild.result = (b.result == "SUCCESS") ? "SUCCESS" : "FAILURE"
+currentBuild.result = b.result
 currentBuild.displayName = "[${b.result}] ${b.displayName}"
 currentBuild.description = b.description

--- a/scheduled-jobs/build/ocp-4.4-full/Jenkinsfile
+++ b/scheduled-jobs/build/ocp-4.4-full/Jenkinsfile
@@ -14,6 +14,6 @@ def b = build(
     ],
 )
 
-currentBuild.result = (b.result == "SUCCESS") ? "SUCCESS" : "FAILURE"
+currentBuild.result = b.result
 currentBuild.displayName = "[${b.result}] ${b.displayName}"
 currentBuild.description = b.description

--- a/scheduled-jobs/build/ocp-4.4-incremental/Jenkinsfile
+++ b/scheduled-jobs/build/ocp-4.4-incremental/Jenkinsfile
@@ -7,6 +7,6 @@ properties([
 currentBuild.displayName += " 4.4 incremental build"
 def b = build job: '../aos-cd-builds/build%2Fose4.4', propagate: false
 
-currentBuild.result = (b.result == "SUCCESS") ? "SUCCESS" : "FAILURE"
+currentBuild.result = b.result
 currentBuild.displayName = "[${b.result}] ${b.displayName}"
 currentBuild.description = b.description

--- a/scheduled-jobs/build/ocp-4.5-full/Jenkinsfile
+++ b/scheduled-jobs/build/ocp-4.5-full/Jenkinsfile
@@ -14,6 +14,6 @@ def b = build(
     ],
 )
 
-currentBuild.result = (b.result == "SUCCESS") ? "SUCCESS" : "FAILURE"
+currentBuild.result = b.result
 currentBuild.displayName = "[${b.result}] ${b.displayName}"
 currentBuild.description = b.description

--- a/scheduled-jobs/build/ocp-4.5-incremental/Jenkinsfile
+++ b/scheduled-jobs/build/ocp-4.5-incremental/Jenkinsfile
@@ -7,6 +7,6 @@ properties([
 currentBuild.displayName += " 4.5 incremental build"
 def b = build job: '../aos-cd-builds/build%2Fose4.5', propagate: false
 
-currentBuild.result = (b.result == "SUCCESS") ? "SUCCESS" : "FAILURE"
+currentBuild.result = b.result
 currentBuild.displayName = "[${b.result}] ${b.displayName}"
 currentBuild.description = b.description


### PR DESCRIPTION
As a triage manager, it is confusing to have failed builds when the subsequent jobs exited with "unstable". It takes some clicks to find out if it is a real failure or something we can safely ignore (i.e. `freeze_automation`)

I see that `b.result` is being appended to currentBuild's description, but maybe we could have a better use for that space, such as the reason for failure/unstable.

This PR is more of a conversation starter ... I'd be happy even if we don't merge it, but end up with a good explanation for why we opted for doing this:
```
currentBuild.result = (b.result == "SUCCESS") ? "SUCCESS" : "FAILURE"
```

cc @joepvd 