### PR TITLE
Add ticket type when sending request to RCM

### DIFF
--- a/jobs/build/tarball-sources/Jenkinsfile
+++ b/jobs/build/tarball-sources/Jenkinsfile
@@ -123,7 +123,7 @@ node {
                     passwordVariable: 'JIRA_PASSWORD',
                 )]) {
                     withEnv(["ds=${description}"]){
-                        cmd = "jirago -password=${JIRA_PASSWORD} -summary=\"OCP Tarball sources\" -description=\"${ds}\""
+                        cmd = "jirago -password=${JIRA_PASSWORD} -type \"Ticket\" -summary=\"OCP Tarball sources\" -description=\"${ds}\""
                         jira = commonlib.shell(
                             script: cmd,
                             returnStdout: true


### PR DESCRIPTION
the default type is task, they need to change to ticket type, so we can create with ticket type.
$ jirago --help
Usage of jirago:
  -type string
    	jira issue type (default "Task")