### PR TITLE
[ART-1728] Create `build/olm_bundle` job

### DIFF
--- a/jobs/build/olm_bundle/Jenkinsfile
+++ b/jobs/build/olm_bundle/Jenkinsfile
@@ -1,0 +1,123 @@
+node {
+    checkout scm
+    olm_bundles = load('olm_bundles.groovy')
+}
+
+pipeline {
+    agent any
+
+    options {
+        disableResume()
+        skipDefaultCheckout()
+    }
+
+    parameters {
+        choice(
+            name: 'BUILD_VERSION',
+            choices: olm_bundles.commonlib.ocpVersions,
+            description: 'OCP Version'
+        )
+        string(
+            name: 'ONLY',
+            description: '(Optional) List **only** the operators you want '  +
+                         'to build, everything else gets ignored.\n'         +
+                         'Format: Comma and/or space separated list of brew '+
+                         'packages (e.g.: cluster-nfd-operator-container)\n' +
+                         'Leave empty to build all (except EXCLUDE, if defined)',
+            defaultValue: ''
+        )
+        string(
+            name: 'EXCLUDE',
+            description: '(Optional) List the operators you **don\'t** want ' +
+                         'to build, everything else gets built.\n'            +
+                         'Format: Comma and/or space separated list of brew ' +
+                         'packages (e.g.: cluster-nfd-operator-container)\n'  +
+                         'Leave empty to build all (or ONLY, if defined)',
+            defaultValue: 'cluster-nfd-operator-container'
+            /* Temporarily excluding cluster-nfd-operator-container, until
+               https://github.com/openshift/cluster-nfd-operator/issues/82
+               gets solved */
+        )
+        string(
+            name: 'EXTRAS_ADVISORY',
+            description: '(Optional) Fetch OLM Operators NVRs from advisory.\n'  +
+                         'Leave empty to fetch NVRs from "brew latest-build".\n' +
+                         'Bundles won\'t be attached to any advisory if empty.',
+            defaultValue: ''
+        )
+        booleanParam(
+            name: 'DRY_RUN',
+            description: 'Just show what would happen, without actually executing the steps',
+            defaultValue: false
+        )
+    }
+
+    stages {
+        stage('Set build info') {
+            steps {
+                script {
+                    currentBuild.displayName += " (${params.BUILD_VERSION})"
+                    currentBuild.description  = "${params.EXTRAS_ADVISORY ?: '-'} "
+
+                    def only = olm_bundles.commonlib.cleanCommaList(params.ONLY).split(',')
+                    def exclude = olm_bundles.commonlib.cleanCommaList(params.EXCLUDE).split(',')
+                    operator_packages = (only ?: olm_bundles.get_olm_operators()) - exclude
+                }
+            }
+        }
+        stage('Get advisory builds') {
+            when {
+                expression { ! params.EXTRAS_ADVISORY.isEmpty() }
+            }
+            steps {
+                script {
+                    operator_nvrs = olm_bundles.get_builds_from_advisory().findAll {
+                        nvr -> operator_packages.any { nvr.startsWith(it) }
+                    }
+                }
+            }
+        }
+        stage('Get latest builds') {
+            when {
+                expression { params.EXTRAS_ADVISORY.isEmpty() }
+            }
+            steps {
+                script {
+                    operator_nvrs = olm_bundles.get_latest_builds(operator_packages)
+                }
+            }
+        }
+        stage('Build bundles') {
+            when {
+                expression { ! operator_nvrs.isEmpty() }
+            }
+            steps {
+                script {
+                    lock("olm_bundle-${params.BUILD_VERSION}") {
+                        if (params.DRY_RUN) {
+                            bundle_packages = operator_packages.collect {
+                                it.replace('-operator', '-operator-bundle')
+                            }
+                            bundle_nvrs = olm_bundles.get_latest_builds(bundle_packages)
+                            print(bundle_nvrs.join('\n'))
+                            return
+                        }
+                        bundle_nvrs = olm_bundles.build_bundles(operator_nvrs)
+                    }
+                }
+            }
+        }
+        stage('Attach bundles to advisory') {
+            when {
+                expression { ! params.EXTRAS_ADVISORY.isEmpty() }
+            }
+            steps {
+                script {
+                    lock("olm_bundle-${params.BUILD_VERSION}") {
+                        olm_bundles.attach_to_bundles_advisory(bundle_nvrs)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/jobs/build/olm_bundle/olm_bundles.groovy
+++ b/jobs/build/olm_bundle/olm_bundles.groovy
@@ -1,0 +1,57 @@
+buildlib = load('pipeline-scripts/buildlib.groovy')
+commonlib = buildlib.commonlib
+
+def doozer(cmd) {
+    buildlib.doozer("-g openshift-${params.BUILD_VERSION} ${cmd}", [capture: true])
+}
+
+def elliott(cmd) {
+    buildlib.elliott("-g openshift-${params.BUILD_VERSION} ${cmd}", [capture: true])
+}
+
+/*
+ * Return the brew package name of all OLM operators present in <params.BUILD_VERSION>
+ */
+def get_olm_operators() {
+    doozer('olm-bundle:list-olm-operators').split("\n")
+}
+
+/*
+ * Return list of OLM Operator NVRs attached to given <advisory>
+ */
+def get_builds_from_advisory(advisory) {
+    def json = elliott("get --json - ${advisory}")
+    readJSON(text: json).errata_builds.values().flatten()
+}
+
+/*
+ * Return the latest build of given <packages> for <tag>
+ */
+def get_latest_builds(packages) {
+    def tag = "rhaos-${params.BUILD_VERSION}-rhel-7-candidate"
+    commonlib.shell(
+        script: "brew --quiet latest-build ${tag} ${packages.join(' ')}",
+        returnAll: true
+    ).stdout.split("\n").collect { it.split(" ")[0] }
+}
+
+/*
+ * Build corresponding bundle containers for given <operator_nvrs>
+ * Return a list of built <bundle_nvrs>
+ */
+def build_bundles(operator_nvrs) {
+    doozer("olm-bundle:rebase-and-build ${operator_nvrs.join(' ')}").split("\n")
+}
+
+/*
+ * Attach given <bundle_nvrs> to <params.EXTRAS_ADVISORY>
+ */
+def attach_bundles_to_extras_advisory(bundle_nvrs) {
+    elliott("change-state -s NEW_FILES -a ${params.EXTRAS_ADVISORY} ${params.DRY_RUN ? '--noop' : ''}")
+    flags = bundle_nvrs.collect { "--build ${it}" }.join(' ')
+    elliott("find-builds -k image ${flags} --attach ${params.EXTRAS_ADVISORY}")
+    elliott("change-state -s QE -a ${params.EXTRAS_ADVISORY} ${params.DRY_RUN ? '--noop' : ''}")
+
+}
+
+return this


### PR DESCRIPTION
Related story: [ART-1728](https://issues.redhat.com/browse/ART-1728)

### What is introduced by this PR

A new job, called `build/olm_bundle` that builds bundle containers for OLM Operators, either attached to an advisory or the latest build found.

Test runs are happening at https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/talessio-aos-cd-jobs/job/ART-1728