### PR TITLE
Fix double class load failure

### DIFF
--- a/jobs/build/buildvm-maint/Jenkinsfile
+++ b/jobs/build/buildvm-maint/Jenkinsfile
@@ -30,6 +30,7 @@ node('openshift-build-1') {
     checkout scm
 
     def buildlib = load( "pipeline-scripts/buildlib.groovy" )
+    buildlib.initialize()
     def commonlib = buildlib.commonlib
 
     // doozer_working must be in WORKSPACE in order to have artifacts archived
@@ -37,9 +38,6 @@ node('openshift-build-1') {
     buildlib.cleanWorkdir(doozer_working)
 
     try {
-        buildlib = load('pipeline-scripts/buildlib.groovy')
-        buildlib.initialize()
-
         sshagent(["openshift-bot"]) {
 
             // Capture exceptions and don't let one problem stop other cleanup from executing


### PR DESCRIPTION
```
java.lang.LinkageError: loader (instance of  org/jenkinsci/plugins/workflow/cps/CpsGroovyShell$CleanGroovyClassLoader): attempted  duplicate class definition for name: "SlackOutputter"
```

In https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fbuildvm-maint/938/console