### PR TITLE
ART-1971 Compress brew-logs before archiving build artifacts

### DIFF
--- a/build-scripts/find-and-compress-brew-logs.sh
+++ b/build-scripts/find-and-compress-brew-logs.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euxo pipefail
+
+BREWLOGS=`find . -name brew-logs -type d`
+
+
+if [ -s "${BREWLOGS}" ]; then
+    echo "Brew logs (${BREWLOGS}) currently taking space:"
+    du -sh $BREWLOGS
+else
+    echo "No brew logs found"
+    exit 0
+fi
+
+
+tar -cjf brew-logs.tar.bz2 ${BREWLOGS}
+tar -tf brew-logs.tar.bz2
+mv brew-logs.tar.bz2 doozer_working/brew-logs.tar.bz2
+rm -rf $BREWLOGS
+
+echo "Compressed brew logs:"
+ls -lh doozer_working/brew-logs.tar.bz2

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -158,9 +158,10 @@ View the build artifacts and console output on Jenkins:
         }
         throw err  // gets us a stack trace FWIW
     } finally {
+        commonlib.compressBrewLogs()
         commonlib.safeArchiveArtifacts([
             "doozer_working/*.log",
-            "doozer_working/brew-logs/**",
+            "doozer_working/brew-logs.tar.bz2",
             "doozer_working/*.yaml",
             "doozer_working/*.yml",
         ])

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -293,6 +293,16 @@ def safeArchiveArtifacts(List patterns) {
 }
 
 
+/**
+ * Try to find 'brew-logs' directories and then automatically compress
+ * them so we can save space and inodes on our storage devices.
+
+ * Won't explode if called and doozer never got to save any brew-logs.
+**/
+def compressBrewLogs() {
+    this.shell(script: "${env.WORKSPACE}/build-scripts/find-and-compress-brew-logs.sh")
+}
+
 import java.util.concurrent.atomic.AtomicInteger
 shellCounter = new AtomicInteger()
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-1971

Test job run:

* https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/tbielawa-aos-cd-jobs/job/build%252Focp4/5/console

If we ever want to in the future we can easily incorporate this into other jobs by calling `commonlib.compressBrewLogs()` :+1: 

This won't explode if no brew logs were ever created. The shell script will just run away and hide :smiley_cat: 

----

You can see in the build job status page if you expand all artifacts that no "brew-logs" directory exists. Instead you will see a `brew-logs.tar.bz2` file. 