### PR TITLE
ART-1697: sends VirtualTopic.qe.ci.jenkins messages for all minor ver…

### DIFF
--- a/jobs/build/send-umb-messages/Jenkinsfile
+++ b/jobs/build/send-umb-messages/Jenkinsfile
@@ -1,8 +1,10 @@
 #!/usr/bin/env groovy
+import java.net.URLEncoder
 
 node {
     checkout scm
-    def buildlib = load("pipeline-scripts/buildlib.groovy")
+    def release = load("pipeline-scripts/release.groovy")
+    def buildlib = release.buildlib
     def commonlib = buildlib.commonlib
     commonlib.describeJob("send-umb-messages", """
         <h2>Send UMB messages when new releases/nightlies are accepted</h2>
@@ -12,7 +14,6 @@ node {
         release images and publishes a UMB message that others can use to
         trigger their automation (e.g. QE can trigger testing).
     """)
-
 
     properties([
             buildDiscarder(
@@ -27,62 +28,75 @@ node {
             disableConcurrentBuilds(),
     ])
 
-    // we only care to publish messages for the following releases
-    releases = commonlib.ocp4SendUMBVersions
+    // Send UMB messages for these new nightlies, yields a list like:
+    //     [4.6.0-0.nightly, 4.5.0-0.nightly, 4.4.0-0.nightly, ...]
+    def nightlies = commonlib.ocp4Versions.collect { it + ".0-0.nightly" }
+    // Send UMB messages for these new stables, yields a list like:
+    //     [4-stable:4.6, 4-stable:4.5, 4-stable:4.4, ...]
+    def stables = commonlib.ocp4Versions.collect { "4-stable:" + it }
+    def releaseStreams = stables + nightlies
     currentBuild.description = ""
     currentBuild.displayName = ""
 
     stage("send UMB messages for new releases") {
         dir ("/mnt/nfs/home/jenkins/.cache/releases") {
-            for (String release : releases) {
+            for (String key : releaseStreams) {
                 try {
+                    def keySplit = key.split(":")  // 4-stable:4.6 -> [4-stable, 4.6]
+                    def releaseStream = keySplit[0]
+                    def majorMinor = keySplit.length > 1 ? keySplit[1] : null
                     // There are different release controllers for OCP - one for each architecture.
-                    RELEASE_CONTROLLER_URL = commonlib.getReleaseControllerURL(release)
-                    latestRelease = sh(
-                        returnStdout: true,
-                        script: "curl -L -sf ${RELEASE_CONTROLLER_URL}/api/v1/releasestream/${release}/latest",
-                    ).trim()
-                    latestReleaseVersion = readJSON(text: latestRelease).name
-                    echo "${release}: latestRelease=${latestRelease}"
+                    def url = "${commonlib.getReleaseControllerURL(releaseStream)}/api/v1/releasestream/${URLEncoder.encode(releaseStream, "utf-8")}/latest"
+                    if (majorMinor) {
+                        def (major, minor) = commonlib.extractMajorMinorVersionNumbers(majorMinor)
+                        def queryParams = [
+                            "in": ">${major}.${minor}.0-0 < ${major}.${minor + 1}.0-0"
+                        ]
+                        def queryString = queryParams.collect {
+                                (URLEncoder.encode(it.key, "utf-8") + "=" +  URLEncoder.encode(it.value, "utf-8"))
+                            }.join('&')
+                        url += "?" + queryString
+                    }
+                    def response = httpRequest(
+                        url: url,
+                        httpMode: 'GET',
+                        acceptType: 'APPLICATION_JSON',
+                        timeout: 30,
+                    )
+                    latestRelease = readJSON text: response.content
+                    latestReleaseVersion = latestRelease.name
+                    echo "${key}: latestRelease=${latestRelease}"
                     try {
-                        previousRelease = readFile("${release}.current")
-                        echo "${release}: previousRelease=${previousRelease}"
+                        previousRelease = readJSON(file: "${key}.current")
+                        echo "${key}: previousRelease=${previousRelease}"
                     } catch (readex) {
                         // The first time this job is ran and the first
                         // time any new release is added the 'readFile'
                         // won't find the file and will raise a
                         // NoSuchFileException exception.
-                        echo "${release}: Error reading revious release: ${readex}"
-                        touch file: "${release}.current"
-                        previousRelease = ""
+                        echo "${key}: Error reading previous release: ${readex}"
+                        touch file: "${key}.current"
+                        previousRelease = [:]
                     }
 
                     if ( latestRelease != previousRelease ) {
                         def previousReleaseVersion = "0.0.0"
                         if (previousRelease)
-                            previousReleaseVersion = readJSON(text: previousRelease).name
-                            currentBuild.displayName += "🆕 ${release}: ${previousReleaseVersion} -> ${latestReleaseVersion}"
-                            currentBuild.description += "\n🆕 ${release}: ${previousReleaseVersion} -> ${latestReleaseVersion}"
-
-                        sendCIMessage(
-                            messageProperties: "release=${release}",
-                            messageContent: latestRelease,
-                            messageType: 'Custom',
-                            failOnError: true,
-                            overrides: [topic: 'VirtualTopic.qe.ci.jenkins'],
-                            providerName: 'Red Hat UMB'
-                        )
-                        writeFile file: "${release}.current", text: "${latestRelease}"
+                            previousReleaseVersion = previousRelease.name
+                        currentBuild.displayName += "🆕 ${key}: ${previousReleaseVersion} -> ${latestReleaseVersion}"
+                        currentBuild.description += "\n🆕 ${key}: ${previousReleaseVersion} -> ${latestReleaseVersion}"
+                        release.sendPreReleaseMessage(latestRelease, releaseStream)
+                        writeJSON file: "${key}.current", json: latestRelease
                     } else {
-                        currentBuild.description += "\nUnchanged: ${release}"
+                        currentBuild.description += "\nUnchanged: ${key}"
                     }
                 } catch (org.jenkinsci.plugins.workflow.steps.FlowInterruptedException ex) {
                     // don't try to recover from cancel
                     throw ex
                 } catch (ex) {
                     // but do tolerate other per-release errors
-                    echo "Error during release ${release}: ${ex}"
-                    currentBuild.description += "\nFailed: ${release}"
+                    echo "Error during release ${key}: ${ex}"
+                    currentBuild.description += "\nFailed: ${key}"
                 }
             }
         }

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -13,11 +13,6 @@ ocp4Versions = [
     "4.2",
 ]
 
-// Send UMB messages for these new nightlies, yields a list like:
-//
-//     [4-stable, 4.1.0-0.nightly, 4.2.0-0.nightly, 4.3.0-0.nightly, ...]
-ocp4SendUMBVersions = ocp4Versions.collect(["4-stable"]) { it + ".0-0.nightly" }
-
 // Which versions should undergo merges from origin->ose
 ocpMergeVersions = [
     "4.6",
@@ -364,9 +359,9 @@ def shell(arg) {
     // concurrency-safe creation of output dir and removal of any previous output dirs
     sh """#!/bin/bash +x
         # Make the directory we are going to stream output to
-        mkdir -p ${shellSubdir} 
+        mkdir -p ${shellSubdir}
         # Remove any old shell content from prior jobs
-        rm -rf `ls -d ${shellBase}/shell.* | grep -v shell.${currentBuild.number}`  
+        rm -rf `ls -d ${shellBase}/shell.* | grep -v shell.${currentBuild.number}`
     """
 
     echo "Running shell script via commonlib.shell:\n${script}"

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -446,6 +446,26 @@ def void sendReleaseCompleteMessage(Map release, int advisoryNumber, String advi
     }
 }
 
+def sendPreReleaseMessage(Map release, String releaseStreamName, String providerName = 'Red Hat UMB') {
+    timeout(3) {
+        def sendResult = sendCIMessage(
+            messageProperties:
+                """release=${release.name}
+                release_stream: ${releaseStreamName}
+                product=OpenShift Container Platform
+                """,
+            messageContent: JsonOutput.toJson(release),
+            messageType: 'Custom',
+            failOnError: true,
+            overrides: [topic: 'VirtualTopic.qe.ci.jenkins'],
+            providerName: providerName,
+        )
+        echo 'Message sent.'
+        echo "Message ID: ${sendResult.getMessageId()}"
+        echo "Message content: ${sendResult.getMessageContent()}"
+    }
+}
+
 def createAdvisoriesFor(ocpVersion, dry_run=false) {
     build(
         job: "build%2Fadvisories",


### PR DESCRIPTION
…sions

Previously send-umb-messages only looks at "latest" In the 4-stable channel, which only covers the latest z-stream releases with the latest minor version.

Now it sends messages for all minor versions.

Test run: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/yuxzhu-aos-cd-jobs/job/build%252Fsend-umb-messages/11/console (messages sent to stage UMB)