### PR TITLE
ART-2283: Publish coreos-installer to mirror

### DIFF
--- a/jobs/build/coreos-installer_sync/Jenkinsfile
+++ b/jobs/build/coreos-installer_sync/Jenkinsfile
@@ -1,0 +1,114 @@
+#!/usr/bin/env groovy
+node {
+    checkout scm
+    def buildlib = load("pipeline-scripts/buildlib.groovy")
+    def commonlib = buildlib.commonlib
+
+    commonlib.describeJob("coreos-installer_sync", """
+        <h2>Sync contents of the coreos-installer RPM to mirror</h2>
+        http://mirror.openshift.com/pub/openshift-v4/clients/coreos-installer/
+
+        Timing: This is only ever run by humans, upon request.
+    """)
+
+    properties([
+        disableResume(),
+        buildDiscarder(
+            logRotator(
+                artifactDaysToKeepStr: '',
+                artifactNumToKeepStr: '',
+                daysToKeepStr: '',
+                numToKeepStr: ''
+            )
+        ),
+        [
+            $class: 'ParametersDefinitionProperty',
+            parameterDefinitions: [
+                string(
+                    name: "NVR",
+                    description: "NVR of the blessed brew build",
+                    defaultValue: "",
+                    trim: true,
+                ),
+                string(
+                    name: "VERSION",
+                    description: "Desired version name. Example: v3.0.1",
+                    defaultValue: "",
+                    trim: true,
+                ),
+                string(
+                    name: "ARCHES",
+                    description: "Arches to extract from the brew build. Defaults to all contained in the rpm",
+                    defaultValue: "",
+                    trim: true,
+                ),
+                commonlib.dryrunParam(),
+                commonlib.mockParam(),
+            ],
+        ]
+    ])
+
+    workdir = "${env.WORKSPACE}/coreos-installer_sync"
+    commonlib.checkMock()
+    buildlib.initialize()
+    buildlib.cleanWorkdir(workdir)
+
+    stage("Validate params") {
+        if (!params.NVR) {
+            error "NVR must be specified"
+        }
+        if (!params.VERSION) {
+            error "VERSION must be specified"
+        }
+    }
+
+    stage("Download RPM") {
+        commonlib.shell(
+            script: [
+                "set -exuo pipefail",
+                "cd ${workdir}",
+                "rm --recursive --force ./*",
+                "brew --quiet download-build ${params.NVR}",
+                "rm *bootinfra* *.src.rpm",
+                "tree",
+            ].join('\n'),
+        )
+    }
+
+    stage("Extract RPM contents") {
+        commonlib.shell(
+            script: "./extract.sh '${workdir}' '${params.VERSION}' '${params.ARCHES}'",
+        )
+    }
+    stage("Sync to mirror") {
+        def mirror = "use-mirror-upload.ops.rhcloud.com"
+        def dir = "/srv/pub/openshift-v4/clients/coreos-installer"
+
+        if (params.DRY_RUN) {
+            commonlib.shell(
+                script: [
+                    "echo 'Would have synced the following to ${mirror}:'",
+                    "tree ${workdir}/${params.VERSION}",
+                ].join('\n')
+            )
+            return
+        }
+
+        sshagent(['aos-cd-test']) {
+            commonlib.shell(
+                script: [
+                    "set -euxo pipefail",
+                    "cd ${workdir}",
+                    "ssh ${mirror} mkdir -p ${dir}",
+                    "scp -r ${params.VERSION} ${mirror}:${dir}/${params.VERSION}",
+                    "if [[ -f ${params.VERSION}/coreos-installer_amd64 ]]; then",
+                        "ssh ${mirror} ln --symbolic --force --no-dereference coreos-installer_amd64 ${dir}/${params.VERSION}/coreos-installer",
+                    "fi",
+                    "ssh ${mirror} ln --symbolic --force --no-dereference ${params.VERSION} ${dir}/latest",
+                    "ssh ${mirror} tree ${dir}",
+                    "ssh ${mirror} /usr/local/bin/push.pub.sh openshift-v4/clients/coreos-installer -v",
+                ].join('\n')
+            )
+        }
+    }
+}

--- a/jobs/build/coreos-installer_sync/Jenkinsfile
+++ b/jobs/build/coreos-installer_sync/Jenkinsfile
@@ -99,18 +99,18 @@ node {
 
         sshagent(['aos-cd-test']) {
             commonlib.shell(
-                script: [
-                    "set -euxo pipefail",
-                    "cd ${workdir}",
-                    "ssh ${mirror} mkdir -p ${dir}",
-                    "scp -r ${params.VERSION} ${mirror}:${dir}/${params.VERSION}",
-                    "if [[ -f ${params.VERSION}/coreos-installer_amd64 ]]; then",
-                        "ssh ${mirror} ln --symbolic --force --no-dereference coreos-installer_amd64 ${dir}/${params.VERSION}/coreos-installer",
-                    "fi",
-                    "ssh ${mirror} ln --symbolic --force --no-dereference ${params.VERSION} ${dir}/latest",
-                    "ssh ${mirror} tree ${dir}",
-                    "ssh ${mirror} /usr/local/bin/push.pub.sh openshift-v4/clients/coreos-installer -v",
-                ].join('\n')
+                script: """
+                    set -euxo pipefail
+                    cd ${workdir}
+                    ssh ${mirror} mkdir -p ${dir}
+                    scp -r ${params.VERSION} ${mirror}:${dir}/${params.VERSION}
+                    if [[ -f ${params.VERSION}/coreos-installer_amd64 ]]; then
+                        ssh ${mirror} ln --symbolic --force --no-dereference coreos-installer_amd64 ${dir}/${params.VERSION}/coreos-installer
+                    fi
+                    ssh ${mirror} ln --symbolic --force --no-dereference ${params.VERSION} ${dir}/latest
+                    ssh ${mirror} tree ${dir}
+                    ssh ${mirror} /usr/local/bin/push.pub.sh openshift-v4/clients/coreos-installer -v
+                """
             )
         }
     }

--- a/jobs/build/coreos-installer_sync/Jenkinsfile
+++ b/jobs/build/coreos-installer_sync/Jenkinsfile
@@ -64,22 +64,25 @@ node {
 
     stage("Download RPM") {
         commonlib.shell(
-            script: [
-                "set -exuo pipefail",
-                "cd ${workdir}",
-                "rm --recursive --force ./*",
-                "brew --quiet download-build ${params.NVR}",
-                "rm *bootinfra* *.src.rpm",
-                "tree",
-            ].join('\n'),
+            script: """
+                set -exuo pipefail
+                cd ${workdir}
+                rm --recursive --force ./*
+                brew --quiet download-build ${params.NVR}
+                shopt -s nullglob
+                rm --force *bootinfra* *.src.rpm
+                tree
+            """
         )
     }
 
     stage("Extract RPM contents") {
+        def arches = commonlib.cleanCommaList(params.ARCHES)
         commonlib.shell(
-            script: "./extract.sh '${workdir}' '${params.VERSION}' '${params.ARCHES}'",
+            script: "./extract.sh '${workdir}' '${params.VERSION}' '${arches}'",
         )
     }
+
     stage("Sync to mirror") {
         def mirror = "use-mirror-upload.ops.rhcloud.com"
         def dir = "/srv/pub/openshift-v4/clients/coreos-installer"

--- a/jobs/build/coreos-installer_sync/extract.sh
+++ b/jobs/build/coreos-installer_sync/extract.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+WORKDIR="$1"
+cd "$WORKDIR"
+VERSION="$2"
+ARCHES=""
+if [[ -n "${3-}" ]]; then
+  ARCHES="${3//,/ }"
+  rm -rf keep/
+  mkdir keep/
+  for arch in $ARCHES; do
+    [[ "$arch" == "amd64" ]] && arch=x86_64
+    mv *.$arch.rpm keep/
+  done
+  rm *.rpm
+  mv keep/* .
+  rmdir keep/
+fi
+
+rm -rf "$VERSION"
+mkdir "$VERSION"
+
+for rpm in *.rpm; do
+  arch="$(awk -F'[.]' '{a = $(NF-1); print a=="x86_64" ? "amd64" : a}' <<<"$rpm")"
+  rpm2cpio "${rpm}" | cpio -idm --quiet ./usr/bin/coreos-installer
+  mv usr/bin/coreos-installer "$VERSION/coreos-installer_$arch"
+done
+
+tree "$VERSION"


### PR DESCRIPTION
This commit creates a job that downloads the RPMs of a build of

The end result looks like this:
```
+ ssh use-mirror-upload.ops.rhcloud.com tree /srv/pub/openshift-v4/clients/coreos-installer
/srv/pub/openshift-v4/clients/coreos-installer
├── latest -> v0.6.0-3
└── v0.6.0-3
    ├── coreos-installer -> coreos-installer_amd64
    ├── coreos-installer_aarch64
    ├── coreos-installer_amd64
    ├── coreos-installer_ppc64le
    └── coreos-installer_s390x
```
(This is the intermediary step, as this is not yet published!).

For ART-ists, here is an [example run](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/jdelft-aos-cd-jobs/job/build%252Fcoreos-installer_sync/19/console) (omitting the `push.pub.sh` step).