### PR TITLE
merge_ocp: don't scan sources if no build will result

### DIFF
--- a/jobs/build/merge_ocp/Jenkinsfile
+++ b/jobs/build/merge_ocp/Jenkinsfile
@@ -153,8 +153,8 @@ node {
                                 def scheduleBuild = false
                                 def isOCP4 = version.startsWith('4.')
 
-                                if (isOCP4) {
-                                    // Scan upstream for relevant changes
+                                if (isOCP4 && params.SCHEDULE_INCREMENTAL) {
+                                    // Scan upstream for relevant changes, unless we won't run builds anyway.
                                     buildlib.cleanWorkdir(doozer_working)
 
                                     def yamlData = readYaml text: buildlib.doozer(


### PR DESCRIPTION
if all we really wanted was to merge origin->ose (like the name implies) then we may not want to waste time scanning sources (especially when it's broken...).

if you just wanted to know what would have changed, you'd run ocp4 in DRY_RUN mode anyway. although i suppose that wouldn't tell you that a merge was pending.