### PR TITLE
[ART-2342] Use latest release controller URL

### DIFF
--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -518,7 +518,7 @@ node {
 
         dry_subject = ""
         if (params.DRY_RUN) { dry_subject = "[DRY RUN] "}
-
+        releaseArch = arch == "x86_64" ? "amd64" : "${arch}"
         commonlib.email(
             to: "${params.MAIL_LIST_SUCCESS}",
             replyTo: "aos-team-art@redhat.com",
@@ -526,7 +526,7 @@ node {
             subject: "${dry_subject}Success building release payload: ${release_name} (${arch})",
             body: """
 Jenkins Job: ${env.BUILD_URL}
-Release Page: https://openshift-release${release.getArchPrivSuffix(arch, false)}.svc.ci.openshift.org/releasestream/4-stable${release.getArchPrivSuffix(arch, false)}/release/${release_name}
+Release Page: https://${releaseArch}.ocp.releases.ci.openshift.org/releasestream/4-stable${release.getArchPrivSuffix(arch, false)}/release/${release_name}
 Quay PullSpec: quay.io/openshift-release-dev/ocp-release:${dest_release_tag}
 
 ${release_info}

--- a/jobs/build/release/Jenkinsfile
+++ b/jobs/build/release/Jenkinsfile
@@ -509,7 +509,7 @@ node {
 
         dry_subject = ""
         if (params.DRY_RUN) { dry_subject = "[DRY RUN] "}
-
+        releaseArch = arch == "x86_64" ? "amd64" : "${arch}"
         commonlib.email(
             to: "${params.MAIL_LIST_SUCCESS}",
             replyTo: "aos-team-art@redhat.com",
@@ -517,7 +517,7 @@ node {
             subject: "${dry_subject}Success building release payload: ${release_name} (${arch})",
             body: """
 Jenkins Job: ${env.BUILD_URL}
-Release Page: https://openshift-release${release.getArchPrivSuffix(arch, false)}.svc.ci.openshift.org/releasestream/4-stable${release.getArchPrivSuffix(arch, false)}/release/${release_name}
+Release Page: https://${releaseArch}.ocp.releases.ci.openshift.org/releasestream/4-stable${release.getArchPrivSuffix(arch, false)}/release/${release_name}
 Quay PullSpec: quay.io/openshift-release-dev/ocp-release:${dest_release_tag}
 
 ${release_info}

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -502,14 +502,14 @@ def canLock(lockName, timeout_seconds=10) {
  * @return Returns something like "https://s390x.ocp.releases.ci.openshift.org"
  */
 def getReleaseControllerURL(releaseStreamName) {
-    def archSuffix = 'amd64'
+    def arch = 'amd64'
     def streamNameComponents = releaseStreamName.split('-') // e.g. ['4', 'stable', 's390x']  or [ '4', 'stable' ]
     if ('s390x' in streamNameComponents) {
-        archSuffix = "s390x" // e.g. -s390x
+        arch = "s390x" // e.g. -s390x
     } else if ('ppc64le' in streamNameComponents) {
-        archSuffix = "ppc64le"
+        arch = "ppc64le"
     }
-    return "https://${archSuffix}.ocp.releases.ci.openshift.org"
+    return "https://${arch}.ocp.releases.ci.openshift.org"
 }
 
 def inputRequired(slackOutput=null, cl) {

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -499,17 +499,17 @@ def canLock(lockName, timeout_seconds=10) {
  * on different routes. This method returns a URL based on the name of the
  * release stream you want to query.
  * @param releaseStreamName - e.g. 4-stable or 4-stable-s390x
- * @return Returns something like "https://openshift-release-s390x.svc.ci.openshift.org"
+ * @return Returns something like "https://s390x.ocp.releases.ci.openshift.org"
  */
 def getReleaseControllerURL(releaseStreamName) {
-    def archSuffix = ''
+    def archSuffix = 'amd64'
     def streamNameComponents = releaseStreamName.split('-') // e.g. ['4', 'stable', 's390x']  or [ '4', 'stable' ]
     if ('s390x' in streamNameComponents) {
-        archSuffix = "-s390x" // e.g. -s390x
+        archSuffix = "s390x" // e.g. -s390x
     } else if ('ppc64le' in streamNameComponents) {
-        archSuffix = "-ppc64le"
+        archSuffix = "ppc64le"
     }
-    return "https://openshift-release${archSuffix}.svc.ci.openshift.org"
+    return "https://${archSuffix}.ocp.releases.ci.openshift.org"
 }
 
 def inputRequired(slackOutput=null, cl) {


### PR DESCRIPTION
DPTP says the old URLs will eventually be deprecated. 
https://amd64.ocp.releases.ci.openshift.org/ -> https://openshift-release.svc.ci.openshift.org
https://s390x.ocp.releases.ci.openshift.org/ -> https://openshift-release-s390x.svc.ci.openshift.org
https://ppc64le.ocp.releases.ci.openshift.org/ -> https://openshift-release-ppc64le.svc.ci.openshift.org