### PR TITLE
appregistry: Add advisories to description

### DIFF
--- a/jobs/build/appregistry/Jenkinsfile
+++ b/jobs/build/appregistry/Jenkinsfile
@@ -83,7 +83,11 @@ node {
     appregistry.initialize(workDir)
 
     currentBuild.description = "Collecting appregistry images for ${appregistry.buildVersion} (${params.STREAM} stream)"
-    currentBuild.displayName += " - ${appregistry.buildVersion} (${params.STREAM})"
+    currentBuild.displayName += " - ${appregistry.buildVersion}-${params.STREAM}"
+    if (params.STREAM in ['prod', 'stage']) {
+        currentBuild.displayName += " (extras: ${params.OLM_OPERATOR_ADVISORIES}, metadata: ${params.METADATA_ADVISORY})"
+    }
+        
 
     def skipPush = params.SKIP_PUSH
 


### PR DESCRIPTION
Currently, it takes time to find the right jobs from the jenkins search
interface when one wants to look at what happened in the past. This
change adds the advisory IDs in the job's description, so that can be
used to query.