### PR TITLE
Notify owners of missing bz information

### DIFF
--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -321,6 +321,8 @@ def stageUpdateDistgit() {
     // TODO: if rebase fails for required images, notify image owners, and still notify on other reconciliations
     buildlib.notify_dockerfile_reconciliations(doozerWorking, version.stream)
     // TODO: if a non-required rebase fails, notify ART and the image owners
+
+    buildlib.notify_bz_info_missing(doozerWorking, version.stream)
 }
 
 /**


### PR DESCRIPTION
In conjunction with doozer code, https://github.com/openshift/doozer/pull/293, will send nag emails to component owners that they need to add BZ component information to their upstream OWNERS file. Doozer ensures that this nag message will only be sent once a week.