### PR TITLE
Advisories: Fix duplicate class error

### DIFF
--- a/jobs/build/advisories/Jenkinsfile
+++ b/jobs/build/advisories/Jenkinsfile
@@ -88,7 +88,6 @@ node {
         currentBuild.description = ""
         try {
             stage("kinit") {
-                buildlib = load("pipeline-scripts/buildlib.groovy")
                 buildlib.kinit()
             }
             stage("create rpm advisory") {


### PR DESCRIPTION
```
java.lang.LinkageError: loader (instance of  org/jenkinsci/plugins/workflow/cps/CpsGroovyShell$CleanGroovyClassLoader): attempted  duplicate class definition for name: "SlackOutputter"
```

https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fadvisories/75/console