### PR TITLE
sweep: attach cve trackers too

### DIFF
--- a/jobs/build/sweep/Jenkinsfile
+++ b/jobs/build/sweep/Jenkinsfile
@@ -93,6 +93,7 @@ node {
                 "--group=openshift-${version}",
                 "find-bugs",
                 "--mode sweep",
+                "--cve-trackers",
                 "--status ON_QA",
                 "--status VERIFIED",
                 "--into-default-advisories",


### PR DESCRIPTION
This will effectively complete our new RHSA strategy by including CVE trackers in the sweep to advisories. Then we will use `elliott attach-cve-flaws` at promotion to attach the relevant flaw bugs. I'll need to announce that to QE and ProdSec so they'll know what to expect.