### PR TITLE
[ART-2102] Update 'odo' sync automation

### DIFF
--- a/jobs/build/odo_sync/Jenkinsfile
+++ b/jobs/build/odo_sync/Jenkinsfile
@@ -6,13 +6,23 @@ pipeline {
 
     parameters {
         string(
-            name: "RPM_URL",
-            description: "Redistributable RPM URL. Example: http://brew-task-repos.usersys.redhat.com/repos/official/openshift-odo/1.0.3/1.el7/x86_64/openshift-odo-redistributable-1.0.3-1.el7.x86_64.rpm",
+            name: "VERSION",
+            description: "Desired version name. Example: v1.0.3",
             defaultValue: ""
         )
         string(
-            name: "VERSION",
-            description: "Desired version name. Example: v1.0.3",
+            name: "LINUX_BINARIES_LOCATION",
+            description: "Example: http://download.eng.bos.redhat.com/staging-cds/developer/odo/1.2.5-1/signed/linux/",
+            defaultValue: ""
+        )
+        string(
+            name: "MACOS_BINARIES_LOCATION",
+            description: "Example: http://download.eng.bos.redhat.com/staging-cds/developer/odo/1.2.5-1/signed/macos/",
+            defaultValue: ""
+        )
+        string(
+            name: "WINDOWS_BINARIES_LOCATION",
+            description: "Example: http://download.eng.bos.redhat.com/staging-cds/developer/odo/1.2.5-1/signed/windows/",
             defaultValue: ""
         )
     }
@@ -21,31 +31,46 @@ pipeline {
         stage("Validate params") {
             steps {
                 script {
-                    if (!params.RPM_URL) {
-                        error "RPM_URL must be specified"
-                    }
                     if (!params.VERSION) {
                         error "VERSION must be specified"
                     }
                 }
             }
         }
-        stage("Download RPM") {
+        stage("Clean working dir") {
             steps {
-                sh "rm --force odo.rpm"
-                sh "wget --no-verbose ${params.RPM_URL} --output-document=odo.rpm"
+                sh "rm -rf ${params.VERSION}"
             }
         }
-        stage("Extract RPM contents") {
-            steps {
-                sh "rpm2cpio odo.rpm | cpio --extract --make-directories"
-                sh "rm --recursive --force ${params.VERSION} && mkdir ${params.VERSION}"
-                sh "mv --verbose ./usr/share/*odo-redistributable/* ${params.VERSION}/"
-                sh "tree ${params.VERSION}"
+        stage("Download binaries") {
+            parallel {
+                stage("linux")   { steps { script { downloadRecursive(params.LINUX_BINARIES_LOCATION,   params.VERSION) }}}
+                stage("macos")   { steps { script { downloadRecursive(params.MACOS_BINARIES_LOCATION,   params.VERSION) }}}
+                stage("windows") { steps { script { downloadRecursive(params.WINDOWS_BINARIES_LOCATION, params.VERSION) }}}
             }
         }
+        stage("Organize directory") {
+            parallel {
+                stage("Combine SHA256SUM files") {
+                    steps {
+                        sh "cat ${params.VERSION}/SHA256SUM.* >> ${params.VERSION}/SHA256SUM"
+                        sh "rm ${params.VERSION}/SHA256SUM.*"
+                    }
+                }
+                stage("Copy odo.exe") {
+                    steps {
+                        sh "cp ${params.VERSION}/odo-windows-amd64.exe ${params.VERSION}/odo.exe"
+                        sh "cd ${params.VERSION} ; sha256sum odo.exe >> SHA256SUM ; cd .."
+                    }
+                }
+            }
+        }
+
         stage("Sync to mirror") {
             steps {
+                sh "tree ${params.VERSION}"
+                sh "cat ${params.VERSION}/SHA256SUM"
+
                 sshagent(['aos-cd-test']) {
                     sh "scp -r ${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/clients/odo/"
                     sh "ssh use-mirror-upload.ops.rhcloud.com -- ln --symbolic --force --no-dereference ${params.VERSION} /srv/pub/openshift-v4/clients/odo/latest"
@@ -54,4 +79,8 @@ pipeline {
             }
         }
     }
+}
+
+def downloadRecursive(path, destination) {
+    sh "wget --recursive --no-parent --reject 'index.html*' --no-directories --directory-prefix ${destination} ${path}"
 }

--- a/jobs/build/odo_sync/Jenkinsfile
+++ b/jobs/build/odo_sync/Jenkinsfile
@@ -50,19 +50,12 @@ pipeline {
             }
         }
         stage("Organize directory") {
-            parallel {
-                stage("Combine SHA256SUM files") {
-                    steps {
-                        sh "cat ${params.VERSION}/SHA256SUM.* >> ${params.VERSION}/SHA256SUM"
-                        sh "rm ${params.VERSION}/SHA256SUM.*"
-                    }
-                }
-                stage("Copy odo.exe") {
-                    steps {
-                        sh "cp ${params.VERSION}/odo-windows-amd64.exe ${params.VERSION}/odo.exe"
-                        sh "cd ${params.VERSION} ; sha256sum odo.exe >> SHA256SUM ; cd .."
-                    }
-                }
+            steps {
+                sh "cat ${params.VERSION}/SHA256SUM.* >> ${params.VERSION}/SHA256SUM"
+                sh "rm ${params.VERSION}/SHA256SUM.*"
+                sh "cp ${params.VERSION}/odo-windows-amd64.exe ${params.VERSION}/odo.exe"
+                sh "cd ${params.VERSION} ; sha256sum odo.exe >> SHA256SUM ; cd .."
+                sh "mv ${params.VERSION}/SHA256SUM ${params.VERSION}/sha256sum.txt"
             }
         }
 

--- a/jobs/build/odo_sync/Jenkinsfile
+++ b/jobs/build/odo_sync/Jenkinsfile
@@ -49,12 +49,10 @@ pipeline {
                 stage("windows") { steps { script { downloadRecursive(params.WINDOWS_BINARIES_LOCATION, params.VERSION) }}}
             }
         }
-        stage("Organize directory") {
+        stage("Combine SHA256SUMs") {
             steps {
                 sh "cat ${params.VERSION}/SHA256SUM.* >> ${params.VERSION}/SHA256SUM"
                 sh "rm ${params.VERSION}/SHA256SUM.*"
-                sh "cp ${params.VERSION}/odo-windows-amd64.exe ${params.VERSION}/odo.exe"
-                sh "cd ${params.VERSION} ; sha256sum odo.exe >> SHA256SUM ; cd .."
                 sh "mv ${params.VERSION}/SHA256SUM ${params.VERSION}/sha256sum.txt"
             }
         }
@@ -62,7 +60,7 @@ pipeline {
         stage("Sync to mirror") {
             steps {
                 sh "tree ${params.VERSION}"
-                sh "cat ${params.VERSION}/SHA256SUM"
+                sh "cat ${params.VERSION}/sha256sum.txt"
 
                 sshagent(['aos-cd-test']) {
                     sh "scp -r ${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/clients/odo/"


### PR DESCRIPTION
![odo](https://comicvine1.cbsistatic.com/uploads/original/3/30334/1135545-trek2634.jpg)

[Sample run on hack space](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/talessio-aos-cd-jobs/job/ART-2012-hack/9/console), creates the following directory structure & contents:

![sample-run-build-params](https://user-images.githubusercontent.com/190616/89406910-2a7c4780-d71e-11ea-9252-444e0d940354.png)

```
+ tree v1.2.5
v1.2.5
├── odo-darwin-amd64
├── odo-darwin-amd64.tar.gz
├── odo.exe
├── odo-linux-amd64
├── odo-linux-amd64.tar.gz
├── odo-linux-arm64
├── odo-linux-arm64.tar.gz
├── odo-linux-ppc64le
├── odo-linux-ppc64le.tar.gz
├── odo-linux-s390x
├── odo-linux-s390x.tar.gz
├── odo-windows-amd64.exe
├── odo-windows-amd64.exe.tar.gz
└── SHA256SUM

0 directories, 14 files
```
```
+ cat v1.2.5/SHA256SUM
11b262aee32e376f29f1be488d8268d4e30cf67cd786f60ba6e840c937919de8  odo-linux-amd64
f5bc1fa254afc0de93b1965ac2fd5f54943bfacdb6da6a6f887bf2d2da8ab8c6  odo-linux-amd64.tar.gz
f263129773034a54df4020f4036a8d55e55f9233ef5edc2b677fb4a47143edc8  odo-linux-arm64
a0e954b9a58b081295051d3fce507afd47e527d6b2784b1b51bb0546917a3355  odo-linux-arm64.tar.gz
f9c034931b8229b2ec2437d3e5e7a77a30e61f1060d4b10fef35eb46f020d35d  odo-linux-ppc64le
8fd6939e5fdfaf9e8cea508e692e5fcdf3285f5db159c4579e1d2b136142c777  odo-linux-ppc64le.tar.gz
d3371a50209d84daea59fa3b280f635e5fc85731e5be2574eaa0e2d6408e80c5  odo-linux-s390x
d3b6f83517e1243ef68d09bfba5ed03bc492e4743559f0ed531c3579f25e3a97  odo-linux-s390x.tar.gz
bda0b3136fdcdd449e2d197745e119181599fc18e864e3ea62b99a9cc0372a8a  odo-darwin-amd64
6f925e8b555bdefb8c1f39db74cfa752227dac97fec447264df39a8b9f73eaf9  odo-darwin-amd64.tar.gz
2c801dc772a13641c9a4f5f52028e2f4c50827924655ac90ef8fe847c4159a62  odo-windows-amd64.exe
09c4a61826076e909b68eb04375fa126efd1f1b6d946e86b2679856c485cdd93  odo-windows-amd64.exe.tar.gz
2c801dc772a13641c9a4f5f52028e2f4c50827924655ac90ef8fe847c4159a62  odo.exe
```

**UPDATE:** https://github.com/openshift/aos-cd-jobs/pull/2309/commits/80185f742061afc7b98f367703fc29a0dca9f035 renames `SHA256SUM` to `sha256sum.txt` to keep consistency with previous releases.