### PR TITLE
rhcos_sync: use whitelist when publishing artifacts to mirror

### DIFF
--- a/jobs/build/rhcos_sync/build.groovy
+++ b/jobs/build/rhcos_sync/build.groovy
@@ -8,6 +8,9 @@ baseUrl = ""
 metaUrl = ""
 baseDir = ""
 syncList = "rhcos-synclist-${currentBuild.number}.txt"
+// RHCOS artifacts that were published in 4.2/4.3
+// TODO: keep list updated for each new release
+rhcos_whitelist = [ "gcp", "initramfs", "iso", "kernel", "metal", "openstack", "vmware" ]
 
 def initialize() {
     buildlib.cleanWorkdir(rhcosWorking)
@@ -52,7 +55,9 @@ def rhcosSyncPrintArtifacts() {
     dir ( rhcosWorking ) {
         def meta = readJSON file: 'meta.json', text: ''
         meta.images.eachWithIndex { name, value, i ->
-            imageUrls.add(baseUrl + "/${value.path}")
+            if (rhcos_whitelist.contains(name)) {
+                imageUrls.add(baseUrl + "/${value.path}")
+            }
         }
     }
     currentBuild.displayName += " [${imageUrls.size()} Images]"


### PR DESCRIPTION
We don't want customers having direct access to all the artifacts that
RHCOS produces during its build.  (Crafty customers can still figure
it out on their own.)

This provides a whitelisted set of artifacts that we want on
mirror.openshift.com for each GA release.  Unfortunately, this may
change as we produce additional artifacts for future releases or
change policies on what artifacts are on the mirror.