### PR TITLE
ART-1812: Deprecate el8-rebuilds

### DIFF
--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -159,18 +159,6 @@ node {
 
                     def buildRpms = { ->
                         buildlib.doozer command
-                        def rpmList = rpms.split(",")
-                        // given this may run without locks, don't blindly rebuild for el8 unless building for el7
-                        if (rpmList.contains("openshift") || rpmList.contains("openshift-clients") || !rpmList) {
-                            build(
-                                job: "build%2Fel8-rebuilds",
-                                propagate: true,
-                                parameters: [
-                                    string(name: "BUILD_VERSION", value: params.BUILD_VERSION),
-                                    booleanParam(name: "MOCK", value: false),
-                                ],
-                            )
-                        }
                     }
                     params.IGNORE_LOCKS ?  buildRpms() : lock("github-activity-lock-${params.BUILD_VERSION}") { buildRpms() }
                 }
@@ -275,7 +263,7 @@ node {
                     }
                 }
             }
-            
+
             stage('sync images') {
                 if (majorVersion == "4") {
                     buildlib.sync_images(

--- a/jobs/build/el8-rebuilds/Jenkinsfile
+++ b/jobs/build/el8-rebuilds/Jenkinsfile
@@ -4,7 +4,9 @@ node {
     checkout scm
     def buildlib = load("pipeline-scripts/buildlib.groovy")
     def commonlib = buildlib.commonlib
-    commonlib.describeJob("el8-rebuilds", """
+    commonlib.describeJob("⛔❌⛔ el8-rebuilds (deprecated) ⛔❌⛔ ", """
+        <h1 style="color:red;">Deprecated!!!</h1>
+        <p style="color:red;">Doozer will automatically handle el8 rpm rebuilds if multiple targets are specified in ocp-build-data.</p>
         <h2>Rebuild 4.x packages on RHEL8 for RHCOS</h2>
         This job rebuilds the openshift and openshift-clients packages against
         a RHEL 8 buildroot with exactly the same version and release as they

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -264,19 +264,10 @@ def stageBuildRpms() {
     buildPlan.dryRun ? echo("doozer ${cmd}") : buildlib.doozer(cmd)
     if (buildPlan.dryRun) {
         echo("${buildlib.DOOZER_BIN} ${cmd}")
-        echo("run job: build%2Fel8-rebuilds")
         return
     }
 
     buildlib.doozer(cmd)
-    build(
-        job: "build%2Fel8-rebuilds",
-        propagate: true,
-        parameters: [
-            string(name: "BUILD_VERSION", value: version.stream),
-            booleanParam(name: "MOCK", value: false),
-        ],
-    )
 }
 
 /**


### PR DESCRIPTION
It is handled by Doozer once https://github.com/openshift/doozer/pull/320 and https://github.com/openshift/ocp-build-data/pull/742 are merged.