### PR TITLE
ART-2049: Make separate plashets for embargoed & unembargoed rpms

### DIFF
--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -192,8 +192,10 @@ node {
                         } else {
                             echo 'Building 4.x plashet'
                             // For 4.x, use plashets
-                            buildlib.buildBuildingPlashet(version, release, 7)  // build el7 plashet
-                            buildlib.buildBuildingPlashet(version, release, 8)  // build el8 plashet
+                            buildlib.buildBuildingPlashet(version, release, 8, true)  // build el8 embargoed plashet
+                            buildlib.buildBuildingPlashet(version, release, 7, true)  // build el7 embargoed plashet
+                            buildlib.buildBuildingPlashet(version, release, 8, false)  // build el8 unembargoed plashet
+                            buildlib.buildBuildingPlashet(version, release, 7, false)  // build el7 unembargoed plashet
                         }
                     }
                 }

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -297,10 +297,12 @@ def stageBuildCompose(auto_signing_advisory=54765) {
         return
     }
 
-    def plashet = buildlib.buildBuildingPlashet(version.full, version.release, 7, auto_signing_advisory)  // build el7 plashet
+    buildlib.buildBuildingPlashet(version.full, version.release, 8, true, auto_signing_advisory)  // build el8 embargoed plashet
+    buildlib.buildBuildingPlashet(version.full, version.release, 7, true, auto_signing_advisory)  // build el7 embargoed plashet
+    buildlib.buildBuildingPlashet(version.full, version.release, 8, false, auto_signing_advisory)  // build el8 unembargoed plashet
+    def plashet = buildlib.buildBuildingPlashet(version.full, version.release, 7, false, auto_signing_advisory)  // build el7 unembargoed plashet
     rpmMirror.plashetDirName = plashet.plashetDirName
     rpmMirror.localPlashetPath = plashet.localPlashetPath
-    buildlib.buildBuildingPlashet(version.full, version.release, 8, auto_signing_advisory)  // build el8 plashet
 }
 
 def stageUpdateDistgit() {


### PR DESCRIPTION
With https://github.com/openshift/aos-cd-jobs/pull/2292, Plashet by default only includes unembargoed historical builds of RPMs to the normal plashet.
This PR creates embargoed plashets then symlinks them as follows:

- plashets/{MAJOR}.{MINOR}/building    (normal invocation)
- plashets/{MAJOR}.{MINOR}/building*-embargoed*   (build with --include-embargoed)
- plashets/{MAJOR}.{MINOR}-el8/building    (normal invocation)
- plashets/{MAJOR}.{MINOR}-el8/building*-embargoed* (build with --include-embargoed)

Only unembargoed plashets will be synced to use-mirror.

Once this PR is merged, we also need to update ocp-build-data to point to embargoed plashets for ART builds.

Test job runs:
- https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/yuxzhu/job/aos-cd-jobs/job/build%252Fcustom/8/
- https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/yuxzhu/job/aos-cd-jobs/job/build%252Focp4/10/