### PR TITLE
ART-1844 - Fix missing fields in json claim signing request

### DIFF
--- a/jobs/signing/sign-artifacts/umb_producer.py
+++ b/jobs/signing/sign-artifacts/umb_producer.py
@@ -343,12 +343,6 @@ payload images". After the json digest is signed we publish the
 signature in a location which follows a specific directory pattern,
 thus allowing the signature to be looked up programmatically.
     """
-    # NOTE: The example claim JSON I've seen includes an 'optional' section
-    # like this (same level as 'critical'):
-    #
-    # "optional": {
-    #     "creator": "Red Hat RCM Pub 0.21.0-final "
-    # }
     json_claim = {
         "critical": {
             "image": {
@@ -358,6 +352,9 @@ thus allowing the signature to be looked up programmatically.
             "identity": {
                 "docker-reference": None,
             }
+        },
+        "optional": {
+            "creator": "Red Hat OpenShift Signing Authority 0.0.1",
         },
     }
 


### PR DESCRIPTION
Adds the specified ".optional.creator" field per:

https://github.com/containers/image/blob/master/docs/containers-signature.5.md#optionalcreator

https://issues.redhat.com/browse/ART-1844

