### PR TITLE
sign-artifacts: Ensure python2

### DIFF
--- a/jobs/signing/sign-artifacts/umb_producer.py
+++ b/jobs/signing/sign-artifacts/umb_producer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import base64
 import json
 import logging


### PR DESCRIPTION
There is an error importing `rhmsg`. I did not quickly find `rhmsg` being available for python3 for our platform, so ensuring python2 is used.