### PR TITLE
[ART-1455] Fix latest symlink update

### DIFF
--- a/jobs/build/odo_sync/Jenkinsfile
+++ b/jobs/build/odo_sync/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
             steps {
                 sshagent(['aos-cd-test']) {
                     sh "scp -r ${VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/clients/odo/"
-                    sh "ssh -o StrictHostKeychecking=no use-mirror-upload.ops.rhcloud.com ln -sf ${VERSION} /srv/pub/openshift-v4/clients/odo/latest"
+                    sh "ssh -o StrictHostKeychecking=no use-mirror-upload.ops.rhcloud.com ln -sfn ${VERSION} /srv/pub/openshift-v4/clients/odo/latest"
                     sh "ssh -o StrictHostKeychecking=no use-mirror-upload.ops.rhcloud.com /usr/local/bin/push.pub.sh openshift-v4/clients/odo -v"
                 }
             }


### PR DESCRIPTION
Adding `-n` (`--no-dereference`) when updating latest symlink.

#### before
```
$ /bin/ls -l
latest -> v1
v1
v2

$ /bin/ls -l v1

$ /bin/ls -l v2

$ /bin/ln -sf v2 latest

$ /bin/ls -l
latest -> v1
v1
v2

$ /bin/ls -l v1
v2 -> v2

$ /bin/ls -l v2

```

#### after
```
$ /bin/ls -l
latest -> v1
v1
v2

$ /bin/ls -l v1

$ /bin/ls -l v2

$ /bin/ln -sfn v2 latest

$ /bin/ls -l
latest -> v2
v1
v2

$ /bin/ls -l v1

$ /bin/ls -l v2

```