### PR TITLE
el8-rebuild: Rebuild when default branch is rhel7

### DIFF
--- a/jobs/build/el8-rebuilds/Jenkinsfile
+++ b/jobs/build/el8-rebuilds/Jenkinsfile
@@ -51,32 +51,35 @@ node {
 
     def version = params.BUILD_VERSION
     currentBuild.displayName += " - ${version}"
-    try {
-        buildlib.kinit()
-        def builds = [
-            "openshift": {
-                stage("openshift RPM") {
-                    commonlib.shell("./rebuild_rpm.sh openshift ${version}")
+    def branch = buildlib.doozer("--group openshift-${version} config:read-group branch", [capture: true]).trim()
+    if (branch.endsWith('-rhel-7')) {
+        try {
+            buildlib.kinit()
+            def builds = [
+                "openshift": {
+                    stage("openshift RPM") {
+                        commonlib.shell("./rebuild_rpm.sh openshift ${version}")
+                    }
+                },
+                "clients": {
+                    stage("openshift-clients RPM") {
+                        commonlib.shell("./rebuild_rpm.sh openshift-clients ${version}")
+                    }
                 }
-            },
-            "clients": {
-                stage("openshift-clients RPM") {
-                    commonlib.shell("./rebuild_rpm.sh openshift-clients ${version}")
-                }
-            }
-        ]
-        parallel builds
-    } catch(err) {
-        echo "Package build failed:\n${err}"
-        currentBuild.result = "FAILURE"
-        currentBuild.description = "\nerror: ${err.getMessage()}"
-        commonlib.email(
-            to: "${params.MAIL_LIST_FAILURE}",
-            from: "aos-art-automation@redhat.com",
-            replyTo: "aos-team-art@redhat.com",
-            subject: "Error rebuilding ${version} el8 RPMs for RHCOS",
-            body: "Encountered error(s) while running pipeline:\n${err}",
-        )
-        throw err
+            ]
+            parallel builds
+        } catch(err) {
+            echo "Package build failed:\n${err}"
+            currentBuild.result = "FAILURE"
+            currentBuild.description = "\nerror: ${err.getMessage()}"
+            commonlib.email(
+                to: "${params.MAIL_LIST_FAILURE}",
+                from: "aos-art-automation@redhat.com",
+                replyTo: "aos-team-art@redhat.com",
+                subject: "Error rebuilding ${version} el8 RPMs for RHCOS",
+                body: "Encountered error(s) while running pipeline:\n${err}",
+            )
+            throw err
+        }
     }
 }


### PR DESCRIPTION
Since changing the base to rhel-8 with ocp4.6, rpms do not need to be rebuilt anymore for 4.6 and newer.

This PR checks for the value of `branch` in `group.yml`, and builds it when the default branch ends with `rhel-7` (and not when it ends with `rhel-8`)

4.6: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/jdelft-aos-cd-jobs/job/build%252Fel8-rebuilds/6/console
4.2: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/jdelft-aos-cd-jobs/job/build%252Fel8-rebuilds/5/console