### PR TITLE
Look for latest 4.6 builds in rhel-8 tag instead of rhel-7

### DIFF
--- a/jobs/build/olm_bundle/olm_bundles.groovy
+++ b/jobs/build/olm_bundle/olm_bundles.groovy
@@ -32,7 +32,7 @@ def get_builds_from_advisory(advisory) {
  */
 def get_latest_builds(packages) {
     if (!packages) { return [] }
-    def tag = "rhaos-${params.BUILD_VERSION}-rhel-7-candidate"
+    def tag = "rhaos-${params.BUILD_VERSION}-rhel-8-candidate"
     commonlib.shell(
         script: "brew --quiet latest-build ${tag} ${packages.join(' ')}",
         returnAll: true


### PR DESCRIPTION
Since 4.6 started being built on rhel-8, `bundles` stopped finding the real latest-builds, and it is trying to fetch whatever is latest in the `rhel-7` tag.
Not an ideal solution, but we only run this job for 4.6 at the moment; Hacky patch to get bundles working again and gain us some time to think about a proper way to infer the correct brew tag.