### PR TITLE
odo-sync: Expect new file location in RPM

### DIFF
--- a/jobs/build/odo_sync/Jenkinsfile
+++ b/jobs/build/odo_sync/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
             steps {
                 sh "rpm2cpio odo.rpm | cpio --extract --make-directories"
                 sh "rm --recursive --force ${params.VERSION} && mkdir ${params.VERSION}"
-                sh "mv --verbose ./usr/share/openshift-odo-redistributable/* ${params.VERSION}/"
+                sh "mv --verbose ./usr/share/*odo-redistributable/* ${params.VERSION}/"
                 sh "tree ${params.VERSION}"
             }
         }


### PR DESCRIPTION
Looks like the brew package has changed from [openshift-odo](https://brewweb.engineering.redhat.com/brew/packageinfo?packageID=73128) to [odo](https://brewweb.engineering.redhat.com/brew/packageinfo?packageID=74660).
With this, the file locations have changed inside the archive from `usr/share/openshift-odo-redistributable` to `usr/share/odo-redistributable`.

This change makes our code work in both cases.