### PR TITLE
ART-1475: allow ignoring lock in custom builds

### DIFF
--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -107,19 +107,22 @@ node {
         sshagent(["openshift-bot"]) {
             // To work on private repos, buildlib operations must run
             // with the permissions of openshift-bot
+
             lock("github-activity-lock-${params.BUILD_VERSION}") {
                 stage("initialize") { build.initialize() }
                 buildlib.assertBuildPermitted(doozerOpts)
                 stage("build RPMs") { build.stageBuildRpms() }
-                stage("build compose") { build.stageBuildCompose() }
+                lock("compose-lock-${params.BUILD_VERSION}") {
+                    stage("build compose") { build.stageBuildCompose() }
+                }
                 stage("update dist-git") { build.stageUpdateDistgit() }
                 stage("build images") { build.stageBuildImages() }
-                stage("mirror RPMs") { build.stageMirrorRpms() }
-                stage("sync images") { build.stageSyncImages() }
-                stage("sweep") {
-                    if (!params.DRY_RUN) {
-                        buildlib.sweep(params.BUILD_VERSION, true)
-                    }
+            }
+            stage("mirror RPMs") { build.stageMirrorRpms() }
+            stage("sync images") { build.stageSyncImages() }
+            stage("sweep") {
+                if (!params.DRY_RUN) {
+                    buildlib.sweep(params.BUILD_VERSION, true)
                 }
             }
         }


### PR DESCRIPTION
at the same time, narrow the scope of "github activity" lock so it does
not include extraneous activity, and make sure parallel puddle/composes
still do not conflict.