### PR TITLE
Stop syncing 4.2 and 4.3

### DIFF
--- a/scheduled-jobs/build/sync-for-ci/Jenkinsfile
+++ b/scheduled-jobs/build/sync-for-ci/Jenkinsfile
@@ -24,7 +24,8 @@ def runFor(group, dir, arch="x86_64") {
 
 @NonCPS
 def sortedVersions() {
-  return commonlib.ocp4Versions.sort(false)
+  def disabled = ['4.3', '4.2']
+  return commonlib.ocp4Versions.sort(false).findAll { !disabled.contains(it) }
 }
 
 node() {


### PR DESCRIPTION
Alert! This is... not smart. 4.2 and 4.3 need to be built, so this
commit needs to be reverted soon.

This is to avoid disk space issues on buildvm. A lot of space is
consumed by the artifacts of the resposync job under `/mnt/workspace/reposync/`.
This will be temporarily deleted.