### PR TITLE
[ART-2354] Update helm_sync to multi-OS/multi-arch

### DIFF
--- a/jobs/build/helm_sync/Jenkinsfile
+++ b/jobs/build/helm_sync/Jenkinsfile
@@ -2,9 +2,9 @@
 node {
     checkout scm
     load('pipeline-scripts/commonlib.groovy').describeJob("helm_sync", """
-        ---------------------------------------
-        Sync contents of the helm RPM to mirror
-        ---------------------------------------
+        --------------------------
+        Sync Helm client to mirror
+        --------------------------
         http://mirror.openshift.com/pub/openshift-v4/clients/helm/
 
         Timing: This is only ever run by humans, upon request.
@@ -17,14 +17,38 @@ pipeline {
 
     parameters {
         string(
-            name: "RPM_URL",
-            description: "Redistributable RPM URL. Example: http://download.eng.bos.redhat.com/brewroot/vol/rhel-7/packages/helm/3.0.1/4.el7/x86_64/helm-redistributable-3.0.1-4.el7.x86_64.rpm",
+            name: "VERSION",
+            description: "Desired version name. Example: v3.0.1",
             defaultValue: "",
             trim: true,
         )
         string(
-            name: "VERSION",
-            description: "Desired version name. Example: v3.0.1",
+            name: "LINUX_AMD64_BINARIES_LOCATION",
+            description: "Example: http://download.eng.bos.redhat.com/staging-cds/developer/helm/3.2.3-4/signed/linux/helm-linux-amd64.tar.gz",
+            defaultValue: "",
+            trim: true,
+        )
+        string(
+            name: "LINUX_PPC64LE_BINARIES_LOCATION",
+            description: "Example: http://download.eng.bos.redhat.com/brewroot/vol/rhel-8/packages/helm/3.2.3/4.el8/ppc64le/helm-3.2.3-4.el8.ppc64le.rpm",
+            defaultValue: "",
+            trim: true,
+        )
+        string(
+            name: "LINUX_S390X_BINARIES_LOCATION",
+            description: "Example: http://download.eng.bos.redhat.com/brewroot/vol/rhel-8/packages/helm/3.2.3/4.el8/s390x/helm-3.2.3-4.el8.s390x.rpm",
+            defaultValue: "",
+            trim: true,
+        )
+        string(
+            name: "DARWIN_AMD64_BINARIES_LOCATION",
+            description: "Example: http://download.eng.bos.redhat.com/staging-cds/developer/helm/3.2.3-4/signed/macos/helm-darwin-amd64.tar.gz",
+            defaultValue: "",
+            trim: true,
+        )
+        string(
+            name: "WINDOWS_AMD64_BINARIES_LOCATION",
+            description: "Example: http://download.eng.bos.redhat.com/staging-cds/developer/helm/3.2.3-4/signed/windows/helm-windows-amd64.exe.tar.gz",
             defaultValue: "",
             trim: true,
         )
@@ -34,38 +58,65 @@ pipeline {
         stage("Validate params") {
             steps {
                 script {
-                    if (!params.RPM_URL) {
-                        error "RPM_URL must be specified"
-                    }
                     if (!params.VERSION) {
                         error "VERSION must be specified"
                     }
                 }
             }
         }
-        stage("Download RPM") {
+        stage("Clean working dir") {
             steps {
-                sh "rm --force helm-redistributable.rpm"
-                sh "wget --no-verbose ${params.RPM_URL} --output-document=helm-redistributable.rpm"
+                sh "rm -rf ${params.VERSION} && mkdir ${params.VERSION}"
             }
         }
-        stage("Extract RPM contents") {
+        stage("Download binaries") {
+            parallel {
+                stage("linux amd64")   { steps { script { download(params.LINUX_AMD64_BINARIES_LOCATION,   params.VERSION) }}}
+                stage("linux ppc64le") { steps { script { download(params.LINUX_PPC64LE_BINARIES_LOCATION, params.VERSION) }}}
+                stage("linux s390x")   { steps { script { download(params.LINUX_S390X_BINARIES_LOCATION,   params.VERSION) }}}
+                stage("darwin amd64")  { steps { script { download(params.DARWIN_AMD64_BINARIES_LOCATION,  params.VERSION) }}}
+                stage("windows amd64") { steps { script { download(params.WINDOWS_AMD64_BINARIES_LOCATION, params.VERSION) }}}
+            }
+        }
+        stage("Organize directory") {
             steps {
-                sh "rpm2cpio helm-redistributable.rpm | cpio --extract --make-directories"
-                sh "rm --recursive --force ${params.VERSION} && mkdir ${params.VERSION}"
-                sh "mv --verbose ./usr/share/helm-redistributable/* ${params.VERSION}/"
-                sh "mv --verbose ${params.VERSION}/*/* ${params.VERSION}/ && /bin/ls --directory ${params.VERSION}/*/ | xargs rmdir"
-                sh "tree ${params.VERSION}"
+                sh """
+                cd ${params.VERSION} &&
+
+                mv \$(basename -- ${LINUX_PPC64LE_BINARIES_LOCATION}) helm-linux-ppc64le &&
+                mv \$(basename -- ${LINUX_S390X_BINARIES_LOCATION}) helm-linux-s390x &&
+
+                tar -zxvf \$(basename -- ${LINUX_AMD64_BINARIES_LOCATION}) &&
+                mv helm helm-linux-amd64 &&
+
+                tar -zxvf \$(basename -- ${DARWIN_AMD64_BINARIES_LOCATION}) &&
+                mv helm helm-darwin-amd64 &&
+
+                tar -zxvf \$(basename -- ${WINDOWS_AMD64_BINARIES_LOCATION}) &&
+                mv helm.exe helm-windows-amd64.exe &&
+
+                rm *.tar.gz &&
+                sha256sum * > sha256sum.txt &&
+
+                cd ..
+                """
             }
         }
         stage("Sync to mirror") {
             steps {
+                sh "tree ${params.VERSION}"
+                sh "cat ${params.VERSION}/sha256sum.txt"
+
                 sshagent(['aos-cd-test']) {
                     sh "scp -r ${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/clients/helm/"
-                    sh "ssh use-mirror-upload.ops.rhcloud.com ln --symbolic --force --no-dereference ${params.VERSION} /srv/pub/openshift-v4/clients/helm/latest"
-                    sh "ssh use-mirror-upload.ops.rhcloud.com /usr/local/bin/push.pub.sh openshift-v4/clients/helm -v"
+                    sh "ssh use-mirror-upload.ops.rhcloud.com -- ln --symbolic --force --no-dereference ${params.VERSION} /srv/pub/openshift-v4/clients/helm/latest"
+                    sh "ssh use-mirror-upload.ops.rhcloud.com -- /usr/local/bin/push.pub.sh openshift-v4/clients/helm -v"
                 }
             }
         }
     }
+}
+
+def download(path, destination) {
+    sh "wget --recursive --no-parent --no-directories --directory-prefix ${destination} ${path}"
 }


### PR DESCRIPTION
Change helm_sync job to accept multiple artifacts, organize directory accordingly, generate sha256sum and sync it to the mirror.

Sample output:
```
+ tree 3.2.3
3.2.3
├── helm-darwin-amd64
├── helm-linux-amd64
├── helm-linux-ppc64le
├── helm-linux-s390x
├── helm-windows-amd64.exe
└── sha256sum.txt

0 directories, 6 files
```
```
+ cat 3.2.3/sha256sum.txt
b7c2a1e6b58cea26c6207ea5c807d55d91a6e8f4089af70012e9375548ecc938  helm-darwin-amd64
32a621d96cb196300169eb8061cbcca52fc2760c9fbccb66bf03681b7a0af92d  helm-linux-amd64
158684bd352f70ff71c1d278782df387330422e9e4b557405d91ce2045165a4d  helm-linux-ppc64le
a776b5908cd96265a09d6297f290c60348ca3b86beeb4f77b5d4815f6a6401cc  helm-linux-s390x
83005def780fa86e22a837985e1159781971567c057ca79a651325916c631911  helm-windows-amd64.exe
```