### PR TITLE
Fix slack notification on tarball-sources job

### DIFF
--- a/jobs/build/tarball-sources/Jenkinsfile
+++ b/jobs/build/tarball-sources/Jenkinsfile
@@ -145,7 +145,8 @@ node {
             }
 
             stage("slack notification to release channel") {
-                jiraCardURL = "https://projects.engineering.redhat.com/browse/${jira.Key}"
+                def jiraKey = (jira =~ /CLOUDDST-\d+/)[0]
+                jiraCardURL = "https://projects.engineering.redhat.com/browse/${jiraKey}"
 
                 slacklib.to(version).say("""
                 *:heavy_check_mark: tarball-sources sent to CLOUDDST*


### PR DESCRIPTION
Despite its misleading format, `jira` is a string, not an object.
So we have to extract the key out of it:

```
groovy:000> jira = """(*jira.Issue)(0xc0000ec070)({
groovy:001>  Expand: (string) "",
groovy:002>  ID: (string) (len=6) "945735",
groovy:003>  Self: (string) (len=63)
"https://projects.engineering.redhat.com/rest/api/2/issue/945735",
groovy:004>  Key: (string) (len=13) "CLOUDDST-4353",
groovy:005>  Fields: (*jira.IssueFields)(<nil>),
groovy:006>  RenderedFields: (*jira.IssueRenderedFields)(<nil>),
groovy:007>  Changelog: (*jira.Changelog)(<nil>),
groovy:008>  Transitions: ([]jira.Transition) <nil>
groovy:009> })
groovy:010> """

groovy:000> key = (jira =~ /CLOUDDST-\d+/)[0]
===> CLOUDDST-4353
```