### PR TITLE
Cincinnati PR opening changes

### DIFF
--- a/jobs/build/cincinnati-prs/Jenkinsfile
+++ b/jobs/build/cincinnati-prs/Jenkinsfile
@@ -1,0 +1,49 @@
+#!/usr/bin/env groovy
+
+node {
+    checkout scm
+    def release = load("pipeline-scripts/release.groovy")
+    def commonlib = release.commonlib
+
+    // Expose properties for a parameterized build
+    properties(
+        [
+            buildDiscarder(
+                logRotator(
+                    artifactDaysToKeepStr: '',
+                    artifactNumToKeepStr: '',
+                    daysToKeepStr: '',
+                    numToKeepStr: '500')),
+            [
+                $class: 'ParametersDefinitionProperty',
+                parameterDefinitions: [
+                    [
+                        name: 'RELEASE_NAME',
+                        description: 'The name of the release to add to Cincinnati via PRs',
+                        $class: 'hudson.model.StringParameterDefinition',
+                        defaultValue: ""
+                    ],
+                    [
+                        name: 'ADVISORY_NUM',
+                        description: 'Internal advisory number for release (i.e. https://errata.devel.redhat.com/advisory/??????)',
+                        $class: 'hudson.model.StringParameterDefinition',
+                        defaultValue: ""
+                    ],
+                    [
+                        name: 'GITHUB_ORG',
+                        description: 'The github org containing cincinnati-graph-data fork to open PRs against (use for testing)',
+                        $class: 'hudson.model.StringParameterDefinition',
+                        defaultValue: "openshift"
+                    ],
+                    commonlib.mockParam(),
+                ]
+            ],
+            disableResume(),
+            disableConcurrentBuilds()
+        ]
+    )
+
+    commonlib.checkMock()
+    release.openCincinnatiPRs(params.RELEASE_NAME.trim(), params.ADVISORY_NUM.trim(), params.GITHUB_ORG.trim())
+    buildlib.cleanWorkdir("${env.WORKSPACE}")
+}

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -382,7 +382,7 @@ def inputRequired(cl) {
     }
 }
 
-def _retryWithOptions(goal, options, prompt='', slackOutput=null, cl) {
+def _retryWithOptions(goal, options, slackOutput=null, prompt='', cl) {
     def success = false
     if (!slackOutput) {
         slackOutput = slacklib.to(null)
@@ -432,12 +432,12 @@ def _retryWithOptions(goal, options, prompt='', slackOutput=null, cl) {
     }
 }
 
-def retrySkipAbort(goal, prompt='', slackOutput=null, cl) {
-    _retryWithOptions(goal, ['RETRY', 'SKIP', 'ABORT'], prompt, slackOutput, cl)
+def retrySkipAbort(goal, slackOutput=null, prompt='', cl) {
+    _retryWithOptions(goal, ['RETRY', 'SKIP', 'ABORT'], slackOutput, prompt, cl)
 }
 
-def retryAbort(goal, prompt='', slackOutput=null, cl) {
-    _retryWithOptions(goal, ['RETRY', 'ABORT'], prompt, slackOutput, cl)
+def retryAbort(goal, slackOutput=null, prompt='', cl) {
+    _retryWithOptions(goal, ['RETRY', 'ABORT'], slackOutput, prompt, cl)
 }
 
 return this


### PR DESCRIPTION
- OTA has requested that the link provided be the internal errata tool URL (since the live-id doesn't show anything until the advisory ships) and that we do not put the advisory information in the YAML.
- OTA also asked that we only create the PRs after x86_64 release is accepted by release controller. 
- Extract PR opening into separately runnable job