### PR TITLE
[ART-2250] Fix "pip not found" (only pip3 now)

### DIFF
--- a/jobs/build/buildvm-maint/scripts/gen_snapshot.sh
+++ b/jobs/build/buildvm-maint/scripts/gen_snapshot.sh
@@ -2,7 +2,7 @@
 
 echo "INSTALLED PYTHON PACKAGES"
 echo "========================="
-pip freeze
+pip3 freeze
 
 echo ""
 echo "INSTALLED YUM PACKAGES"


### PR DESCRIPTION
buildvm-maint job failed: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fbuildvm-maint/1126/console

```
[jenkins@buildvm ~]$ which -a pip
/usr/bin/which: no pip in (/home/jenkins/.local/bin:/home/jenkins/bin:/mnt/nfs/home/jenkins/google-cloud-sdk/bin:/sbin:/bin:/usr/sbin:/usr/bin)

[jenkins@buildvm ~]$ which -a pip3
/bin/pip3
/usr/bin/pip3
```