### PR TITLE
[ART-2059] new sweep flow

### DIFF
--- a/jobs/build/crc/Jenkinsfile
+++ b/jobs/build/crc/Jenkinsfile
@@ -42,11 +42,7 @@ node {
                         defaultValue: 'aos-art-automation+failed-crc-release@redhat.com',
                         trim: true,
                     ),
-                    booleanParam(
-                        name: 'DRY_RUN',
-                        description: 'Do not rsync the bits. Just download them and show what would have been copied',
-                        defaultValue: false
-                    ),
+                    commonlib.dryrunParam('Do not rsync the bits. Just download them and show what would have been copied XXX'),
                     commonlib.mockParam(),
                 ]
             ],

--- a/jobs/build/crc/Jenkinsfile
+++ b/jobs/build/crc/Jenkinsfile
@@ -42,7 +42,7 @@ node {
                         defaultValue: 'aos-art-automation+failed-crc-release@redhat.com',
                         trim: true,
                     ),
-                    commonlib.dryrunParam('Do not rsync the bits. Just download them and show what would have been copied XXX'),
+                    commonlib.dryrunParam('Do not rsync the bits. Just download them and show what would have been copied'),
                     commonlib.mockParam(),
                 ]
             ],

--- a/jobs/build/ocp3/Jenkinsfile
+++ b/jobs/build/ocp3/Jenkinsfile
@@ -308,12 +308,6 @@ node {
                         description: 'Sign RPMs with openshifthosted key? (for SD - generally not useful',
                         defaultValue: false,
                     ),
-                    commonlib.mockParam(),
-                    booleanParam(
-                        name: 'DRY_RUN',
-                        description: 'Run as much code as possible without pushing / building',
-                        defaultValue: false,
-                    ),
                     string(
                         name: 'SPECIAL_NOTES',
                         description: 'Include special notes in the build email',
@@ -336,6 +330,8 @@ node {
                         description: 'Build golden image after building images?',
                         defaultValue: true,
                     ),
+                    commonlib.mockParam(),
+                    commonlib.dryrunParam(),
                 ]
             ],
             disableResume(),

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -29,11 +29,7 @@ node {
             [
                 $class: 'ParametersDefinitionProperty',
                 parameterDefinitions: [
-                    booleanParam(
-                        name: 'DRY_RUN',
-                        description: 'Take no action, just echo what the build would have done.',
-                        defaultValue: false,
-                    ),
+                    commonlib.dryrunParam(),
                     commonlib.mockParam(),
                     commonlib.ocpVersionParam('BUILD_VERSION', '4'),
                     string(

--- a/jobs/build/pre-release/Jenkinsfile
+++ b/jobs/build/pre-release/Jenkinsfile
@@ -59,11 +59,6 @@ node {
                         defaultValue: false,
                     ),
                     booleanParam(
-                        name: 'DRY_RUN',
-                        description: 'Only do dry run test and exit.',
-                        defaultValue: false,
-                    ),
-                    booleanParam(
                         name: 'MIRROR',
                         description: 'Sync clients to mirror.',
                         defaultValue: true,
@@ -81,6 +76,7 @@ node {
                         ].join(','),
                         trim: true,
                     ),
+                    commonlib.dryrunParam(),
                     commonlib.mockParam(),
                     commonlib.suppressEmailParam(),
                 ]

--- a/jobs/build/release/Jenkinsfile
+++ b/jobs/build/release/Jenkinsfile
@@ -113,11 +113,6 @@ node {
                         description: 'Prevent creation of advisories for the next z-stream of given OCP version',
                         defaultValue: false,
                     ),
-                    booleanParam(
-                        name: 'DRY_RUN',
-                        description: 'Take no actions. Note: still notifies and runs signing job (which fails).',
-                        defaultValue: false,
-                    ),
                     string(
                         name: 'MAIL_LIST_SUCCESS',
                         description: 'Success Mailing List',
@@ -136,6 +131,7 @@ node {
                         ].join(','),
                         trim: true,
                     ),
+                    commonlib.dryrunParam('Take no actions. Note: still notifies and runs signing job (which fails)'),
                     commonlib.mockParam(),
                 ]
             ],

--- a/jobs/build/rhcos_sync/Jenkinsfile
+++ b/jobs/build/rhcos_sync/Jenkinsfile
@@ -57,11 +57,6 @@ node {
                         defaultValue: "",
                         trim: true,
                     ),
-                    booleanParam(
-                        name: 'DRY_RUN',
-                        description: 'Run commands with their dry-run options enabled (test everything)',
-                        defaultValue: false,
-                    ),
                     string(
                         name: 'SYNC_LIST',
                         description: 'Instead of figuring out items to sync from meta.json, use this input file.\nMust be a URL reachable from buildvm, contents must be reachable from use-mirror-upload',
@@ -84,6 +79,7 @@ node {
                         defaultValue: false,
                     ),
                     commonlib.suppressEmailParam(),
+                    commonlib.dryrunParam(),
                     commonlib.mockParam(),
                 ],
             ]

--- a/jobs/build/signed-compose/Jenkinsfile
+++ b/jobs/build/signed-compose/Jenkinsfile
@@ -42,11 +42,6 @@ node {
                         description: 'Run a compose without changing the state of advisory',
                         defaultValue: false,
                     ),
-                    booleanParam(
-                        name: 'DRY_RUN',
-                        description: 'Do not attach builds or update the puddle. Just show what would have happened',
-                        defaultValue: false,
-                    ),
                     commonlib.suppressEmailParam(),
                     string(
                         name: 'MAIL_LIST_SUCCESS',
@@ -60,6 +55,7 @@ node {
                         defaultValue: 'aos-art-automation+failed-signed-puddle@redhat.com',
                         trim: true,
                     ),
+                    commonlib.dryrunParam(),
                     commonlib.mockParam(),
                 ]
             ],

--- a/jobs/build/sweep/Jenkinsfile
+++ b/jobs/build/sweep/Jenkinsfile
@@ -63,9 +63,10 @@ node {
 
     commonlib.checkMock()
 
-    def version = params.BUILD_VERSION
-    doozerOpts = "--group openshift-${version}"
     stage("Init") {
+        version = params.BUILD_VERSION
+        doozerOpts = "--group openshift-${version}"
+
         echo "Initializing bug sweep for ${version}. Sync: #${currentBuild.number}"
         currentBuild.displayName = "${version} bug sweep"
 
@@ -83,13 +84,11 @@ node {
         return
     }
 
-    def (major, minor) = commonlib.extractMajorMinorVersionNumbers(version)
+    stage("Sweep bugs") {
+        currentBuild.description = "Sweeping new bugs<br/>"
 
-    currentBuild.description = "Repairing state and sweeping new bugs.\n"
-
-    if (params.ATTACH_BUGS) {
-        stage("Attach bugs to advisories") {
-            currentBuild.description += "* Attaching ON_QA and VERIFIED bugs to default advisories\n"
+        if (params.ATTACH_BUGS) {
+            currentBuild.description += "* Attaching ON_QA and VERIFIED bugs to default advisories<br/>"
             cmd = [
                 "--group=openshift-${version}",
                 "find-bugs",
@@ -98,38 +97,26 @@ node {
                 "--status VERIFIED",
                 "--into-default-advisories",
             ]
-            if (params.DRY_RUN) {
-                cmd << "--dry-run"
-            }
-            retry (3) {
-                try {
-                    buildlib.elliott(cmd.join(' '))
-                } catch (Exception elliottErr) {
-                    echo("Error attaching bugs to advisories (will retry a few times):\n${elliottErr}")
-                    sleep(time: 1, unit: 'MINUTES')
-                    throw elliottErr
-                }
-            }
-        }
-    } else {
-        stage("Set MODIFIED bugs to ON_QA") {
-            currentBuild.description += "* Changing MODIFIED bugs to ON_QA\n"
+        } else {
+            currentBuild.description += "* Changing MODIFIED bugs to ON_QA<br/>"
             cmd = [
                 "--group=openshift-${version}",
                 "find-bugs",
                 "--mode qe",
             ]
-            if (params.DRY_RUN) {
-                cmd << "--dry-run"
-            }
-            retry(3) {
-                try {
-                    buildlib.elliott(cmd.join(" "))
-                } catch (Exception elliottErr) {
-                    echo("Error moving bugs to ON_QA (will retry):\n${elliottErr}")
-                    sleep(time: 1, unit: 'MINUTES')
-                    throw elliottErr
-                }
+        }
+
+        if (params.DRY_RUN) {
+            cmd << "--dry-run"
+        }
+
+        retry (3) {
+            try {
+                buildlib.elliott(cmd.join(' '))
+            } catch (Exception elliottErr) {
+                echo("Error attaching bugs to advisories (will retry a few times):\n${elliottErr}")
+                sleep(time: 1, unit: 'MINUTES')
+                throw elliottErr
             }
         }
     }

--- a/jobs/build/sweep/Jenkinsfile
+++ b/jobs/build/sweep/Jenkinsfile
@@ -5,25 +5,24 @@ node {
     def buildlib = load("pipeline-scripts/buildlib.groovy")
     def commonlib = buildlib.commonlib
     commonlib.describeJob("sweep", """
-        <h2>Sweep bugs into the standard advisories</h2>
-        <b>Timing</b>: This runs after component builds (ocp3/ocp4/custom jobs).
-        Can be run manually but this should be rarely needed.
+        <h2>Sweep bugs</h2>
+        <b>Timing</b>: This runs after component builds (ocp3/ocp4/custom jobs),
+        or when preparing a nightly for examination by QE.
 
-        Bugs are attached into the appropriate advisories for the release,
-        according to those recorded in ocp-build-data group.yml.
+        After component builds, bugs are queried that are in MODIFIED state,
+        and are set to ON_QA. This is the signal to QE that they can test the bug.
+        In this mode of operation, ATTACH_BUGS is false.
+
+        When preparing a set of nightlies and advisories for QE, the sweep job will
+        look for all bugs that are in ON_QA or VERIFIED state, and attach them
+        to the default advisories, according to those recorded in ocp-build-data
+        group.yml.
         For 3.11, all bugs are swept into the rpm advisory.
         For 4.y, bugs are swept into the image or extras advisory.
-        CVEs are not currently swept by this job at all.
+        CVEs are not currently swept by this job.
 
-        Any bugs in the MODIFIED state are attached, without regard for whether
-        their PRs have actually merged or been built. This causes them to
-        transition to the ON_QA state.
-        Bugs which are already attached and in the MODIFIED state are also
-        transitioned to ON_QA so QE will look at them.
-
-        Optionally, builds from our brew candidate tags may also be swept. This
-        will only work with advisories in the NEW_FILES state (bugs can be
-        attached to advisories in the QE state as well, but not builds).
+        Optionally, builds from our brew candidate tags may also be swept. If necessary,
+        the advisory will be first set to NEW_FILES.
     """)
 
 
@@ -42,12 +41,21 @@ node {
                 $class : 'ParametersDefinitionProperty',
                 parameterDefinitions: [
                     commonlib.ocpVersionParam('BUILD_VERSION'),
-                    commonlib.mockParam(),
                     booleanParam(
                         name: 'SWEEP_BUILDS',
                         defaultValue: true,
-                        description: 'Sweep and attach builds to advisories',
+                        description: 'Attach builds to default advisories',
                     ),
+                    booleanParam(
+                        name: 'ATTACH_BUGS',
+                        defaultValue: false,
+                        description: [
+                          'If <b>on</b>: Attach ON_QA and VERIFIED bugs to their advisories',
+                          'If <b>off</b>: Set MODIFIED bugs to ON_QA. Do not change advisories',
+                        ].join('\n')
+                    ),
+                    commonlib.dryrunParam(),
+                    commonlib.mockParam(),
                 ],
             ],
         ]
@@ -75,34 +83,53 @@ node {
         return
     }
 
-    currentBuild.description = "Repairing state and sweeping new bugs.\n"
     def (major, minor) = commonlib.extractMajorMinorVersionNumbers(version)
-    def kinds = major >= 4 ? ["image", "extras"] : ["rpm"]
 
-    stage("Repair bug state") {
-        currentBuild.description += "* Moving attached bugs in MODIFIED state to ON_QA...\n"
-        for (kind in kinds) {
+    currentBuild.description = "Repairing state and sweeping new bugs.\n"
+
+    if (params.ATTACH_BUGS) {
+        stage("Attach bugs to advisories") {
+            currentBuild.description += "* Attaching ON_QA and VERIFIED bugs to default advisories\n"
+            cmd = [
+                "--group=openshift-${version}",
+                "find-bugs",
+                "--mode sweep",
+                "--status ON_QA",
+                "--status VERIFIED",
+                "--into-default-advisories",
+            ]
+            if (params.DRY_RUN) {
+                cmd << "--dry-run"
+            }
             retry (3) {
                 try {
-                    buildlib.elliott "--group=openshift-${version} repair-bugs --use-default-advisory ${kind} --auto"
-                } catch (elliottErr) {
-                    echo("Error repairing (will retry a few times):\n${elliottErr}")
+                    buildlib.elliott(cmd.join(' '))
+                } catch (Exception elliottErr) {
+                    echo("Error attaching bugs to advisories (will retry a few times):\n${elliottErr}")
                     sleep(time: 1, unit: 'MINUTES')
                     throw elliottErr
                 }
             }
         }
-    }
-
-    stage("Sweep bugs") {
-        currentBuild.description += "* Searching for and attaching new bugs in MODIFIED state...\n"
-        retry (3) {
-            try {
-                buildlib.elliott "--group=openshift-${version} find-bugs --mode sweep --into-default-advisories"
-            } catch (elliottErr) {
-                echo("Error sweeping bugs (will retry a few times):\n${elliottErr}")
-                sleep(time: 1, unit: 'MINUTES')
-                throw elliottErr
+    } else {
+        stage("Set MODIFIED bugs to ON_QA") {
+            currentBuild.description += "* Changing MODIFIED bugs to ON_QA\n"
+            cmd = [
+                "--group=openshift-${version}",
+                "find-bugs",
+                "--mode qe",
+            ]
+            if (params.DRY_RUN) {
+                cmd << "--dry-run"
+            }
+            retry(3) {
+                try {
+                    buildlib.elliott(cmd.join(" "))
+                } catch (Exception elliottErr) {
+                    echo("Error moving bugs to ON_QA (will retry):\n${elliottErr}")
+                    sleep(time: 1, unit: 'MINUTES')
+                    throw elliottErr
+                }
             }
         }
     }

--- a/jobs/build/sweep/README.md
+++ b/jobs/build/sweep/README.md
@@ -1,4 +1,15 @@
-Parameterized job for running bugzilla bug sweeps.
+# Parameterized job for running bug and build sweeps
 
-Preferably a wrapper job will run on a schedule which calls out to
-this job with a BUILD_VERSION parameter.
+This job is run as a concluding part of the [ocp4], [ocp3], and [custom] jobs.
+In that case, the aim is to get bugs that are in state MODIFIED to ON_QA. Also,
+the advisories are updated to have the newest builds attached. To run the job in
+this mode, keep `SWEEP_BUILDS` to true, and `ATTACH_BUGS` to false (the
+defaults).
+
+The second mode is to take all bugs that QE is looking at or has verified, and
+collect those in the right advisories. To do that, set `ATTACH_BUGS` to true.
+
+
+[ocp4]: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp4/
+[ocp3]: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp3/
+[custom]: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fcustom/

--- a/jobs/maintenance/buildvm_backup/Jenkinsfile
+++ b/jobs/maintenance/buildvm_backup/Jenkinsfile
@@ -18,12 +18,7 @@ node {
             [
                 $class: 'ParametersDefinitionProperty',
                 parameterDefinitions: [
-                    [
-                        name: 'DRY_RUN',
-                        description: 'Take no action, just echo what the build would have done.',
-                        $class: 'hudson.model.BooleanParameterDefinition',
-                        defaultValue: false
-                    ],
+                    commonlib.dryrunParam(),
                     commonlib.mockParam(),
                     commonlib.suppressEmailParam(),
                     [

--- a/jobs/signing/sign-artifacts/Jenkinsfile
+++ b/jobs/signing/sign-artifacts/Jenkinsfile
@@ -86,11 +86,7 @@ node {
                         defaultValue: "",
                         trim: true,
                     ),
-                    booleanParam(
-                        name: 'DRY_RUN',
-                        description: 'Only do dry run test and exit\nDoes not send anything over the bus',
-                        defaultValue: false,
-                    ),
+                    commonlib.dryrunParam('Only do dry run test and exit\nDoes not send anything over the bus'),
                     commonlib.mockParam(),
                 ]
             ],

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -759,14 +759,16 @@ def build_ami(major, minor, version, release, yum_base_url, ansible_branch, mail
  *
  * @param String buildVersion: OCP build version (e.g. 4.2, 4.1, 3.11)
  * @param Boolean sweepBuilds: Enable/disable build sweeping
+ * @param Boolean attachBugs: Enable/disable bug sweeping
  */
-def sweep(String buildVersion, Boolean sweepBuilds) {
+def sweep(String buildVersion, Boolean sweepBuilds, Boolean attachBugs = false) {
     def sweepJob = build(
         job: 'build%2Fsweep',
         propagate: false,
         parameters: [
             string(name: 'BUILD_VERSION', value: buildVersion),
             booleanParam(name: 'SWEEP_BUILDS', value: sweepBuilds),
+            booleanParam(name: 'ATTACH_BUGS', value: attachBugs),
         ]
     )
     if (sweepJob.result != 'SUCCESS') {

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -156,6 +156,15 @@ def mockParam() {
     ]
 }
 
+def dryrunParam(description = 'Run job without side effects') {
+    return [
+        name: 'DRY_RUN',
+        description: description,
+        $class: 'BooleanParameterDefinition',
+        defaultValue: false,
+    ]
+}
+
 def ocpVersionParam(name='MINOR_VERSION', majorVersion='all') {
     return [
         name: name,


### PR DESCRIPTION
The sweep job will grow a new boolean option ATTACH_BUGS which is false by default.

When false, the sweep job will use elliott find-bugs --qe to transition MODIFIED bug state without changing advisory attachment.
When true, the sweep job will use elliott find-bugs to attach only bugs in ON_QA or VERIFIED states to the default advisories.
The current invocation of repair-bugs can be removed (will be handled by the --qe sweep).
When the ocp4 and custom jobs invoke the "sweep" job they will invoke it with ATTACH_BUGS false (so, no change needed).
The sweep job with ATTACH_BUGS true can be invoked manually or (eventually) by the advisories job to fill advisories for a release.

Also, extract the common `DRY_RUN` parameter into a method in `commonlib`. An optional argument with the description is accepted (yet a generic one is used when called without argument).