### PR TITLE
[ART-2182] update-base-images: Use actually released images

### DIFF
--- a/jobs/build/update-base-images/pullspecs.yaml
+++ b/jobs/build/update-base-images/pullspecs.yaml
@@ -16,13 +16,13 @@ jboss.openjdk18.rhel7:
   pullspec: jboss/openjdk18-rhel7:latest
   user: "185"
 rhel7:
-  pullspec: rhel7:7-released
+  pullspec: registry.redhat.io/rhel7:7.8
   user: "0"
 ubi7:
-  pullspec: ubi7:7-released
+  pullspec: registry.redhat.io/ubi7:7.8
   user: "0"
 ubi8:
-  pullspec: ubi8:8-released
+  pullspec: registry.redhat.io/ubi8:8.2
   user: "0"
 rhscl.nodejs.6.rhel7:
   user: "1001"
@@ -32,34 +32,29 @@ rhscl.nodejs.6.rhel7:
   # brew_tag: rhscl-3.2-rhel-7-container-released
 rhscl.nodejs.10.rhel7:
   user: "1001"
-  package: rh-nodejs10-container
-  brew_tag: rhscl-3.5-rhel-7-container-released
+  pullspec: registry.redhat.io/rhscl/nodejs-10-rhel7
 rhscl.nodejs.12.rhel7:
   user: "1001"
   # lock in nodejs 12.16.1, cannot be updated without corresponding
   # update of headers tarball in ose-console
-  pullspec: rhscl/nodejs-12-rhel7:1-6.1582646197
-  # package: rh-nodejs12-container
-  # brew_tag: rhscl-3.5-rhel-7-container-released
+  pullspec: registry.redhat.io/rhscl/nodejs-12-rhel7:1-6.1584463517
 rhscl.ruby.25.rhel7:
   user: "1001"
-  package: rh-ruby25-container
-  brew_tag: rhscl-3.5-rhel-7-container-released
+  pullspec: registry.redhat.io/rhscl/ruby-25-rhel7
 rhscl.python.36.rhel7:
   user: "1001"
-  package: rh-python36-container
-  brew_tag: rhscl-3.5-rhel-7-container-released
+  pullspec: registry.redhat.io/rhscl/python-36-rhel7
 ubi8.nodejs.10:
   user: "1001"
-  pullspec: ubi8/nodejs-10:1-released
+  pullspec: registry.redhat.io/ubi8/nodejs-10
 ubi8.nodejs.12:
   # lock in nodejs 12.16.1, cannot be updated without corresponding
   # update of headers tarball in ose-console
   user: "1001"
-  pullspec: ubi8/nodejs-12:1-45
+  pullspec: registry.redhat.io/ubi8/nodejs-12:1-45
 ubi8.python.36:
   user: "1001"
-  pullspec: ubi8/python-36:1-released
+  pullspec: registry.redhat.io/ubi8/python-36
 ubi8.ruby.25:
   user: "1001"
-  pullspec: ubi8/ruby-25:1-released
+  pullspec: registry.redhat.io/ubi8/ruby-25


### PR DESCRIPTION
The `-released` brew tags are deprecated and will soon be removed.

This PR ensures the base images are based off of the formally released images, by using registry.redhat.io as the registry. 

The code change has been run here:
https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/jdelft-aos-cd-jobs/job/build%252Fupdate-base-images/11/console