### PR TITLE
Fix slacklib redefinition in release job

### DIFF
--- a/jobs/build/release/Jenkinsfile
+++ b/jobs/build/release/Jenkinsfile
@@ -4,7 +4,6 @@ import groovy.transform.Field
 node {
     checkout scm
     def release = load("pipeline-scripts/release.groovy")
-    def slacklib = load("pipeline-scripts/slacklib.groovy")
     def buildlib = release.buildlib
     def commonlib = release.commonlib
     def slacklib = commonlib.slacklib


### PR DESCRIPTION
Fixes 
```
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
WorkflowScript: 10: The current scope already contains a variable of the name slacklib
 @ line 10, column 9.
       def slacklib = commonlib.slacklib
```