### PR TITLE
Drop rhaos-4.6-rhel-7 from devex jenkins jobs

### DIFF
--- a/jobs/devex/jenkins-bump-version/Jenkinsfile
+++ b/jobs/devex/jenkins-bump-version/Jenkinsfile
@@ -12,7 +12,7 @@ properties(
                     name: 'OCP_BRANCH',
                     description: 'OCP target branch',
                     $class: 'hudson.model.ChoiceParameterDefinition',
-                    choices: ['rhaos-4.6-rhel-8', 'rhaos-4.6-rhel-7', 'rhaos-4.5-rhel-7', 'rhaos-4.4-rhel-7', 'rhaos-4.3-rhel-7', 'rhaos-4.2-rhel-7', 'rhaos-4.1-rhel-7', 'rhaos-4.0-rhel-7', 'rhaos-3.11-rhel-7', 'rhaos-3.10-rhel-7', 'rhaos-3.9-rhel-7','rhaos-3.8-rhel-7','rhaos-3.7-rhel-7', 'rhaos-3.6-rhel-7'].join('\n'),
+                    choices: ['rhaos-4.6-rhel-8', 'rhaos-4.5-rhel-7', 'rhaos-4.4-rhel-7', 'rhaos-4.3-rhel-7', 'rhaos-4.2-rhel-7', 'rhaos-4.1-rhel-7', 'rhaos-4.0-rhel-7', 'rhaos-3.11-rhel-7', 'rhaos-3.10-rhel-7', 'rhaos-3.9-rhel-7','rhaos-3.8-rhel-7','rhaos-3.7-rhel-7', 'rhaos-3.6-rhel-7'].join('\n'),
                     defaultValue: 'rhaos-4.1-rhel-7'
                 ],
                 [

--- a/jobs/devex/jenkins-plugins/Jenkinsfile
+++ b/jobs/devex/jenkins-plugins/Jenkinsfile
@@ -13,7 +13,7 @@ properties(
                     name: 'OCP_BRANCH',
                     description: 'OCP target branch',
                     $class: 'hudson.model.ChoiceParameterDefinition',
-                    choices: ['rhaos-4.6-rhel-8', 'rhaos-4.6-rhel-7', 'rhaos-4.5-rhel-7', 'rhaos-4.4-rhel-7', 'rhaos-4.3-rhel-7', 'rhaos-4.2-rhel-7', 'rhaos-4.1-rhel-7', 'rhaos-4.0-rhel-7', 'rhaos-3.11-rhel-7', 'rhaos-3.10-rhel-7', 'rhaos-3.9-rhel-7','rhaos-3.8-rhel-7','rhaos-3.7-rhel-7', 'rhaos-3.6-rhel-7', 'rhaos-3.5-rhel-7', 'rhaos-3.4-rhel-7', 'rhaos-3.3-rhel-7'].join('\n'),
+                    choices: ['rhaos-4.6-rhel-8', 'rhaos-4.5-rhel-7', 'rhaos-4.4-rhel-7', 'rhaos-4.3-rhel-7', 'rhaos-4.2-rhel-7', 'rhaos-4.1-rhel-7', 'rhaos-4.0-rhel-7', 'rhaos-3.11-rhel-7', 'rhaos-3.10-rhel-7', 'rhaos-3.9-rhel-7','rhaos-3.8-rhel-7','rhaos-3.7-rhel-7', 'rhaos-3.6-rhel-7', 'rhaos-3.5-rhel-7', 'rhaos-3.4-rhel-7', 'rhaos-3.3-rhel-7'].join('\n'),
                     defaultValue: 'rhaos-4.0-rhel-7'
                 ],
                 [


### PR DESCRIPTION
4.6 has switched to RHEL 8.

/cc @sosiouxme