### PR TITLE
Request upgrade tests with slack

### DIFF
--- a/jobs/build/release/Jenkinsfile
+++ b/jobs/build/release/Jenkinsfile
@@ -158,9 +158,13 @@ node {
                     testLines << "test upgrade ${from_release} ${NAME} ${mode}"
                     testIndex++
                 }
-                def slackChannel = slacklib.to('#team-art')
-                slackChannel.say("Hi @release-artists . A new release is ready and needs some upgrade tests to be triggered. "
+                try {  // don't let a slack outage break the job
+                    def slackChannel = slacklib.to('#team-art')
+                    slackChannel.say("Hi @release-artists . A new release is ready and needs some upgrade tests to be triggered. "
                         + "Please open a chat with @cluster-bot and issue each of these lines individually:\n${testLines.join('\n')}")
+                } catch(ex) {
+                    echo "slack notification failed: ${ex}"
+                }
                 currentBuild.description += "\n@cluster-bot requests:\n${testLines.join('\n')}\n"
             }
 

--- a/jobs/build/release/Jenkinsfile
+++ b/jobs/build/release/Jenkinsfile
@@ -144,6 +144,26 @@ node {
 
             stage("tag stable") { release.stageTagRelease(quay_url, release_name, dest_release_tag, arch) }
 
+            stage("request upgrade tests") {
+                def (major,minor) = extractMajorMinorVersion(NAME)
+                def previousList = PREVIOUS.trim().tokenize('\t ,')
+                def modeOptions = [ 'aws', 'gcp', 'azure,mirror' ]
+                if ( major == '4' && minor == '1') {
+                    modeOptions = ['aws'] // gcp and azure were not supported in 4.1
+                }
+                def testIndex = 0
+                def testLines = []
+                for ( String from_release : previousList) {
+                    mode = modeOptions[testIndex % modeOptions.size()]
+                    testLines << "test upgrade ${from_release} ${NAME} ${mode}"
+                    testIndex++
+                }
+                def slackChannel = slacklib.to('#team-art')
+                slackChannel.say("Hi @release-artists . A new release is ready and needs some upgrade tests to be triggered. "
+                        + "Please open a chat with @cluster-bot and issue each of these lines individually:\n${testLines.join('\n')}")
+                currentBuild.description += "\n@cluster-bot requests:\n${testLines.join('\n')}\n"
+            }
+
             stage("wait for stable") {
                 commonlib.retrySkipAbort("Waiting for stable ${release_name}",
                                         "Release ${release_name} is not currently Accepted by release controller. Issue cluster-bot requests for each upgrade test. "


### PR DESCRIPTION
Right now it seems that cluster-bot will ignore requests directly from art-bot. So notifying art-team as an intermediary until I can figure that out.