### PR TITLE
WIP: [ART-2291] Sign odo sha256sum.txt

### DIFF
--- a/jobs/build/odo_sync/Jenkinsfile
+++ b/jobs/build/odo_sync/Jenkinsfile
@@ -71,7 +71,34 @@ pipeline {
                 sh "mv ${params.VERSION}/SHA256SUM ${params.VERSION}/sha256sum.txt"
             }
         }
-
+        stage("Sign sha256sum.txt") {
+            steps {
+                withCredentials([file(credentialsId: 'msg-openshift-art-signatory-prod.crt', variable: 'busCertificate'),
+                                 file(credentialsId: 'msg-openshift-art-signatory-prod.key', variable: 'busKey')]) {
+                    script {
+                        def buildUserId = env.BUILD_USER_ID ?: "automated-process"
+                        def cmd = ("""
+                                ../umb_producer.py message-digest
+                                --requestor "${buildUserId}"
+                                --sig-keyname redhatrelease2
+                                --client-cert ${busCertificate}
+                                --client-key ${busKey}
+                                --env "prod"
+                                --product openshift
+                                --arch x86_64
+                                --client-type odo
+                                --release-name "${params.VERSION}"
+                                --request-id 'openshift-odo-message-digest-${env.BUILD_ID}'
+                            """
+                            .replaceAll(' *\\\n *', ' ')
+                            .replaceAll(' *\n *', ' ')
+                            .trim()
+                        )
+                        sh "${cmd}"
+                    }
+                }
+            }
+        }
         stage("Sync to mirror") {
             steps {
                 sh "tree ${params.VERSION}"


### PR DESCRIPTION
ART received a request to start signing the generated `sha256sum.txt` of `odo`.
@tbielawa I'm not sure how to test signing ... I just `echo`ed the generated command instead of executing it on my hack space.

<https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/talessio-aos-cd-jobs/job/ART-2291-hack/5/console>

```
Would run the following command:
../umb_producer.py message-digest
--requestor "automated-process"
--sig-keyname redhatrelease2
--client-cert ****
--client-key ****
--env "prod"
--product openshift
--arch x86_64
--client-type odo
--release-name "v2.0.0"
--request-id 'openshift-odo-message-digest-5'
```