### PR TITLE
Expect None `tag_res` on signed-compose job

### DIFF
--- a/jobs/build/signed-compose/ocp-tag-signed-errata-builds.py
+++ b/jobs/build/signed-compose/ocp-tag-signed-errata-builds.py
@@ -72,7 +72,7 @@ def tag_builds(koji_proxy, tag, nvrs, tagged_builds, test=False):
             time.sleep(30)
         print()
         tag_res = koji_proxy.getTaskResult(task_id, raise_fault=False)
-        if 'faultCode' in tag_res:
+        if tag_res and 'faultCode' in tag_res:
             print('Failed tagging task! {}\n{}'.format(task_id, tag_res))
             task_failures = True
 


### PR DESCRIPTION
This week I got several signed-compose job failures because `tag_res` was `None`:

```
Traceback (most recent call last):
  File "./ocp-tag-signed-errata-builds.py", line 389, in <module>
Waiting for task 28376015 to finish
.
    main()
  File "./ocp-tag-signed-errata-builds.py", line 385, in main
    tag_builds(koji_proxy, opts.brew_pending_tag, missing, tagged_builds, test=opts.test)
  File "./ocp-tag-signed-errata-builds.py", line 75, in tag_builds
    if 'faultCode' in tag_res:
TypeError: argument of type 'NoneType' is not iterable

----------------------------------------

Finished: FAILURE
```