### PR TITLE
sanitize invisible

### DIFF
--- a/jobs/signing/sign-artifacts/Jenkinsfile
+++ b/jobs/signing/sign-artifacts/Jenkinsfile
@@ -98,7 +98,6 @@ node {
 
     stage('sign-artifacts') {
         def noop = params.DRY_RUN ? " --noop" : " "
-        def digest = params.DIGEST ? "--digest ${params.DIGEST}" : ""
 
         currentBuild.displayName += "- ${params.NAME}"
         if (params.DRY_RUN) {
@@ -112,9 +111,11 @@ node {
             requestIdSuffix = ""
         }
 
-        if ( !(env.DIGEST ==~ /sha256:[0-9a-f]{64}/) ) {
+        def digest = commonlib.sanitizeInvisible(params.DIGEST).trim()
+        def digestParam = digest ? "--digest ${digest}" : ""
+        if ( !(digest ==~ /sha256:[0-9a-f]{64}/) ) {
             currentBuild.description = "bad digest"
-            error("The digest does not look like 'sha256:hex64'. If you copied it from jenkins job output, it might include invisible unicode.")
+            error("The digest does not look like 'sha256:hex64'")
         }
 
         wrap([$class: 'BuildUser']) {
@@ -138,7 +139,7 @@ node {
                         // ######################################################################
                         def openshiftJsonSignParams = buildlib.cleanWhitespace("""
                              ${baseUmbParams} --product openshift --arch ${params.ARCH} --client-type ${params.CLIENT_TYPE}
-                             --request-id 'openshift-json-digest-${env.BUILD_ID}${requestIdSuffix}' ${digest} ${noop}
+                             --request-id 'openshift-json-digest-${env.BUILD_ID}${requestIdSuffix}' ${digestParam} ${noop}
                          """)
 
                         echo "Submitting OpenShift Payload JSON claim signature request"

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -193,10 +193,17 @@ def standardVersion(String version, Boolean withV=true) {
     return withV ? "v${version}" : version
 }
 
+def sanitizeInvisible(str) {
+    // Jenkins has a tendency to put invisible breaks that people copy and paste into job parameters.
+    // This causes very confusing failures.
+    // First turn newlines into space to preserve separation in lists; then remove other non-printables
+    return str.replaceAll(/\s/, " ").replaceAll(/[^\p{Print}]/, '')
+}
+
 def parseList(str) {
     // turn the string of a list separated by commas or spaces into a list
     str = (str == null) ? "" : str
-    return str.replaceAll(',', ' ').split()
+    return sanitizeInvisible(str).replaceAll(',', ' ').split()
 }
 
 def cleanCommaList(str) {


### PR DESCRIPTION
Jenkins has a tendency to put invisible breaks that people copy and paste into job parameters.
This causes very confusing failures.
First turn newlines into space to preserve separation in lists; then remove other non-printables.
Make list parameters use this, and the sign-artifacts job.

[Test run](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/lmeyer/job/lmeyer-dev/job/dev-build%252Fsign-artifacts/35/console)