### PR TITLE
Add ticket type when sending request to RCM

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -123,7 +123,7 @@ node {
                     passwordVariable: 'JIRA_PASSWORD',
                 )]) {
                     withEnv(["ds=${description}"]){
-                        cmd = "jirago -password=${JIRA_PASSWORD} -summary=\"OCP Tarball sources\" -description=\"${ds}\""
+                        cmd = "jirago -password=${JIRA_PASSWORD} -type \"Ticket\" -summary=\"OCP Tarball sources\" -description=\"${ds}\""
                         jira = commonlib.shell(
                             script: cmd,
                             returnStdout: true


### PR DESCRIPTION
When we create ticket to RCM for tarball-sources the JIRA type is Task as it is the default type, every time RCM change the JIRA type to Ticket, so we can create JIRA card with Ticket type for them.
