### PR TITLE
rhcos_sync: add QEMU artifact to whitelist

### DIFF
--- a/jobs/build/rhcos_sync/build.groovy
+++ b/jobs/build/rhcos_sync/build.groovy
@@ -9,8 +9,9 @@ metaUrl = ""
 baseDir = ""
 syncList = "rhcos-synclist-${currentBuild.number}.txt"
 // RHCOS artifacts that were published in 4.2/4.3
+// QEMU added because bare-metal IPI installs need it for now
 // TODO: keep list updated for each new release
-rhcos_whitelist = [ "gcp", "initramfs", "iso", "kernel", "metal", "openstack", "vmware" ]
+rhcos_whitelist = [ "gcp", "initramfs", "iso", "kernel", "metal", "openstack", "qemu", "vmware" ]
 
 def initialize() {
     buildlib.cleanWorkdir(rhcosWorking)


### PR DESCRIPTION
The bare-metal IPI workflow currently depends on the QEMU image, so
add it to the whitelist that can be synced to the mirror.