### PR TITLE
[ART-1066] add KEEP_ADVISORY_STATE option

### DIFF
--- a/jobs/build/signed-compose/Jenkinsfile
+++ b/jobs/build/signed-compose/Jenkinsfile
@@ -28,6 +28,12 @@ node {
                         defaultValue: true
                     ],
                     [
+                        name: 'KEEP_ADVISORY_STATE',
+                        description: 'Run a compose without changing the state of advisory',
+                        $class: 'BooleanParameterDefinition',
+                        defaultValue: false
+                    ],
+                    [
                         name: 'DRY_RUN',
                         description: 'Do not attach builds or update the puddle. Just show what would have happened',
                         $class: 'BooleanParameterDefinition',

--- a/jobs/build/signed-compose/build.groovy
+++ b/jobs/build/signed-compose/build.groovy
@@ -94,6 +94,10 @@ def signedComposeStateQE() {
         echo("would have run: ${elliottOpts} change-state --state QE ${advisoryOpt}")
         return
     }
+    if (params.KEEP_ADVISORY_STATE) {
+        echo("Would not change the state of adivosry since KEEP_ADVISORY_STATE was checked.")
+        return
+    }
     def seconds = 0
     retry(3) {
         sleep seconds


### PR DESCRIPTION
There was a 3.x compose I tried to generate once but it failed because the only advisory in that group was in SHIPPED_LIVE state. I think it was being referenced in ocp-build-data.

The job tried to transition it to NEW_FILES
That failed because it can't change in SHIPPED_LIVE state
The signed-compose job needs to account for erratum in this state and give a more helpful error message when it occurs. We already have the option to uncheck ATTACH_BUILDS to leave the advisory alone. Add an option KEEP_ADVISORY_STATE to make the "change to QE state" optional.

jira link
https://issues.redhat.com/browse/ART-1066
