### PR TITLE
pipeline-scripts/release: Do not ping ota-monitor

### DIFF
--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -677,6 +677,7 @@ def openCincinnatiPRs(releaseName, advisory, candidate_only = false,ghorg = 'ope
                 pr_title = "Enable ${releaseName} in ${prefix} channel(s)"
 
                 labelArgs = ''
+                extraSlackComment = ''
 
                 pr_messages = [ pr_title ]
 
@@ -685,6 +686,8 @@ def openCincinnatiPRs(releaseName, advisory, candidate_only = false,ghorg = 'ope
                         case 'prerelease':
                         case 'candidate':
                             pr_messages << "Please merge immediately. This PR does not need to wait for an advisory to ship, but the associated advisory is ${internal_errata_url} ."
+                            labelArgs = "-l 'lgtm,approved'"
+                            extraSlackComment = "automatically approved"
                             break
                         case 'fast':
                             pr_messages << "Please merge as soon as ${internal_errata_url} is shipped live OR if a Cincinnati-first release is approved."
@@ -771,10 +774,8 @@ def openCincinnatiPRs(releaseName, advisory, candidate_only = false,ghorg = 'ope
                         export GITHUB_TOKEN=${access_token}
                         hub pull-request -b ${ghorg}:master ${labelArgs} -h ${ghorg}:${branchName} ${messageArgs} > ${prefix}.pr
                         cat ${prefix}.pr >> ${prs_file}    # Aggregate all PRs
-                        if [[ "${prefix}" == "candidate" ]]; then
-                            id=`cat candidate.pr |awk -F 'pull/' '{print \$2}'`
-                            hub api -XPUT "repos/${ghorg}/cincinnati-graph-data/pulls/\$id/merge" "\$@"
-                            echo "(automatically merged)" >> "${prs_file}"
+                        if test -n "${extraSlackComment}"; then
+                            echo "${extraSlackComment}" >> "${prs_file}"
                         fi
                         """
 

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -774,6 +774,7 @@ def openCincinnatiPRs(releaseName, advisory, candidate_only = false,ghorg = 'ope
                         if [[ "${prefix}" == "candidate" ]]; then
                             id=`cat candidate.pr |awk -F 'pull/' '{print \$2}'`
                             hub api -XPUT "repos/${ghorg}/cincinnati-graph-data/pulls/\$id/merge" "\$@"
+                            echo "(automatically merged)" >> "${prs_file}"
                         fi
                         """
 
@@ -783,7 +784,7 @@ def openCincinnatiPRs(releaseName, advisory, candidate_only = false,ghorg = 'ope
 
             def prs = readFile(prs_file).trim()
             if ( prs ) {  // did we open any?
-                def slack_msg = "Hi @ota-monitor . ART has opened Cincinnati PRs requiring your attention for ${releaseName}:\n${prs}"
+                def slack_msg = "ART has opened Cincinnati PRs for ${releaseName}:\n${prs}"
                 if ( ghorg == 'openshift' && !noSlackOutput) {
                     slacklib.to('#forum-release').say(slack_msg)
                 } else {


### PR DESCRIPTION
@vrutkovs has been running an auto-approver for a while now, and with the recent 1b7b8aeefd (#2456), it's locally clear that the candidate pull-request are auto-merging.  This commit adds a note to the message labeling the auto-merged PRs.  It also removes the monitor ping, since there's no longer anything that humans need to be aware of at ART-files-PRs time.