### PR TITLE
[ART-1191] Fix latest symlink update

### DIFF
--- a/jobs/build/helm_sync/Jenkinsfile
+++ b/jobs/build/helm_sync/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
             steps {
                 sshagent(['aos-cd-test']) {
                     sh "scp -r ${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/clients/helm/"
-                    sh "ssh use-mirror-upload.ops.rhcloud.com ln --symbolic --force ${params.VERSION} /srv/pub/openshift-v4/clients/helm/latest"
+                    sh "ssh use-mirror-upload.ops.rhcloud.com ln --symbolic --force --no-dereference ${params.VERSION} /srv/pub/openshift-v4/clients/helm/latest"
                     sh "ssh use-mirror-upload.ops.rhcloud.com /usr/local/bin/push.pub.sh openshift-v4/clients/helm -v"
                 }
             }


### PR DESCRIPTION
Adding `-n` (`--no-dereference`) when updating latest symlink.

#### before
```
$ /bin/ls -l
latest -> v1
v1
v2

$ /bin/ls -l v1

$ /bin/ls -l v2

$ /bin/ln -sf v2 latest

$ /bin/ls -l
latest -> v1
v1
v2

$ /bin/ls -l v1
v2 -> v2

$ /bin/ls -l v2

```

#### after
```
$ /bin/ls -l
latest -> v1
v1
v2

$ /bin/ls -l v1

$ /bin/ls -l v2

$ /bin/ln -sfn v2 latest

$ /bin/ls -l
latest -> v2
v1
v2

$ /bin/ls -l v1

$ /bin/ls -l v2

```