### PR TITLE
[ART-2426] Freeze plashets along with automation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ sjb/generated/*.sh
 
 # Emacs backups
 *~
+
+# Intellij Ignores
+*.iml

--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -3,6 +3,7 @@ node {
 
     def buildlib = load("pipeline-scripts/buildlib.groovy")
     def commonlib = buildlib.commonlib
+    def slacklib = commonlib.slacklib
     commonlib.describeJob("custom", """
         <h2>Run component builds in ways other jobs can't</h2>
         <b>Timing</b>: This is only ever run by humans, as needed. No job should be calling it.
@@ -173,6 +174,18 @@ node {
                         if ("${majorVersion}" == "4") {
                             buildlib.buildBuildingPlashet(version, release, 8, true, auto_signing_advisory)  // build el8 embargoed plashet
                             buildlib.buildBuildingPlashet(version, release, 8, false, auto_signing_advisory)  // build el8 unembargoed plashet
+
+                            if(params.COMPOSE)
+                                notificationMessage = """
+                                    *:alert: custom ocp4 build compose ran during automation freeze*
+                                    COMPOSE parameter was set to true that forced build compose during automation freeze."""
+                            else:
+                                notificationMessage = """
+                                    *:alert: custom ocp4 build compose ran during automation freeze*
+                                    There were RPMs in the build plan that forced build compose during automation freeze."""
+
+                            slacklib.to(commonlib.extractMajorMinorVersion(params.RELEASE_NAME)).say(notificationMessage)
+
                         }
                     }
                 }

--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -179,7 +179,7 @@ node {
                                 notificationMessage = """
                                     *:alert: custom ocp4 build compose ran during automation freeze*
                                     COMPOSE parameter was set to true that forced build compose during automation freeze."""
-                            else:
+                            else
                                 notificationMessage = """
                                     *:alert: custom ocp4 build compose ran during automation freeze*
                                     There were RPMs in the build plan that forced build compose during automation freeze."""

--- a/jobs/build/custom/README.md
+++ b/jobs/build/custom/README.md
@@ -111,6 +111,9 @@ built in between building RPMs (if any) and images (if any).
 If this run is building RPMs, this parameter is ignored and new
 plashets/compose are always built to include them.
 
+A slack notification is sent to the respective release channel in both the case, 
+that is if this parameter is set true or if this run is building RPMs.
+
 > :warning: Note that for 3.11 this job cannot create a signed compose (perhaps
 > it should be changed to invoke `signed-compose` when the `SIGNED` flag is set
 > along with this one). For now `signed-compose` should be run separately.

--- a/jobs/build/custom/README.md
+++ b/jobs/build/custom/README.md
@@ -111,7 +111,7 @@ built in between building RPMs (if any) and images (if any).
 If this run is building RPMs, this parameter is ignored and new
 plashets/compose are always built to include them.
 
-A slack notification is sent to the respective release channel in both the case, 
+A slack notification is sent to the respective release channel in either case,
 that is if this parameter is set true or if this run is building RPMs.
 
 > :warning: Note that for 3.11 this job cannot create a signed compose (perhaps

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -137,7 +137,7 @@ node {
                         stage("build compose") { build.stageBuildCompose() }
                         stage("build compose notification") {
                             // this is where a notification should be sent on slack
-                            slacklib.to(commonlib.extractMajorMinorVersion(params.RELEASE_NAME)).say("""
+                            slacklib.to(commonlib.extractMajorMinorVersion(params.BUILD_VERSION)).say("""
                                 *:alert: ocp4 build compose ran during automation freeze*
                                  There were RPMs in the build plan that forced build compose during automation freeze.
                             """)

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -4,14 +4,17 @@ node {
     checkout scm
     def build = load("build.groovy")
     def commonlib = build.commonlib
+    def slacklib = commonlib.slacklib
+
     commonlib.describeJob("ocp4", """
         <h2>Build OCP 4.y components incrementally</h2>
         <b>Timing</b>: Usually run automatically from merge_ocp.
         Humans may run as needed. Locks prevent conflicts.
 
         In typical usage, scans for changes that could affect package or image
-        builds and rebuilds the affected components.  Creates new plashets on
-        each run, and runs other jobs to sync builds to nightlies, create
+        builds and rebuilds the affected components.  Creates new plashets if
+        the automation is not frozen or if there are RPMs that are built in this run, 
+        and runs other jobs to sync builds to nightlies, create
         operator metadata, and sweep bugs and builds into advisories.
 
         May also build unconditionally or with limited components.
@@ -119,9 +122,29 @@ node {
                 stage("initialize") { build.initialize() }
                 buildlib.assertBuildPermitted(doozerOpts)
                 stage("build RPMs") { build.stageBuildRpms() }
-                lock("compose-lock-${params.BUILD_VERSION}") {
-                    stage("build compose") { build.stageBuildCompose() }
+
+                // if the automation is not frozen perform compose
+                // otherwise if automation is frozen but there
+                // are rpms in the build plan perform compose
+                // and announce on slack
+
+                if(buildlib.getAutomationState(doozerOpts) in ["no", "False"]){
+                    lock("compose-lock-${params.BUILD_VERSION}") {
+                        stage("build compose") { build.stageBuildCompose() }
+                    }
+                } else if(build.buildPlan.buildRpms){
+                    lock("compose-lock-${params.BUILD_VERSION}") {
+                        stage("build compose") { build.stageBuildCompose() }
+                        stage("build compose notification") {
+                            // this is where a notification should be sent on slack
+                            slacklib.to(commonlib.extractMajorMinorVersion(params.RELEASE_NAME)).say("""
+                                *:alert: ocp4 build compose ran during automation freeze*
+                                 There were RPMs in the build plan that forced build compose during automation freeze.
+                            """)
+                        }
+                    }
                 }
+
                 stage("update dist-git") { build.stageUpdateDistgit() }
                 stage("build images") { build.stageBuildImages() }
             }

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -169,7 +169,7 @@ def planBuilds() {
         }
         if (!buildPlan.buildRpms) {
             report "RPMs: not building."
-            report "Will still create RPM compose."
+            report "Will not create RPM compose if automation is frozen."
         } else if (changed.rpms) {
             report "RPMs: building " + changed.rpms.join(", ")
             report "Will create RPM compose."

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -1304,14 +1304,22 @@ String extractBugId(String bugzillaOut) {
 }
 
 /**
+ * Returns the status of freeze_automation in the group.yml
+ */
+def getAutomationState(doozerOpts){
+    String freeze_automation = doozer("${doozerOpts} config:read-group --default 'no' freeze_automation",
+            [capture: true]).trim()
+    return freeze_automation
+}
+
+/**
  * Checks the status of the freeze_automation key in the group.yml and
  * returns whether the current run is permitted accordingly.
  * @param doozerOpts A string containing, at least, a `--group` parameter.
  */
 def isBuildPermitted(doozerOpts) {
     // check whether the group should be built right now
-    def freeze_automation = doozer("${doozerOpts} config:read-group --default 'no' freeze_automation",
-                                   [capture: true]).trim()
+    def freeze_automation = getAutomationState(doozerOpts)
 
     def builderEmail
     wrap([$class: 'BuildUser']) {


### PR DESCRIPTION
ocp4 job: If the automation is frozen and there are no rpms in build plan then plashets should not be build. If automation is frozen but there are rpms in build plan then plashets are build with a slack notification sent to respective release channel. 

custom job: if COMPOSE parameter is set to true or there are rpms in the build plan then plashets are built with suitable slack notification are sent.

Changes to isBuildPermitted() method in pipeline-scripts/buildlib.groovy. The part where the method checks for the status of freeze_automation is put into a separate method getAutomationState() and is used in isBuildPermitted().