### PR TITLE
add some failures check for tarball job

### DIFF
--- a/jobs/build/tarball-sources/Jenkinsfile
+++ b/jobs/build/tarball-sources/Jenkinsfile
@@ -82,10 +82,13 @@ node {
 
             stage("rsync") {
                 cmd = "rsync -avz --chmod=go+rX ${outdir} ${rcm_guest}"
-                commonlib.shell(
+                res = commonlib.shell(
                     script: cmd,
                     returnAll: true
                 )
+                if(res.returnStatus != 0 || res.stderr != "") {
+                    error "rsync executing failed..."
+                }
             }
 
             stage("file ticket to RCM") {


### PR DESCRIPTION
seems even if I use 
```
returnStatus: true
```
it still not going into this error check section https://github.com/openshift/aos-cd-jobs/blob/2ba7c25aa40aa08db65f232c46885342d8871612/pipeline-scripts/commonlib.groovy#L279

so explicitly add some check: https://localhost:8888/job/hack/job/shiywang-aos-cd-jobs/job/build%252Ftarball-sources/119/console
