### PR TITLE
[ART-2081] build-sync: Backup all imagestreams in api.ci

### DIFF
--- a/jobs/build/build-sync/Jenkinsfile
+++ b/jobs/build/build-sync/Jenkinsfile
@@ -82,6 +82,10 @@ node {
         lock("mirroring-lock-OCP-${params.BUILD_VERSION}") {
             stage("oc image mirror") { build.buildSyncMirrorImages() }
         }
+        // // An incident where a bug in oc destroyed the content of a critical imagestream ocp:is/release uncovered the fact that this vital data was not being backed up by any process.
+        // DPTP will be asked to backup etcd on this cluster, but ART should also begin backing up these imagestreams during normal operations as a first line of defense.
+        // In the build-sync job, prior to updating the 4.x-art-latest imagestreams, a copy of all imagestreams in the various release controller namespaces should be performed.
+        stage("backup imagestreams") { build.backupAllImageStreams() }
         lock("oc-applying-lock-OCP-${params.BUILD_VERSION}") {
             stage("oc apply") { build.buildSyncApplyImageStreams() }
         }


### PR DESCRIPTION
An incident where a bug in oc destroyed the content of a critical imagestream ocp:is/release uncovered the fact that this vital data was not being backed up by any process.
DPTP will be asked to backup etcd on this cluster, but ART should also begin backing up these imagestreams during normal operations as a first line of defense.

In the build-sync job, prior to updating the 4.x-art-latest imagestreams, a copy of all imagestreams in the various release controller namespaces should be performed.

Test job run: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/yuxzhu/job/aos-cd-jobs/job/build%252Fbuild-sync/16/console
Created archives: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/yuxzhu/job/aos-cd-jobs/job/build%252Fbuild-sync/16/artifact/

@jupierce PTAL