### PR TITLE
Add tekton job `link-pull-request-to-jira`

### DIFF
--- a/tekton-pipelines/README.md
+++ b/tekton-pipelines/README.md
@@ -1,0 +1,216 @@
+# Tekton Demo: Put the link to GitHub Pull Request to JIRA
+
+## Prerequisites
+- A Kubernetes cluster version 1.15+ or OpenShift cluster 3.11+.
+  Use [Minikube][] to runs a single-node Kubernetes cluster in a virtual machine on your personal computer.
+
+- Tekton Pipelines
+    ``` sh
+    # Kubernetes
+    kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+    # OpenShift
+    oc apply -f https://storage.googleapis.com/tekton-releases/pipeline/latest/release.notags.yaml
+    ```
+    ``` sh
+    # check for installation
+    kubectl get pods --namespace tekton-pipelines
+    kubectl get svc -n tekton-pipelines tekton-dashboard
+    ```
+- Tekton Triggers
+    ``` sh
+    kubectl apply -f https://storage.googleapis.com/tekton-releases/triggers/latest/release.yaml
+    ```
+    ``` sh
+    # check for installation
+    kubectl get pods --namespace tekton-pipelines
+    ```
+- (Optional) Tekton Dashboard
+    ``` sh
+    # Kubernetes
+    kubectl apply -f https://github.com/tektoncd/dashboard/releases/latest/download/tekton-dashboard-release.yaml
+    # OpenShift
+    oc apply -f https://github.com/tektoncd/dashboard/releases/latest/download/openshift-tekton-dashboard-release.yaml
+    ```
+    ``` sh
+    # check for installation
+    kubectl get pods --namespace tekton-pipelines
+    kubectl get svc -n tekton-pipelines tekton-dashboard
+    ```
+- (Optional) Tekton CLI
+    ```sh
+    # Linux
+    curl -LO https://github.com/tektoncd/cli/releases/download/v0.10.0/tkn_0.10.0_Linux_x86_64.tar.gz
+    tar -xvzf tkn_0.10.0_Linux_x86_64.tar.gz -C /usr/local/bin/ tkn
+    # macOS
+    brew tap tektoncd/tools
+    brew install tektoncd/tools/tektoncd-cli
+    ```
+    ``` sh
+    # check for installation
+    tkn version
+    ```
+
+# Create and Run a Task
+- Edit `secrets/jira.yaml` for your issues.redhat.com username and password.
+  Then create a secret:
+  ``` sh
+  kubectl apply -f secrets/jira.yaml
+  ```
+- Create a task:
+  ```sh
+  kubectl apply -f tasks/jira-set-link-to-pr.yaml
+  ```
+  List all created tasks:
+  ```sh
+  kubectl get tasks
+  # or
+  tkn task list
+  ```
+- Run a standalone task:
+  Manually create a TaskRun named `jira-set-link-to-pr-run-1`:
+  ```yaml
+  apiVersion: tekton.dev/v1beta1
+  kind: TaskRun
+  metadata:
+    name: jira-set-link-to-pr-run-1
+  spec:
+    params:
+    - name: REPO_FULL_NAME
+      value: vfreex/elliott
+    - name: PR_NUMBER
+      value: "1"
+    serviceAccountName: ""
+    taskRef:
+      name: jira-set-link-to-pr
+  ```
+  Or use the `tkn` command:
+  ```sh
+  # interactively
+  tkn task start jira-set-link-to-pr
+  # or non-interactively
+  tkn task start jira-set-link-to-pr -p REPO_FULL_NAME=vfreex/elliott -p PR_NUMBER=1
+  ```
+- See logs:
+  ``` sh
+  tkn taskrun logs --last -f
+  ```
+- List all taskruns:
+  ```sh
+  kubectl get taskruns
+  # or
+  tkn taskrun list
+  ```
+
+## Create and Run a Pipeline
+- Create a pipeline:
+  ```sh
+  kubectl apply -f pipelines/link-pull-request-to-jira.yaml
+  ```
+- List all pipelines:
+  ```
+  kubectl get pipelines
+  # or
+  tkn pipeline list
+  ```
+- Run a pipeline:
+  Manually create a PipelineRun named `link-pull-request-to-jira-run-1`:
+  ```yaml
+  apiVersion: tekton.dev/v1beta1
+  kind: PipelineRun
+  metadata:
+    name: link-pull-request-to-jira-run-1
+  spec:
+    params:
+    - name: PR_NUMBER
+      value: "1"
+    - name: REPO_FULL_NAME
+      value: vfreex/elliott
+    pipelineRef:
+      name: link-pull-request-to-jira
+  ```
+  Or use the `tkn` command:
+  ```sh
+  # interactively
+  tkn pipeline start link-pull-request-to-jira
+  # or non-interactively
+  tkn pipeline start link-pull-request-to-jira -p REPO_FULL_NAME=vfreex/elliott -p PR_NUMBER=1
+  ```
+- See logs:
+  ``` sh
+  tkn pipelinerun logs --last -f
+  ```
+- List all pipelines:
+  ```sh
+  kubectl get pipelineruns
+  # or
+  tkn pipelinerun list
+  ```
+
+## Automatically Trigger a PipelineRun using GitHub Webhooks
+- Add a TriggerBinding to convert GitHub webhook payload to parameters and a TriggerTemplate to template PipelineRun resource:
+  ```sh
+  kubectl apply -f ./triggers/link-pull-request-to-jira.yaml
+  ```
+- Add an EventListener.
+
+  Edit `secrets/github-webhook.yaml` for your webhook secret then add it to Kubernetes:
+  ```sh
+  kubectl apply -f secrets/github-webhook.yaml
+  ```
+  Create the EventListener:
+  ```sh
+  kubectl apply -f infra/rbac.yaml
+  kubectl apply -f infra/github-event-listener.yaml
+  ```
+- (On a public cloud) Expose the EventListener service via Ingress or Route.
+  ``` sh
+  # OpenShift
+  oc expose service/el-github-event-listener
+  ```
+- Add a webhook to your GitHub repo:
+  ```
+  # Settings -> Webhook -> Add webhook
+  Payload URL: your exposed event listener URL
+  Content type: application/json
+  Secret: your secret in secrets/github-webhook.yaml
+  Which events would you like to trigger this webhook? "Let me select individual events." Check "Pull requests".
+  Active: check
+  ```
+- Test your trigger
+  Forward your local 8080 port to the event listener pod:
+  ```sh
+  kubectl get po -l eventlistener=github-event-listener
+  kubectl port-forward <pod-name> 8080
+  ```
+  Send a webhook payload. For example:
+  ```sh
+  curl -v \
+    -H 'X-GitHub-Event: pull_request' \
+    -H 'X-Hub-Signature: sha1=13eaa0168f8d8efcdf5189ea75b782cf89809de6' \
+    -H 'Content-Type: application/json' \
+    -d '{"action": "opened", "head_commit":{"id":"master"},"repository":{"url": "https://github.com/tektoncd/triggers"}}' \
+    http://localhost:8080
+  ```
+  See [Webhook event payloads][] for the format.
+## (Optional) Proxy GitHub webhook behind a secure firewall with smee.io
+- Create a new channel at https://smee.io/.
+- Run `smee` CLI behind your firewall.
+  ```sh
+  # forward https://smee.io/<channel> to https://127.0.0.1:8080
+  smee -u https://smee.io/<channel> -t https://127.0.0.1:8080
+  ```
+- Go to your GitHub repo webhook settings, use `https://smee.io/<channel>` as the Payload URL.
+
+## Cleanup
+```sh
+kubectl delete pipelineruns --all
+kubectl delete pipelines --all
+kubectl delete taskruns --all
+kubectl delete tasks --all
+kubectl delete eventlisteners --all
+kubectl delete triggerbindings --all
+kubectl delete triggertemplates --all
+```
+
+[Minikube]: https://kubernetes.io/docs/tasks/tools/install-minikube/
+[Webhook event payloads]: https://developer.github.com/webhooks/event-payloads/#pull_request

--- a/tekton-pipelines/infra/github-event-listener.yaml
+++ b/tekton-pipelines/infra/github-event-listener.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: EventListener
+metadata:
+  name: github-event-listener
+spec:
+  serviceAccountName: tekton-triggers-github-sa
+  triggers:
+    - name: link-pull-request-to-jira
+      interceptors:
+        - github:
+            secretRef:
+              secretName: github-webhook
+              secretKey: secretToken
+            eventTypes:
+              - pull_request
+        - cel:
+            filter: "body.action in ['opened', 'edited', 'reopened', 'closed']"
+      bindings:
+        - ref: link-pull-request-to-jira
+      template:
+        name: link-pull-request-to-jira

--- a/tekton-pipelines/infra/rbac.yaml
+++ b/tekton-pipelines/infra/rbac.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-triggers-github-sa
+secrets:
+  - name: github-webhook
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-triggers-github-binding
+subjects:
+  - kind: ServiceAccount
+    name: tekton-triggers-github-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tekton-triggers-github-minimal
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-triggers-github-minimal
+rules:
+  # Permissions for every EventListener deployment to function
+  - apiGroups: ["triggers.tekton.dev"]
+    resources: ["eventlisteners", "triggerbindings", "triggertemplates"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    # secrets are only needed for Github/Gitlab interceptors, serviceaccounts only for per trigger authorization
+    resources: ["configmaps", "secrets", "serviceaccounts"]
+    verbs: ["get", "list", "watch"]
+  # Permissions to create resources in associated TriggerTemplates
+  - apiGroups: ["tekton.dev"]
+    resources: ["pipelineruns", "pipelineresources", "taskruns"]
+    verbs: ["create"]

--- a/tekton-pipelines/pipelines/link-pull-request-to-jira.yaml
+++ b/tekton-pipelines/pipelines/link-pull-request-to-jira.yaml
@@ -1,0 +1,19 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: link-pull-request-to-jira
+spec:
+  params:
+    - name: REPO_FULL_NAME
+    - name: PR_NUMBER
+  tasks:
+    - name: set-link-to-pull-request
+      retries: 3
+      Timeout: "3m"
+      taskRef:
+        name: jira-set-link-to-pr
+      params:
+        - name: REPO_FULL_NAME
+          value: $(params.REPO_FULL_NAME)
+        - name: PR_NUMBER
+          value: $(params.PR_NUMBER)

--- a/tekton-pipelines/secrets/github-webhook.yaml
+++ b/tekton-pipelines/secrets/github-webhook.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-webhook
+type: Opaque
+stringData:
+  secretToken: "your-webhook-token"

--- a/tekton-pipelines/secrets/jira.yaml
+++ b/tekton-pipelines/secrets/jira.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: jira
+type: Opaque
+stringData:
+  username: your-username  # without `@redhat.com`
+  password: your-password

--- a/tekton-pipelines/tasks/jira-set-link-to-pr.yaml
+++ b/tekton-pipelines/tasks/jira-set-link-to-pr.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: jira-set-link-to-pr
+spec:
+  params:
+  - name: REPO_FULL_NAME
+  - name: PR_NUMBER
+  - name: GITHUB_API_URL
+    default: https://api.github.com
+  - name: JIRA_HOST_URL
+    default: https://issues.redhat.com
+  - name: JIRA_SECRET
+    default: jira
+  - name: JIRA_ISSUE_KEY_REGEX
+    default: "(ART-\\d+)"
+  steps:
+  - name: jira-set-link-to-pr
+    image: quay.io/openshift-art/art-ci-toolkit:latest
+    env:
+    - name: JIRA_USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: $(params.JIRA_SECRET)
+          key: username
+    - name: JIRA_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: $(params.JIRA_SECRET)
+          key: password
+    # if you need a proxy
+    # - name: http_proxy
+    #   value: http://192.168.64.1:11087
+    # - name: https_proxy
+    #   value: http://192.168.64.1:11087
+    script: |
+      #!/usr/bin/env python3
+      import os
+      import re
+      import requests
+      from requests.auth import HTTPBasicAuth
+      from urllib.parse import urlparse, quote
+
+      r = requests.get("$(params.GITHUB_API_URL)/repos/$(params.REPO_FULL_NAME)/pulls/$(params.PR_NUMBER)")
+      r.raise_for_status()
+      pr_res = r.json()
+
+      # parse pull request metadata
+      pr_title = pr_res["title"]
+      jira_issue_keys = re.findall(r"$(params.JIRA_ISSUE_KEY_REGEX)", pr_title)
+      if not jira_issue_keys:
+        raise ValueError(f"Pull request title '{pr_title}' doesn't include any valid JIRA issue keys.")
+      state = pr_res["state"]
+      label = state.upper()
+      if state == "open":
+        icon = "https://fonts.gstatic.com/s/i/materialicons/comment/v6/24px.svg"  # "comment" icon
+        if pr_title.startswith("WIP"):
+          label = "WIP"
+          icon = "https://fonts.gstatic.com/s/i/materialicons/hourglass_empty/v5/24px.svg"  # "hourglass" icon
+      elif state == "closed":
+        icon = "https://fonts.gstatic.com/s/i/materialicons/block/v6/24px.svg"  # "block" icon
+        if pr_res.get("merged"):
+          label = "MERGED"
+          icon = "https://fonts.gstatic.com/s/i/materialicons/done_outline/v6/24px.svg"  # "done" icon
+
+      pr_url = pr_res["html_url"]
+      data = {
+          "globalId": f"PR={pr_url}",
+          "application": {},
+          "object": {
+              "url": pr_url,
+              "title": "[{}] {} PR#{}".format(label, "$(params.REPO_FULL_NAME)", "$(params.PR_NUMBER)"),
+              "icon":{"url16x16":"https://github.com/favicon.ico"},
+              "status": {
+                  "resolved": state == "closed",
+                  "icon":{"url16x16":icon}
+              }
+          }
+      }
+      auth=HTTPBasicAuth(os.environ["JIRA_USERNAME"], os.environ["JIRA_PASSWORD"])
+      session = requests.session()
+      for jira_issue_key in jira_issue_keys:
+        print(f"Adding PR link to {jira_issue_key}...")
+        url = "{}/rest/api/2/issue/{}/remotelink".format("$(params.JIRA_HOST_URL)", quote(jira_issue_key))
+        r = session.post(url, json=data, auth=auth)
+        r.raise_for_status()
+        res = r.json()
+        print(jira_issue_key + ": PR link updated: " + res['self'])

--- a/tekton-pipelines/triggers/link-pull-request-to-jira.yaml
+++ b/tekton-pipelines/triggers/link-pull-request-to-jira.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: link-pull-request-to-jira
+spec:
+  params:
+    - name: GIT_REVISION
+      value: $(body.pull_request.head.sha)
+    - name: REPO_FULL_NAME
+      value: $(body.repository.full_name)
+    - name: PR_NUMBER
+      value: $(body.number)
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: link-pull-request-to-jira
+spec:
+  params:
+    - name: REPO_FULL_NAME
+    - name: PR_NUMBER
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
+    metadata:
+      generateName: link-pull-request-to-jira-run-
+    spec:
+      pipelineRef:
+        name: link-pull-request-to-jira
+      params:
+      - name: REPO_FULL_NAME
+        value: $(params.REPO_FULL_NAME)
+      - name: PR_NUMBER
+        value: $(params.PR_NUMBER)


### PR DESCRIPTION
We can use this job as a start point for exploring Tekton.

This pipeline job is from the demo in the ART knowledge share on July 9, 2020.
Original repo https://github.com/vfreex/example-tekton-pipelines. See https://drive.google.com/file/d/1tfil9bQ10n9a15YzlRbqeEE0pnxeao48/view for the recording.