### PR TITLE
Change naming convention of nightly

### DIFF
--- a/jobs/build/release/Jenkinsfile
+++ b/jobs/build/release/Jenkinsfile
@@ -166,7 +166,8 @@ node {
     } else if (params.RELEASE_TYPE.startsWith('4.')) {   // Just a hotfix for a specific customer
         direct_release_nightly = true
         detect_previous = false
-        release_name = params.FROM_RELEASE_TAG.trim()   // ignore offset. Release is named same as nightly.
+        // ignore offset. Release is named same as nightly but with 'hotfix' instead of 'nightly'.
+        release_name = params.FROM_RELEASE_TAG.trim().replaceAll('nightly', 'hotfix')
         CLIENT_TYPE = 'ocp-dev-preview'  // Trigger beta2 key
     } else {
         error('Unknown release type: ' + params.RELEASE_TYPE)


### PR DESCRIPTION
ex: 4.4.0-0.hotfix-2020-07-30-212136
Requested because available documentation explicitly recommends
against upgrading to/from "nightlies".