### PR TITLE
Revert "commonlib: don't automate 4.5 until master stops forwarding t…

### DIFF
--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -19,7 +19,7 @@ ocp4Versions = [
 
 // Which versions should undergo merges from origin->ose
 ocpMergeVersions = [
-    // "4.5", // wait until master stops forwarding to 4.4
+    "4.5",
     "4.4",
     "4.3",
     "4.2",


### PR DESCRIPTION
…o 4.4"

This reverts commit 6de43ce37aa6d6d2c67d163979f5333828949fe4.

Enables 4.5 builds

https://issues.redhat.com/browse/ART-1567
