### PR TITLE
pipeline-scripts: enable ARM and Z in 3.11 plashets

### DIFF
--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -99,7 +99,7 @@ ocpReleaseState = [
         ],
         "3.11": [
             "release": [ 'x86_64', 'ppc64le' ],
-            "pre-release": [],
+            "pre-release": [ 's390x', 'aarch64' ],
         ],
 ]
 


### PR DESCRIPTION
These are used to maintain internal resources.