### PR TITLE
Rename release job to promote job

### DIFF
--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -8,10 +8,7 @@ node {
     def commonlib = release.commonlib
     def slacklib = commonlib.slacklib
     def quay_url = "quay.io/openshift-release-dev/ocp-release"
-    commonlib.describeJob("⛔❌⛔ release (deprecated) ⛔❌⛔ ", """
-        <h1 style="color:red;">Deprecated!!!</h1>
-        <p style="color:red;">This now goes under the name of <a href="${env.JOB_URL.replace('%252release/', '%252promote/')}">promote</a></p>
-
+    commonlib.describeJob("release", """
         <h2>Publish official OCP 4 release artifacts</h2>
         <b>Timing</b>: <a href="https://github.com/openshift/art-docs/blob/master/4.y.z-stream.md#create-the-release-image" target="_blank">4.y z-stream doc</a>
         Be aware that by default the job stops for user input very early on. It
@@ -45,7 +42,7 @@ node {
                 parameterDefinitions: [
                     string(
                         name: 'FROM_RELEASE_TAG',
-                        description: """<h1 style="color:red;">Deprecated!!!</h1><p style="color:red;">This now goes under the name of <a href="${env.JOB_URL.replace('%252release/', '%252promote/')}">promote</a></p>""",
+                        description: 'Build tag to pull from (e.g. 4.1.0-0.nightly-2019-04-22-005054)',
                         trim: true,
                     ),
                     choice(

--- a/jobs/build/promote/advisory_images.py
+++ b/jobs/build/promote/advisory_images.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python
+# -*- coding: utf8 -*-
+'''
+Created on Oct 19, 2016
+@author: zhizhang@redhat.com
+'''
+
+
+from bs4 import BeautifulSoup
+import getpass
+import urllib2
+import socket
+import re
+import base64
+import ssl
+
+
+major = raw_input("Please enter the OpenShift major version (3 or 4): ")
+if major not in ['3', '4']:
+    print "You must choose OCP 3 or 4."
+    exit(1)
+advisory = raw_input("Please enter the image advisory number (number): ")
+if advisory == '' or not advisory.isdigit():
+    print "You must enter a numeric advisory."
+    exit(1)
+user_name = raw_input("Please input your kerberos username: ")
+if user_name == '':
+    print "You must enter a username with access to erratatool."
+    exit(1)
+password = getpass.getpass("Please input your kerberos passwd: ")
+if password == '':
+    print "You must enter a password for this user."
+    exit(1)
+
+
+image_prefix = 'openshift' + major + '/'
+repo_prefix = 'redhat-openshift' + major + '-'
+link = 'https://errata.devel.redhat.com/errata/content/' + advisory
+print 'advisory content link is :', link
+print 'user_name is :', user_name
+
+
+context = ssl._create_unverified_context()
+request = urllib2.Request(link)
+base64string = base64.encodestring('%s:%s' % (user_name, password)).replace('\n', '')
+request.add_header("Authorization", "Basic %s" % base64string)
+response = urllib2.urlopen(request, context=context)
+html_data = response.read()
+soup = BeautifulSoup(html_data)
+
+
+print 'start to analyze---------------'
+first_part=soup.find("table", {"class": "bug_list content_list"}).find_all(class_='bz_even')
+second_part=soup.find("table", {"class": "bug_list content_list"}).find_all(class_='bz_odd')
+print '#########'
+for item in first_part:
+    first = item.td.a.contents[0]
+    second = item.findAll(class_='toggle-files dist_name')[0].contents[0].replace(repo_prefix, '')
+    pattern = re.compile(r'-(v|[0-9])+[^a-z]*$')
+    mach_for2 = pattern.search(first)
+    if mach_for2:
+        final = image_prefix + second + ":" + mach_for2.group().lstrip()[1:]
+        print str(final).replace(" ", "")
+    else:
+        print 'This line does not look right:', first
+for item in second_part:
+    first = item.td.a.contents[0]
+    second = item.findAll(class_='toggle-files dist_name')[0].contents[0].replace(repo_prefix,'')
+    pattern = re.compile(r'-(v|[0-9])+[^a-z]*$')
+    mach_for2 = pattern.search(first)
+    if mach_for2:
+        final = image_prefix + second + ":" + mach_for2.group().lstrip()[1:]
+        print str(final).replace(" ", "")
+    else:
+        print 'This line does not look right:', first
+print '############'


### PR DESCRIPTION
The word **release** is a tad overloaded. To release a payload can mean
multiple things, some of which this job is concerned with. This is a
pull request to figure out a better name.

What the job does, is:
- to give a payload a name
- to protect the payload from garbage collection
- to extract other artifacts and persist them
- to sign all artifacts
- to kick off processes that publish the artifacts to customers

I think _to promote_ is a good word to summarize these actions.