### PR TITLE
Leverage auto-signing capability

### DIFF
--- a/build-scripts/plashet.py
+++ b/build-scripts/plashet.py
@@ -1,0 +1,440 @@
+#!/usr/bin/python3
+
+import click
+import xmlrpc.client as xmlrpclib
+import os
+import pathlib
+from kobo.rpmlib import parse_nvr
+import koji
+import logging
+import requests
+import ssl
+import time
+from requests_kerberos import HTTPKerberosAuth
+from types import SimpleNamespace
+
+BREW_URL = "https://brewhub.engineering.redhat.com/brewhub"
+ERRATA_URL = "http://errata-xmlrpc.devel.redhat.com/errata/errata_service"
+ERRATA_API_URL = "https://errata.engineering.redhat.com/api/v1/"
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger()
+
+
+def mkdirs(path, mode=0o755):
+    """
+    Make sure a directory exists. Similar to shell command `mkdir -p`.
+    :param path: Str path
+    :param mode: create directories with mode
+    """
+    pathlib.Path(str(path)).mkdir(mode=mode, parents=True, exist_ok=True)
+
+
+def update_advisory_builds(config, errata_proxy, advisory_id, nvrs, nvr_product_version):
+    """
+    Attempts to get a specific set of RPM nvrs attached to an advisory
+    :param errata_proxy: proxy
+    :param advisory_id: The advisory to modify (should be in NEW_FILES)
+    :param product_version: Product version to attach RPMs for (e.g. RHEL-7-OSE-4.5)
+    :param nvrs: A list of RPM nvrs
+    :param nvr_product_version: A map of nvr->product_version
+    :return: n/a
+    Exception thrown if there is an error.
+    """
+    desired_nvrs = set(nvrs)
+    errata_nvrs = set()
+    for build in errata_proxy.getErrataBrewBuilds(advisory_id):
+        nvr = build["brew_build_nvr"]
+        errata_nvrs.add(nvr)
+
+    to_remove = errata_nvrs.difference(desired_nvrs)
+    to_add = desired_nvrs.difference(errata_nvrs)
+
+    logger.info(f'Found currently attached to advisory: {to_remove}')
+    logger.info(f'Found not attached to advisory: {to_add}')
+
+    auth = HTTPKerberosAuth()
+    for nvr in to_remove:
+        remove_nvr_payload = {
+            'nvr': nvr,
+        }
+        res = requests.post(f'{ERRATA_API_URL}/erratum/{advisory_id}/remove_build',
+                            verify=ssl.get_default_verify_paths().openssl_cafile,
+                            auth=auth,
+                            json=remove_nvr_payload,
+                            )
+        if res.status_code not in (200, 201):
+            logger.error(f'Error remove build from advisory: {res.content}')
+            raise IOError(f'Unable to remove nvr from advisory {advisory_id}: {nvr}')
+
+    add_builds_payload = []
+    for nvr in to_add:
+        parsed_nvr = parse_nvr(nvr)
+        package_name = parsed_nvr["name"]
+
+        if package_name in config.exclude_package:
+            logger.info(f'Skipping advisory attach for excluded package: {nvr}')
+            continue
+
+        add_builds_payload.append({
+            "product_version": nvr_product_version[nvr],
+            "build": nvr,
+            "file_types": ['rpm']
+        })
+
+    if add_builds_payload:
+        res = requests.post(f'{ERRATA_API_URL}/erratum/{advisory_id}/add_builds',
+                            verify=ssl.get_default_verify_paths().openssl_cafile,
+                            auth=HTTPKerberosAuth(),
+                            json=add_builds_payload,
+                            )
+
+        if res.status_code not in (201, 200):
+            logger.error(f'Error attaching builds to advisory')
+            logger.error(f'Request: {add_builds_payload}')
+            logger.error(f'Response {res.status_code}: {res.content}')
+            raise IOError(f'Unable to add nvrs to advisory {advisory_id}: {to_add}')
+
+
+def assemble_repo(config, nvrs):
+    """
+    Assembles one or more architecture specific repos in the
+    dest_dir with the specified nvrs. It is expected by the time this method
+    is called that all RPMs are signed if any of those arches requires signing.
+    :param config: cli config
+    :param nvrs: a list of nvrs to include.
+    :return: n/a
+    An exception will be thrown if no RPMs can be found matching an nvr.
+    """
+
+    for arch_name, signing_mode in config.arch:
+        # These directories shouldn't exist yet. They will be created during assemble.
+        dest_arch_path = os.path.join(config.dest_dir, arch_name)
+        if config.repo_subdir:
+            dest_arch_path += '/' + config.repo_subdir.strip('/')  # strip / from start and end
+        links_dir = os.path.join(dest_arch_path, 'Packages')
+        rpm_list_path = os.path.join(dest_arch_path, 'rpm_list')
+        mkdirs(links_dir)
+
+        # Each arch will have its own yum repo & thus needs its own rpm_list
+        with open(rpm_list_path, mode='w+') as rl:
+
+            for nvr in nvrs:
+                matched_count = 0
+
+                parsed_nvr = parse_nvr(nvr)
+                package_name = parsed_nvr["name"]
+
+                if package_name in config.exclude_package:
+                    logger.info(f'Skipping repo addition for excluded package: {nvr}')
+                    continue
+
+                signed = (signing_mode == 'signed')
+                br_arch_base_path = get_brewroot_arch_base_path(config, nvr, signed)
+
+                # Include noarch in each arch specific repo.
+                include_arches = [arch_name, 'noarch']
+                for a in include_arches:
+                    brewroot_arch_path = os.path.join(br_arch_base_path, a)
+
+                    if not os.path.isdir(brewroot_arch_path):
+                        logger.debug(f'No {a} arch directory for {nvr}')
+                        continue
+
+                    logger.info(f'Found {"signed" if signed else "unsigned"} {a} arch directory for {nvr}')
+                    link_name = '{nvr}__{arch}'.format(
+                        nvr=nvr,
+                        arch=a,
+                    )
+                    if signed:
+                        link_name += f'__{config.signing_key_id}'
+
+                    package_link_path = os.path.join(links_dir, link_name)
+                    os.symlink(brewroot_arch_path, package_link_path)
+
+                    rpms = os.listdir(package_link_path)
+                    if not rpms:
+                        raise IOError('Did not find any rpms in {}'.format(brewroot_arch_path))
+
+                    for r in rpms:
+                        rpm_path = os.path.join('Packages', link_name, r)
+                        rl.write(rpm_path + '\n')
+                        matched_count += 1
+
+                if not matched_count:
+                    logger.warning("Unable to find any {arch} rpms for {nvr} in {p} ; this may be ok if the package doesn't support the arch and it is not required for that arch".format(
+                                       arch=arch_name, nvr=nvr, p=get_brewroot_arch_base_path(config, nvr, signed)))
+
+        if os.system('cd {repo_dir} && createrepo -i rpm_list .'.format(repo_dir=dest_arch_path)) != 0:
+            raise IOError('Error creating repo at: {repo_dir}'.format(repo_dir=dest_arch_path))
+
+        print('Successfully created repo at: {repo_dir}'.format(repo_dir=dest_arch_path))
+
+
+def get_brewroot_arch_base_path(config, nvr, signed):
+    """
+    :param config: Base cli config object
+    :param nvr: Will return the base directory under which the arch directories should exist.
+    :param signed: If True, the base directory under which signed arch directories should exit.
+    An exception will be raised if the nvr cannot be found unsigned in the brewroot as this
+    indicates the nvr has not been built.
+    """
+    parsed_nvr = parse_nvr(nvr)
+    package_name = parsed_nvr["name"]
+    package_version = parsed_nvr["version"]
+    package_release = parsed_nvr["release"]
+
+    unsigned_arch_base_path = '{brew_packages}/{package_name}/{package_version}/{package_release}'.format(
+            brew_packages=config.packages_path,
+            package_name=package_name,
+            package_version=package_version,
+            package_release=package_release,
+    )
+
+    if not os.path.isdir(unsigned_arch_base_path):
+        raise IOError(f'Unable to find {nvr} in brewroot filesystem: {unsigned_arch_base_path}')
+
+    if not signed:
+        return unsigned_arch_base_path
+    else:
+        return '{unsigned_arch_path}/data/signed/{signing_key_id}'.format(
+            unsigned_arch_path=unsigned_arch_base_path,
+            signing_key_id=config.signing_key_id,
+        )
+
+
+def is_signed(config, nvr):
+    """
+    :param config: cli config object
+    :param nvr: The nvr to check
+    :return: Returns whether the specified nvr is signed with the signing key id. An exception
+    will be raise if the nvr can't be found at all in the brew root (i.e. unsigned can't be found).
+    """
+    return os.path.isdir(get_brewroot_arch_base_path(config, nvr, True))
+
+
+def signed_desired(config):
+    """
+    :param config: The cli config.
+    :return: Returns True if any of the arches specified on the command line require signing.
+    """
+    for a, mode in config.arch:
+        if mode == 'signed':
+            return True
+        if mode != 'unsigned':
+            raise IOError(f'Unexpected signing mode for arch {a} (must be signed or unsigned): {mode}')
+
+
+def assert_signed(config, nvr, poll_for=15):
+    """
+    Raises an exception if the nvr has not been specified by the config signing key.
+    :param config: The cli config
+    :param nvr: The nvr to check
+    :param poll_for: The number of minutes to continue checking until an exception is raised.
+    :return: number of minutes used for polling during successful wait for signing
+    """
+    time_used = 0
+    while not is_signed(config, nvr):
+        if poll_for <= 0:
+            br_arch_base_path = get_brewroot_arch_base_path(config, nvr, True)
+            logger.info('Package {nvr} has not been signed; {signed_path} does not exist'.format(
+                nvr=nvr,
+                signed_path=br_arch_base_path,
+            ))
+            raise IOError('Package {nvr} has not been signed; {signed_path} does not exist'.format(
+                nvr=nvr,
+                signed_path=br_arch_base_path,
+            ))
+        print(f'Waiting for up to {poll_for} more minutes')
+        poll_for -= 1
+        time_used += 1
+        time.sleep(60)
+    return time_used
+
+
+@click.group()
+@click.pass_context
+@click.option('--base-dir', default=os.getcwd(),
+              help='Parent directory for repo directory. Defaults to current working directory.')
+@click.option('--name', metavar='NAME', required=True, help='Directory name to create relative to base directory.')
+@click.option('--repo-subdir', metavar='REL_PATH', required=False, help='Directory under each arch repo to create yum repo (e.g. "os" will create x86_64/os/repodata)')
+@click.option('--signing-key-id', required=False, metavar='HEX',
+              help='Signing key to require for signed arches if you fd431d51 is not desired.')
+@click.option('--arch', multiple=True, metavar='ARCH <signed|unsigned>',
+              required=True, nargs=2,
+              help='For each arch to include in the plashet. Each arch will be a repo beneath the plashet dir.')
+@click.option('--errata-xmlrpc-url', default=ERRATA_URL, help='The errata xmlrpmc url')
+@click.option('--brew-root', metavar='PATH', default='/mnt/redhat/brewroot', help='Filesystem location of brew root')
+@click.option('--brew-url', metavar='URL', default=BREW_URL, help='Override default brew API url')
+@click.option('-x', '--exclude-package', metavar='NAME',
+              multiple=True, default=[], help='Exclude one or more package names')
+def cli(ctx, base_dir, brew_root, name, signing_key_id, **kwargs):
+    """
+    Creates a directory contining one or more arch specific yum repositories by using local
+    symlinks to a brewroot filesystem location. This avoids network transfer time.
+
+    If you need to transfer the resultant repo to a mirror which does not have a
+    brewroot (e.g. the openshift mirrors), using rsync --copy-links. If you are transferring
+    the repo to a system with a brewroot filesystem (e.g. rcm-guest), preserve the
+    links (using --links) and the transfer should be extremely quick.
+
+    You must specify one or more --arch parameters. For each architecture, you can
+    request that it contain signed or unsigned RPMs in the result arch repository.
+
+    \b
+    Example invocations:
+    $ ./plashet.py
+        --base-dir /some/base/dir --name my_plashet
+        --repo-subdir os
+        --arch x86_64 signed  --arch s390x unsigned
+        from-tags -t rhaos-4.4-rhel-7-candidate RHEL-7-OSE-4.4 --signing-advisory-id 54765
+
+        \b
+        This preceding command will make:
+            /some/base/dir/my_plashet/x86_64/os  - with signed RPMs (any unsigned RPMs will be signed using 54765)
+            and
+            /some/base/dir/my_plashet/xs390x/os  - with unsigned RPMs
+
+    \b
+    $ ./plashet.py
+        --name my_repo
+        --arch x86_64 unsigned  --arch s390x unsigned
+        from-advisories --advisory-id 54701
+    """
+
+    brew_root_path = os.path.abspath(brew_root)
+    packages_path = os.path.join(brew_root_path, 'packages')
+    if not os.path.isdir(packages_path):
+        print('{} does not exist; unable to start'.format(packages_path))
+        exit(1)
+
+    base_dir_path = os.path.abspath(base_dir)
+    mkdirs(base_dir_path)
+
+    dest_dir = os.path.join(base_dir_path, name)
+    if os.path.exists(dest_dir):
+        print('Destination {} already exists; name must be unique'.format(dest_dir))
+        exit(1)
+
+    ctx.obj = SimpleNamespace(base_dir=base_dir,
+                              brew_root=brew_root,
+                              name=name,
+                              brew_root_path=brew_root_path,
+                              packages_path=packages_path,
+                              base_dir_path=base_dir_path,
+                              dest_dir=dest_dir,
+                              signing_key_id=signing_key_id if signing_key_id else 'fd431d51',
+                              **kwargs)
+
+
+@cli.command('from-tags', short_help='Collects a set of RPMs from specified brew tags -- signing if necessary.')
+@click.pass_obj
+@click.option('-t', '--brew-tag', multiple=True, required=True, nargs=2, help='One or more brew tags whose RPMs should be included in the repo; format is: <tag> <product_version>')
+@click.option('--signing-advisory-id', required=False, help='Use this auto-signing advisory to sign RPMs if necessary.')
+@click.option('--signing-advisory-mode', required=False, default="clean", type=click.Choice(['leave', 'clean'], case_sensitive=False),
+              help='clean=remove all builds on start and successful exit; leave=leave builds attached which the invocation attempted to sign')
+@click.option('--poll-for', default=15, type=click.INT, help='Allow up to this number of minutes for auto-signing')
+@click.option('--event', required=False, help='The brew event for the desired tag states')
+def from_tags(config, brew_tag, signing_advisory_id, signing_advisory_mode, poll_for, event):
+    """
+    The repositories are filled with RPMs derived from the list of
+    brew tags. If the RPMs are not signed and a repo should contain signed content,
+    the specified advisory will be used for signing the RPMs (requires
+    automatic sign on attach).
+
+    \b
+    --brew-tag <tag> <product_version> example: --brew-tag rhaos-4.5-rhel-8-candidate OSE-4.5-RHEL-8 --brew-tag .. ..
+    """
+
+    koji_proxy = koji.ClientSession(config.brew_url, opts={'krbservice': 'brewhub'})
+    koji_proxy.gssapi_login()
+    errata_proxy = xmlrpclib.ServerProxy(config.errata_xmlrpc_url)
+
+    desired_nvrs = set()
+    nvr_product_version = {}
+    for tag, product_version in brew_tag:
+        for build in koji_proxy.listTagged(tag, latest=True, inherit=False, event=event):
+
+            if build['package_name'] in config.exclude_package:
+                logger.info(f'Skipping tagged but excluded package: {nvr}')
+                continue
+
+            # Make sure this is an RPM
+            # e.g. node-maintenance-operator-bundle is a docker tar
+            if not build['package_name'].endswith(('-container', '-apb', '-bundle')):
+                nvr = build['nvr']
+                logger.info(f'{tag} contains rpm: {nvr}')
+                desired_nvrs.add(nvr)
+                nvr_product_version[nvr] = product_version
+
+    if signing_advisory_id and signing_advisory_mode == 'clean':
+        # Remove all builds attached to advisory before attempting signing
+        update_advisory_builds(config, errata_proxy, signing_advisory_id, [], nvr_product_version)
+
+    # Did any of the archs require signed content?
+    possible_signing_needed = signed_desired(config)
+
+    if possible_signing_needed:
+        logger.info(f'At least one architecture requires signed nvrs')
+
+        if signing_advisory_id:
+            nvrs_for_advisory = []
+
+            for nvr in desired_nvrs:
+                if not is_signed(config, nvr):
+                    logger.info(f'Found an unsigned nvr (will attempt to signed): {nvr}')
+                    nvrs_for_advisory.append(nvr)
+
+            logger.info(f'Updating advisory to get nvrs signed: {signing_advisory_id}')
+            update_advisory_builds(config, errata_proxy, signing_advisory_id, nvrs_for_advisory, nvr_product_version)
+
+        else:
+            logger.warning('No signing advisory specified; will simply poll and hope')
+
+        # Whether we've attached to advisory or no, wait until signing require is met
+        # or throw exception on timeout.
+        logger.info('Waiting for all nvrs to be signed..')
+        for nvr in desired_nvrs:
+            poll_for -= assert_signed(config, nvr)
+
+    if signing_advisory_id and signing_advisory_mode == 'clean':
+        # Seems that everything is signed; remove builds from the advisory.
+        update_advisory_builds(config, errata_proxy, signing_advisory_id, [], nvr_product_version)
+
+    assemble_repo(config, desired_nvrs)
+
+
+@cli.command('from-advisories', short_help='Collects a set of RPMs attached to specified advisories.')
+@click.pass_obj
+@click.option('-a', '--advisory-id', multiple=True, required=True, help='Advisories to check')
+@click.option('--poll-for', default=0, type=click.INT, help='Allow up to this number of minutes for signing')
+@click.option('--module-builds', default=False)
+def from_advisories(config, advisory_id, module_builds, poll_for):
+    """
+    Creates a directory containing arch specific yum repository subdirectories based on RPMs
+    attached to one or more advisories.
+    """
+    errata_proxy = xmlrpclib.ServerProxy(config.errata_xmlrpc_url)
+
+    nvrs = set()
+    for id in advisory_id:
+        for build in errata_proxy.getErrataBrewBuilds(id):
+            nvr = build["brew_build_nvr"]
+            is_module = build["is_module"]
+
+            if module_builds and not is_module:
+                continue
+
+            if not module_builds and is_module:
+                continue
+
+            if signed_desired(config):
+                poll_for -= assert_signed(config, nvr, poll_for=poll_for)
+
+            nvrs.add(nvr)
+
+    assemble_repo(config, nvrs)
+
+
+if __name__ == '__main__':
+    cli()

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -22,15 +22,15 @@ buildPlan = [
     buildRpms: false,
     rpmsIncluded: "", // comma-separated list
     rpmsExcluded: "", // comma-separated list
-    puddleConf: "",  // URL to download the puddle conf
     buildImages: false,
     imagesIncluded: "", // comma-separated list
     imagesExcluded: "", // comma-separated list
 ]
-// initialized but composeDir only filled in when puddle creates a compose
-rpmMirror = [       // where to mirror RPM compose
-    composeDir: "", // e.g. "YYYY-MM-DD.1"
-    url: "",
+// These values are filled in later by stageBuildCompose
+rpmMirror = [       // how to mirror RPM compose
+    composeName: "", // The name of the yum repo directory created.
+    localComposePath: "",  // will be populated with full path to yum repo created on buildvm
+    url: "", // url to directory where new repo can be found after mirroring
 ]
 
 // some state to record and preserve between stages
@@ -76,11 +76,6 @@ def initialize() {
 
     echo "Initial build plan: ${buildPlan}"
 
-    // figure out the puddle configuration
-    aosCdJobsCommitSha = commonlib.shell(script: "git rev-parse HEAD", returnStdout: true).trim()
-    def puddleConfBase = "https://raw.githubusercontent.com/openshift/aos-cd-jobs/" +
-                         "${aosCdJobsCommitSha}/build-scripts/puddle-conf"
-    buildPlan.puddleConf = "${puddleConfBase}/atomic_openshift-${version.stream}.conf"
     // and where to mirror the compose when it's done
     rpmMirror.url = "https://mirror.openshift.com/enterprise/enterprise-${version.stream}"
 
@@ -268,10 +263,13 @@ def stageBuildRpms() {
 }
 
 /**
- * If necessary, puddle a new compose from our candidate tag.
- * Set the new puddle directory (e.g. "YYYY-MM-DD.1")
+ * Unless no RPMs have changed, create multiple yum repos (one for each arch) of RPMs based on -candidate tags.
+ * Based on commonlib.ocp4ReleaseState, those repos can be signed (release state) or unsigned (pre-release state).
+ * @param auto_signing_advisory - The advisory method can use for auto-signing. This should be
+ *          unique to this release (to avoid simultaneous modifications. i.e. different
+ *          advisories for 4.1, 4.2, ...
  */
-def stageBuildCompose() {
+def stageBuildCompose(auto_signing_advisory=54765) {
 
     // we may or may not have (successfully) built the openshift RPM in this run.
     // in order to script the correct version to publish later, determine what's there now.
@@ -283,21 +281,99 @@ def stageBuildCompose() {
         echo "No RPMs built, not a force build; no need to create a compose"
         return
     }
+
+    baseDir = "${env.WORKSPACE}/plashets"
+    plashetDirName = "${version.full}-${version.release}"
+    rpmMirror.localPlashetPath = "${baseDir}/${plashetDirName}"  // where to find source for mirroring
+    rpmMirror.plashetDirName = "${plashetDirName}"  // what to name the mirrored repo directory
+
     if(buildPlan.dryRun) {
-        echo "Build puddle with conf ${buildPlan.puddleConf}"
-        rpmMirror.composeDir = "YYYY-MM-DD.1"
+        echo "Running in dry-run mode -- will not run plashet."
         return
     }
 
-    rpmMirror.composeDir = buildlib.build_puddle(
-        buildPlan.puddleConf,    // The puddle configuration file to use
-        null,   // signing key
-        "-b",   // do not fail if we are missing dependencies
-        "-d",   // print debug information
-        "-n",   // do not send an email for this puddle
-        "-s",   // do not create a "latest" link since this puddle is for building images
-        "--label=building"   // create a symlink named "building" for the puddle
-    )
+    /**
+     * plashet will build one or more yum repos for us -- one for each
+     * architecture enabled for the a release. For each arch, a yum repo
+     * {baseDir}/{plashetName}/{arch}/os will be created.
+     * plashet will examine RPM packages currently tagged in the rhel-7 candidate
+     * and build the yum repos. plashet allows each arch to have different signing
+     * characteristics (i.e. x86_64 can be signed and s390x can be unsigned).
+     * commonlib.ocp4ReleaseState declares which arches should be signed/unsigned.
+     * Read the comment on that map to understand why.
+     */
+    def archReleaseStates = commonlib.ocp4ReleaseState[version.stream]
+    plashet_arch_args = ""
+
+    for (String release_arch : archReleaseStates['release']) {
+        plashet_arch_args += " --arch ${release_arch} signed"
+    }
+
+    for (String pre_release_arch : archReleaseStates['pre-release']) {
+        plashet_arch_args += " --arch ${pre_release_arch} unsigned"
+    }
+
+    // In the current implementation, the same signing advisory is used for every signing task.
+    // To prevent add/remove races between versions, a lock is used.
+    lock('signing-advisory') {
+        retry(2) {
+            commonlib.shell([
+                    "${env.WORKSPACE}/build-scripts/plashet.py",
+                    "--base-dir ${baseDir}",  // Directory in which to create the yum repo
+                    "--name ${plashetDirName}",  // The name of the directory to create within baseDir to contain the arch repos.
+                    "--repo-subdir os",  // This is just to be compatible with legacy doozer puddle layouts which had {arch}/os.
+                    plashet_arch_args,
+                    "from-tags", // plashet mode of operation => build from brew tags
+                    "--brew-tag rhaos-${version.stream}-rhel-7-candidate  OSE-${version.stream}-RHEL-7",  // --brew-tag <tag> <associated-advisory-product-version>
+                    auto_signing_advisory?"--signing-advisory-id ${auto_signing_advisory}":"",    // The advisory to use for signing
+                    "--signing-advisory-mode clean",
+                    "--poll-for 15",   // wait up to 15 minutes for auto-signing to work its magic.
+            ].join(' '))
+        }
+    }
+
+    /**
+     * The yum repos that plashet creates are very lightweight because
+     * it only symlinks out to the desired RPMs on buildvm's /mnt/redhat
+     * share. We now want to copy the new repo out to rcm-guest. The
+     * good news is that we can keep it lightweight! rcm-guest has the
+     * exact same share path. The symlinks plashet created can be copied
+     * as symlinks. Note that if you copy the puddle to a system without
+     * these links, you should use rsync --copy-links which will transfer
+     * the linked file's content to the destination filename.
+     *
+     * Now.. let's copy to rcm-guest! Why? Because when we build images in
+     * brew, OSBS will only let the Dockerfile's yum invocations
+     * access certain remote locations. One of those whitelisted locations
+     * is rcm-guest, so copy our lightweight repo there.
+     *
+     * ocp-build is a user established for us on the rcm-guest host by
+     * Red Hat PnT devops. See /home/jenkins/.ssh.config.
+     */
+
+    // During an image build, doozer will provide repo files pointing back to a directory named
+    // 'building' in this rcm-guest directory. Before creating 'building', let's get the
+    // repo over there.
+    destBaseDir = "/mnt/rcm-guest/puddles/RHAOS/plashets/${version.stream}"
+    // Just in case this is the first time we have built this release, create the landing place on rcm-guest.
+    commonlib.shell("ssh ocp-build@rcm-guest -- mkdir -p ${destBaseDir}")
+    commonlib.shell([
+            "rsync",
+            "-av",  // archive mode, verbose
+            "--links",  // include links, but keep them as symlinks
+            "--progress",
+            "-h", // human readable numbers
+            "--no-g",  // use default group on rcm-guest for the user
+            "--omit-dir-times",
+            "--chmod=Dug=rwX,ugo+r",
+            "--perms",
+            "${rpmMirror.localPlashetPath}",  // plashet we just created
+            "ocp-build@rcm-guest:${destBaseDir}"  // the plashetDirName will be created in this destBaseDir
+    ].join(" "))
+
+    // So we have a yum repo out on rcm-guest. Now we need to name it 'building' so the
+    // doozer repo files (which have static urls back to rcm-guest) will resolve.
+    commonlib.shell("ssh -t ocp-build@rcm-guest \"cd ${destBaseDir}; ln -sfn ${plashetDirName} building\" ")
 }
 
 def stageUpdateDistgit() {
@@ -311,6 +387,7 @@ def stageUpdateDistgit() {
         ${includeExclude "images", buildPlan.imagesIncluded, buildPlan.imagesExcluded}
         images:rebase --version v${version.full} --release ${version.release}
         --message 'Updating Dockerfile version and release v${version.full}-${version.release}' --push
+        --message '${env.BUILD_URL}'
         """
     if(buildPlan.dryRun) {
         echo "doozer ${cmd}"
@@ -331,6 +408,13 @@ def stageBuildImages() {
         return
     }
     try {
+        /**
+         * TODO: make gpgcheck=1 for signed arches and =0 for unsigned arches.  Right now, if we
+         * run doozer with --repo-type=signed, it will set gpgcheck=1 and unsigned arch builds will
+         * explode. The workaround is to tell let doozer run in unsigned mode, where it doesn't care
+         * about signatures. In practice, the concept of --repo-type should diminish in importance,
+         * so maybe gpgcheck will no longer be necessary with the more predictable pipeline.
+         */
         def cmd =
             """
             ${doozerOpts}
@@ -362,32 +446,66 @@ def stageBuildImages() {
     }
 }
 
+/**
+ * Copy the plashet created earlier out to the openshift mirrors. This allows QE to
+ * easily find the RPMs we used in the creation of the images. These RPMs may be
+ * required for bare metal installs.
+ */
 def stageMirrorRpms() {
     if (!buildPlan.buildRpms && !buildPlan.forceBuild) {
         echo "No updated RPMs to mirror."
         return
     }
 
-    def versionRelease = "${version.full}-${version.release}"
+    def openshift_mirror_bastion = "use-mirror-upload.ops.rhcloud.com"
+    def openshift_mirror_user = "jenkins_aos_cd_bot"
+    def destBaseDir = "/srv/enterprise/enterprise-${version.stream}"
+    def stagingDir = "${destBaseDir}/staging"
 
-    // Push the building puddle out to the mirrors
-    def symlinkName = "latest"
-
-    if(buildPlan.dryRun) {
-        // this is silly, but we can't use *args to DRY -- see https://issues.jenkins-ci.org/browse/JENKINS-46163
-        echo("invoke_on_rcm_guest push-to-mirrors.sh ${symlinkName} ${versionRelease} pre-release")
-    } else {
-        buildlib.invoke_on_rcm_guest("push-to-mirrors.sh", symlinkName, versionRelease, "pre-release")
+    if (buildPlan.dryRun) {
+        echo "Would have copied plashet to ${openshift_mirror_user}@${openshift_mirror_bastion}:${destBaseDir}"
+        return
     }
 
-    def binaryPkgName = "openshift"
-    if(buildPlan.dryRun) {
-        echo("invoke_on_rcm_guest publish-oc-v4-binary.sh ${version.stream} ${finalRpmVersionRelease} ${binaryPkgName}")
-    } else {
-        buildlib.invoke_on_rcm_guest("publish-oc-v4-binary.sh", version.stream, finalRpmVersionRelease, binaryPkgName)
-    }
+    /**
+     * Just in case this is the first time we have built this release, create the release's staging directory.
+     * What is staging? Glad you asked. rsync isn't dumb. If it finds a remote file already present,
+     * it will avoid transferring the source file. That means you can dramatically speed up rsync if your
+     * source and destination on differ by a little.
+     * Each time we build 4.x, probably only a few RPMs actually change. So, we have a 4.x staging directory
+     * we rsync to.
+     */
+    commonlib.shell("ssh ${openshift_mirror_user}@${openshift_mirror_bastion} -- mkdir -p ${stagingDir}")
+    commonlib.shell([
+            "rsync",
+            "-av",  // archive mode, verbose
+            "--copy-links",  // The local repo is composed of symlinks to brewroot; use-mirror does not have brewroot mounted, so we need to copy content, not the symlinks
+            "--progress",
+            "-h", // human readable numbers
+            "--no-g",  // use default group on mirror for the user we are logging in with
+            "--omit-dir-times",
+            "--delete-after", // anything that was in staging, but is no longer there, delete it after a successful transfer
+            "--chmod=Dug=rwX,ugo+r",
+            "--perms",
+            "${rpmMirror.localPlashetPath}/",  // local directory we just built with plashet. NOTICE THE TRAILILNG slash. This means copy the files within, but not the directory name.
+            "${openshift_mirror_user}@${openshift_mirror_bastion}:${stagingDir}"  // we want the arch repos to land in staging.
+    ].join(" "))
 
-    echo "Finished building OCP ${versionRelease}"
+    // We now have a staging plashet out on the mirror bastion with yum repo content. Now we need to
+    // make copy of it with the real plashet name. We could use hardlinks, but that seems to cause issues
+    // with the mirror infrastructure's replication to subordinates.
+    commonlib.shell("ssh ${openshift_mirror_user}@${openshift_mirror_bastion} -- cp -a ${stagingDir} ${destBaseDir}/${rpmMirror.plashetDirName}")
+    //  Now we have a plashet named after the original on the mirror. QE wants a 'latest' link there.
+    commonlib.shell("ssh -t ${openshift_mirror_user}@${openshift_mirror_bastion} \"cd ${destBaseDir}; ln -sfn ${rpmMirror.plashetDirName} latest\"")
+    //  For historical reasons, all puddles were linked to from 'all' directory as well.
+    commonlib.shell("ssh ${openshift_mirror_user}@${openshift_mirror_bastion} -- ln -sfn ${destBaseDir}/${rpmMirror.plashetDirName} /srv/enterprise/all/${version.stream}/${rpmMirror.plashetDirName}")
+    // Also establish latest link
+    commonlib.shell("ssh -t ${openshift_mirror_user}@${openshift_mirror_bastion} \"cd /srv/enterprise/all/${version.stream}; ln -sfn ${rpmMirror.plashetDirName} latest\"")
+    // Instruct the mirror infrastructure to push content to the subordinate hosts.
+    commonlib.shell("ssh ${openshift_mirror_user}@${openshift_mirror_bastion} -- push.enterprise.sh -v  enterprise-${version.stream}")
+    commonlib.shell("ssh ${openshift_mirror_user}@${openshift_mirror_bastion} -- push.enterprise.sh -v  all")
+
+    echo "Finished mirroring OCP ${version.full} to openshift mirrors"
 }
 
 def stageSyncImages() {
@@ -415,7 +533,6 @@ def stageReportSuccess() {
 
     def stateYaml = builtNothing ? [:] : readYaml(file: "${doozerWorking}/state.yaml")
     messageSuccess(rpmMirror.url)
-    emailSuccess(rpmMirror.url, timingReport, getImageBuildReport(recordLog), stateYaml)
 }
 
 def messageSuccess(mirrorURL) {
@@ -429,7 +546,7 @@ def messageSuccess(mirrorURL) {
                 messageContent: "New build for OpenShift: ${version.full}",
                 messageProperties:
                     """build_mode=pre-release
-                    puddle_url=${rpmMirror.url}/${rpmMirror.composeDir}
+                    puddle_url=${rpmMirror.url}/${rpmMirror.plashetDirName}
                     image_registry_root=registry.reg-aws.openshift.com:443
                     product=OpenShift Container Platform
                     """,
@@ -441,83 +558,6 @@ def messageSuccess(mirrorURL) {
     } catch (mex) {
         echo "Error while sending CI message: ${mex.getMessage()}"
     }
-}
-
-def emailSuccess(mirrorURL, timingReport, imageList, stateYaml) {
-    def mailList = params.MAIL_LIST_SUCCESS.trim()
-    // note: the default for the parameter is empty.
-    // normally this would probably only be set for full builds, if then.
-    // but it's there in case you want to notify someone, perhaps yourself.
-    if (!mailList) { return }
-
-    def subjectTags = ""
-    if (buildPlan.dryRun) { subjectTags += " [DRY RUN]" }
-
-    if (buildPlan.buildImages) {
-        if (buildPlan.imagesIncluded || buildPlan.imagesExcluded) {
-            subjectTags += " [partial]"
-        }
-        def result = stateYaml.get("images:rebase", [:])
-        if (result['success'] != result['total']) {
-            currentBuild.displayName += " [rebase failure]"
-            subjectTags += " [rebase failure]"
-        }
-        result = stateYaml.get("images:build", [:])
-        if (result['success'] != result['total']) {
-            currentBuild.displayName += " [image failure]"
-            subjectTags += " [image failure]"
-        }
-    } else if (buildPlan.buildRpms) {
-        subjectTags += " [RPM only]"
-    } else {
-        // no builds attempted; could only happen if incremental build found no changes
-        subjectTags += " [no changes]"
-    }
-
-    def injectNotes = (params.SPECIAL_NOTES.trim() == "") ? "" :
-"""
-Special notes associated with this build:
-*****************************************
-${params.SPECIAL_NOTES.trim()}
-*****************************************
-"""
-
-    def composeDetails = (!buildPlan.buildRpms && !buildPlan.forceBuild) ? "" :
-"""\
-RPMs:
-    RPM Compose (internal): http://download-node-02.eng.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift/${version.stream}/${rpmMirror.composeDir}
-    External Mirror: ${mirrorURL}/${rpmMirror.composeDir}
-"""
-
-    def imageDetails = (!buildPlan.buildImages) ? "" :
-"""\
-${timingReport}
-Images:
-  - Images have been pushed to registry.reg-aws.openshift.com:443     (Get pull access [1])
-    [1] https://github.com/openshift/ops-sop/blob/master/services/opsregistry.asciidoc#using-the-registry-manually-using-rh-sso-user
-${imageList}
-"""
-
-    commonlib.email(
-        to: mailList,
-        from: "aos-art-automation@redhat.com",
-        replyTo: "aos-team-art@redhat.com",
-        subject: "[ART] New build for OCP: ${version.full}${subjectTags}",
-        body:
-"""\
-Pipeline build "${currentBuild.displayName}" finished successfully.
-${injectNotes}
-The build description it finished with is:
-******************************************
-${currentBuild.description}\
-******************************************
-
-${composeDetails}\
-${imageDetails}\
-View the build artifacts and console output on Jenkins:
-    - Jenkins job: ${commonlib.buildURL()}
-    - Console output: ${commonlib.buildURL('console')}
-""");
 }
 
 // extract timing information from the recordLog and write a report string

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -49,23 +49,26 @@ ocpVersions = ocp4Versions + ocp3Versions
  *
  * We need them to continue to be unsigned!
  *
- * The reason being that we are prohibited by product security agreements
- * from releasing publicly any signed RPM which will not be passing through
+ * Any code we sign using the auto-signing facility should be passed through
  * the errata process / rpmdiff.
  *
  * Hence we need a very explicit source of truth on where our images are
  * destined. If it will ship via errata (state=release), we want to build signed. For
  * early access without an errata (state=pre-release).
  *
- * For extra complexity, different architectures in a release can be in release
- * or pre-release. For example, s390x might still be pre-release even after
- * x86_64 is shipping for a given 4.x. Sooooo... we need the ability to build
- * arch specific release payloads, during the exact same ocp4 Jenkins job / doozer run,
- * where different architectures might be signed / unsigned.
+ * For extra complexity, different architectures in a release can be in
+ * different release states. For example, s390x might still be pre-release
+ * even after x86_64 is shipping for a given 4.x. While we could theoretically build the
+ * x86_64 image with signed RPMs, and s390x images with unsigned RPMS, OSBS
+ * prohibits this since it considers it an error.
+ * TODO: ask osbs to make this a configurable option?
  *
- * Why is the following information not in doozer. It could be.
+ * Sooooo... when all arches are pre-release, we need to build unsigned. When any
+ * arch is in release mode, we need to build all images with signed RPMs.
+ *
+ * Why is release map information not in doozer metadata. It could be.
  * 1) I think it would need some refactoring that won't be practical until
- * the auto-signing work is validated.
+ *    the auto-signing work is validated.
  * 2) We normally initialize a new doozer group by copying an old one. This
  *    release state could easily be copied unintentionally.
  * 3) pre-release data is presently stored in poll-payload. This just tries

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -33,6 +33,74 @@ ocpMergeVersions = [
 
 ocpVersions = ocp4Versions + ocp3Versions
 
+/**
+ * Why is ocp4ReleaseState needed?
+ *
+ * Before auto-signing, images were either built signed or unsigned.
+ * Unsigned images were the norm and then, right before GA, we would rebuild
+ * puddles and build as signed. In the new model, we always want to build
+ * signed **if we plan on releasing the builds via an advisory**.
+ *
+ * There are a category of builds that we DON'T plan on releasing through
+ * an advisory. For a brand new release stream (or new arch) in 4.x, we want
+ * to build nightlies and make them available as pre-release builds so that
+ * even the general public can start experimenting with the new features of the release.
+ * These pre-release images contain RPMs which have traditionally been unsigned.
+ *
+ * We need them to continue to be unsigned!
+ *
+ * The reason being that we are prohibited by product security agreements
+ * from releasing publicly any signed RPM which will not be passing through
+ * the errata process / rpmdiff.
+ *
+ * Hence we need a very explicit source of truth on where our images are
+ * destined. If it will ship via errata (state=release), we want to build signed. For
+ * early access without an errata (state=pre-release).
+ *
+ * For extra complexity, different architectures in a release can be in release
+ * or pre-release. For example, s390x might still be pre-release even after
+ * x86_64 is shipping for a given 4.x. Sooooo... we need the ability to build
+ * arch specific release payloads, during the exact same ocp4 Jenkins job / doozer run,
+ * where different architectures might be signed / unsigned.
+ *
+ * Why is the following information not in doozer. It could be.
+ * 1) I think it would need some refactoring that won't be practical until
+ * the auto-signing work is validated.
+ * 2) We normally initialize a new doozer group by copying an old one. This
+ *    release state could easily be copied unintentionally.
+ * 3) pre-release data is presently stored in poll-payload. This just tries
+ *    to make it available for other jobs.
+ *
+ * Alternatively, maybe this becomes the source of truth and confusing aspects like
+ * 'archOverrides' goes away in doozer config.
+ */
+ocp4ReleaseState = [
+        "4.6": [
+                'release': [],
+                "pre-release": [ 'x86_64', 's390x', 'ppc64le' ],
+        ],
+        "4.5": [
+            'release': [],
+            "pre-release": [ 'x86_64', 's390x', 'ppc64le' ],
+        ],
+        "4.4": [
+            "release": [ 'x86_64' ],
+            "pre-release": ['s390x', 'ppc64le'],
+        ],
+        "4.3": [
+            "release": [ 'x86_64', 's390x', 'ppc64le' ],
+            "pre-release": [],
+        ],
+        "4.2": [
+            "release": [ 'x86_64', 's390x' ],
+            "pre-release": [],
+        ],
+        "4.1": [
+            "release": [ 'x86_64' ],
+            "pre-release": [],
+        ]
+]
+
 ocpMajorVersions = [
     "4": ocp4Versions,
     "3": ocp3Versions,


### PR DESCRIPTION
ocp-build-data for each release needs to be updated to eliminate 'signed' vs 'unsigned' for our repos. All builds should point to plashet `building`. Very similar to this commit: https://github.com/openshift/ocp-build-data/commit/74d18e091ed01427fc1d2e04d72abfe953c5d586#diff-e853cd43964ffb417b38e3d5817728b8  (but without turning off reposync)