### PR TITLE
plashet from-tags: Add option to inherit

### DIFF
--- a/build-scripts/plashet.py
+++ b/build-scripts/plashet.py
@@ -459,7 +459,9 @@ class KojiWrapper(wrapt.ObjectProxy):
 @click.option('--event', required=False, default=None, help='The brew event for the desired tag states')
 @click.option('--include-embargoed', default=False, is_flag=True,
               help='If specified, embargoed/unshipped RPMs will be included in the plashet')
-def from_tags(config, brew_tag, embargoed_brew_tag, embargoed_nvr, signing_advisory_id, signing_advisory_mode, poll_for, event, include_embargoed):
+@click.option('--inherit', required=False, default=False, is_flag=True,
+              help='Descend into brew tag inheritance')
+def from_tags(config, brew_tag, embargoed_brew_tag, embargoed_nvr, signing_advisory_id, signing_advisory_mode, poll_for, event, include_embargoed, inherit):
     """
     The repositories are filled with RPMs derived from the list of
     brew tags. If the RPMs are not signed and a repo should contain signed content,
@@ -518,7 +520,7 @@ def from_tags(config, brew_tag, embargoed_brew_tag, embargoed_nvr, signing_advis
                 package_name = build['package_name']
                 released_package_nvrs[package_name] = parse_nvr(build['nvr'])
 
-        for build in koji_proxy.listTagged(tag, latest=True, inherit=False, event=event, type='rpm'):
+        for build in koji_proxy.listTagged(tag, latest=True, inherit=inherit, event=event, type='rpm'):
             package_name = build['package_name']
             nvr = build['nvr']
             parsed_nvr = parse_nvr(nvr)

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -1458,6 +1458,7 @@ def buildBuildingPlashet(version, release, el_major, include_embargoed, auto_sig
                     "from-tags", // plashet mode of operation => build from brew tags
                     include_embargoed? "--include-embargoed" : "",
                     "--brew-tag rhaos-${major_minor}-rhel-${el_major}-candidate ${productVersion}",  // --brew-tag <tag> <associated-advisory-product-version>
+                    (major == 3) ? "--inherit" :  "", // For OCP3.11, we depend on tag inheritance to populate the OSE repo
                     auto_signing_advisory?"--signing-advisory-id ${auto_signing_advisory}":"",    // The advisory to use for signing
                     "--signing-advisory-mode clean",
                     "--poll-for 15",   // wait up to 15 minutes for auto-signing to work its magic.


### PR DESCRIPTION
For 3.11, we depend on brew inheritance to build the OSE repositories.
The plashet implementation does not descend into the inheritance tree.

This commit adds the boolean option `--inherit` to `plashet from-tags`
to look into children tags as well. Defaults to False.

Test runs:
- [custom 3.11](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/jdelft-aos-cd-jobs/job/build%252Fcustom/2/console): includes `--inherit`, resulting [plashet](http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/3.11/3.11.348-1/x86_64/os/Packages/) includes the needed packages
- [custom 4.2](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/jdelft-aos-cd-jobs/job/build%252Fcustom/3/console) does not incl;ude `--inherit` in the plashet invocation.