### PR TITLE
[ART-2460] update eus-4.6 channel in cincinnati PR

### DIFF
--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -16,6 +16,11 @@ ocp4Versions = [
 
 ocpVersions = ocp4Versions + ocp3Versions
 
+eusVersions = [
+    "4.6",
+    "4.10",
+]
+
 /**
  * Why is ocp4ReleaseState needed?
  *

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -579,6 +579,10 @@ def signArtifacts(Map signingParams) {
     )
 }
 
+def isSupportEUS(ocpVersion) {
+  return ocpVersion in commonlib.eusVersions
+}
+
 /**
  * Opens a series of PRs against the cincinnati-graph-data GitHub repository.
  *    Specifically, a PR for each channel prefix (e.g. candidate, fast, stable) associated with the specified release
@@ -616,7 +620,7 @@ def openCincinnatiPRs(releaseName, advisory, candidate_only = false,ghorg = 'ope
             if ( major == 4 && minor == 1 ) {
                 prefixes = [ "prerelease", "stable"]
             }
-            if ( major == 4 && minor >= 6 ) {
+            if ( isSupportEUS(commonlib.extractMajorMinorVersion) ) {
                 prefixes = [ "candidate", "fast", "stable", "eus"]
             }
 
@@ -717,9 +721,6 @@ def openCincinnatiPRs(releaseName, advisory, candidate_only = false,ghorg = 'ope
                             labelArgs = "-l 'do-not-merge/hold'"
                             pr_messages << "Please merge within 48 hours of ${internal_errata_url} shipping live OR a Cincinnati-first release."
 
-                            if (prURLs.containsKey('prerelease')) {
-                                pr_messages << "This should provide adequate soak time for prerelease channel PR ${prURLs.prerelease}"
-                            }
                             if (prURLs.containsKey('fast')) {
                                 pr_messages << "This should provide adequate soak time for fast channel PR ${prURLs.fast}"
                             }

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -616,6 +616,9 @@ def openCincinnatiPRs(releaseName, advisory, candidate_only = false,ghorg = 'ope
             if ( major == 4 && minor == 1 ) {
                 prefixes = [ "prerelease", "stable"]
             }
+            if ( major == 4 && minor >= 6 ) {
+                prefixes = [ "candidate", "fast", "stable", "eus"]
+            }
 
             if (isReleaseCandidate) {
                 // Release Candidates never go past candidate
@@ -633,8 +636,10 @@ def openCincinnatiPRs(releaseName, advisory, candidate_only = false,ghorg = 'ope
                 if (fileExists(channelFile)) {
                     channelYaml = readYaml(file: channelFile)
                 } else {
-                    // create the channel if it does not already exist
-                    writeFile(file: channelFile, text: "name: ${channel}\nversions:\n" )
+                    if (prefix != "eus") { // for now we only have eus-4.6
+                      // create the channel if it does not already exist
+                      writeFile(file: channelFile, text: "name: ${channel}\nversions:\n" )
+                    }
                 }
 
                 /**
@@ -696,6 +701,19 @@ def openCincinnatiPRs(releaseName, advisory, candidate_only = false,ghorg = 'ope
                             break
                         case 'stable':
                             // For non-candidate, put a hold on the PR to prevent accidental merging
+                            labelArgs = "-l 'do-not-merge/hold'"
+                            pr_messages << "Please merge within 48 hours of ${internal_errata_url} shipping live OR a Cincinnati-first release."
+
+                            if (prURLs.containsKey('prerelease')) {
+                                pr_messages << "This should provide adequate soak time for prerelease channel PR ${prURLs.prerelease}"
+                            }
+                            if (prURLs.containsKey('fast')) {
+                                pr_messages << "This should provide adequate soak time for fast channel PR ${prURLs.fast}"
+                            }
+
+                            break
+                        case 'eus':
+                            // currently put eus change in a seperate PR as same as stable channel
                             labelArgs = "-l 'do-not-merge/hold'"
                             pr_messages << "Please merge within 48 hours of ${internal_errata_url} shipping live OR a Cincinnati-first release."
 


### PR DESCRIPTION
For 4.6 releases we need to update both stable-4.6 and eus-4.6 when create cincinnati PRs, and I think when comes to 4.7 will still have stable-4.7 but eus-4.x will hold until eus-4.10 created.