### PR TITLE
cincinnati-prs: fix workspace deletion problem

### DIFF
--- a/jobs/build/cincinnati-prs/Jenkinsfile
+++ b/jobs/build/cincinnati-prs/Jenkinsfile
@@ -56,7 +56,10 @@ node {
     )
 
     commonlib.checkMock()
-    buildlib.cleanWorkdir("${env.WORKSPACE}")
-    release.openCincinnatiPRs(params.RELEASE_NAME.trim(), params.ADVISORY_NUM.trim(), params.CANDIDATE_CHANNEL_ONLY, params.GITHUB_ORG.trim(), params.SKIP_OTA_SLACK_NOTIFICATION)
-    buildlib.cleanWorkdir("${env.WORKSPACE}")
+    workdir = "${env.WORKSPACE}/workdir"
+    buildlib.cleanWorkdir(workdir, true)
+    dir(workdir) {
+        release.openCincinnatiPRs(params.RELEASE_NAME.trim(), params.ADVISORY_NUM.trim(), params.CANDIDATE_CHANNEL_ONLY, params.GITHUB_ORG.trim(), params.SKIP_OTA_SLACK_NOTIFICATION)
+    }
+    buildlib.cleanWorkdir(workdir)
 }


### PR DESCRIPTION
we really don't want to use `env.WORKSPACE` as our workspace (it has code and stuff and shouldn't be deleted). we really want a subdir. `buildlib.cleanWorkspace` was literally removing the jenkins job's workspace.

(changes are mostly whitespace)

test run at https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/lmeyer/job/lmeyer-dev/job/dev-build%252Fcincinnati-prs/9/console