### PR TITLE
stop automatically sweeping incremental builds

### DIFF
--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -131,7 +131,7 @@ node {
             stage("sync images") { build.stageSyncImages() }
             stage("sweep") {
                 if (!params.DRY_RUN) {
-                    buildlib.sweep(params.BUILD_VERSION, true)
+                    buildlib.sweep(params.BUILD_VERSION, false)
                 }
             }
         }

--- a/jobs/build/sweep/Jenkinsfile
+++ b/jobs/build/sweep/Jenkinsfile
@@ -43,7 +43,7 @@ node {
                     commonlib.ocpVersionParam('BUILD_VERSION'),
                     booleanParam(
                         name: 'SWEEP_BUILDS',
-                        defaultValue: true,
+                        defaultValue: false,
                         description: 'Attach builds to default advisories',
                     ),
                     booleanParam(


### PR DESCRIPTION
If we're waiting until release prep to create advisories, don't sweep before then.