### PR TITLE
[ART-1858] verify payload as promotion preflight check

### DIFF
--- a/jobs/build/pre-release/Jenkinsfile
+++ b/jobs/build/pre-release/Jenkinsfile
@@ -136,7 +136,7 @@ node {
             def CLIENT_TYPE = "ocp-dev-preview"
 
             stage("validation") {
-                release.stageValidation(quay_url, dest_release_tag, -1, params.PERMIT_PAYLOAD_OVERWRITE)
+                release.stageValidation(quay_url, dest_release_tag, -1, params.PERMIT_PAYLOAD_OVERWRITE, false, params.FROM_RELEASE_TAG, arch)
             }
 
             stage("build payload") {

--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -305,7 +305,7 @@ node {
                     errata_url = ''
                     return
                 }
-                def retval = release.stageValidation(quay_url, dest_release_tag, advisory, params.PERMIT_PAYLOAD_OVERWRITE, params.PERMIT_ALL_ADVISORY_STATES)
+                def retval = release.stageValidation(quay_url, dest_release_tag, advisory, params.PERMIT_PAYLOAD_OVERWRITE, params.PERMIT_ALL_ADVISORY_STATES, params.FROM_RELEASE_TAG, arch)
                 advisory = advisory?:retval.advisoryInfo.id
                 errata_url = retval.errataUrl
             }

--- a/jobs/build/release/Jenkinsfile
+++ b/jobs/build/release/Jenkinsfile
@@ -296,7 +296,7 @@ node {
                     errata_url = ''
                     return
                 }
-                def retval = release.stageValidation(quay_url, dest_release_tag, advisory, params.PERMIT_PAYLOAD_OVERWRITE, params.PERMIT_ALL_ADVISORY_STATES)
+                def retval = release.stageValidation(quay_url, dest_release_tag, advisory, params.PERMIT_PAYLOAD_OVERWRITE, params.PERMIT_ALL_ADVISORY_STATES, params.FROM_RELEASE_TAG, arch)
                 advisory = advisory?:retval.advisoryInfo.id
                 errata_url = retval.errataUrl
             }

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -121,20 +121,20 @@ Map stageValidation(String quay_url, String dest_release_tag, int advisory = 0, 
     }
 
     if (arch == 'amd64' || arch == 'x86_64') {
-￼        echo "Verifying payload"
-￼        res = commonlib.shell(
-￼                returnAll: true,
-￼                script: "elliott --group=openshift-${version} verify-payload amd64.ocp.releases.ci.openshift.org/ocp/release:${nightly} ${advisory}"
-￼                )
-￼￼       if (res.returnStatus != 0) {
-￼            def cd = currentBuild.description
-￼            currentBuild.description = "${currentBuild.description} - INPUT REQUIRED"
-￼            slackChannel = slacklib.to(version)
-￼            slackChannel.failure("Verify-payload failed. User input required to proceed")
-￼            input 'Advisory contents does not match payload. Proceed anyway?'
-￼            currentBuild.description = cd
-￼￼       }
-￼￼   }
+        echo "Verifying payload"
+        res = commonlib.shell(
+                returnAll: true,
+                script: "elliott --group=openshift-${version} verify-payload amd64.ocp.releases.ci.openshift.org/ocp/release:${nightly} ${advisory}"
+                )
+        if (res.returnStatus != 0) {
+            def cd = currentBuild.description
+            currentBuild.description = "${currentBuild.description} - INPUT REQUIRED"
+            slackChannel = slacklib.to(version)
+            slackChannel.failure("Verify-payload failed. User input required to proceed")
+            input 'Advisory contents does not match payload. Proceed anyway?'
+            currentBuild.description = cd
+        }
+    }
     return retval
 }
 

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -124,7 +124,7 @@ Map stageValidation(String quay_url, String dest_release_tag, int advisory = 0, 
         echo "Verifying payload"
         res = commonlib.shell(
                 returnAll: true,
-                script: "elliott --group=openshift-${version} verify-payload amd64.ocp.releases.ci.openshift.org/ocp/release:${nightly} ${advisory}"
+                script: "elliott --group=openshift-${version} verify-payload registry.svc.ci.openshift.org/ocp/release:${nightly} ${advisory}"
                 )
         if (res.returnStatus != 0) {
             def cd = currentBuild.description


### PR DESCRIPTION
Before promoting a nightly, it needs to be checked that the images in the advisory match the ones in the payload. This uses elliott verify-payload as an input validator.

There might be false positives when payload images are in RHSAs. For this reason, the operator is asked for input.