### PR TITLE
Fix 3.Y sweep

### DIFF
--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -304,7 +304,7 @@ node {
 
             stage('sweep') {
                 if (params.SWEEP_BUGS) {
-                    buildlib.sweep(params.BUILD_VERSION, false)
+                    buildlib.sweep(params.BUILD_VERSION)
                 }
             }
 

--- a/jobs/build/ocp3/Jenkinsfile
+++ b/jobs/build/ocp3/Jenkinsfile
@@ -925,9 +925,7 @@ images:build
             }
 
             stage("sweep") {
-                if (!params.DRY_RUN) {
-                    buildlib.sweep(params.BUILD_VERSION, true)
-                }
+                buildlib.sweep(params.BUILD_VERSION)
             }
 
             echo "Finished building OCP ${NEW_FULL_VERSION}"

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -130,9 +130,7 @@ node {
             }
             stage("sync images") { build.stageSyncImages() }
             stage("sweep") {
-                if (!params.DRY_RUN) {
-                    buildlib.sweep(params.BUILD_VERSION, false)
-                }
+                buildlib.sweep(params.BUILD_VERSION)
             }
         }
         stage("report success") { build.stageReportSuccess() }


### PR DESCRIPTION
After an OCP3 build, the sweep job gets called with the instruction to attach builds to the advisories. See [this build](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/view/OCP4%20Build%20Dashboard/job/aos-cd-builds/job/build%252Fsweep/12385/console) as an example. This should not happen, as collecting builds into advisories should not happen automatically.

This change alters the buildlib.sweep function to assume no builds will be swept, unless told otherwise.

This also will propagate the DRY_RUN parameter to the sweep job if it was present in the job calling the sweep job.