### PR TITLE
[ART-1455] Apply feedback from "helm_sync" review

### DIFF
--- a/jobs/build/odo_sync/Jenkinsfile
+++ b/jobs/build/odo_sync/Jenkinsfile
@@ -17,6 +17,14 @@ pipeline {
     }
 
     stages {
+        stage("Validate params") {
+            if (!params.RPM_URL) {
+                error "RPM_URL must be specified"
+            }
+            if (!params.VERSION) {
+                error "VERSION must be specified"
+            }
+        }
         stage("Download RPM") {
             steps {
                 sh "wget ${params.RPM_URL} -O odo.rpm"

--- a/jobs/build/odo_sync/Jenkinsfile
+++ b/jobs/build/odo_sync/Jenkinsfile
@@ -43,8 +43,8 @@ pipeline {
             steps {
                 sshagent(['aos-cd-test']) {
                     sh "scp -r ${VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/clients/odo/"
-                    sh "ssh -o StrictHostKeychecking=no use-mirror-upload.ops.rhcloud.com ln --symbolic --force --no-dereference ${VERSION} /srv/pub/openshift-v4/clients/odo/latest"
-                    sh "ssh -o StrictHostKeychecking=no use-mirror-upload.ops.rhcloud.com /usr/local/bin/push.pub.sh openshift-v4/clients/odo -v"
+                    sh "ssh ln --symbolic --force --no-dereference ${VERSION} /srv/pub/openshift-v4/clients/odo/latest"
+                    sh "ssh /usr/local/bin/push.pub.sh openshift-v4/clients/odo -v"
                 }
             }
         }

--- a/jobs/build/odo_sync/Jenkinsfile
+++ b/jobs/build/odo_sync/Jenkinsfile
@@ -34,16 +34,16 @@ pipeline {
         stage("Extract RPM contents") {
             steps {
                 sh "rpm2cpio odo.rpm | cpio --extract --make-directories"
-                sh "rm --recursive --force ${VERSION} && mkdir ${VERSION}"
-                sh "mv --verbose ./usr/share/openshift-odo-redistributable/* ${VERSION}/"
-                sh "tree ${VERSION}"
+                sh "rm --recursive --force ${params.VERSION} && mkdir ${params.VERSION}"
+                sh "mv --verbose ./usr/share/openshift-odo-redistributable/* ${params.VERSION}/"
+                sh "tree ${params.VERSION}"
             }
         }
         stage("Sync to mirror") {
             steps {
                 sshagent(['aos-cd-test']) {
-                    sh "scp -r ${VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/clients/odo/"
-                    sh "ssh ln --symbolic --force --no-dereference ${VERSION} /srv/pub/openshift-v4/clients/odo/latest"
+                    sh "scp -r ${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/clients/odo/"
+                    sh "ssh ln --symbolic --force --no-dereference ${params.VERSION} /srv/pub/openshift-v4/clients/odo/latest"
                     sh "ssh /usr/local/bin/push.pub.sh openshift-v4/clients/odo -v"
                 }
             }

--- a/jobs/build/odo_sync/Jenkinsfile
+++ b/jobs/build/odo_sync/Jenkinsfile
@@ -27,6 +27,7 @@ pipeline {
         }
         stage("Download RPM") {
             steps {
+                sh "rm --force odo.rpm"
                 sh "wget --no-verbose ${params.RPM_URL} --output-document=odo.rpm"
             }
         }

--- a/jobs/build/odo_sync/Jenkinsfile
+++ b/jobs/build/odo_sync/Jenkinsfile
@@ -27,14 +27,14 @@ pipeline {
         }
         stage("Download RPM") {
             steps {
-                sh "wget ${params.RPM_URL} -O odo.rpm"
+                sh "wget --no-verbose ${params.RPM_URL} --output-document=odo.rpm"
             }
         }
         stage("Extract RPM contents") {
             steps {
-                sh "rpm2cpio odo.rpm | cpio -id"
-                sh "rm -rf ${VERSION} && mkdir ${VERSION}"
-                sh "mv ./usr/share/openshift-odo-redistributable/* ${VERSION}/"
+                sh "rpm2cpio odo.rpm | cpio --extract --make-directories"
+                sh "rm --recursive --force ${VERSION} && mkdir ${VERSION}"
+                sh "mv --verbose ./usr/share/openshift-odo-redistributable/* ${VERSION}/"
                 sh "tree ${VERSION}"
             }
         }
@@ -42,7 +42,7 @@ pipeline {
             steps {
                 sshagent(['aos-cd-test']) {
                     sh "scp -r ${VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/clients/odo/"
-                    sh "ssh -o StrictHostKeychecking=no use-mirror-upload.ops.rhcloud.com ln -sfn ${VERSION} /srv/pub/openshift-v4/clients/odo/latest"
+                    sh "ssh -o StrictHostKeychecking=no use-mirror-upload.ops.rhcloud.com ln --symbolic --force --no-dereference ${VERSION} /srv/pub/openshift-v4/clients/odo/latest"
                     sh "ssh -o StrictHostKeychecking=no use-mirror-upload.ops.rhcloud.com /usr/local/bin/push.pub.sh openshift-v4/clients/odo -v"
                 }
             }


### PR DESCRIPTION
@joepvd dropped some golden suggestions in PR https://github.com/openshift/aos-cd-jobs/pull/2105 (`build/helm_sync` job), for example:

* Make explicit use of `${params.VERSION}`
* Use long format of CLI options/flags when scripting
* Param validation stage

And since this one (`build/odo_sync`) is so similar, I'd like to make them consistent.