### PR TITLE
[ART-1188] publish rpms to mirror

### DIFF
--- a/jobs/build/publish-rpms/Jenkinsfile
+++ b/jobs/build/publish-rpms/Jenkinsfile
@@ -27,12 +27,12 @@ node {
                         description: 'Target release version',
                         trim: true,
                     ),
+                    commonlib.mockParam(),
                 ]
             ],
             disableConcurrentBuilds()
         ]
     )
-    commonlib.mockParam()
     commonlib.checkMock()
 
     version = params.BUILD_VERSION

--- a/jobs/build/publish-rpms/Jenkinsfile
+++ b/jobs/build/publish-rpms/Jenkinsfile
@@ -1,0 +1,47 @@
+#!/usr/bin/env groovy
+
+node {
+    checkout scm
+    buildlib = load( "pipeline-scripts/buildlib.groovy" )
+    commonlib = buildlib.commonlib
+    commonlib.describeJob("publish-rpms", """
+        <h2>Automatically publishing rpms to mirror</h2>
+    """)
+
+    properties(
+        [
+            disableResume(),
+            buildDiscarder(
+                logRotator(
+                    artifactDaysToKeepStr: '',
+                    artifactNumToKeepStr: '',
+                    daysToKeepStr: '',
+                    numToKeepStr: ''
+                )
+            ),
+            [
+                $class : 'ParametersDefinitionProperty',
+                parameterDefinitions: [
+                    string(
+                        name: 'BUILD_VERSION',
+                        description: 'Target release version',
+                        trim: true,
+                    ),
+                ]
+            ],
+            disableConcurrentBuilds()
+        ]
+    )
+    commonlib.mockParam()
+    commonlib.checkMock()
+
+    version = params.BUILD_VERSION
+    mirror_dir = "/srv/pub/openshift-v4/dependencies/rpms/${version}-beta"
+    commonlib.shell(
+        script: """
+            ./collect-deps.sh ${version}
+            scp -r ${version}-beta/ use-mirror-upload:$mirror_dir
+            ssh use-mirror-upload 'createrepo --database $mirror_dir;/usr/local/bin/push.pub.sh openshift-v4/dependencies/rpms/${version}-beta -v'
+        """
+    )
+}

--- a/jobs/build/publish-rpms/README.md
+++ b/jobs/build/publish-rpms/README.md
@@ -1,0 +1,20 @@
+# Publish latest RHEL 7 worker RPMs to mirror
+
+## Purpose
+
+This job will publish the dependent RPMs to mirror location under https://mirror.openshift.com/pub/openshift-v4/dependencies/rpms/<4.y-beta>
+So that we can test out pre-GA versions on RHEL 7 workers
+
+## Timing
+
+The [pull-payload](https://github.com/openshift/aos-cd-jobs/tree/master/scheduled-jobs/build/poll-payload) job will trigger this job when create a new release branch for x86.
+
+## Parameters
+
+### BUILD\_VERSION
+
+The name of the latest pre release, for example "4.7".
+
+## Known issues
+
+None yet.

--- a/jobs/build/publish-rpms/collect-deps.sh
+++ b/jobs/build/publish-rpms/collect-deps.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+if [[ -z "$1" ]]; then
+	echo "Syntax: <major>.<minor>"
+	exit 1
+fi
+
+cat > rhel-7.conf <<EOF
+[main]
+cachedir=${PWD}/cache/
+keepcache=0
+debuglevel=2
+logfile=${PWD}/rhe-7-yum.log
+exactarch=1
+obsoletes=1
+gpgcheck=1
+plugins=1
+installonly_limit=3
+
+[rhel-server-optional-rpms]
+name = rhel-server-optional-rpms
+baseurl = http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/optional/os/
+gpgcheck = 0
+enabled = 1
+
+[rhel-server-extras-rpms]
+name = rhel-server-extras-rpms
+baseurl = http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/extras/os/
+enabled = 1
+gpgcheck = 0
+
+[rhel-server-rpms]
+name = rhel-server-rpms
+baseurl = http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/os/
+enabled = 1
+gpgcheck = 0
+
+[rhel-server-ose-rpms]
+name = rhel-server-ose-rpms
+baseurl = http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/${1}/building/x86_64/os
+enabled = 1
+gpgcheck = 0
+
+EOF
+
+# clear anything that might already exist
+TARGET_DIR="${1}-beta"
+rm -rf "cache"
+rm -rf ${TARGET_DIR}
+sudo yum -c rhel-7.conf  install --downloadonly --downloaddir="${TARGET_DIR}" criu runc cri-o cri-tools skopeo openshift-clients openshift-hyperkube openshift-clients-redistributable slirp4netns
+
+echo "${TARGET_DIR} contains the files to mirror"
+echo "Make sure to run createrepo on the mirror and /usr/local/bin/push.pub.sh"

--- a/jobs/build/publish-rpms/collect-deps.sh
+++ b/jobs/build/publish-rpms/collect-deps.sh
@@ -46,8 +46,17 @@ EOF
 # clear anything that might already exist
 TARGET_DIR="${1}-beta"
 rm -rf "cache"
-rm -rf ${TARGET_DIR}
-sudo yum -c rhel-7.conf  install --downloadonly --downloaddir="${TARGET_DIR}" criu runc cri-o cri-tools skopeo openshift-clients openshift-hyperkube openshift-clients-redistributable slirp4netns
+rm -rf "${TARGET_DIR}"
+sudo yum -c rhel-7.conf install --downloadonly --downloaddir="${TARGET_DIR}"\
+ criu\
+ runc\
+ cri-o\
+ cri-tools\
+ skopeo\
+ openshift-clients\
+ openshift-hyperkube\
+ openshift-clients-redistributable\
+ slirp4netns
 
 echo "${TARGET_DIR} contains the files to mirror"
 echo "Make sure to run createrepo on the mirror and /usr/local/bin/push.pub.sh"

--- a/scheduled-jobs/build/poll-payload/Jenkinsfile
+++ b/scheduled-jobs/build/poll-payload/Jenkinsfile
@@ -31,19 +31,6 @@ def startPreReleaseJob(String releaseStream, Map latestRelease, Map previousRele
     )
 }
 
-// collect latest rpms and populate the files on mirror
-def publishLatestRpms(String buildVersion) {
-    // collect rpms and populate on mirror
-    scripts_dir = "${env.WORKSPACE}/rhel-7-deps-mirroring/collect-deps.sh"
-    mirror_dir = "/srv/pub/openshift-v4/dependencies/rpms/$buildVersion-beta"
-    withEnv(["PATH+SCRIPTS=${scripts_dir}"]) {
-        sh "collect-deps.sh $buildVersion"
-        sh "rm -rf /srv/pub/openshift-v4/dependencies/rpms/$buildVersion-beta/*"
-        sh "scp -r $buildVersion-beta/ use-mirror-upload:$mirror_dir"
-        sh "ssh use-mirror-upload 'createrepo --database $mirror_dir;/usr/local/bin/push.pub.sh openshift-v4/dependencies/rpms/$buildVersion-beta -v'"
-    }
-}
-
 /**
  * Determine if the latest release has been changed
  * @param releaseStream release stream name
@@ -103,7 +90,14 @@ node() {
                 description += " [no change]\n"
                 continue
             }
-            publishLatestRpms(commonlib.extractMajorMinorVersion(releaseStream))
+            if (commonlib.extractArchFromReleaseName(latestRelease) == "x86_64") {
+                build(
+                    job: '/aos-cd-builds/build%2Fpublish-rpms',
+                    parameters: [
+                        string(name: 'BUILD_VERSION', value: commonlib.extractMajorMinorVersion(releaseStream)),
+                    ],
+                )
+            }
             actionArguments[releaseStream] = [releaseStream, latestRelease, previousRelease]
             saveToReleaseCache(latestRelease, "${releaseStream}.json")
         } catch (Exception ex) {

--- a/scheduled-jobs/build/poll-payload/Jenkinsfile
+++ b/scheduled-jobs/build/poll-payload/Jenkinsfile
@@ -31,6 +31,18 @@ def startPreReleaseJob(String releaseStream, Map latestRelease, Map previousRele
     )
 }
 
+// collect latest rpms and populate the files on mirror
+def publishLatestRpms(String buildVersion) {
+    // collect rpms and populate on mirror
+    scripts_dir = "${env.WORKSPACE}/rhel-7-deps-mirroring/collect-deps.sh"
+    mirror_dir = "/srv/pub/openshift-v4/dependencies/rpms/$buildVersion-beta"
+    withEnv(["PATH+SCRIPTS=${scripts_dir}"]) {
+        sh "collect-deps.sh $buildVersion"
+        sh "rm -rf /srv/pub/openshift-v4/dependencies/rpms/$buildVersion-beta/*"
+        sh "scp -r $buildVersion-beta/ use-mirror-upload:$mirror_dir"
+        sh "ssh use-mirror-upload 'createrepo --database $mirror_dir;/usr/local/bin/push.pub.sh openshift-v4/dependencies/rpms/$buildVersion-beta -v'"
+    }
+}
 
 /**
  * Determine if the latest release has been changed
@@ -91,6 +103,7 @@ node() {
                 description += " [no change]\n"
                 continue
             }
+            publishLatestRpms(commonlib.extractMajorMinorVersion(releaseStream))
             actionArguments[releaseStream] = [releaseStream, latestRelease, previousRelease]
             saveToReleaseCache(latestRelease, "${releaseStream}.json")
         } catch (Exception ex) {


### PR DESCRIPTION
Automate publishing rpms to mirror, every time a new pre-release accepted update latest RHEL 7 worker RPMs on mirror.