### PR TITLE
Fix `No such property: build` error

### DIFF
--- a/jobs/build/ocp3/Jenkinsfile
+++ b/jobs/build/ocp3/Jenkinsfile
@@ -969,6 +969,6 @@ Jenkins job: ${env.BUILD_URL}
             "doozer_working/*.yaml",
             "doozer_working/*.yml",
         ])
-        buildlib.cleanWorkdir(build.doozerWorking)
+        buildlib.cleanWorkdir(DOOZER_WORKING)
     }
 }


### PR DESCRIPTION
https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp3/250/console