### PR TITLE
ART-1937: use .p? convention for OCP 4 releases

### DIFF
--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -27,7 +27,7 @@ node {
                     ],
                     [
                         name: 'RELEASE',
-                        description: '(Optional) Release string for build instead of default (1 for 3.x, timestamp for 4.x)',
+                        description: '(Optional) Release string for build instead of default (1 for 3.x, timestamp.p? for 4.x)',
                         $class: 'hudson.model.StringParameterDefinition',
                         defaultValue: ""
                     ],
@@ -148,7 +148,7 @@ node {
                     currentBuild.description = "building RPM(s): ${rpms}\n"
                     command = doozerOpts
                     if (rpms) { command += "-r '${rpms}' " }
-                    command += "rpms:build --version ${version} --release ${release} "
+                    command += "rpms:build --version ${version} --release '${release}' "
                     if (params.IGNORE_LOCKS) {
                          buildlib.doozer command
                     } else {
@@ -205,7 +205,7 @@ node {
                 currentBuild.description += "building image(s): ${include_exclude ?: 'all'}"
                 command = doozerOpts
                 command += "--latest-parent-version ${include_exclude} "
-                command += "images:${params.IMAGE_MODE} --version v${version} --release ${release} "
+                command += "images:${params.IMAGE_MODE} --version v${version} --release '${release}' "
                 command += "--repo-type ${repo_type} "
                 command += "--message 'Updating Dockerfile version and release ${version}-${release}' --push "
                 if (params.IGNORE_LOCKS) {

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -256,7 +256,7 @@ def stageBuildRpms() {
         ${doozerOpts}
         ${includeExclude "rpms", buildPlan.rpmsIncluded, buildPlan.rpmsExcluded}
         rpms:build --version v${version.full}
-        --release ${version.release}
+        --release '${version.release}'
         """
 
     buildPlan.dryRun ? echo("doozer ${cmd}") : buildlib.doozer(cmd)
@@ -434,7 +434,7 @@ def stageUpdateDistgit() {
         """
         ${doozerOpts}
         ${includeExclude "images", buildPlan.imagesIncluded, buildPlan.imagesExcluded}
-        images:rebase --version v${version.full} --release ${version.release}
+        images:rebase --version v${version.full} --release '${version.release}'
         --message 'Updating Dockerfile version and release v${version.full}-${version.release}' --push
         --message '${env.BUILD_URL}'
         """

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -1206,7 +1206,7 @@ def latestOpenshiftRpmBuild(stream, branch) {
 }
 
 def defaultReleaseFor(stream) {
-    return stream.startsWith("3") ? "1" : new Date().format("yyyyMMddHHmm")
+    return stream.startsWith("3") ? "1" : (new Date().format("yyyyMMddHHmm") + ".p?")
 }
 
 // From a brew NVR of openshift, return just the V part.


### PR DESCRIPTION
Adds `.p?` suffix to auto-generated release values.
Requires https://github.com/openshift/doozer/pull/222.

3.11 builds should still be able to use the current release convention.
Not sure if there's anywhere else missing though.