### PR TITLE
Disable resume on jobs

### DIFF
--- a/pipeline-scripts/Jenkinsfile
+++ b/pipeline-scripts/Jenkinsfile
@@ -47,7 +47,8 @@ properties(
                 ],
             ]
         ],
-        disableConcurrentBuilds()
+        disableConcurrentBuilds(),
+        disableResume(),
     ]
 )
 

--- a/scheduled-jobs/build/buildvm-maint/Jenkinsfile
+++ b/scheduled-jobs/build/buildvm-maint/Jenkinsfile
@@ -1,7 +1,9 @@
 
 properties( [
     buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '360')),
-    disableConcurrentBuilds()] )
+    disableConcurrentBuilds(),
+    disableResume(),
+])
 
 build job: '../maintenance/maintenance%2Fbuildvm_backup',
     parameters: [

--- a/scheduled-jobs/build/enforce-firewall/Jenkinsfile
+++ b/scheduled-jobs/build/enforce-firewall/Jenkinsfile
@@ -1,13 +1,21 @@
 
-properties( [
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '8')),
+properties([
+    buildDiscarder(logRotator(
+        artifactDaysToKeepStr: '',
+        artifactNumToKeepStr: '',
+        daysToKeepStr: '',
+        numToKeepStr: '8')),
     disableConcurrentBuilds(),
-    ] )
+    disableResume(),
+])
 
 description = ""
 failed = false
 
-b = build       job: '../aos-cd-builds/build%2Fenforce-firewall', propagate: false
+b = build(
+    job: '../aos-cd-builds/build%2Fenforce-firewall',
+    propagate: false,
+)
 
 description += "${b.displayName} - ${b.result}\n"
 failed |= (b.result != "SUCCESS")

--- a/scheduled-jobs/build/merge/Jenkinsfile
+++ b/scheduled-jobs/build/merge/Jenkinsfile
@@ -1,13 +1,18 @@
 
 properties( [
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '100')),
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '100')),
     disableConcurrentBuilds(),
-    ] )
+    disableResume(),
+])
 
 description = ""
 failed = false
 
-b = build job: '../aos-cd-builds/build%2Fmerge_ocp',  parameters: [booleanParam(name: 'SCHEDULE_INCREMENTAL', value: true)], propagate: false
+b = build(
+    job: '../aos-cd-builds/build%2Fmerge_ocp',
+    parameters: [booleanParam(name: 'SCHEDULE_INCREMENTAL', value: true)],
+    propagate: false,
+)
 description += "${b.displayName} - ${b.result}\n"
 
 currentBuild.description = description.trim()

--- a/scheduled-jobs/build/new-payload/Jenkinsfile
+++ b/scheduled-jobs/build/new-payload/Jenkinsfile
@@ -1,13 +1,16 @@
 
-properties( [
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '90', numToKeepStr: '')),
+properties([
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '90', numToKeepStr: '')),
     disableConcurrentBuilds(),
-    ] )
+    disableResume(),
+])
 
 description = ""
 failed = false
 
-b = build       job: '../aos-cd-builds/build%2Fsend-umb-messages'
+b = build(
+    job: '../aos-cd-builds/build%2Fsend-umb-messages',
+)
 
 description += "${b.displayName} - ${b.result}\n"
 failed |= (b.result != "SUCCESS")

--- a/scheduled-jobs/build/ocp-3.11/Jenkinsfile
+++ b/scheduled-jobs/build/ocp-3.11/Jenkinsfile
@@ -2,7 +2,8 @@
 properties( [
     buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '100')),
     disableConcurrentBuilds(),
-    ] )
+    disableResume(),
+] )
 
 description = ""
 failed = false

--- a/scheduled-jobs/build/ocp-4.2-bump/Jenkinsfile
+++ b/scheduled-jobs/build/ocp-4.2-bump/Jenkinsfile
@@ -2,6 +2,7 @@
 properties([
     buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '60', numToKeepStr: '')),
     disableConcurrentBuilds(),
+    disableResume(),
 ])
 
 currentBuild.displayName += " 4.2 version bump"

--- a/scheduled-jobs/build/ocp-4.3-bump/Jenkinsfile
+++ b/scheduled-jobs/build/ocp-4.3-bump/Jenkinsfile
@@ -2,6 +2,7 @@
 properties([
     buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '60', numToKeepStr: '')),
     disableConcurrentBuilds(),
+    disableResume(),
 ])
 
 currentBuild.displayName += " 4.3 version bump"

--- a/scheduled-jobs/build/ocp4_scan/Jenkinsfile
+++ b/scheduled-jobs/build/ocp4_scan/Jenkinsfile
@@ -2,6 +2,7 @@
 properties( [
     buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '100')),
     disableConcurrentBuilds(),
+    disableResume(),
 ] )
 
 b = build job: '../aos-cd-builds/build%2Focp4_scan', propagate: false

--- a/scheduled-jobs/build/odo_sync/Jenkinsfile
+++ b/scheduled-jobs/build/odo_sync/Jenkinsfile
@@ -1,13 +1,17 @@
 
-properties( [
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '8')),
+properties([
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '8')),
     disableConcurrentBuilds(),
-    ] )
+    disableResume(),
+])
 
 description = ""
 failed = false
 
-b = build       job: '../aos-cd-builds/build%2Fodo_sync', propagate: false
+b = build(
+    job: '../aos-cd-builds/build%2Fodo_sync',
+    propagate: false,
+)
 
 description += "${b.displayName} - ${b.result}\n"
 failed |= (b.result != "SUCCESS")

--- a/scheduled-jobs/build/poll-payload/Jenkinsfile
+++ b/scheduled-jobs/build/poll-payload/Jenkinsfile
@@ -71,6 +71,7 @@ def saveToReleaseCache(Map release, String releaseCacheFile) {
 properties([
     buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '30', numToKeepStr: '')),
     disableConcurrentBuilds(),
+    disableResume(),
 ])
 
 node() {

--- a/scheduled-jobs/build/sync-ci-images/Jenkinsfile
+++ b/scheduled-jobs/build/sync-ci-images/Jenkinsfile
@@ -1,5 +1,8 @@
 // Monitor all branches of ocp-build-data
-properties([disableConcurrentBuilds()])
+properties([
+    disableConcurrentBuilds(),
+    disableResume(),
+])
 
 @NonCPS
 def sortedVersions() {

--- a/scheduled-jobs/build/sync-for-ci/Jenkinsfile
+++ b/scheduled-jobs/build/sync-for-ci/Jenkinsfile
@@ -1,19 +1,22 @@
-properties( [
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '100')),
-        disableConcurrentBuilds(),
-            ]
-)
+properties([
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '100')),
+    disableConcurrentBuilds(),
+    disableResume(),
+])
 
 description = ""
 failed = false
 
 def runFor(group, dir, arch="x86_64") {
     echo "Triggering reposync for ${group}-${arch}"
-    b = build       job: '/aos-cd-builds/build%2Fsync-for-ci', propagate: false,
-                    parameters: [ string(name: 'GROUP', value: group ),
-                                  string(name: 'REPOSYNC_DIR', value: dir),
-                                  string(name: 'ARCH', value: arch),
-                                ]
+    b = build(
+        job: '/aos-cd-builds/build%2Fsync-for-ci', propagate: false,
+        parameters: [
+            string(name: 'GROUP', value: group ),
+            string(name: 'REPOSYNC_DIR', value: dir),
+            string(name: 'ARCH', value: arch),
+        ],
+    )
 
     description += "${group}-${arch} - ${b.result}\n"
     failed |= (b.result != "SUCCESS")

--- a/scheduled-jobs/build/sync-iib-images/Jenkinsfile.groovy
+++ b/scheduled-jobs/build/sync-iib-images/Jenkinsfile.groovy
@@ -1,5 +1,8 @@
-properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '100')),
-            disableConcurrentBuilds()])
+properties([
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '100')),
+    disableConcurrentBuilds(),
+    disableResume(),
+])
 
 node {
 

--- a/scheduled-jobs/build/update-base-images/Jenkinsfile
+++ b/scheduled-jobs/build/update-base-images/Jenkinsfile
@@ -1,6 +1,10 @@
 
-properties( [
+properties([
     buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '60', numToKeepStr: '')),
-    disableConcurrentBuilds()] )
+    disableConcurrentBuilds(),
+    disableResume(),
+])
 
-b = build       job: '../aos-cd-builds/build%2Fupdate-base-images'
+b = build(
+    job: '../aos-cd-builds/build%2Fupdate-base-images',
+)

--- a/scheduled-jobs/maintenance/set_cincinnati_links/Jenkinsfile
+++ b/scheduled-jobs/maintenance/set_cincinnati_links/Jenkinsfile
@@ -1,8 +1,8 @@
-properties( [
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '100')),
-        disableConcurrentBuilds(),
-            ]
-)
+properties([
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '100')),
+    disableConcurrentBuilds(),
+    disableResume(),
+])
 
 
 description = ""

--- a/scheduled-jobs/scanning/images-health/Jenkinsfile
+++ b/scheduled-jobs/scanning/images-health/Jenkinsfile
@@ -1,9 +1,8 @@
-properties( [
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '100')),
-        disableConcurrentBuilds(),
-            ]
-)
-
+properties([
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '100')),
+    disableConcurrentBuilds(),
+    disableResume(),
+])
 
 description = ""
 failed = false


### PR DESCRIPTION
After a jenkins incident earlier this week, a job attempted to resume,
and did not get further. This blocked scheduled runs of that job. This
change will prevent that behavior, and ensure that jobs don't silently
stop to run.