### PR TITLE
sweep: include MODIFIED bugs when sweeping to advisory

### DIFF
--- a/jobs/build/sweep/Jenkinsfile
+++ b/jobs/build/sweep/Jenkinsfile
@@ -14,7 +14,7 @@ node {
         In this mode of operation, ATTACH_BUGS is false.
 
         When preparing a set of nightlies and advisories for QE, the sweep job will
-        look for all bugs that are in ON_QA or VERIFIED state, and attach them
+        look for all bugs that are in MODIFIED, ON_QA or VERIFIED state, and attach them
         to the default advisories, according to those recorded in ocp-build-data
         group.yml.
         For 3.11, all bugs are swept into the rpm advisory.
@@ -50,7 +50,7 @@ node {
                         name: 'ATTACH_BUGS',
                         defaultValue: false,
                         description: [
-                          'If <b>on</b>: Attach ON_QA and VERIFIED bugs to their advisories',
+                          'If <b>on</b>: Attach MODIFIED, ON_QA, and VERIFIED bugs to their advisories',
                           'If <b>off</b>: Set MODIFIED bugs to ON_QA. Do not change advisories',
                         ].join('\n')
                     ),
@@ -88,12 +88,13 @@ node {
         currentBuild.description = "Sweeping new bugs<br/>"
 
         if (params.ATTACH_BUGS) {
-            currentBuild.description += "* Attaching ON_QA and VERIFIED bugs to default advisories<br/>"
+            currentBuild.description += "* Attaching MODIFIED, ON_QA, and VERIFIED bugs to default advisories<br/>"
             cmd = [
                 "--group=openshift-${version}",
                 "find-bugs",
                 "--mode sweep",
                 "--cve-trackers",
+                "--status MODIFIED",
                 "--status ON_QA",
                 "--status VERIFIED",
                 "--into-default-advisories",

--- a/jobs/build/sweep/README.md
+++ b/jobs/build/sweep/README.md
@@ -1,13 +1,12 @@
 # Parameterized job for running bug and build sweeps
 
 This job is run as a concluding part of the [ocp4], [ocp3], and [custom] jobs.
-In that case, the aim is to get bugs that are in state MODIFIED to ON_QA. Also,
-the advisories are updated to have the newest builds attached. To run the job in
-this mode, keep `SWEEP_BUILDS` to true, and `ATTACH_BUGS` to false (the
+In that case, the aim is to get bugs that are in state `MODIFIED` to `ON_QA`.  To
+run the job in this mode, keep `SWEEP_BUILDS` and `ATTACH_BUGS` as false (the
 defaults).
 
-The second mode is to take all bugs that QE is looking at or has verified, and
-collect those in the right advisories. To do that, set `ATTACH_BUGS` to true.
+The second mode is attach the latest bugs and builds to the release advisories.
+To do that, set `SWEEP_BUILDS` and `ATTACH_BUGS` to true.
 
 
 [ocp4]: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp4/


### PR DESCRIPTION
This should help avoid another [incident](https://coreos.slack.com/archives/GNQH80Q5A/p1607022673170100?thread_ts=1607021848.169400&cid=GNQH80Q5A) like [ocp4/12567](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp4/12567/console) where it failed
to run the sweep and then we never swept again before the automation
freeze.