### PR TITLE
Enable scheduled opening PRs for >= 4.7

### DIFF
--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -369,25 +369,24 @@ def stageBuildImages() {
         if (r.total > 10 && r.ratio > 0.25 || r.total > 1 && r.failed == r.total) {
             echo "${r.failed} of ${r.total} image builds failed; probably not the owners' fault, will not spam"
         } else {
-
-			// Disable automatic mirror-streams until we are beyond ubi8/1.15 migration
-			if ( /*r.total > 10 ||*/ params.FORCE_MIRROR_STREAMS ) {
-				// This was a relatively successful build. We want to mirror images in streams.yml
-				// to CI when they change AND they are successful in the ART build.
-				// This ensures that CI is building with the same images (base & builder) that
-				// ART is, but also makes sure that IF streams.yml gets borked in some way (e.g.
-				// golang was bumped to something awful), we don't want mirror it automatically.
-
-				// Make sure our token for api.ci is fresh
-				sh "oc --kubeconfig=/home/jenkins/kubeconfigs/art-publish.kubeconfig registry login"
-
-				// Push!
-				buildlib.doozer "${doozerOpts} images:mirror-streams"
-			}
-
-
             buildlib.mail_build_failure_owners(failed_map, "aos-team-art@redhat.com", params.MAIL_LIST_FAILURE)
         }
+    }
+
+	recordLog = buildlib.parse_record_log(doozerWorking)
+	def success_map = buildlib.get_successful_builds(recordLog, true)
+	if (success_map.containsKey('ose-openshift-apiserver')) {
+        // If the API server builds, we mirror out the streams to CI. If ART builds a bad golang builder image
+        // it will break CI builds for most upstream components if we don't catch it before we push. So we use
+        // apiserver as bellweather to make sure that the currently builder image is good enough. We can still
+        // break CI (e.g. pushing a bad ruby-25 image along with this push, but it will not be a catastrophic
+        // event like breaking the apiserver.
+
+        // Make sure our api.ci token is fresh
+        sh "oc --kubeconfig=/home/jenkins/kubeconfigs/art-publish.kubeconfig registry login"
+
+        // TODO:enable this
+        // buildlib.doozer "${doozerOpts} images:streams mirror"
     }
 }
 

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -929,13 +929,8 @@ def branch_arches(String branch, boolean gaOnly=false) {
     return arches_list
 }
 
-// Search the build log for failed builds
-def get_failed_builds(String log_dir, Boolean fullRecord=false) {
-    record_log = parse_record_log(log_dir)
-    this.get_failed_builds(record_log, fullRecord)
-}
-
 def get_failed_builds(Map record_log, Boolean fullRecord=false) {
+    // Returns a map of distgit => task_url OR full record.log dict entry IFF the distgit's build failed
     builds = record_log.get('build', [])
     failed_map = [:]
     for (i = 0; i < builds.size(); i++) {
@@ -952,6 +947,21 @@ def get_failed_builds(Map record_log, Boolean fullRecord=false) {
     }
 
     return failed_map
+}
+
+def get_successful_builds(Map record_log, Boolean fullRecord=false) {
+    // Returns a map of distgit => task_url OR full record.log dict entry IFF the distgit's build succeeded
+    builds = record_log.get('build', [])
+    success_map = [:]
+    for (i = 0; i < builds.size(); i++) {
+        bld = builds[i]
+        distgit = bld['distgit']
+        if (bld['status'] == '0') {
+            success_map[distgit] = fullRecord ? bld : bld['task_url']
+        }
+    }
+
+    return success_map
 }
 
 // gets map of emails to notify from output of parse_record_log
@@ -1032,9 +1042,9 @@ Why am I receiving this?
 ------------------------
 You are receiving this message because you are listed as an owner for an
 OpenShift related image - or you recently made a modification to the definition
-of such an image in github. 
+of such an image in github.
 
-To comply with prodsec requirements, all images in the OpenShift product 
+To comply with prodsec requirements, all images in the OpenShift product
 should identify their Bugzilla component. To accomplish this, ART
 expects to find Bugzilla component information in the default branch of
 the image's upstream repository or requires it in ART image metadata.
@@ -1043,12 +1053,12 @@ What should I do?
 ------------------------
 There are two options to supply Bugzilla component information.
 1) The OWNERS file in the default branch (e.g. main / master) of ${public_upstream_url}
-   can be updated to include the bugzilla component information. 
+   can be updated to include the bugzilla component information.
 
-2) The component information can be specified directly in the 
-   ART metadata for the image ${distgit}.  
+2) The component information can be specified directly in the
+   ART metadata for the image ${distgit}.
 
-Details for either approach can be found here: 
+Details for either approach can be found here:
 https://docs.google.com/document/d/1V_DGuVqbo6CUro0RC86THQWZPrQMwvtDr0YQ0A75QbQ/edit?usp=sharing
 
 Thanks for your help!

--- a/scheduled-jobs/build/sync-ci-images/Jenkinsfile
+++ b/scheduled-jobs/build/sync-ci-images/Jenkinsfile
@@ -15,6 +15,7 @@ node {
     for ( String version : sortedVersions() ) {
         group = "openshift-${version}"
         echo "Checking group: ${group}"
+        (major, minor) = commonlib.extractMajorMinorVersionNumbers(version)
 
         sh "rm -rf ${group}"
         sh "git clone https://github.com/openshift/ocp-build-data --branch ${group} --single-branch --depth 1 ${group}"
@@ -33,10 +34,22 @@ node {
         if (now_hash != prev_hash) {
             echo "Changes detected in ocp-build-data group: ${group}"
 
-            sh "KUBECONFIG=/home/jenkins/kubeconfigs/art-publish.kubeconfig ${buildlib.DOOZER_BIN} --group ${group} images:streams gen-buildconfigs -o ${group}.yaml --apply"
-            sh "KUBECONFIG=/home/jenkins/kubeconfigs/art-publish.kubeconfig oc registry login"
-            sh "KUBECONFIG=/home/jenkins/kubeconfigs/art-publish.kubeconfig ${buildlib.DOOZER_BIN} --group ${group} images:streams mirror --only-if-missing"
-            sh "KUBECONFIG=/home/jenkins/kubeconfigs/art-publish.kubeconfig ${buildlib.DOOZER_BIN} --group ${group} images:streams start-builds"
+			withEnv(['KUBECONFIG=/home/jenkins/kubeconfigs/art-publish.kubeconfig']) {
+				sh "doozer --group ${group} images:streams gen-buildconfigs -o ${group}.yaml --apply"
+				sh "oc registry login"
+				sh "doozer --group ${group} images:streams mirror --only-if-missing"
+				sh "doozer --group ${group} images:streams start-builds"
+				// Allow the builds to run for about 20 minutes
+				sleep time: 20, unit: 'MINUTES'
+				// Print out status of builds for posterity
+				sh "doozer --group ${group} images:streams check-upstream"
+				withCredentials([string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN')]) {
+					if ( (major == 4 && minor >= 7) || major > 4 ) {
+						// Only open PRs on >= 4.7 to leave well enough alone.
+						sh "doozer --group ${group} images:streams prs open --github-access-token ${GITHUB_TOKEN}"
+					}
+				}
+			}
 
             sh "rm -rf ${prev_dir_name}"
             sh "mv ${group} ${prev_dir_name}"


### PR DESCRIPTION
Begin opening upstream PRs as streams.yml change. 
Prep to automatically push builder images when build of the apiserver is successful.