### PR TITLE
Generate 'releases' for send-umb-message from commonlib.ocp4Versions

### DIFF
--- a/jobs/build/send-umb-messages/Jenkinsfile
+++ b/jobs/build/send-umb-messages/Jenkinsfile
@@ -19,7 +19,7 @@ node {
     ])
 
     // we only care to publish messages for the following releases
-    releases = ["4-stable", "4.6.0-0.nightly", "4.5.0-0.nightly", "4.4.0-0.nightly", "4.3.0-0.nightly", "4.2.0-0.nightly", "4.1.0-0.nightly"]
+    releases = commonlib.ocp4SendUMBVersions
     currentBuild.description = ""
     currentBuild.displayName = ""
 

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -16,6 +16,12 @@ ocp4Versions = [
     "4.1",
 ]
 
+// Send UMB messages for these new nightlies, yields a list like:
+//
+//     [4-stable, 4.1.0-0.nightly, 4.2.0-0.nightly, 4.3.0-0.nightly, ...]
+ocp4SendUMBVersions = ocp4Versions.collect([]) { it + ".0-0.nightly" }
+ocp4SendUMBVersions.add(0, "4-stable")
+
 // Which versions should undergo merges from origin->ose
 ocpMergeVersions = [
     "4.5",

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -19,8 +19,7 @@ ocp4Versions = [
 // Send UMB messages for these new nightlies, yields a list like:
 //
 //     [4-stable, 4.1.0-0.nightly, 4.2.0-0.nightly, 4.3.0-0.nightly, ...]
-ocp4SendUMBVersions = ocp4Versions.collect([]) { it + ".0-0.nightly" }
-ocp4SendUMBVersions.add(0, "4-stable")
+ocp4SendUMBVersions = ocp4Versions.collect(["4-stable"]) { it + ".0-0.nightly" }
 
 // Which versions should undergo merges from origin->ose
 ocpMergeVersions = [


### PR DESCRIPTION
Discovered during 4.6 branch cut when we accidentally missed adding
4.6 to the send-umb-message job