### PR TITLE
Allow for use of "keys"

### DIFF
--- a/hacks/ocp-cat/ocp-cat
+++ b/hacks/ocp-cat/ocp-cat
@@ -62,7 +62,8 @@ filter() {
   local sep=""
   local jq_prog="{\"$release\": {"
   for object in ${objects[@]}; do
-    jq_prog="$(printf '%s%s"%s": .%s' "$jq_prog" "$sep" "$object" "$object")"
+    [[ "$object" == keys ]] && dot="" || dot="."
+    jq_prog="$(printf '%s%s"%s": %s%s' "$jq_prog" "$sep" "$object" "$dot" "$object")"
     sep=", "
   done
   jq_prog="$jq_prog }}"


### PR DESCRIPTION
For ..convenience, the queried object gets prepended with a dot. This breaks when using a key word or built in function in `ocp-cat`. With this change, it is possible to get a list of keys:

```console
$ ocp-cat streams.yml keys
'3.11':
  keys:
    - ansible-runner
    - elasticsearch
    - golang
    - golang-1.11
    - jboss-openjdk18
    - nodejs-6
    - rhel
'4.2':
  keys:
    - elasticsearch
    - golang-1.11
    - golang-1.12
    - nodejs-6
    - rhel
    - rhel8
    - ruby-25
'4.3':
  keys:
    - elasticsearch
    - golang
    - nodejs-6
    - rhel
    - rhel-8-golang
    - rhel8
    - ruby-25
'4.4':
  keys:
    - elasticsearch
    - golang
    - nodejs-12
    - nodejs-6
    - python-36
    - rhel
    - rhel-8-golang
    - rhel8
    - ruby-25
'4.5':
  keys:
    - elasticsearch
    - golang
    - nodejs-10
    - nodejs-12
    - nodejs-6
    - rhel
    - rhel-8-golang
    - rhel8
    - ruby-25
'4.6':
  keys:
    - etcd_golang
    - golang
    - golang-1.15
    - hadoop-builder
    - nodejs-10
    - nodejs-12
    - python-36
    - rhel
    - rhel-7
    - rhel-7-golang
    - rhel-8-golang-1.14-ci-build-root
    - rhel-8-golang-1.15-ci-build-root
    - ruby-25
```