### PR TITLE
ART-2004: mirror images targeting ocp priv namespaces on api.ci

### DIFF
--- a/jobs/build/build-sync/Jenkinsfile
+++ b/jobs/build/build-sync/Jenkinsfile
@@ -42,6 +42,12 @@ node {
                                             defaultValue: "",
                                     ],
                                     [
+                                            name        : 'BREW_EVENT_ID',
+                                            description : '(Optional) Look for the last images as of the given Brew event instead of latest',
+                                            $class      : 'hudson.model.StringParameterDefinition',
+                                            defaultValue: "",
+                                    ],
+                                    [
                                             name        : 'ORGANIZATION',
                                             description : '(Optional) Quay.io organization to mirror to',
                                             $class      : 'hudson.model.StringParameterDefinition',


### PR DESCRIPTION
build_sync job currently only assumes an arch suffix. It should take all files like src_dest.* / image_stream.*.yaml into consideration.

Also adds `BREW_EVENT_ID` parameter to sync last images of the given moment (requires https://github.com/openshift/doozer/pull/236).

Test run: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/yuxzhu/job/aos-cd-jobs/job/build%252Fbuild-sync/8/console