### PR TITLE
load commonlib from buildlib

### DIFF
--- a/scheduled-jobs/build/poll-payload/Jenkinsfile
+++ b/scheduled-jobs/build/poll-payload/Jenkinsfile
@@ -75,7 +75,8 @@ properties([
 
 node() {
     checkout scm
-    commonlib = load("pipeline-scripts/commonlib.groovy")
+    buildlib = load("pipeline-scripts/buildlib.groovy")
+    commonlib = buildlib.commonlib
     description = ""
     def actionArguments = [:]
     if (ACTIONS.isEmpty()) {


### PR DESCRIPTION
The pull-payload job failed due to can not load commonlib correctly, I thought it caused by missing init step, so use the same method in other script to import.