### PR TITLE
--filter-by-os needs to follow the verb

### DIFF
--- a/jobs/build/ocp3/Jenkinsfile
+++ b/jobs/build/ocp3/Jenkinsfile
@@ -861,8 +861,8 @@ images:rebase --version v${NEW_VERSION}
 --working-dir ${DOOZER_WORKING} --group openshift-${params.BUILD_VERSION}
 ${ODCS_FLAG}
 ${exclude}
---filter-by-os amd64
 images:build
+--filter-by-os amd64
 --push-to-defaults ${ODCS_OPT}
 """
                     }


### PR DESCRIPTION
Should fix the issue with https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp3/292/