### PR TITLE
some small error message updates

### DIFF
--- a/jobs/build/signed-compose/build.groovy
+++ b/jobs/build/signed-compose/build.groovy
@@ -102,7 +102,7 @@ def signedComposeStateQE() {
     retry(3) {
         sleep seconds
         seconds = seconds + 30
-        out = buildlib.elliott("${elliottOpts} change-state --state QE ${advisoryOpt}")
+        out = buildlib.elliott("${elliottOpts} change-state --state QE ${advisoryOpt}", [capture: true])
         echo("${out}")
     }
 }

--- a/jobs/build/signed-compose/build.groovy
+++ b/jobs/build/signed-compose/build.groovy
@@ -102,7 +102,8 @@ def signedComposeStateQE() {
     retry(3) {
         sleep seconds
         seconds = seconds + 30
-        buildlib.elliott("${elliottOpts} change-state --state QE ${advisoryOpt}")
+        out = buildlib.elliott("${elliottOpts} change-state --state QE ${advisoryOpt}")
+        echo("${out}")
     }
 }
 


### PR DESCRIPTION
@sosiouxme  since I updated elliott PR, https://github.com/openshift/elliott/pull/126 I think it is good already since the error message in here https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fsigned-compose/51/ is obvious enough with new error message, but I print it out here as well, since this common.shell() function is always bizarre to me those sh.out.txt is the where we save the error message not err.txt and same as the function and redirect mechanism I discovered in this PR https://github.com/openshift/aos-cd-jobs/pull/2190#issue-404272862, not fully understand the logic... 
