### PR TITLE
ART-1906: Use separate signing advisory for each release

### DIFF
--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -199,10 +199,11 @@ node {
                         } else {
                             echo 'Building 4.x plashet'
                             // For 4.x, use plashets
-                            buildlib.buildBuildingPlashet(version, release, 8, true)  // build el8 embargoed plashet
-                            buildlib.buildBuildingPlashet(version, release, 7, true)  // build el7 embargoed plashet
-                            buildlib.buildBuildingPlashet(version, release, 8, false)  // build el8 unembargoed plashet
-                            buildlib.buildBuildingPlashet(version, release, 7, false)  // build el7 unembargoed plashet
+                            def auto_signing_advisory = Integer.parseInt(buildlib.doozer("${doozerOpts} config:read-group signing_advisory", [capture: true]).trim())
+                            buildlib.buildBuildingPlashet(version, release, 8, true, auto_signing_advisory)  // build el8 embargoed plashet
+                            buildlib.buildBuildingPlashet(version, release, 7, true, auto_signing_advisory)  // build el7 embargoed plashet
+                            buildlib.buildBuildingPlashet(version, release, 8, false, auto_signing_advisory)  // build el8 unembargoed plashet
+                            buildlib.buildBuildingPlashet(version, release, 7, false, auto_signing_advisory)  // build el7 unembargoed plashet
                         }
                     }
                 }

--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -199,7 +199,7 @@ node {
                         } else {
                             echo 'Building 4.x plashet'
                             // For 4.x, use plashets
-                            def auto_signing_advisory = Integer.parseInt(buildlib.doozer("${doozerOpts} config:read-group signing_advisory", [capture: true]).trim())
+                            def auto_signing_advisory = Integer.parseInt(buildlib.doozer("${doozerOpts} config:read-group --default=0 signing_advisory", [capture: true]).trim())
                             buildlib.buildBuildingPlashet(version, release, 8, true, auto_signing_advisory)  // build el8 embargoed plashet
                             buildlib.buildBuildingPlashet(version, release, 7, true, auto_signing_advisory)  // build el7 embargoed plashet
                             buildlib.buildBuildingPlashet(version, release, 8, false, auto_signing_advisory)  // build el8 unembargoed plashet

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -282,15 +282,14 @@ def stageBuildRpms() {
 /**
  * Unless no RPMs have changed, create multiple yum repos (one for each arch) of RPMs based on -candidate tags.
  * Based on commonlib.ocp4ReleaseState, those repos can be signed (release state) or unsigned (pre-release state).
- * @param auto_signing_advisory - The advisory method can use for auto-signing. This should be
- *          unique to this release (to avoid simultaneous modifications. i.e. different
- *          advisories for 4.1, 4.2, ...
  */
-def stageBuildCompose(auto_signing_advisory=54765) {
+def stageBuildCompose() {
     if(buildPlan.dryRun) {
         echo "Running in dry-run mode -- will not run plashet."
         return
     }
+
+    def auto_signing_advisory = Integer.parseInt(buildlib.doozer("${doozerOpts} config:read-group signing_advisory", [capture: true]).trim())
 
     buildlib.buildBuildingPlashet(version.full, version.release, 8, true, auto_signing_advisory)  // build el8 embargoed plashet
     buildlib.buildBuildingPlashet(version.full, version.release, 7, true, auto_signing_advisory)  // build el7 embargoed plashet

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -289,7 +289,7 @@ def stageBuildCompose() {
         return
     }
 
-    def auto_signing_advisory = Integer.parseInt(buildlib.doozer("${doozerOpts} config:read-group signing_advisory", [capture: true]).trim())
+    def auto_signing_advisory = Integer.parseInt(buildlib.doozer("${doozerOpts} config:read-group --default=0 signing_advisory", [capture: true]).trim())
 
     buildlib.buildBuildingPlashet(version.full, version.release, 8, true, auto_signing_advisory)  // build el8 embargoed plashet
     buildlib.buildBuildingPlashet(version.full, version.release, 7, true, auto_signing_advisory)  // build el7 embargoed plashet

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -1477,13 +1477,16 @@ def getChanges(yamlData) {
  * @param release  The 4.x release field (usually a timestamp)
  * @param el_major The RHEL major version (7 or 8)
  * @param include_embargoed If true, the plashet will include the very latest rpms (embargoed & unembargoed). Otherwise Plashet will only include unembargoed historical builds of rpms
- * @param auto_signing_advisory The signing advisory to use
+ * @param auto_signing_advisory The signing advisory to use. Set to 0 to use the default advisory.
  * @return { 'localPlashetPath' : 'path/to/local/workspace/plashetDirName',
  *           'plashetDirName' : 'e.g. 4.5.0-<release timestamp>' or 4.5.0-<release timestamp>-embargoed'
  *
  * }
  */
-def buildBuildingPlashet(version, release, el_major, include_embargoed, auto_signing_advisory) {
+def buildBuildingPlashet(version, release, el_major, include_embargoed, auto_signing_advisory=0) {
+    if (!auto_signing_advisory) {
+        auto_signing_advisory = 54765
+    }
     def baseDir = "${env.WORKSPACE}/plashets/el${el_major}"
 
     def plashetDirName = "${version}-${release}" // e.g. 4.6.22-<release timestamp>

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -1016,9 +1016,9 @@ Why am I receiving this?
 ------------------------
 You are receiving this message because you are listed as an owner for an
 OpenShift related image - or you recently made a modification to the definition
-of such an image in github. 
+of such an image in github.
 
-To comply with prodsec requirements, all images in the OpenShift product 
+To comply with prodsec requirements, all images in the OpenShift product
 should identify their Bugzilla component. To accomplish this, ART
 expects to find Bugzilla component information in the default branch of
 the image's upstream repository or requires it in ART image metadata.
@@ -1027,12 +1027,12 @@ What should I do?
 ------------------------
 There are two options to supply Bugzilla component information.
 1) The OWNERS file in the default branch (e.g. main / master) of ${public_upstream_url}
-   can be updated to include the bugzilla component information. 
+   can be updated to include the bugzilla component information.
 
-2) The component information can be specified directly in the 
-   ART metadata for the image ${distgit}.  
+2) The component information can be specified directly in the
+   ART metadata for the image ${distgit}.
 
-Details for either approach can be found here: 
+Details for either approach can be found here:
 https://docs.google.com/document/d/1V_DGuVqbo6CUro0RC86THQWZPrQMwvtDr0YQ0A75QbQ/edit?usp=sharing
 
 Thanks for your help!
@@ -1483,7 +1483,7 @@ def getChanges(yamlData) {
  *
  * }
  */
-def buildBuildingPlashet(version, release, el_major, include_embargoed, auto_signing_advisory=54765) {
+def buildBuildingPlashet(version, release, el_major, include_embargoed, auto_signing_advisory) {
     def baseDir = "${env.WORKSPACE}/plashets/el${el_major}"
 
     def plashetDirName = "${version}-${release}" // e.g. 4.6.22-<release timestamp>


### PR DESCRIPTION
Signing advisories will be read from group.yml instead of hardcoded 54765.