### PR TITLE
[ART-1728] Run olm_bundle instead of appregistry for 4.6

### DIFF
--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -782,12 +782,14 @@ def sync_images(major, minor, mail_list, build_number) {
     }
     def fullVersion = "${major}.${minor}"
     def results = []
+    def metadataJob = fullVersion == '4.6' ? 'build%2Folm_bundle' : 'build%2Fappregistry'
+
     parallel "build-sync": {
         results.add build(job: 'build%2Fbuild-sync', propagate: false, parameters:
             [ param('String', 'BUILD_VERSION', fullVersion) ]  // https://stackoverflow.com/a/53735041
         )
-    }, appregistry: {
-        results.add build(job: 'build%2Fappregistry', propagate: false, parameters:
+    }, metadata: {
+        results.add build(job: metadataJob, propagate: false, parameters:
             [ param('String', 'BUILD_VERSION', fullVersion) ]  // https://stackoverflow.com/a/53735041
         )
     }


### PR DESCRIPTION
build/ocp4 and build/custom jobs trigger the appregistry job towards the end of the pipeline.
This change will trigger the new `build/olm_bundle` job instead of appregistry, if the build version is 4.6.