### PR TITLE
promote: skipVerifyBugs if next is not release

### DIFF
--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -19,6 +19,9 @@ ocpVersions = ocp4Versions + ocp3Versions
 /**
  * Why is ocp4ReleaseState needed?
  *
+ * To decide whether to build and use signed RPMs, and to decide if a strict
+ * bug validation flow is necessary.
+ *
  * Before auto-signing, images were either built signed or unsigned.
  * Unsigned images were the norm and then, right before GA, we would rebuild
  * puddles and build as signed. In the new model, we always want to build


### PR DESCRIPTION
Currently, bugs are verified at Promote time if they have been VERIFIED
in the next minor stream. The reason for this is to ensure customers do
not regress when upgrading their clusters. For the newest minor release,
this leads to unnecessary prompts during the promote job.

This proposal uses the ocp4ReleaseState from commonlib to determine if
any architecture in the next minor version has been marked as "release".
This is done at the moment where we are close enough to shipping to
build and use signed rpms.

The conjecture of this patch is that that moment resembles when we ought
to pay attention to what has been verified in the next release to ensure
customers do not regress for a bug when upgrading their clusters.