### PR TITLE
Allow links to be managed by Cincinnati data

### DIFF
--- a/build-scripts/use-mirror/set-v4-client-latest.sh
+++ b/build-scripts/use-mirror/set-v4-client-latest.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -eo pipefail
 
-if [[ -z "$1" ]]; then
-    echo "Syntax: $0 <release> <client_type> [arches]"
-    echo "  release examples:  4.2.4   or   4.3.0-0.nightly-2019-11-08-080321"
+if [[ "$#" -lt 3 ]]; then
+    echo "Syntax: $0 <release_or_channel> <client_type> <link_name> [arches]"
+    echo "  release_or_channel examples: stable-4.3  or  4.2.4   or   4.3.0-0.nightly-2019-11-08-080321"
     echo "  client_type: ocp  or  ocp-dev-preview"
+    echo "  link_name: e.g. 'latest', 'stable, 'fast', ..."
     echo "  arches:  - 'all' (autodetect and require success in all)"
     echo "           - 'any' (autodetect and tolerate missing releases for any given arch"
     echo "           - space delimited list like 'x86_64 s390x'"
@@ -18,20 +19,45 @@ set -u
 
 RELEASE=$1    # e.g. 4.2.0 or 4.3.0-0.nightly-2019-11-08-080321
 CLIENT_TYPE=$2   # e.g. ocp or ocp-dev-preview
-ARCHES="${3:-x86_64}"  # e.g. "x86_64 ppc64le s390x"  OR  "all" to detect arches automatically
+LINK_NAME=$3   # e.g. latest
+ARCHES="${4:-x86_64}"  # e.g. "x86_64 ppc64le s390x"  OR  "all" to detect arches automatically
 
 BASE_DIR="/srv/pub/openshift-v4"
-MAJOR_MINOR=$(echo ${RELEASE} |awk -F '[.-]' '{print $1 "." $2}')  # e.g. 4.3.0-0.nightly-2019-11-08-080321 -> 4.3
+
+if [[ $RELEASE =~ ^[0-9].* ]]; then
+    MAJOR_MINOR=$(echo ${RELEASE} |awk -F '[.-]' '{print $1 "." $2}')  # e.g. 4.3.0-0.nightly-2019-11-08-080321 -> 4.3
+    USE_CHANNEL=""
+    CHANNEL_PREFIX=""
+else
+    # Otherwise, the RELEASE arg is assumed to be a channel
+    MAJOR_MINOR=$(echo ${RELEASE} |awk -F '[.-]' '{print $2 "." $3}')  # fast-4.3 -> 4.3
+    USE_CHANNEL="${RELEASE}"
+    CHANNEL_PREFIX=$(echo ${RELEASE} |awk -F '[.-]' '{print $1}')  # fast-4.3 -> fast
+fi
 # Later, we also need to know what Y stream comes after this one.
 MAJOR_NEXT_MINOR=$(echo ${MAJOR_MINOR} |awk -F '[.-]' '{print $1 "." $2+1}')  # e.g. 4.3 -> 4.4
 
 
-function create_latest_links {
+function idempotent_create_link {
+    TARGET="$1"
+    LINK="$2"
+    if [[ ! -e ${LINK} ]]; then
+        ln -svfn "${TARGET}" "${LINK}"
+        return
+    fi
+    if [[ "$(readlink -f ${TARGET})" != "$(readlink -f ${LINK})" ]]; then
+        ln -svfn "${TARGET}" "${LINK}"
+    else
+        echo "Link is already up-to-date for ${LINK} -> ${TARGET}"
+    fi
+}
+
+function create_links {
     local client_base_dir="$1" # e.g. /srv/pub/openshift-v4/s390x/clients/ocp-dev-preview
 
     # Does this client base directory even exist? (it may not if this arch hasn't built clients yet)
     if [[ ! -d "${client_base_dir}" ]]; then
-        echo "Unable to find client base directory: ${client_base_dir} ; will not update latest"
+        echo "Unable to find client base directory: ${client_base_dir} ; will not update ${LINK_NAME}"
         return 1
     fi
 
@@ -39,26 +65,26 @@ function create_latest_links {
 
     # If the release does not exist in the directory
     if [[ ! -d "${RELEASE}" ]]; then
-        echo "Unable to find ${RELEASE} directory in ${PWD} ; will not update latest"
+        echo "Unable to find ${RELEASE} directory in ${PWD} ; will not update ${LINK_NAME}"
         return 1
     fi
 
-    MAJOR_MINOR_LATEST="latest-${MAJOR_MINOR}"
+    MAJOR_MINOR_LINK="${LINK_NAME}-${MAJOR_MINOR}"  # e.g. latest-4.3  or  stable-4.3
 
-    # Here's the easy part. The caller told us what is latest for a given major.minor; set it.
-    ln -svfn ${RELEASE} ${MAJOR_MINOR_LATEST}
-    echo "${MAJOR_MINOR_LATEST}  now points to ${RELEASE} in ${client_base_dir}"
+    # Here's the easy part. The caller told us what is link is for a given major.minor; set it.
+    idempotent_create_link ${RELEASE} ${MAJOR_MINOR_LINK}
+    echo "${MAJOR_MINOR_LINK}  now points to ${RELEASE} in ${client_base_dir}"
 
     # Here's the harder part - is this major.minor the latest Y stream? If it is, we need to set
-    # the overall 'latest'. We already calculated MAJOR_NEXT_MINOR  (e.g. "4.5") so see if that
+    # the overall link name. We already calculated MAJOR_NEXT_MINOR  (e.g. "4.5") so see if that
     # exists someone on the mirror.
     if ls -d "${MAJOR_NEXT_MINOR}".*/ > /dev/null  2>&1; then
-        echo "This is not the highest Y release -- will not set overall latest"
+        echo "This is not the highest Y release -- will not set overall ${LINK_NAME} link"
         return 0
     fi
 
-    ln -svfn ${RELEASE} latest
-    echo "Overall latest now points to ${RELEASE} in ${client_base_dir}"
+    idempotent_create_link ${RELEASE} ${LINK_NAME}
+    echo "Overall ${LINK_NAME} link now points to ${RELEASE} in ${client_base_dir}"
     return 0
 }
 
@@ -72,6 +98,26 @@ if [[ "${MODE}" == "all" || "${MODE}" == "any" ]]; then
 fi
 
 for arch in ${ARCHES}; do
+
+    if [[ ! -z "$USE_CHANNEL" ]]; then
+        qarch="${arch}"
+        if [[ "${qarch}" == "x86_64" ]]; then
+            # Graph uses go arch names; translate from brew arch names
+            qarch="amd64"
+        fi
+        CHANNEL_RELEASES=$(curl -sH 'Accept:application/json' "https://api.openshift.com/api/upgrades_info/v1/graph?channel=${USE_CHANNEL}&arch=${qarch}" | jq '.nodes[].version' -r)
+        if [[ -z "$CHANNEL_RELEASES" ]]; then
+            echo "No versions current detected in ${USE_CHANNEL} for arch ${qarch} ; No ${LINK_NAME} will be set"
+            if [[ "${MODE}" == "all" ]]; then
+                echo "Missing builds - could not satisfy all mode."
+                exit 1
+            fi
+            continue
+        fi
+        echo "Found releases in channel ${USE_CHANNEL}: ${CHANNEL_RELEASES}"
+        RELEASE=$(echo "${CHANNEL_RELEASES}" | sort -V | tail -n 1)
+    fi
+
     target_path="${arch}/clients/${CLIENT_TYPE}"
     target_dir="${BASE_DIR}/${target_path}"
     # Check that the clients for this arch exists.
@@ -80,7 +126,7 @@ for arch in ${ARCHES}; do
         continue
     fi
 
-    if ! create_latest_links "${target_dir}"; then
+    if ! create_links "${target_dir}"; then
         echo "Failure creating links in ${target_dir}"
         if [[ "${MODE}" != "any" ]]; then
             echo "This was a required operation; exiting with failure"

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -186,6 +186,7 @@ def parseOcpRelease(text) {
 }
 
 def stageSetClientLatest(from_release_tag, arch, client_type) {
+
     if (params.DRY_RUN) {
         echo "Would have tried to set latest for ${from_release_tag} (client type: ${client_type}, arch: {$arch})"
         return
@@ -194,8 +195,9 @@ def stageSetClientLatest(from_release_tag, arch, client_type) {
     build(
         job: 'build%2Fset_client_latest',
         parameters: [
-            buildlib.param('String', 'RELEASE', from_release_tag),
+            buildlib.param('String', 'CHANNEL_OR_RELEASE', from_release_tag),
             buildlib.param('String', 'CLIENT_TYPE', client_type),
+            buildlib.param('String', 'LINK_NAME', 'latest'),
             buildlib.param('String', 'ARCHES', arch),
         ]
     )

--- a/scheduled-jobs/maintenance/set_cincinnati_links/Jenkinsfile
+++ b/scheduled-jobs/maintenance/set_cincinnati_links/Jenkinsfile
@@ -1,0 +1,39 @@
+
+def runFor(version, channelPrefix, linkName) {
+    b = build(
+            job: '../aos-cd-builds/build%2Fset_client_latest',
+            parameters: [
+                string(name: 'CHANNEL_OR_RELEASE', value: "${channelPrefix}-${version}"),
+                string(name: 'CLIENT_TYPE', value: 'ocp'),
+                string(name: 'LINK_NAME', value: linkName),
+                string(name: 'ARCHES', value: 'any'),
+            ],
+            propagate: false,
+        )
+    description += "${channel}-${version} - ${b.result}\n"
+    failed |= (b.result != "SUCCESS")
+}
+
+@NonCPS
+def sortedVersions() {
+  return commonlib.ocp4Versions.sort(false)
+}
+
+node() {
+    checkout scm
+    buildlib = load("pipeline-scripts/buildlib.groovy")
+    commonlib = buildlib.commonlib
+
+    for ( String version : sortedVersions() ) {
+        runFor(version, 'stable', 'stable')
+        if ( version == '4.1' ) {
+            // 4.1 is old and had a different channel scheme; ignore the prerelease-4.1 channel.
+            runFor(version, 'stable', 'latest')
+        } else {
+            runFor(version, 'fast', 'latest') // the latest links should track fast
+            runFor(version, 'fast', 'fast')
+            runFor(version, 'candidate', 'candidate')
+        }
+    }
+
+}

--- a/scheduled-jobs/maintenance/set_cincinnati_links/README.md
+++ b/scheduled-jobs/maintenance/set_cincinnati_links/README.md
@@ -1,0 +1,2 @@
+Runs periodically to keep mirror links like:
+/srv/pub/openshift-v4/x86_64/clients/ocp/stable-4.3  ->  latest release in cincinnati stable-4.3 channel


### PR DESCRIPTION
In addition to legacy function of setting `latest` and `latest-4.x` link to a specified release, this implementation allows the periodic management of links on the mirror to point links to releases in the Cincinnati graph.
Invocations which specify a channel name instead of a specific release can now be invoked.
`./set-v4-client-latest.sh fast-4.2 ocp fast any`  - means that the fast-4.2 channel should be queried for all architectures. For each arch, the latest release in Cincinnati should be linked as `fast-4.2` . If 4.2 happened to be latest MINOR version released, `fast` would also be linked to point to the release.

