### PR TITLE
ART-2048 Workspace cleanup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,4 +57,5 @@ Jenkins job: ${env.BUILD_URL}
 """)
     throw err
   }
+  buildlib.cleanWorkspace()
 }

--- a/jobs/build/advisories/Jenkinsfile
+++ b/jobs/build/advisories/Jenkinsfile
@@ -226,6 +226,8 @@ node {
                 )
             }
             throw err  // gets us a stack trace FWIW
+        } finally {
+            buildlib.cleanWorkspace()
         }
     }
 }

--- a/jobs/build/appregistry/Jenkinsfile
+++ b/jobs/build/appregistry/Jenkinsfile
@@ -162,5 +162,6 @@ node {
         commonlib.safeArchiveArtifacts([
             "workDir/*",
         ])
+        buildlib.cleanWorkspace()
     }
 }

--- a/jobs/build/aws-ami/Jenkinsfile
+++ b/jobs/build/aws-ami/Jenkinsfile
@@ -120,5 +120,7 @@ Jenkins job: ${env.BUILD_URL}
 """);
         // Re-throw the error in order to fail the job
         throw err
+    } finally {
+        buildlib.cleanWorkspace()
     }
 }

--- a/jobs/build/build-sync/Jenkinsfile
+++ b/jobs/build/build-sync/Jenkinsfile
@@ -114,5 +114,6 @@ There was an issue running build-sync for OCP ${params.BUILD_VERSION}:
         throw (err)
     } finally {
         commonlib.safeArchiveArtifacts(build.artifacts)
+        buildlib.cleanWorkspace()
     }
 }

--- a/jobs/build/buildvm-maint/Jenkinsfile
+++ b/jobs/build/buildvm-maint/Jenkinsfile
@@ -128,6 +128,8 @@ Jenkins job: ${env.BUILD_URL}
 """);
         // Re-throw the error in order to fail the job
         throw err
+    } finally {
+        buildlib.cleanWorkspace()
     }
 
 }

--- a/jobs/build/cincinnati-prs/Jenkinsfile
+++ b/jobs/build/cincinnati-prs/Jenkinsfile
@@ -70,4 +70,5 @@ node {
         release.openCincinnatiPRs(params.RELEASE_NAME.trim(), params.ADVISORY_NUM.trim(), params.CANDIDATE_CHANNEL_ONLY, params.GITHUB_ORG.trim(), params.SKIP_OTA_SLACK_NOTIFICATION)
     }
     buildlib.cleanWorkdir(workdir)
+    buildlib.cleanWorkspace()
 }

--- a/jobs/build/coreos-installer_sync/Jenkinsfile
+++ b/jobs/build/coreos-installer_sync/Jenkinsfile
@@ -114,4 +114,6 @@ node {
             )
         }
     }
+
+    buildlib.cleanWorkspace()
 }

--- a/jobs/build/crc/Jenkinsfile
+++ b/jobs/build/crc/Jenkinsfile
@@ -83,5 +83,6 @@ node {
                 'email/*',
             ]
         )
+        buildlib.cleanWorkspace()
     }
 }

--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -317,5 +317,6 @@ Job console: ${commonlib.buildURL('console')}
                 "doozer_working/brew-logs/**",
             ])
         buildlib.cleanWorkdir(doozer_working)
+        buildlib.cleanWorkspace()
     }
 }

--- a/jobs/build/oc_sync/Jenkinsfile
+++ b/jobs/build/oc_sync/Jenkinsfile
@@ -106,4 +106,5 @@ Jenkins Job: ${buildURL}
         throw err
     }
     buildlib.cleanWorkdir(env.WORKSPACE)  // at end of job, ok to wipe out code
+    buildlib.cleanWorkspace()
 }

--- a/jobs/build/ocp3/Jenkinsfile
+++ b/jobs/build/ocp3/Jenkinsfile
@@ -789,5 +789,6 @@ Jenkins job: ${env.BUILD_URL}
             "doozer_working/*.yml",
         ])
         buildlib.cleanWorkdir(DOOZER_WORKING)
+        buildlib.cleanWorkspace()
     }
 }

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -173,6 +173,6 @@ View the build artifacts and console output on Jenkins:
             "doozer_working/*.yml",
         ])
         buildlib.cleanWorkdir(build.doozerWorking)
-        buildlib.cleanWorkspace(build.doozerWorking)
+        buildlib.cleanWorkspace()
     }
 }

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -173,5 +173,6 @@ View the build artifacts and console output on Jenkins:
             "doozer_working/*.yml",
         ])
         buildlib.cleanWorkdir(build.doozerWorking)
+        buildlib.cleanWorkspace(build.doozerWorking)
     }
 }

--- a/jobs/build/ocp4_scan/Jenkinsfile
+++ b/jobs/build/ocp4_scan/Jenkinsfile
@@ -193,5 +193,7 @@ node {
         )
 
         throw err
+    } finally {
+        buildlib.cleanWorkspace()
     }
 }

--- a/jobs/build/pre-release/Jenkinsfile
+++ b/jobs/build/pre-release/Jenkinsfile
@@ -181,5 +181,7 @@ node {
         currentBuild.description = "Error while running OCP pre release:\n${err}"
         currentBuild.result = "FAILURE"
         throw err
+    } finally {
+        buildlib.cleanWorkspace()
     }
 }

--- a/jobs/build/prepare-release/Jenkinsfile
+++ b/jobs/build/prepare-release/Jenkinsfile
@@ -109,5 +109,6 @@ node {
                 "pyartcd_working/**/*.log",
             ])
         }
+        buildlib.cleanWorkspace()
     }
 }

--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -553,5 +553,6 @@ Quay PullSpec: quay.io/openshift-release-dev/ocp-release:${dest_release_tag}
 
 ${release_info}
         """);
+        buildlib.cleanWorkspace()
     }
 }

--- a/jobs/build/publish-rpms/Jenkinsfile
+++ b/jobs/build/publish-rpms/Jenkinsfile
@@ -44,4 +44,5 @@ node {
             ssh use-mirror-upload 'createrepo --database $mirror_dir;/usr/local/bin/push.pub.sh openshift-v4/dependencies/rpms/${version}-beta -v'
         """
     )
+    buildlib.cleanWorkspace()
 }

--- a/jobs/build/release/Jenkinsfile
+++ b/jobs/build/release/Jenkinsfile
@@ -523,4 +523,5 @@ Quay PullSpec: quay.io/openshift-release-dev/ocp-release:${dest_release_tag}
 ${release_info}
         """);
     }
+    buildlib.cleanWorkspace()
 }

--- a/jobs/build/rhcos_sync/Jenkinsfile
+++ b/jobs/build/rhcos_sync/Jenkinsfile
@@ -125,5 +125,6 @@ There was an issue running build-sync for OCP ${params.RHCOS_MIRROR_PREFIX}:
         throw ( err )
     } finally {
         commonlib.safeArchiveArtifacts(build.artifacts)
+        buildlib.cleanWorkspace()
     }
 }

--- a/jobs/build/set_client_latest/Jenkinsfile
+++ b/jobs/build/set_client_latest/Jenkinsfile
@@ -93,6 +93,8 @@ node {
         currentBuild.description = "Error while setting latest ocp client:\n${err}"
         currentBuild.result = "FAILURE"
         throw err
+    } finally {
+        buildlib.cleanWorkdir(env.WORKSPACE)  // at end of job, ok to wipe out code
+        buildlib.cleanWorkspace()
     }
-    buildlib.cleanWorkdir(env.WORKSPACE)  // at end of job, ok to wipe out code
 }

--- a/jobs/build/sweep/Jenkinsfile
+++ b/jobs/build/sweep/Jenkinsfile
@@ -136,4 +136,5 @@ node {
         buildlib.attachBuildsToAdvisory(["rpm", "image"], params.BUILD_VERSION)
     }
     currentBuild.description = "Ran without errors\n---------------\n" + currentBuild.description
+    buildlib.cleanWorkspace()
 }

--- a/jobs/build/tarball-sources/Jenkinsfile
+++ b/jobs/build/tarball-sources/Jenkinsfile
@@ -154,5 +154,8 @@ node {
         currentBuild.description = "Error while running OCP Tarball sources:\n${err}"
         currentBuild.result = "FAILURE"
         throw err
+    } finally {
+        buildlib.cleanWorkspace()
     }
+    
 }

--- a/jobs/build/update-base-images/Jenkinsfile
+++ b/jobs/build/update-base-images/Jenkinsfile
@@ -104,5 +104,7 @@ node {
         currentBuild.description += "${red_p}ERROR: ${err}</p>"
 
         throw err
+    } finally {
+        buildlib.cleanWorkspace()
     }
 }

--- a/jobs/devex/jenkins-plugins/Jenkinsfile
+++ b/jobs/devex/jenkins-plugins/Jenkinsfile
@@ -141,5 +141,7 @@ node(TARGET_NODE) {
 
         // Re-throw the error in order to fail the job
         throw err
+    } finally {
+        buildlib.cleanWorkspace()
     }
 }

--- a/jobs/signing/sign-artifacts/Jenkinsfile
+++ b/jobs/signing/sign-artifacts/Jenkinsfile
@@ -396,4 +396,6 @@ node {
             sh "/bin/rclone --dry-run ${logCopyOpts}"
         }
     }
+
+    buildlib.cleanWorkspace()
 }

--- a/pipeline-scripts/Jenkinsfile
+++ b/pipeline-scripts/Jenkinsfile
@@ -83,4 +83,6 @@ node(TARGET_NODE) {
         testlib.test_sort_versions()
         echo "END: test_sort_versions()"
     }
+
+    buildlib.cleanWorkspace()
 }

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -1174,6 +1174,19 @@ def getGroupBranch(doozerOpts) {
     return branch
 }
 
+def cleanWorkspace() {
+    cleanWs(cleanWhenFailure: false, notFailBuild: true)
+    dir("${workspace}@tmp") {
+        deleteDir()
+    }
+    dir("${workspace}@script") {
+        deleteDir()
+    }
+    dir("${workspace}@libs") {
+        deleteDir()
+    }
+}
+
 WORKDIR_COUNTER=0 // ensure workdir cleanup can be invoked multiple times per job
 def cleanWorkdir(workdir, synchronous=false) {
     // get a fresh workdir; removing the old one can be synchronous or background.

--- a/scheduled-jobs/build/sync-ci-images/Jenkinsfile
+++ b/scheduled-jobs/build/sync-ci-images/Jenkinsfile
@@ -109,4 +109,5 @@ node {
         }
     }
 
+    buildlib.cleanWorkspace()
 }

--- a/scheduled-jobs/build/sync-for-ci-ironic/Jenkinsfile
+++ b/scheduled-jobs/build/sync-for-ci-ironic/Jenkinsfile
@@ -55,4 +55,6 @@ node() {
     timeout(time: 2, unit: 'HOURS') {
         sh "ssh -o StrictHostKeyChecking=no ${MIRROR_TARGET} -- push.enterprise.sh -v ${MIRROR_RELATIVE_REPOSYNC}"
     }
+
+    buildlib.cleanWorkspace()
 }

--- a/scheduled-jobs/maintenance/set_cincinnati_links/Jenkinsfile
+++ b/scheduled-jobs/maintenance/set_cincinnati_links/Jenkinsfile
@@ -39,7 +39,7 @@ node() {
         runFor(version, 'fast', 'fast')
         runFor(version, 'candidate', 'candidate')
     }
-
+    buildlib.cleanWorkspace()
 }
 
 currentBuild.description = description.trim()

--- a/scheduled-jobs/scanning/images-health/Jenkinsfile
+++ b/scheduled-jobs/scanning/images-health/Jenkinsfile
@@ -32,6 +32,7 @@ node() {
     for ( String version : sortedVersions() ) {
         runFor(version)
     }
+    buildlib.cleanWorkspace()
 }
 
 currentBuild.description = description.trim()


### PR DESCRIPTION
### Summary
Change to add pre/post build workspace cleanup steps, using workspace cleanup plugin. It was suggested in the story to use it at the top, but after reading, the step only takes the build state in account when it's run after the build. Also delete tmp workspace folders.

### Links
- [Jira link](https://issues.redhat.com/browse/ART-2048)
- [Workspace cleanup step](https://plugins.jenkins.io/ws-cleanup/) and [params](https://www.jenkins.io/doc/pipeline/steps/ws-cleanup/)
- [Sample run of ocp4 job with the commonlib function](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Focp4/11/console)

