### PR TITLE
oc: change --config to --kubeconfig

### DIFF
--- a/jobs/build/reposync/Jenkinsfile
+++ b/jobs/build/reposync/Jenkinsfile
@@ -89,7 +89,7 @@ node {
                     base_args = "--working-dir ${DOOZER_WORKING} --group ${GROUP}"
 
                     // we need to be able to push images to api.ci, so make sure our token is fresh
-                    sh "oc --config=/home/jenkins/kubeconfigs/art-publish.kubeconfig registry login"
+                    sh "oc --kubeconfig=/home/jenkins/kubeconfigs/art-publish.kubeconfig registry login"
                     buildlib.doozer "${base_args} images:mirror-streams"
 
                     command = "${base_args} beta:reposync --output ${syncDir}/ --cachedir ${cacheDir}/ --repo-type ${REPO_TYPE} --arch ${ARCH}"

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -10,7 +10,7 @@ buildlib = load("pipeline-scripts/buildlib.groovy")
 commonlib = buildlib.commonlib
 slacklib = commonlib.slacklib
 
-oc_cmd = "oc --config=/home/jenkins/kubeconfigs/art-publish.kubeconfig"
+oc_cmd = "oc --kubeconfig=/home/jenkins/kubeconfigs/art-publish.kubeconfig"
 
 // dump important tool versions to console
 def stageVersions() {


### PR DESCRIPTION
Address the following warning:
```
Flag --config has been deprecated, use --kubeconfig instead
```