### PR TITLE
split push to QE quay to a different stage

### DIFF
--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -242,14 +242,7 @@ node {
             stage("build images") {
                 if (!any_images_to_build) { return }
                 base_command = "${doozerOpts} ${include_exclude} --profile ${repo_type}"
-                command = "images:build --push-to-defaults"
-                if (majorVersion == "4") {
-                    config_dir = "${env.WORKSPACE}/qe_quay_config"
-                    buildlib.registry_quay_qe_login(config_dir)
-                    base_command += " --registry-config-dir=${config_dir}"
-                    command += " --filter-by-os='.*'"
-                }
-                command = "${base_command} ${command}"
+                command = "${base_command} images:build"
                 try {
                     buildlib.doozer command
                 } catch (err) {
@@ -267,6 +260,21 @@ node {
                 }
             }
 
+            stage('push images to qe quay') {
+                if (majorVersion == "4") {
+                    config_dir = "${env.WORKSPACE}/qe_quay_config"
+                    buildlib.registry_quay_qe_login(config_dir)
+                    base_command = "${doozerOpts} ${include_exclude} --profile ${repo_type} --registry-config-dir=${config_dir}"
+                    command = "${base_command} images:push --to-defaults"
+                    command += " --filter-by-os='.*'"
+                    try {
+                        buildlib.doozer command
+                    } catch (err) {
+                        echo "image push to qe quay failed, but it's okay we can ignore it"
+                    }
+                }
+            }
+            
             stage('sync images') {
                 if (majorVersion == "4") {
                     buildlib.sync_images(

--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -270,7 +270,8 @@ node {
                     try {
                         buildlib.doozer command
                     } catch (err) {
-                        echo "image push to qe quay failed, but it's okay we can ignore it"
+                        currentBuild.description += "\n<br>image push to qe quay did not completely succeed"
+                        currentBuild.result = "UNSTABLE"
                     }
                 }
             }

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -129,6 +129,7 @@ node {
                 stage("mirror RPMs") { build.stageMirrorRpms() }
             }
             stage("sync images") { build.stageSyncImages() }
+            stage("push qe quay images") { build.stagePushQEImages() }
             stage("sweep") {
                 buildlib.sweep(params.BUILD_VERSION)
             }

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -482,7 +482,8 @@ def stagePushQEImages() {
     try {
         buildlib.doozer(cmd)
     } catch (err) {
-        echo "image push to qe quay failed, but it's okay we can ignore it"
+        currentBuild.description += "\n<br>image push to qe quay did not completely succeed"
+        currentBuild.result = "UNSTABLE"
     }
 }
 

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -337,17 +337,12 @@ def stageBuildImages() {
         def archReleaseStates = commonlib.ocp4ReleaseState[version.stream]
         // If any arch is GA, use signed for everything. See stageBuildCompose for details.
         def signing_mode = archReleaseStates['release']?'signed':'unsigned'
-        config_dir = "${env.WORKSPACE}/qe_quay_config"
-        buildlib.registry_quay_qe_login(config_dir)
         def cmd =
             """
             ${doozerOpts}
             ${includeExclude "images", buildPlan.imagesIncluded, buildPlan.imagesExcluded}
-            --registry-config-dir=${config_dir}
             images:build
             --repo-type ${signing_mode}
-            --push-to-defaults
-            --filter-by-os='.*'
             """
         if(buildPlan.dryRun) {
             echo "${buildlib.DOOZER_BIN} ${cmd}"
@@ -466,6 +461,29 @@ def stageSyncImages() {
         "aos-team-art@redhat.com",
         currentBuild.number
     )
+}
+
+def stagePushQEImages() {
+    config_dir = "${env.WORKSPACE}/qe_quay_config"
+    buildlib.registry_quay_qe_login(config_dir)
+    def cmd =
+            """
+            ${doozerOpts}
+            ${includeExclude "images", buildPlan.imagesIncluded, buildPlan.imagesExcluded}
+            --registry-config-dir=${config_dir}
+            images:push
+            --to-defaults
+            --filter-by-os='.*'
+            """
+    if(buildPlan.dryRun) {
+        echo "doozer ${cmd}"
+        return
+    }
+    try {
+        buildlib.doozer(cmd)
+    } catch (err) {
+        echo "image push to qe quay failed, but it's okay we can ignore it"
+    }
 }
 
 def stageReportSuccess() {


### PR DESCRIPTION
This PR is to fix issue https://issues.redhat.com/browse/ART-2289

it changed:
1. move push to qe quay logic out of the build images stage to a separate stage.
2. in the push qe quay stage try-catch and omit to throw errors even when push failed. 
![image](https://user-images.githubusercontent.com/6284003/97969026-6b0d5f00-1dfa-11eb-99f7-b72fd6555870.png)
pic about is before and after change^^^^
https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/shiywang-aos-cd-jobs/job/build%252Fcustom/47/console
