### PR TITLE
Signing job fails faster if required files are missing

### DIFF
--- a/jobs/signing/sign-artifacts/Jenkinsfile
+++ b/jobs/signing/sign-artifacts/Jenkinsfile
@@ -147,6 +147,21 @@ node {
 
                     if ( params.PRODUCT == 'openshift' ) {
                         // ######################################################################
+                        // Does the required sha256sum.txt file exist yet?
+                        def shaFile = "https://mirror.openshift.com/pub/openshift-v4/${params.ARCH}/clients/${params.CLIENT_TYPE}/${params.NAME}/sha256sum.txt"
+                        try {
+                            echo("Checking if required sha256sum.txt file exists")
+                            httpRequest(
+                                httpMode: 'HEAD',
+                                responseHandle: 'NONE',
+                                url: shaFile,
+                            )
+                        } catch (exc) {
+                            echo("ERROR: Required sha256sum.txt file is missing")
+                            currentBuild.description += "\nCould not submit OpenShift signing requests, the required sha256sum.txt file is missing"
+                            error("Expected to find: ${shaFile} but it was missing")
+                        }
+
                         def openshiftJsonSignParams = buildlib.cleanWhitespace("""
                              ${baseUmbParams} --product openshift --arch ${params.ARCH} --client-type ${params.CLIENT_TYPE}
                              --request-id 'openshift-json-digest-${env.BUILD_ID}${requestIdSuffix}' ${digestParam} ${noop}


### PR DESCRIPTION
This changes the order of operations in the signing job. Previously we
would submit a JSON claim signing request and afterwards attempt to
download the matching sha256sum.txt file for a another signing
request.

NOW we check for the sha256sum.txt file FIRST and fail the job if it
is missing. If it exists then operations continue as normal.