### PR TITLE
olm_bundle: make bundle_nvrs global

### DIFF
--- a/jobs/build/olm_bundle/Jenkinsfile
+++ b/jobs/build/olm_bundle/Jenkinsfile
@@ -14,6 +14,7 @@ node {
         If an extras advisory is provided, bundle images are attached to that advisory.
         Eventually all of this will simply run as part of the release cycle.
     """)
+    bundle_nvrs = []
 }
 
 pipeline {


### PR DESCRIPTION
[When in use today](https://coreos.slack.com/archives/GV3UMNACV/p1606721562360500?thread_ts=1606719582.358700&cid=GV3UMNACV) it appears that defining this var in one stage and using it in the next doesn't work. Hopefully this makes it global? I haven't had a chance to test yet.