### PR TITLE
scheduled-jobs/poll-payload: fix empty input

### DIFF
--- a/scheduled-jobs/build/poll-payload/Jenkinsfile
+++ b/scheduled-jobs/build/poll-payload/Jenkinsfile
@@ -78,6 +78,9 @@ node() {
     commonlib = load("pipeline-scripts/commonlib.groovy")
     description = ""
     def actionArguments = [:]
+    if (ACTIONS.isEmpty()) {
+        return
+    }
     for (releaseStream in ACTIONS.keySet()) {
         def releaseCacheFile = "${releaseStream}.json"
         def changed, latestRelease, previousRelease


### PR DESCRIPTION
Fixes error:
```
hudson.remoting.ProxyException: groovy.lang.MissingMethodException: No signature of method: java.util.ArrayList.keySet() is applicable for argument types: () values: []
```