### PR TITLE
[ART-1564] Fix group.yml update on advisories job

### DIFF
--- a/jobs/build/advisories/Jenkinsfile
+++ b/jobs/build/advisories/Jenkinsfile
@@ -190,12 +190,12 @@ node {
                         rm -rf ocp-build-data ;
                         git clone --single-branch --branch openshift-${params.VERSION} git@github.com:openshift/ocp-build-data.git ;
                         cd ocp-build-data ;
-                        sed -e 's/image:.*/image: ${image_advisory_id}/' -e 's/rpm:.*/rpm: ${rpm_advisory_id}/' -i group.yml ;
+                        sed -E 's/^  image: [0-9]+$/  image: ${image_advisory_id}/' -E 's/^  rpm: [0-9]+$/  rpm: ${rpm_advisory_id}/' -i group.yml ;
                     """
                     if (params.VERSION.startsWith("4")) {
                         cmd += """
-                            sed -e 's/extras:.*/extras: ${extras_advisory_id}/' \
-                                -e 's/metadata:.*/metadata: ${metadata_advisory_id}/' \
+                            sed -E 's/^  extras: [0-9]+$/  extras: ${extras_advisory_id}/' \
+                                -E 's/^  metadata:  [0-9]+$/  metadata: ${metadata_advisory_id}/' \
                             -i group.yml ;
                         """
                     }


### PR DESCRIPTION
The previous `sed` expression was too relaxed, and started replacing unwanted lines after the introduction of "build profiles":

* https://github.com/openshift/ocp-build-data/pull/312
* https://github.com/openshift/ocp-build-data/pull/313
* https://github.com/openshift/ocp-build-data/pull/314
* https://github.com/openshift/ocp-build-data/pull/315