### PR TITLE
[ART-1858] verify payload as promotion preflight check

### DIFF
--- a/jobs/build/pre-release/Jenkinsfile
+++ b/jobs/build/pre-release/Jenkinsfile
@@ -132,7 +132,7 @@ node {
             def CLIENT_TYPE = "ocp-dev-preview"
 
             stage("validation") {
-                release.stageValidation(quay_url, dest_release_tag, -1, params.PERMIT_PAYLOAD_OVERWRITE)
+                release.stageValidation(quay_url, dest_release_tag, -1, params.PERMIT_PAYLOAD_OVERWRITE, params.PERMIT_ALL_ADVISORY_STATES, params.FROM_RELEASE_TAG, arch)
             }
 
             stage("build payload") {

--- a/jobs/build/release/Jenkinsfile
+++ b/jobs/build/release/Jenkinsfile
@@ -184,7 +184,7 @@ node {
             buildlib.registry_quay_dev_login()
             stage("versions") { release.stageVersions() }
             stage("validation") {
-                def retval = release.stageValidation(quay_url, dest_release_tag, advisory, params.PERMIT_PAYLOAD_OVERWRITE, params.PERMIT_ALL_ADVISORY_STATES)
+                def retval = release.stageValidation(quay_url, dest_release_tag, advisory, params.PERMIT_PAYLOAD_OVERWRITE, params.PERMIT_ALL_ADVISORY_STATES, params.FROM_RELEASE_TAG, arch)
                 advisory = advisory?:retval.advisoryInfo.id
                 errata_url = retval.errataUrl
             }


### PR DESCRIPTION
Before promoting a nightly, it needs to be checked that the images in the advisory match the ones in the payload. This uses `elliott verify-payload` as an input validator.

There might be false positives when payload images are in RHSAs. For this reason, the operator is asked for input.