### PR TITLE
3.11 plashets fixup

### DIFF
--- a/build-scripts/rcm-guest/publish-oc-binary.sh
+++ b/build-scripts/rcm-guest/publish-oc-binary.sh
@@ -43,7 +43,7 @@ pkg_tar() {
 OSE_VERSION=$1
 VERSION=$2
 PKG=${3:-atomic-openshift}
-RPM=/mnt/rcm-guest/puddles/RHAOS/AtomicOpenShift/${OSE_VERSION}/building/%s
+RPM=/mnt/rcm-guest/puddles/RHAOS/plashets/${OSE_VERSION}/building/%s
 RPM=${RPM}/os/Packages/${PKG}-clients
 ARCH='aarch64 ppc64le s390x'
 TMPDIR=$(mktemp -dt ocbinary.XXXXXXXXXX)

--- a/jobs/build/ocp3/Jenkinsfile
+++ b/jobs/build/ocp3/Jenkinsfile
@@ -651,8 +651,8 @@ node {
 
                 def auto_signing_advisory = Integer.parseInt(buildlib.doozer("${doozerOpts} config:read-group --default=0 signing_advisory", [capture: true]).trim())
 
-                buildlib.buildBuildingPlashet(spec.version, spec.release, 7, true, auto_signing_advisory)  // build el7 embargoed plashet
-                def plashet = buildlib.buildBuildingPlashet(spec.version, spec.release, 7, false, auto_signing_advisory)  // build el7 unembargoed plashet
+                buildlib.buildBuildingPlashet(NEW_VERSION, NEW_RELEASE, 7, true, auto_signing_advisory)  // build el7 embargoed plashet
+                def plashet = buildlib.buildBuildingPlashet(NEW_VERSION, NEW_RELEASE, 7, false, auto_signing_advisory)  // build el7 unembargoed plashet
                 PLASHET = plashet.plashetDirName
             }
 


### PR DESCRIPTION
- Tell rcm-guest about plashet location
- Fix off-by-one plashet error

The plashet version directories are wrongly calculated for 3.11
plashets. The repo directory, e.g. `3.11.368-1/` contains artifacts for
`3.11.369-1`. With this commit, the correct version is passed to
plashet.

```
rcm-guest:/mnt/rcm-guest/puddles/RHAOS/plashets/3.11
$ ls -1d 3.11.*-1/x86_64/os/Packages/atomic-openshift-cluster*/
3.11.347-1/x86_64/os/Packages/atomic-openshift-cluster-autoscaler-3.11.347-1.git.0.c1f0a03.el7__x86_64__fd431d51/
3.11.347-1/x86_64/os/Packages/atomic-openshift-cluster-autoscaler-3.11.348-1.git.0.0df383d.el7__x86_64__fd431d51/
3.11.348-1/x86_64/os/Packages/atomic-openshift-cluster-autoscaler-3.11.349-1.git.0.229431f.el7__x86_64__fd431d51/
3.11.348-1/x86_64/os/Packages/atomic-openshift-cluster-autoscaler-3.11.351-1.git.0.9d07547.el7__x86_64__fd431d51/
3.11.349-1/x86_64/os/Packages/atomic-openshift-cluster-autoscaler-3.11.350-1.git.0.1023072.el7__x86_64__fd431d51/
3.11.352-1/x86_64/os/Packages/atomic-openshift-cluster-autoscaler-3.11.353-1.git.0.1bc99bc.el7__x86_64__fd431d51/
3.11.353-1/x86_64/os/Packages/atomic-openshift-cluster-autoscaler-3.11.354-1.git.0.c065d72.el7__x86_64__fd431d51/
3.11.354-1/x86_64/os/Packages/atomic-openshift-cluster-autoscaler-3.11.355-1.git.0.6d0e7f8.el7__x86_64__fd431d51/
3.11.355-1/x86_64/os/Packages/atomic-openshift-cluster-autoscaler-3.11.356-1.git.0.ab4422a.el7__x86_64__fd431d51/
3.11.356-1/x86_64/os/Packages/atomic-openshift-cluster-autoscaler-3.11.357-1.git.0.e089ee3.el7__x86_64__fd431d51/
3.11.357-1/x86_64/os/Packages/atomic-openshift-cluster-autoscaler-3.11.358-1.git.0.653cd9a.el7__x86_64__fd431d51/
3.11.358-1/x86_64/os/Packages/atomic-openshift-cluster-autoscaler-3.11.359-1.git.0.d005feb.el7__x86_64__fd431d51/
3.11.359-1/x86_64/os/Packages/atomic-openshift-cluster-autoscaler-3.11.360-1.git.0.8a8df20.el7__x86_64__fd431d51/
3.11.360-1/x86_64/os/Packages/atomic-openshift-cluster-autoscaler-3.11.361-1.git.0.1edcfde.el7__x86_64__fd431d51/
3.11.361-1/x86_64/os/Packages/atomic-openshift-cluster-autoscaler-3.11.362-1.git.0.6fcf433.el7__x86_64__fd431d51/
3.11.362-1/x86_64/os/Packages/atomic-openshift-cluster-autoscaler-3.11.363-1.git.0.519b248.el7__x86_64__fd431d51/
3.11.363-1/x86_64/os/Packages/atomic-openshift-cluster-autoscaler-3.11.364-1.git.0.79dc634.el7__x86_64__fd431d51/
3.11.364-1/x86_64/os/Packages/atomic-openshift-cluster-autoscaler-3.11.365-1.git.0.f720bb7.el7__x86_64__fd431d51/
3.11.365-1/x86_64/os/Packages/atomic-openshift-cluster-autoscaler-3.11.366-1.git.0.a9a34dd.el7__x86_64__fd431d51/
3.11.366-1/x86_64/os/Packages/atomic-openshift-cluster-autoscaler-3.11.367-1.git.0.51d87a6.el7__x86_64__fd431d51/
3.11.367-1/x86_64/os/Packages/atomic-openshift-cluster-autoscaler-3.11.368-1.git.0.966b440.el7__x86_64__fd431d51/
3.11.368-1/x86_64/os/Packages/atomic-openshift-cluster-autoscaler-3.11.369-1.git.0.d627872.el7__x86_64__fd431d51/
```