### PR TITLE
[ART-1193] add new quay registry to be synced for qe

### DIFF
--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -240,9 +240,13 @@ node {
 
             stage("build images") {
                 if (!any_images_to_build) { return }
-                buildlib.registry_quay_qe_login()
                 command = doozerOpts
-                command += "${include_exclude} --profile ${repo_type} images:build --push-to-defaults --registry-config-dir=./qe_quay_config"
+                command += "${include_exclude} --profile ${repo_type} images:build --push-to-defaults"
+                if (majorVersion == "4") {
+                    config_dir = "./qe_quay_config"
+                    buildlib.registry_quay_qe_login(config_dir)
+                    command += " --registry-config-dir=${config_dir}"
+                }
                 try {
                     buildlib.doozer command
                 } catch (err) {

--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -245,7 +245,7 @@ node {
                 if (majorVersion == "4") {
                     config_dir = "./qe_quay_config"
                     buildlib.registry_quay_qe_login(config_dir)
-                    command += " --registry-config-dir=${config_dir}"
+                    command += " --registry-config-dir=${config_dir} --filter-by-os='.*' "
                 }
                 try {
                     buildlib.doozer command

--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -240,13 +240,15 @@ node {
 
             stage("build images") {
                 if (!any_images_to_build) { return }
-                command = doozerOpts
-                command += "${include_exclude} --profile ${repo_type} images:build --push-to-defaults"
+                base_command = "${doozerOpts} ${include_exclude} --profile ${repo_type}"
+                command = "images:build --push-to-defaults"
                 if (majorVersion == "4") {
                     config_dir = "./qe_quay_config"
                     buildlib.registry_quay_qe_login(config_dir)
-                    command += " --registry-config-dir=${config_dir} --filter-by-os='.*' "
+                    base_command += " --registry-config-dir=${config_dir}"
+                    command += " --filter-by-os='.*'"
                 }
+                command = "${base_command} ${command}"
                 try {
                     buildlib.doozer command
                 } catch (err) {

--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -244,7 +244,7 @@ node {
                 if (!any_images_to_build) { return }
                 buildlib.registry_quay_qe_login()
                 command = doozerOpts
-                command += "${include_exclude} --profile ${repo_type} images:build --push-to ${qe_quay_registry} --registry-config=./qe_quay_config"
+                command += "${include_exclude} --profile ${repo_type} images:build --push-to-defaults --registry-config=./qe_quay_config"
                 try {
                     buildlib.doozer command
                 } catch (err) {

--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -140,8 +140,6 @@ node {
     def images = commonlib.cleanCommaList(params.IMAGES)
     def exclude_images = commonlib.cleanCommaList(params.EXCLUDE_IMAGES)
     def rpms = commonlib.cleanCommaList(params.RPMS)
-    // TODO: make this qe additional registry parameterized?
-    def qe_quay_registry = "quay.io/openshift-qe-optional-operator"
 
 
     currentBuild.displayName = "#${currentBuild.number} - ${version}-${release}"
@@ -244,7 +242,7 @@ node {
                 if (!any_images_to_build) { return }
                 buildlib.registry_quay_qe_login()
                 command = doozerOpts
-                command += "${include_exclude} --profile ${repo_type} images:build --push-to-defaults --registry-config=./qe_quay_config"
+                command += "${include_exclude} --profile ${repo_type} images:build --push-to-defaults --registry-config-dir=./qe_quay_config"
                 try {
                     buildlib.doozer command
                 } catch (err) {

--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -140,6 +140,8 @@ node {
     def images = commonlib.cleanCommaList(params.IMAGES)
     def exclude_images = commonlib.cleanCommaList(params.EXCLUDE_IMAGES)
     def rpms = commonlib.cleanCommaList(params.RPMS)
+    // TODO: make this qe additional registry parameterized?
+    def qe_quay_registry = "quay.io/openshift-qe-optional-operator"
 
 
     currentBuild.displayName = "#${currentBuild.number} - ${version}-${release}"
@@ -241,7 +243,7 @@ node {
             stage("build images") {
                 if (!any_images_to_build) { return }
                 command = doozerOpts
-                command += "${include_exclude} --profile ${repo_type} images:build --push-to-defaults"
+                command += "${include_exclude} --profile ${repo_type} images:build --push-to ${qe_quay_registry}"
                 try {
                     buildlib.doozer command
                 } catch (err) {

--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -242,8 +242,9 @@ node {
 
             stage("build images") {
                 if (!any_images_to_build) { return }
+                buildlib.registry_quay_qe_login()
                 command = doozerOpts
-                command += "${include_exclude} --profile ${repo_type} images:build --push-to ${qe_quay_registry}"
+                command += "${include_exclude} --profile ${repo_type} images:build --push-to ${qe_quay_registry} --registry-config=./qe_quay_config"
                 try {
                     buildlib.doozer command
                 } catch (err) {

--- a/jobs/build/ocp3/Jenkinsfile
+++ b/jobs/build/ocp3/Jenkinsfile
@@ -861,6 +861,7 @@ images:rebase --version v${NEW_VERSION}
 --working-dir ${DOOZER_WORKING} --group openshift-${params.BUILD_VERSION}
 ${ODCS_FLAG}
 ${exclude}
+--filter-by-os amd64
 images:build
 --push-to-defaults ${ODCS_OPT}
 """

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -335,7 +335,6 @@ def stageBuildImages() {
         def archReleaseStates = commonlib.ocp4ReleaseState[version.stream]
         // If any arch is GA, use signed for everything. See stageBuildCompose for details.
         def signing_mode = archReleaseStates['release']?'signed':'unsigned'
-        // TODO: make this qe additional registry parameterized?
         buildlib.registry_quay_qe_login()
         def cmd =
             """
@@ -344,7 +343,8 @@ def stageBuildImages() {
             images:build
             --repo-type ${signing_mode}
             --push-to-defaults
-            --registry-config=./qe_quay_config
+            --filter-by-os='.*'
+            --registry-config-dir=./qe_quay_config
             """
         if(buildPlan.dryRun) {
             echo "doozer ${cmd}"

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -335,7 +335,8 @@ def stageBuildImages() {
         def archReleaseStates = commonlib.ocp4ReleaseState[version.stream]
         // If any arch is GA, use signed for everything. See stageBuildCompose for details.
         def signing_mode = archReleaseStates['release']?'signed':'unsigned'
-        buildlib.registry_quay_qe_login()
+        config_dir = "./qe_quay_config"
+        buildlib.registry_quay_qe_login(config_dir)
         def cmd =
             """
             ${doozerOpts}
@@ -344,7 +345,7 @@ def stageBuildImages() {
             --repo-type ${signing_mode}
             --push-to-defaults
             --filter-by-os='.*'
-            --registry-config-dir=./qe_quay_config
+            --registry-config-dir=${config_dir}
             """
         if(buildPlan.dryRun) {
             echo "doozer ${cmd}"

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -336,7 +336,6 @@ def stageBuildImages() {
         // If any arch is GA, use signed for everything. See stageBuildCompose for details.
         def signing_mode = archReleaseStates['release']?'signed':'unsigned'
         // TODO: make this qe additional registry parameterized?
-        def qe_quay_registry = "quay.io/openshift-qe-optional-operator"
         buildlib.registry_quay_qe_login()
         def cmd =
             """
@@ -344,7 +343,7 @@ def stageBuildImages() {
             ${includeExclude "images", buildPlan.imagesIncluded, buildPlan.imagesExcluded}
             images:build
             --repo-type ${signing_mode}
-            --push-to ${qe_quay_registry}
+            --push-to-defaults
             --registry-config=./qe_quay_config
             """
         if(buildPlan.dryRun) {

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -337,6 +337,7 @@ def stageBuildImages() {
         def signing_mode = archReleaseStates['release']?'signed':'unsigned'
         // TODO: make this qe additional registry parameterized?
         def qe_quay_registry = "quay.io/openshift-qe-optional-operator"
+        buildlib.registry_quay_qe_login()
         def cmd =
             """
             ${doozerOpts}
@@ -344,6 +345,7 @@ def stageBuildImages() {
             images:build
             --repo-type ${signing_mode}
             --push-to ${qe_quay_registry}
+            --registry-config=./qe_quay_config
             """
         if(buildPlan.dryRun) {
             echo "doozer ${cmd}"

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -335,14 +335,15 @@ def stageBuildImages() {
         def archReleaseStates = commonlib.ocp4ReleaseState[version.stream]
         // If any arch is GA, use signed for everything. See stageBuildCompose for details.
         def signing_mode = archReleaseStates['release']?'signed':'unsigned'
-
+        // TODO: make this qe additional registry parameterized?
+        def qe_quay_registry = "quay.io/openshift-qe-optional-operator"
         def cmd =
             """
             ${doozerOpts}
             ${includeExclude "images", buildPlan.imagesIncluded, buildPlan.imagesExcluded}
             images:build
             --repo-type ${signing_mode}
-            --push-to-defaults
+            --push-to ${qe_quay_registry}
             """
         if(buildPlan.dryRun) {
             echo "doozer ${cmd}"

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -341,11 +341,11 @@ def stageBuildImages() {
             """
             ${doozerOpts}
             ${includeExclude "images", buildPlan.imagesIncluded, buildPlan.imagesExcluded}
+            --registry-config-dir=${config_dir}
             images:build
             --repo-type ${signing_mode}
             --push-to-defaults
             --filter-by-os='.*'
-            --registry-config-dir=${config_dir}
             """
         if(buildPlan.dryRun) {
             echo "doozer ${cmd}"

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -73,7 +73,7 @@ def registry_quay_qe_login(config_dir="./qe_quay_config") {
     // Login to quay.io for push to quay.io/openshift-qe-optional-operator
     withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'creds_qe_registry.quay.io',
                       usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD']]) {
-        sh 'docker --config  ${config_dir} login -u $USERNAME -p $PASSWORD quay.io'
+        sh "docker --config  ${config_dir} login -u $USERNAME -p $PASSWORD quay.io"
     }
 }
 

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -68,12 +68,12 @@ def registry_login() {
     }
 }
 
-def registry_quay_qe_login() {
+def registry_quay_qe_login(config_dir="./qe_quay_config") {
     // 2020-07-30 (https://issues.redhat.com/browse/ART-1193)
     // Login to quay.io for push to quay.io/openshift-qe-optional-operator
     withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'creds_qe_registry.quay.io',
                       usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD']]) {
-        sh 'docker --config ./qe_quay_config login -u $USERNAME -p $PASSWORD quay.io'
+        sh 'docker --config  ${config_dir} login -u $USERNAME -p $PASSWORD quay.io'
     }
 }
 

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -66,11 +66,14 @@ def registry_login() {
                       usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD']]) {
         sh 'docker login -u $USERNAME -p $PASSWORD quay.io'
     }
+}
+
+def registry_quay_qe_login() {
     // 2020-07-30 (https://issues.redhat.com/browse/ART-1193)
     // Login to quay.io for push to quay.io/openshift-qe-optional-operator
     withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'creds_qe_registry.quay.io',
                       usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD']]) {
-        sh 'docker login -u $USERNAME -p $PASSWORD quay.io'
+        sh 'docker --config ./qe_quay_config login -u $USERNAME -p $PASSWORD quay.io'
     }
 }
 

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -66,6 +66,12 @@ def registry_login() {
                       usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD']]) {
         sh 'docker login -u $USERNAME -p $PASSWORD quay.io'
     }
+    // 2020-07-30 (https://issues.redhat.com/browse/ART-1193)
+    // Login to quay.io for push to quay.io/openshift-qe-optional-operator
+    withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'creds_qe_registry.quay.io',
+                      usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD']]) {
+        sh 'docker login -u $USERNAME -p $PASSWORD quay.io'
+    }
 }
 
 def registry_quay_dev_login() {


### PR DESCRIPTION
1. openshift-qe-optional-operators+art_quay_dev
2. remove doozer images:build --push-to-default
3. use --push-to quay.io/openshift-qe-optional-operator instead

@sosiouxme @anpingli  from the jenkins log and docker login succeed, but seems oc mirror failed due to auth problem....did I miss sth??
jenkins-test:  https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/shiywang-aos-cd-jobs/job/build%252Fcustom/23/consoleFull
local-test:
```
./doozer --data-path /home/nay/shiywang/ocp-build-data --group openshift-4.6 -i openshift-enterprise-tests --profile unsigned images:build --push-to-defaults --dry-run --push-to quay.io/openshift-qe-optional-operator
2020-08-03 13:31:18,953 INFO Initial execution (cwd) directory: /home/nay/shiywang/doozer
2020-08-03 13:31:19,059 INFO Using branch from group.yml: rhaos-4.6-rhel-7
2020-08-03 13:31:20,040 INFO [containers/openshift-enterprise-tests] Distgit directory already exists; skipping clone: /home/nay/shiywang/distgits/containers/openshift-enterprise-tests
2020-08-03 13:31:20,064 INFO Time elapsed (hh:mm:ss.ms) 0:00:00.030746 in /home/nay/shiywang/doozer/doozerlib/runtime.py:1239 from /home/nay/shiywang/doozer/doozerlib/runtime.py:531:self.clone_distgits() : Full runtime clone
2020-08-03 13:31:20,066 INFO [containers/openshift-enterprise-tests] Skipping image build since it is not included: ose-tools
2020-08-03 13:31:20,066 INFO [containers/openshift-enterprise-tests] Building image: openshift/ose-tests:v4.6.0-202008031049.p0
2020-08-03 13:31:20,069 WARNING [containers/openshift-enterprise-tests] [Dry Run] Would have run command rhpkg --path=/home/nay/shiywang/distgits/containers/openshift-enterprise-tests container-build --nowait --repo-url http://pkgs.devel.redhat.com/cgit/containers/openshift-enterprise-tests/plain/.oit/unsigned.repo?h=rhaos-4.6-rhel-7
2020-08-03 13:31:20,069 INFO [containers/openshift-enterprise-tests] [Dry Run] Successfully built image: openshift/ose-tests:v4.6.0-202008031049.p0
**('quay.io/openshift-qe-optional-operator',)**
quay.io/openshift-qe-optional-operator/ose-tests
v4.6.0-202008031049.p0
~~~~~~~~~~~~~~~~~~~~~~~~~~~~

2020-08-03 13:31:20,166 INFO [containers/openshift-enterprise-tests] Adding 'quay.io/openshift-qe-optional-operator/ose-tests:v4.6.0-202008031049.p0' to push list
~~~~~~~~~~~~~~~~~~~~~~~~~~~~

quay.io/openshift-qe-optional-operator/ose-tests
v4.6.0
~~~~~~~~~~~~~~~~~~~~~~~~~~~~

2020-08-03 13:31:20,166 INFO [containers/openshift-enterprise-tests] Adding 'quay.io/openshift-qe-optional-operator/ose-tests:v4.6.0' to push list
~~~~~~~~~~~~~~~~~~~~~~~~~~~~

quay.io/openshift-qe-optional-operator/ose-tests
v4.6.0-202008031049
~~~~~~~~~~~~~~~~~~~~~~~~~~~~

2020-08-03 13:31:20,166 INFO [containers/openshift-enterprise-tests] Adding 'quay.io/openshift-qe-optional-operator/ose-tests:v4.6.0-202008031049' to push list
~~~~~~~~~~~~~~~~~~~~~~~~~~~~

quay.io/openshift-qe-optional-operator/ose-tests
v4.6
~~~~~~~~~~~~~~~~~~~~~~~~~~~~

2020-08-03 13:31:20,166 INFO [containers/openshift-enterprise-tests] Adding 'quay.io/openshift-qe-optional-operator/ose-tests:v4.6' to push list
2020-08-03 13:31:20,169 INFO [containers/openshift-enterprise-tests] Mirroring image [retry=0]
2020-08-03 13:31:20,177 INFO $0: ['oc', 'image', 'mirror', '--filter-by-os=amd64', '--filename=/home/nay/shiywang/push/openshift-enterprise-tests'] - [cwd=/home/nay/shiywang/distgits/containers/openshift-enterprise-tests]: Executing:cmd_gather
^C2020-08-03 13:31:22,001 WARNING SIGINT received, signaling threads to terminate...
2020-08-03 13:31:22,005 INFO Time elapsed (hh:mm:ss.ms) 0:00:01.827182 in /home/nay/shiywang/doozer/doozerlib/exectools.py:159 from /home/nay/shiywang/doozer/doozerlib/distgit.py:606:rc, out, err = exectools.cmd_gather(mirror_cmd) : $0: ['oc', 'image', 'mirror', '--filter-by-os=amd64', '--filename=/home/nay/shiywang/push/openshift-enterprise-tests'] - [cwd=/home/nay/shiywang/distgits/containers/openshift-enterprise-tests]: Executed:cmd_gather
2020-08-03 13:31:22,005 INFO [containers/openshift-enterprise-tests] Error mirroring image -- retrying in 60 seconds.
quay.io/
  openshift-qe-optional-operator/ose-tests
    blobs:
      registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests sha256:e7021e0589e97471d99c4265b7c8e64da328e48f116b5f260353b2e0a2adb373 1.703KiB
      registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests sha256:6ce4364bdb52470a26bdd95b0cec600d7f945c1e796dda9a48d9db7c4929bc51 5.602KiB
      registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests sha256:7c480857b6792d3c0c62b8c18a55ddd1bb86dabf7ef2e48c43a6d10dadb8f103 3.341MiB
      registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests sha256:f0741a966c79acdef39a9c8484f3fab873ca30b099cc144d6d8212375c92457a 9.154MiB
      registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests sha256:2bec075056ac90705024d532235b75292e52c3119896d5e9e04dd0a4692fff38 22.85MiB
      registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests sha256:3a0541e3f2d54d3dd9ddd9c7ae1b006803ef3c1d0469001a5e21bc656881639a 47.68MiB
      registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests sha256:f2e20cbfd336f033f6d59ea5f50586b8c1a6212aaccc07dfd4004406ad626f36 52.2MiB
      registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-tests sha256:fc5b206e9329a1674dd9e8efbee45c9be28d0d0dcbabba3c6bb67a2f22cfcf2a 72.71MiB
    manifests:
      sha256:94a295dcfd0507e9bceb0d42ef980e68ff827bcb91de4f94b3cb214734a9e728 -> v4.6
      sha256:94a295dcfd0507e9bceb0d42ef980e68ff827bcb91de4f94b3cb214734a9e728 -> v4.6.0
      sha256:94a295dcfd0507e9bceb0d42ef980e68ff827bcb91de4f94b3cb214734a9e728 -> v4.6.0-202008031049
      sha256:94a295dcfd0507e9bceb0d42ef980e68ff827bcb91de4f94b3cb214734a9e728 -> v4.6.0-202008031049.p0
  stats: shared=0 unique=8 size=207.9MiB ratio=1.00

phase 0:
  quay.io openshift-qe-optional-operator/ose-tests blobs=8 mounts=0 manifests=4 shared=0

info: Planning completed in 1s
```
