### PR TITLE
promote: only allow skipping individual validations

### DIFF
--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -308,7 +308,7 @@ node {
                     return
                 }
                 skipVerifyBugs = !ga_release || params.SKIP_VERIFY_BUGS
-                commonlib.retrySkipAbort("Validating release", taskThread, "Error running release validation") {
+                commonlib.retryAbort("Validating release", taskThread, "Error running release validation") {
                     def retval = release.stageValidation(quay_url, dest_release_tag, advisory, params.PERMIT_PAYLOAD_OVERWRITE, params.PERMIT_ALL_ADVISORY_STATES, params.FROM_RELEASE_TAG, arch, skipVerifyBugs, params.SKIP_PAYLOAD_CREATION)
                     advisory = advisory ?: retval.advisoryInfo.id
                     errata_url = retval.errataUrl

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -581,6 +581,8 @@ def _retryWithOptions(goal, options, slackOutput=null, prompt='', cl) {
     }
 }
 
+// WARNING: make really sure that nothing in the closure is required for
+// functioning after the user chooses SKIP.
 def retrySkipAbort(goal, slackOutput=null, prompt='', cl) {
     _retryWithOptions(goal, ['RETRY', 'SKIP', 'ABORT'], slackOutput, prompt, cl)
 }


### PR DESCRIPTION
We do need the result of the validation (really, the advisory info) even if one or more validation must be skipped. Instead of allowing skipping the whole stage, prompt individually and allow retrying but not skipping the whole thing.

I was trying for a minimal change since this is so hard to test.