### PR TITLE
[ART-2146] refresh tekton-pipeline jobs

### DIFF
--- a/tekton-pipelines/pipelines/pipeline-jenkins-bump-version.yaml
+++ b/tekton-pipelines/pipelines/pipeline-jenkins-bump-version.yaml
@@ -1,0 +1,38 @@
+﻿apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: jenkins-bump-version
+  namespace: art-jenkins
+spec:
+  params:
+    - default: 2.235.5
+      description: target jenkins version
+      name: jenkins-version
+      type: string
+    - default: rhaos-3.11-rhel-7
+      description: target ocp branch
+      name: ocp-branch
+      type: string
+  tasks:
+    - name: bump-jenkins
+      params:
+        - name: jenkins-version
+          value: $(params.jenkins-version)
+        - name: ocp-branch
+          value: $(params.ocp-branch)
+      taskRef:
+        kind: Task
+        name: bump-jenkins
+    - name: send-email
+      params:
+        - name: result
+          value: $(tasks.bump-jenkins.results.jobresult)
+        - name: branch
+          value: $(params.ocp-branch)
+        - name: version
+          value: $(params.jenkins-version)
+      runAfter:
+        - bump-jenkins
+      taskRef:
+        kind: Task
+        name: send-email

--- a/tekton-pipelines/pipelines/pipeline-jenkins-plugins.yaml
+++ b/tekton-pipelines/pipelines/pipeline-jenkins-plugins.yaml
@@ -1,0 +1,47 @@
+﻿apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: jenkins-plugins
+  namespace: art-jenkins
+spec:
+  params:
+    - default: >-
+        https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_jenkins/1153/pull-ci-openshift-jenkins-release-4.4-images/1306572105390755840/artifacts/build-logs/jenkins.log
+      description: upstream url of jenkins log
+      name: build-url
+      type: string
+    - default: 2.235.5
+      description: target jenkins version
+      name: jenkins-version
+      type: string
+    - default: rhaos-4.4-rhel-7
+      description: target ocp branch
+      name: ocp-branch
+      type: string
+  tasks:
+    - name: collect-jenkins-plugin
+      params:
+        - name: build-url
+          value: $(params.build-url)
+        - name: jenkins-version
+          value: $(params.jenkins-version)
+        - name: ocp-branch
+          value: $(params.ocp-branch)
+      taskRef:
+        kind: Task
+        name: jenkins-plugin
+    - name: send-email
+      params:
+        - name: result
+          value: $(tasks.collect-jenkins-plugin.results.jobresult)
+        - name: branch
+          value: $(params.ocp-branch)
+        - name: version
+          value: $(params.jenkins-version)
+        - name: plugin-list
+          value: $(params.build-url)
+      runAfter:
+        - collect-jenkins-plugin
+      taskRef:
+        kind: Task
+        name: jenkins-plugin-postmail

--- a/tekton-pipelines/tasks/task-bump-jenkins.yaml
+++ b/tekton-pipelines/tasks/task-bump-jenkins.yaml
@@ -1,0 +1,87 @@
+﻿apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: bump-jenkins
+  namespace: art-jenkins
+spec:
+  params:
+    - name: jenkins-version
+      type: string
+    - name: ocp-branch
+      type: string
+  results:
+    - description: the result of this task
+      name: jobresult
+  steps:
+    - image: quay.io/openshift-art/art-ci-toolkit
+      name: ''
+      resources: {}
+      script: >
+        #!/usr/bin/env bash
+
+        set -xeuo pipefail
+
+        echo failed > /tekton/results/jobresult
+
+        #yum install -q -y wget
+
+        #wget -q -P /etc/yum.repos.d/
+        #http://download.devel.redhat.com/rel-eng/RCMTOOLS/rcm-tools-rhel-8-baseos.repo
+
+        #echo "sslverify=false" >> /etc/yum.conf
+
+        #yum install -q -y rhpkg krb5-server krb5-libs krb5-workstation
+
+        wget -q -P /etc/
+        https://raw.githubusercontent.com/openshift/doozer/master/.devcontainer/krb5-redhat.conf
+
+        #cat /etc/krb5-redhat.conf 
+
+        mv /etc/krb5-redhat.conf /etc/krb5.conf 
+
+        cp /etc/secret/jenkins-buildvm-keytab
+        /etc/ocp-build-buildvm.openshift.eng.bos.redhat.com.keytab 
+
+        kinit -f -k -t
+        /etc/ocp-build-buildvm.openshift.eng.bos.redhat.com.keytab
+        ocp-build/buildvm.openshift.eng.bos.redhat.com@REDHAT.COM
+
+        #klist
+
+        echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config
+
+        rhpkg --user=ocp-build clone jenkins
+
+        cd jenkins
+
+        rhpkg switch-branch "$(inputs.params.ocp-branch)"
+
+        wget -q
+        https://updates.jenkins-ci.org/download/war/$(inputs.params.jenkins-version)/jenkins.war
+
+        UVERSION="$(inputs.params.jenkins-version).$(date +%s)"
+
+        mv jenkins.war jenkins.${UVERSION}.war
+
+        wget -q
+        https://raw.githubusercontent.com/openshift/aos-cd-jobs/devex/jenkins-bump-version/rpm-bump-version.sh
+
+        rhpkg new-sources jenkins.${UVERSION}.war
+
+        /bin/bash rpm-bump-version.sh "${UVERSION}"
+
+        rhpkg commit -p -m "Update Jenkins war to ${VERSION}"
+
+        rhpkg build --skip-nvr-check
+
+        echo success > /tekton/results/jobresult
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+      volumeMounts:
+        - mountPath: /etc/secret
+          name: jenkins-secret
+  volumes:
+    - name: jenkins-secret
+      secret:
+        secretName: jenkins-buildvm-keytab

--- a/tekton-pipelines/tasks/task-jenkins-plugin-postmail.yaml
+++ b/tekton-pipelines/tasks/task-jenkins-plugin-postmail.yaml
@@ -1,0 +1,66 @@
+﻿apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: jenkins-plugin-postmail
+  namespace: art-jenkins
+spec:
+  params:
+    - name: result
+      type: string
+    - name: plugin-list
+      type: string
+    - name: branch
+      type: string
+    - name: version
+      type: string
+  steps:
+    - image: docker.io/library/centos
+      name: ''
+      resources: {}
+      script: >
+        #!/usr/bin/env bash
+
+        set -xeuo pipefail
+
+        #yum -q -y install mailx postfix wget
+
+        echo 'set from=ART-Tekton-jenkins.redhat.com' >> /etc/mail.rc
+
+        echo 'set smtp="smtp.corp.redhat.com"' >> /etc/mail.rc
+
+        echo 'search openshift.eng.bos.redhat.com' > /etc/resolv.conf
+
+        echo 'nameserver 10.11.5.19' >> /etc/resolv.conf
+
+        jenkins_version=$(inputs.params.version)
+
+        jenkins_major=${jenkins_version%%.*}
+
+        wget $(inputs.params.plugin-list) 
+
+        plugin_list=`awk '/Installed plugins/{f=1;next};/^$/{f=0};f'
+        jenkins.log`
+
+        distgit_link="http://pkgs.devel.redhat.com/cgit/rpms/jenkins-${jenkins_major}-plugins/?h=$(inputs.params.branch)"
+
+        Title_success="jenkins plugins RPM for $(inputs.params.branch) updated
+        in dist-git"
+
+        Msg_success="The Jenkins plugins RPM for $(inputs.params.branch) has
+        been updated in dist-git: ${distgit_link} Minimum Jenkins version:
+        $(inputs.params.version) Pluginlist: ${plugin_list}"
+
+        Title_error="Error during jenkins plugin RPM update on dist-git"
+
+        Msg_error="The job to update the jenkins plugins RPM in dist-git
+        encountered an
+        error:https://console-openshift-console.apps.ocp4.prod.psi.redhat.com/k8s/ns/art-jenkins/tekton.dev~v1beta1~Pipeline/jenkins-plugins/Runs"
+
+        if [[ "$(inputs.params.result)" == *success* ]]; then
+          mail -v -s "$Title_success" aos-team-art@redhat.com <<< "$Msg_success"
+        else
+          mail -v -s "$Title_error" aos-team-art@redhat.com <<< "$Msg_error"
+        fi
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0

--- a/tekton-pipelines/tasks/task-jenkins-plugin.yaml
+++ b/tekton-pipelines/tasks/task-jenkins-plugin.yaml
@@ -1,0 +1,95 @@
+﻿apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: jenkins-plugin
+  namespace: art-jenkins
+spec:
+  params:
+    - name: build-url
+      type: string
+    - name: jenkins-version
+      type: string
+    - name: ocp-branch
+      type: string
+  results:
+    - description: the result of this task
+      name: jobresult
+    - description: jenkins plugin list content
+      name: plugin-list
+  steps:
+    - image: docker.io/library/centos
+      name: bump-jenkins
+      resources: {}
+      script: >
+        #!/usr/bin/env bash
+
+        set -xeuo pipefail
+
+        echo failed > /tekton/results/jobresult
+
+        #yum install -q -y wget
+
+        #wget -q -P /etc/yum.repos.d/
+        #http://download.devel.redhat.com/rel-eng/RCMTOOLS/rcm-tools-rhel-8-baseos.repo
+
+        #echo "sslverify=false" >> /etc/yum.conf
+
+        #yum install -q -y rhpkg krb5-server krb5-libs krb5-workstation
+
+        wget -q -P /etc/
+        https://raw.githubusercontent.com/openshift/doozer/master/.devcontainer/krb5-redhat.conf
+
+        #cat /etc/krb5-redhat.conf 
+
+        mv /etc/krb5-redhat.conf /etc/krb5.conf 
+
+        cp /etc/secret/jenkins-buildvm-keytab
+        /etc/ocp-build-buildvm.openshift.eng.bos.redhat.com.keytab 
+
+        kinit -f -k -t
+        /etc/ocp-build-buildvm.openshift.eng.bos.redhat.com.keytab
+        ocp-build/buildvm.openshift.eng.bos.redhat.com@REDHAT.COM
+
+        #klist
+
+        echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config
+
+        mkdir /etc/update-jenkins-plugins
+
+        cd /etc/update-jenkins-plugins
+
+        mkdir -p /etc/update-jenkins-plugins/working/hpis
+
+        wget $(inputs.params.build-url)
+
+        wget
+        https://raw.githubusercontent.com/openshift/aos-cd-jobs/master/hacks/update-jenkins-plugins/update-dist-git.sh
+
+        wget
+        https://raw.githubusercontent.com/openshift/aos-cd-jobs/master/hacks/update-jenkins-plugins/collect-jenkins-plugins.sh
+
+        ls /etc/update-jenkins-plugins
+
+        awk '/Installed plugins/{f=1;next};/^$/{f=0};f' jenkins.log >
+        /etc/update-jenkins-plugins/jenkins-plugins.txt
+
+        cat /etc/update-jenkins-plugins/jenkins-plugins.txt >
+        /tekton/results/plugin-list
+
+        sh ./collect-jenkins-plugins.sh $(inputs.params.jenkins-version)
+        /etc/update-jenkins-plugins/jenkins-plugins.txt
+
+        sh ./update-dist-git.sh $(inputs.params.jenkins-version)
+        $(inputs.params.ocp-branch) /etc/update-jenkins-plugins/working/hpis
+
+        echo success > /tekton/results/jobresult
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+      volumeMounts:
+        - mountPath: /etc/secret
+          name: jenkins-secret
+  volumes:
+    - name: jenkins-secret
+      secret:
+        secretName: jenkins-buildvm-keytab

--- a/tekton-pipelines/tasks/task-send-email.yaml
+++ b/tekton-pipelines/tasks/task-send-email.yaml
@@ -1,0 +1,55 @@
+﻿apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: send-email
+  namespace: art-jenkins
+spec:
+  params:
+    - name: result
+      type: string
+    - name: branch
+      type: string
+    - name: version
+      type: string
+  steps:
+    - image: docker.io/library/centos
+      name: ''
+      resources: {}
+      script: >
+        #!/usr/bin/env bash
+
+        set -xeuo pipefail
+
+        #yum -q -y install mailx postfix
+
+        echo 'set from=ART-Tekton-jenkins.redhat.com' >> /etc/mail.rc
+
+        echo 'set smtp="smtp.corp.redhat.com"' >> /etc/mail.rc
+
+        echo 'search openshift.eng.bos.redhat.com' > /etc/resolv.conf
+
+        echo 'nameserver 10.11.5.19' >> /etc/resolv.conf
+
+        Title_success="jenkins RPM for $(inputs.params.branch) updated in
+        dist-git"
+
+        Msg_success="The Jenkins RPM for $(inputs.params.branch) has been
+        updated in dist-git:\n
+        http://pkgs.devel.redhat.com/cgit/rpms/jenkins/?h=$(inputs.params.branch)
+        Jenkins version:$(inputs.params.version)"
+
+        Title_error="Error during jenkins $(inputs.params.branch) RPM update on
+        dist-git"
+
+        Msg_error="The job to update the jenkins RPM in dist-git encountered an
+        error:\n
+        https://console-openshift-console.apps.ocp4.prod.psi.redhat.com/k8s/ns/art-jenkins/tekton.dev~v1beta1~Pipeline/jenkins-bump-version/Runs"
+
+        if [[ "$(inputs.params.result)" == *success* ]]; then
+          mail -v -s "$Title_success" aos-team-art@redhat.com <<< "$Msg_success"
+        else
+          mail -v -s "$Title_error" aos-team-art@redhat.com <<< "$Msg_error"
+        fi
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0


### PR DESCRIPTION
[previous PR](https://github.com/openshift/aos-cd-jobs/pull/2383) is outdated so fresh the PR to make it up to date
[change base image to art-ci-toolkit](https://github.com/openshift/art-ci-toolkit/pull/11) and remove unnecessary value keys

---------------------------------------------
Tekeon pipline teck preview

bump-jenkins-version:

pipeline:https://console-openshift-console.apps.ocp4.prod.psi.redhat.com/k8s/ns/art-jenkins/tekton.dev~v1beta1~Pipeline/jenkins-bump-version
task:https://console-openshift-console.apps.ocp4.prod.psi.redhat.com/k8s/ns/art-jenkins/tekton.dev~v1beta1~Task/bump-jenkins
task:https://console-openshift-console.apps.ocp4.prod.psi.redhat.com/k8s/ns/art-jenkins/tekton.dev~v1beta1~Task/send-email

update-jenkins-plugins:

pipeline:https://console-openshift-console.apps.ocp4.prod.psi.redhat.com/k8s/ns/art-jenkins/tekton.dev~v1beta1~Pipeline/jenkins-plugins
task:https://console-openshift-console.apps.ocp4.prod.psi.redhat.com/k8s/ns/art-jenkins/tekton.dev~v1beta1~Task/jenkins-plugin
task:https://console-openshift-console.apps.ocp4.prod.psi.redhat.com/k8s/ns/art-jenkins/tekton.dev~v1beta1~Task/jenkins-plugin-postmail