### PR TITLE
Rework jenkins update jobs for rhaos-4.6-rhel-8

### DIFF
--- a/hacks/update-jenkins-plugins/update-dist-git.sh
+++ b/hacks/update-jenkins-plugins/update-dist-git.sh
@@ -5,9 +5,9 @@ set -euo pipefail
 
 usage() {
   echo >&2
-  echo "Usage `basename $0` <jenkins-version> <aos-release> <path-to-hpis-dir> " >&2
+  echo "Usage `basename $0` <jenkins-version> <rhaos-branch> <path-to-hpis-dir> " >&2
   echo >&2
-  echo "Example: `basename $0` 2.42  3.7 ./working/hpis" >&2
+  echo "Example: `basename $0` 2.42  rhaos-3.7-rhel-7 ./working/hpis" >&2
   echo >&2
   echo "This example would populate all the HPIs in the specified directory in the dist-git repo jenkins-2-plugins" >&2
   echo "and the branch rhaos-3.7-rhel-7 ." >&2
@@ -27,7 +27,7 @@ fi
 target_jenkins_version="$1"
 jenkins_major=$(echo "${target_jenkins_version}." | cut -d . -f 1)
 repo="jenkins-${jenkins_major}-plugins"
-rhaos_release="$2"
+rhaos_branch="$2"
 hpis_dir=$(realpath "$3")
 
 
@@ -38,7 +38,7 @@ cd ${workingdir}
 echo "Cloning dist-git repository ...."
 REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt rhpkg ${USER_INFO} clone ${repo}
 pushd ${repo}
-REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt rhpkg switch-branch rhaos-${rhaos_release}-rhel-7
+REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt rhpkg switch-branch ${rhaos_branch}
 popd
 
 mkdir -p ${workingdir}/build/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
@@ -87,7 +87,7 @@ for hpi in "${hpis_dir}"/*.hpi ; do
 done
 
 # Make up a version based on date package was built
-VERSION="${rhaos_release}.$(date +%s)"
+VERSION="$(echo ${rhaos_branch} | cut -d- -f2).$(date +%s)"
 
 cat <<EOF > ${topdir}/SPECS/${repo}.spec
 Summary:    OpenShift Jenkins ${jenkins_major} Plugins

--- a/jobs/devex/jenkins-bump-version/Jenkinsfile
+++ b/jobs/devex/jenkins-bump-version/Jenkinsfile
@@ -9,11 +9,11 @@ properties(
                     $class: 'hudson.model.StringParameterDefinition',
                 ],
                 [
-                    name: 'OCP_RELEASE',
-                    description: 'OCP target release',
+                    name: 'OCP_BRANCH',
+                    description: 'OCP target branch',
                     $class: 'hudson.model.ChoiceParameterDefinition',
-                    choices: ['4.6', '4.5', '4.4', '4.3', '4.2', '4.1', '4.0', '3.15', '3.14', '3.13', '3.12', '3.11', '3.10', '3.9', '3.8', '3.7', '3.6'].join('\n'),
-                    defaultValue: '4.1'
+                    choices: ['rhaos-4.6-rhel-8', 'rhaos-4.6-rhel-7', 'rhaos-4.5-rhel-7', 'rhaos-4.4-rhel-7', 'rhaos-4.3-rhel-7', 'rhaos-4.2-rhel-7', 'rhaos-4.1-rhel-7', 'rhaos-4.0-rhel-7', 'rhaos-3.11-rhel-7', 'rhaos-3.10-rhel-7', 'rhaos-3.9-rhel-7','rhaos-3.8-rhel-7','rhaos-3.7-rhel-7', 'rhaos-3.6-rhel-7'].join('\n'),
+                    defaultValue: 'rhaos-4.1-rhel-7'
                 ],
                 [
                     name: 'MAIL_LIST_SUCCESS',
@@ -46,8 +46,6 @@ properties(
     ]
 )
 
-OCP_BRANCH="rhaos-${OCP_RELEASE}-rhel-7"
-
 def mail_success() {
     distgit_link = "http://pkgs.devel.redhat.com/cgit/rpms/jenkins/?h=${OCP_BRANCH}"
 
@@ -55,8 +53,8 @@ def mail_success() {
         to: "${MAIL_LIST_SUCCESS}",
         from: "aos-art-automation@redhat.com",
         replyTo: 'aos-team-art@redhat.com',
-        subject: "jenkins RPM for OCP v${OCP_RELEASE} updated in dist-git",
-        body: """The Jenkins RPM for ${OCP_RELEASE} has been updated in dist-git:
+        subject: "jenkins RPM for ${OCP_BRANCH} updated in dist-git",
+        body: """The Jenkins RPM for ${OCP_BRANCH} has been updated in dist-git:
 ${distgit_link}
 
 Jenkins version: ${JENKINS_VERSION}
@@ -70,7 +68,7 @@ def mail_failure(err) {
         to: "${MAIL_LIST_FAILURE}",
         from: "aos-art-automation@redhat.com",
         replyTo: 'aos-team-art@redhat.com',
-        subject: "Error during jenkins OCP v${OCP_RELEASE} RPM update on dist-git",
+        subject: "Error during jenkins ${OCP_BRANCH} RPM update on dist-git",
         body: """The job to update the jenkins RPM in dist-git encountered an error:
 ${err}
 
@@ -88,7 +86,7 @@ node(TARGET_NODE) {
     try {
 
         stage ("bump jenkins version") {
-            sh "./bump-jenkins.sh ${JENKINS_VERSION} ${OCP_RELEASE}"
+            sh "./bump-jenkins.sh ${JENKINS_VERSION} ${OCP_BRANCH}"
         }
 
         mail_success()

--- a/jobs/devex/jenkins-bump-version/bump-jenkins.sh
+++ b/jobs/devex/jenkins-bump-version/bump-jenkins.sh
@@ -10,9 +10,9 @@ SCRIPTS_DIR="$(pwd)"
 
 usage() {
     echo >&2
-    echo "Usage `basename $0` <jenkins-war-version> <ocp_major_minor>" >&2
+    echo "Usage `basename $0` <jenkins-war-version> <rhaos-branch>" >&2
     echo >&2
-    echo " Example: ./bump-jenkins.sh 2.73.1 3.7" >&2
+    echo " Example: ./bump-jenkins.sh 2.73.1 rhaos-3.7-rhel-7" >&2
     exit 1
 }
 
@@ -80,8 +80,7 @@ TSTAMP="$(date +%s)"
 
 VERSION="$1"
 UVERSION="$VERSION.$TSTAMP"
-OCP_VERSION="$2"
-BRANCH="rhaos-$2-rhel-7"
+BRANCH="$2"
 
 setup_dist_git
 prep_jenkins_war

--- a/jobs/devex/jenkins-plugins/Jenkinsfile
+++ b/jobs/devex/jenkins-plugins/Jenkinsfile
@@ -10,11 +10,11 @@ properties(
                     defaultValue: '2.42'
                 ],
                 [
-                    name: 'OCP_RELEASE',
-                    description: 'OCP target release',
+                    name: 'OCP_BRANCH',
+                    description: 'OCP target branch',
                     $class: 'hudson.model.ChoiceParameterDefinition',
-                    choices: ['4.6', '4.5', '4.4', '4.3', '4.2', '4.1', '4.0', '3.11', '3.10', '3.9','3.8','3.7', '3.6', '3.5', '3.4', '3.3'].join('\n'),
-                    defaultValue: '4.0'
+                    choices: ['rhaos-4.6-rhel-8', 'rhaos-4.6-rhel-7', 'rhaos-4.5-rhel-7', 'rhaos-4.4-rhel-7', 'rhaos-4.3-rhel-7', 'rhaos-4.2-rhel-7', 'rhaos-4.1-rhel-7', 'rhaos-4.0-rhel-7', 'rhaos-3.11-rhel-7', 'rhaos-3.10-rhel-7', 'rhaos-3.9-rhel-7','rhaos-3.8-rhel-7','rhaos-3.7-rhel-7', 'rhaos-3.6-rhel-7', 'rhaos-3.5-rhel-7', 'rhaos-3.4-rhel-7', 'rhaos-3.3-rhel-7'].join('\n'),
+                    defaultValue: 'rhaos-4.0-rhel-7'
                 ],
                 [
                     name: 'PLUGIN_LIST',
@@ -56,14 +56,14 @@ def mail_success() {
 
     jenkins_major = JENKINS_VERSION.tokenize('.')[0].toString()
 
-    distgit_link = "http://pkgs.devel.redhat.com/cgit/rpms/jenkins-${jenkins_major}-plugins/?h=rhaos-${OCP_RELEASE}-rhel-7"
+    distgit_link = "http://pkgs.devel.redhat.com/cgit/rpms/jenkins-${jenkins_major}-plugins/?h=${OCP_BRANCH}"
 
     mail(
         to: "${MAIL_LIST_SUCCESS}",
         from: "aos-art-automation@redhat.com",
         replyTo: 'aos-team-art@redhat.com',
-        subject: "jenkins plugins RPM for OCP ${OCP_RELEASE} updated in dist-git",
-        body: """The Jenkins plugins RPM for OCP ${OCP_RELEASE} has been updated in dist-git:
+        subject: "jenkins plugins RPM for ${OCP_BRANCH} updated in dist-git",
+        body: """The Jenkins plugins RPM for ${OCP_BRANCH} has been updated in dist-git:
 ${distgit_link}
 
 Minimum Jenkins version: ${JENKINS_VERSION}
@@ -117,7 +117,7 @@ node(TARGET_NODE) {
 
         stage ("update dist-git") {
             withEnv(["PATH+SCRIPTS=${scripts_dir}"]) {
-                sh "update-dist-git.sh ${JENKINS_VERSION} ${OCP_RELEASE} ${plugin_dir}"
+                sh "update-dist-git.sh ${JENKINS_VERSION} ${OCP_BRANCH} ${plugin_dir}"
             }
         }
 


### PR DESCRIPTION
This changes the OCP_RELEASE x.y parameters to both jobs to OCP_BRANCH rhaos-X.Y-rhel-N.

Please double-check that this won't break anything with your processes.