### PR TITLE
[ART-1774] appregistry: don't treat timeout as a retry-able error

### DIFF
--- a/jobs/build/appregistry/appregistry.groovy
+++ b/jobs/build/appregistry/appregistry.groovy
@@ -259,6 +259,10 @@ def pushToOMPSWithRetries(token, metadata_nvr) {
                     response_status: response.status,
                     response_content: response.content,
                 ].toString())
+            } catch (org.jenkinsci.plugins.workflow.steps.FlowInterruptedException e) {
+                // This probably means we got a timeout or user abort *during* the request. We don't want to retry.
+                err = e
+                throw err
             } catch (e) {
                 // could also fail because of some error other than bad response
                 err = e


### PR DESCRIPTION
pretty sure this is what is making appregistry wait forever occasionally; if the timeout occurs during an OMPS request it's treated as an exception... which is caught, and retried. there is no second timeout so it retries forever (until something else goes wrong or CVP completes).

running at https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/lmeyer/job/lmeyer-dev/job/dev-build%252Fappregistry/44/