### PR TITLE
build-sync: compare resourceVersion instead of generation

### DIFF
--- a/jobs/build/build-sync/build.groovy
+++ b/jobs/build/build-sync/build.groovy
@@ -123,9 +123,9 @@ def buildSyncApplyImageStreams() {
         writeJSON(file: "pre-apply-${theStream}.json", json: currentIS)
         artifacts.addAll(["pre-apply-${theStream}.json"])
 
-        // We check for updates by comparing the object's 'generation'
-        def currentGeneration = currentIS.metadata.generation
-        echo("Current generation for ${theStream}: ${currentGeneration}")
+        // We check for updates by comparing the object's 'resourceVersion'
+        def currentResourceVersion = currentIS.metadata.resourceVersion
+        echo("Current resourceVersion for ${theStream}: ${currentResourceVersion}")
 
         // Ok, try the update. Jack that debug output up high, just in case
         echo("Going to apply this ImageStream:")
@@ -136,9 +136,9 @@ def buildSyncApplyImageStreams() {
         def newIS = getImageStream(theStream, arch)
         writeJSON(file: "post-apply-${theStream}.json", json: newIS)
         artifacts.addAll(["post-apply-${theStream}.json"])
-        def newGeneration = newIS.metadata.generation
-        if ( newGeneration == currentGeneration ) {
-            echo("IS `.metadata.generation` has not updated, it should have updated. Please use the debug info above to report this issue")
+        def newResourceVersion = newIS.metadata.resourceVersion
+        if ( newResourceVersion == currentResourceVersion ) {
+            echo("IS `.metadata.resourceVersion` has not updated, it should have updated. Please use the debug info above to report this issue")
             throw new Exception("Image Stream ${theStream} did not update")
         }
     }


### PR DESCRIPTION
Checking for image stream updates against the objects generation may
be inaccurate. Instead check against the generation.

https://coreos.slack.com/archives/GDBRP5YJH/p1584643669046500

Justin Pierce  7 minutes ago

The generation number in an imagestream *is* something that might be
slow to update. I think checking the resourceVersion changes will be
immediate & reliable.

I think generation is set by a controller as it works to drive
consistency between desired & actual state. resourceVersion is simpler
and just indicates that a change was made.