### PR TITLE
Advisories improvements

### DIFF
--- a/jobs/build/advisories/Jenkinsfile
+++ b/jobs/build/advisories/Jenkinsfile
@@ -215,7 +215,7 @@ node {
                         cmd += "sed -e 's/freeze_automation:.*/freeze_automation: no/' -i group.yml ; "
                     }
                     if (params.ENABLE_ARCH_OVERRIDE) {
-                        cmd += "gawk --include inplace '/^#? *arches_override:$/{flag=1;print \$NF;next}; NF<=1{flag=0}; flag {print $(NF-1), \$NF;next}; 1'"
+                        cmd += '''gawk --include inplace '/^#? *arches_override:$/{flag=1;print $NF;next}; NF<=1{flag=0}; flag {print $(NF-1), $NF;next}; 1' '''
                     }
                     cmd += """
                         git diff ;

--- a/jobs/build/advisories/Jenkinsfile
+++ b/jobs/build/advisories/Jenkinsfile
@@ -234,6 +234,27 @@ node {
                         )
                     }
                     echo "out: ${out}"
+
+                    jira_cmd = """
+                    if command -v yq; then
+                      rm -rf ocp-build-data;
+                      git clone --single-branch --branch openshift-${params.VERSION} git@github.com:openshift/ocp-build-data.git;
+                      cd ocp-build-data;
+                      yq -r '
+                        .advisories
+                        | keys_unsorted[] as \$k
+                        | "* *\\(\$k)*: https://errata.devel.redhat.com/advisory/\\(.[\$k])"
+                      ' group.yml;
+                    fi || true
+                    """
+                    try {
+                        commonlib.shell(
+                            returnStdout: true,
+                            script: jira_cmd
+                        )
+                    } catch (err) {
+                        echo "Ignoring error ${err}"
+                    }
                 }
             }
             stage("trigger full build") {

--- a/jobs/build/advisories/Jenkinsfile
+++ b/jobs/build/advisories/Jenkinsfile
@@ -35,6 +35,11 @@ node {
                             description: "Uncomment arch_override section if it exists",
                             defaultValue: true
                         ),
+                        booleanParam(
+                            name: "TRIGGER_FULL_BUILD",
+                            description: "Trigger full build",
+                            defaultValue: true
+                        ),
                         string(
                             name: "ASSIGNED_TO",
                             description: "Advisories are assigned to QE",
@@ -229,6 +234,23 @@ node {
                         )
                     }
                     echo "out: ${out}"
+                }
+            }
+            stage("trigger full build") {
+                try {
+                    if (params.TRIGGER_FULL_BUILD) {
+                        build(
+                            job: "../aos-cd-builds/build%2F${params.VERSION}",
+                            propagate: false,
+                            wait: false,
+                            parameters: [
+                                string(name: 'NEW_VERSION', value: '')
+                                booleanParam(name: 'FORCE_BUILD', value: true),
+                            ],
+                        )
+                    }
+                } catch (err) {
+                    echo "Could not trigger full build. Ignoring. Error: ${err}"
                 }
             }
             stage("add placeholder bugs to advisories") {

--- a/jobs/build/advisories/Jenkinsfile
+++ b/jobs/build/advisories/Jenkinsfile
@@ -30,6 +30,11 @@ node {
                             description: "Unfreeze automation to enable building and sweeping into the new advisories",
                             defaultValue: true
                         ),
+                        booleanParam(
+                            name: "ENABLE_ARCH_OVERRIDE",
+                            description: "Uncomment arch_override section if it exists",
+                            defaultValue: true
+                        ),
                         string(
                             name: "ASSIGNED_TO",
                             description: "Advisories are assigned to QE",
@@ -190,7 +195,9 @@ node {
                         rm -rf ocp-build-data ;
                         git clone --single-branch --branch openshift-${params.VERSION} git@github.com:openshift/ocp-build-data.git ;
                         cd ocp-build-data ;
-                        sed -E -e 's/^  image: [0-9]+\$/  image: ${image_advisory_id}/' -e 's/^  rpm: [0-9]+\$/  rpm: ${rpm_advisory_id}/' -i group.yml ;
+                        sed -E -e 's/^  image: [0-9]+\$/  image: ${image_advisory_id}/' \
+                               -e 's/^  rpm: [0-9]+\$/  rpm: ${rpm_advisory_id}/' \
+                        -i group.yml ;
                     """
                     if (params.VERSION.startsWith("4")) {
                         cmd += """
@@ -201,6 +208,9 @@ node {
                     }
                     if (params.ENABLE_AUTOMATION) {
                         cmd += "sed -e 's/freeze_automation:.*/freeze_automation: no/' -i group.yml ; "
+                    }
+                    if (params.ENABLE_ARCH_OVERRIDE) {
+                        cmd += "gawk --include inplace '/^#? *arches_override:$/{flag=1;print \$NF;next}; NF<=1{flag=0}; flag {print $(NF-1), \$NF;next}; 1'"
                     }
                     cmd += """
                         git diff ;


### PR DESCRIPTION
Various small improvements, see individual commits for details

**uncomment arch_override**
When prepping a new release, generally the extra arches should get enabled again. This is automation of a manual step. I believe our tooling should get better in understanding when to build extra arches and when not, yet until that time...

**optionally trigger full build**
When experimental arches are enabled again, image builds are expected when there is a parent-child relation between images, and a child image gets built because of automation. This ensures a full image build is started, is not waited on, to help with the process. (Not tested, I expect to need to make changes here.)

**parse out jira text**
I spend some time updating the release jira texts with links to advisories. This blurps a pastable text into the build log.