### PR TITLE
Add 4.6 puddle configs

### DIFF
--- a/build-scripts/puddle-conf/atomic_openshift-4.6.conf
+++ b/build-scripts/puddle-conf/atomic_openshift-4.6.conf
@@ -1,0 +1,17 @@
+[puddle]
+type = simple
+rootdir = /mnt/rcm-guest/puddles/RHAOS
+mashroot = /mnt/rcm-guest/puddles/RHAOS/mash
+brewroot = file:///mnt/redhat/brewroot
+topurl = http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/
+name = AtomicOpenShift
+version = 4.6
+emails = aos-devel@redhat.com,aos-qe@redhat.com
+announcer = openshift-puddle <aos-devel@redhat.com>
+publish = no
+external = /mnt/redhat/brewroot/repos/rhel-7-build/latest/$arch/
+tag = rhaos-4.6-rhel-7-candidate
+arches = x86_64,ppc64le,aarch64,s390x
+keys = fd431d51,f21541eb
+variant = Server-RH7-RHOSE-4.6
+blacklist = thrift-glib, thrift-qt, v8-python

--- a/build-scripts/puddle-conf/atomic_openshift-4.6.el8.conf
+++ b/build-scripts/puddle-conf/atomic_openshift-4.6.el8.conf
@@ -1,0 +1,17 @@
+[puddle]
+type = simple
+rootdir = /mnt/rcm-guest/puddles/RHAOS
+mashroot = /mnt/rcm-guest/puddles/RHAOS/mash
+brewroot = file:///mnt/redhat/brewroot
+topurl = http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/
+name = AtomicOpenShift
+version = 4.6-el8
+emails = aos-devel@redhat.com,aos-qe@redhat.com
+announcer = openshift-puddle <aos-devel@redhat.com>
+publish = no
+external = /mnt/redhat/brewroot/repos/rhel-8-build/latest/$arch/
+tag = rhaos-4.6-rhel-8-candidate
+arches = x86_64,ppc64le,aarch64,s390x
+keys = fd431d51,f21541eb
+variant = Server-RH8-RHOSE-4.6
+blacklist = thrift-glib, thrift-qt, v8-python

--- a/build-scripts/puddle-conf/errata-puddle-4.6-signed.el7.conf
+++ b/build-scripts/puddle-conf/errata-puddle-4.6-signed.el7.conf
@@ -1,0 +1,18 @@
+[puddle]
+type = simple
+rootdir = /mnt/rcm-guest/puddles/RHAOS
+mashroot = /mnt/rcm-guest/puddles/RHAOS/mash
+brewroot = file:///mnt/redhat/brewroot
+topurl = http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/
+name = AtomicOpenShift-signed
+version = 4.6
+emails = aos-team-art@redhat.com
+announcer = openshift-puddle <aos-team-art@redhat.com>
+publish = no
+external = /mnt/redhat/brewroot/repos/rhel-7-build/latest/$arch/
+arches = x86_64,ppc64le,aarch64,s390x
+keys = fd431d51,f21541eb
+signed = yes
+blacklist = thrift-glib, thrift-qt, v8-python
+tag = rhaos-4.6-rhel-7-image-build
+variant = RHOSE-4.6

--- a/build-scripts/puddle-conf/errata-puddle-4.6-signed.el8.conf
+++ b/build-scripts/puddle-conf/errata-puddle-4.6-signed.el8.conf
@@ -1,0 +1,18 @@
+[puddle]
+type = simple
+rootdir = /mnt/rcm-guest/puddles/RHAOS
+mashroot = /mnt/rcm-guest/puddles/RHAOS/mash
+brewroot = file:///mnt/redhat/brewroot
+topurl = http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/
+name = AtomicOpenShift-signed
+version = 4.6-el8
+emails = aos-team-art@redhat.com
+announcer = openshift-puddle <aos-team-art@redhat.com>
+publish = no
+external = /mnt/redhat/brewroot/repos/rhel-8-build/latest/$arch/
+arches = x86_64,ppc64le,aarch64,s390x
+keys = fd431d51,f21541eb
+signed = yes
+blacklist = thrift-glib, thrift-qt, v8-python
+tag = rhaos-4.6-rhel-8-image-build
+variant = RHOSE-4.6


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-1632

This was based off the example in the template card on JIRA which references https://github.com/openshift/aos-cd-jobs/pull/1974/files

Note that one of the files in there doesn't exist anymore, `build-scripts/puddle-conf/errata-puddle-4.3-signed.conf`. In 8389eaaf6436149288f427c19b00d0cc528f10af @sosiouxme removed many of the signed files because:

> Now that we no longer build composes directly from errata, but instead from a tag, these are obsolete.