### PR TITLE
Only mirror streams when a build is successful

### DIFF
--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -47,6 +47,11 @@ node {
                         description: 'Build regardless of whether source has changed',
                         defaultValue: false,
                     ),
+                    booleanParam(
+                        name: 'FORCE_MIRROR_STREAMS',
+                        description: 'Ensure images:mirror-streams runs after this build, even if it is a small batch',
+                        defaultValue: false,
+                    ),
                     choice(
                         name: 'BUILD_RPMS',
                         description: 'Which RPMs are candidates for building? "only/except" refer to list below',

--- a/jobs/build/sync-for-ci/Jenkinsfile
+++ b/jobs/build/sync-for-ci/Jenkinsfile
@@ -103,11 +103,6 @@ node {
                     }
 
                     base_args = "--working-dir ${DOOZER_WORKING} --group ${GROUP}"
-
-                    // we need to be able to push images to api.ci, so make sure our token is fresh
-                    sh "oc --kubeconfig=/home/jenkins/kubeconfigs/art-publish.kubeconfig registry login"
-                    buildlib.doozer "${base_args} images:mirror-streams"
-
                     command = "${base_args} beta:reposync --output ${syncDir}/ --cachedir ${cacheDir}/ --repo-type ${REPO_TYPE} --arch ${ARCH}"
                     buildlib.doozer command
 


### PR DESCRIPTION
Don't push just _any_ change to CI. Make sure it is part of a successful ART build.