### PR TITLE
Temporarily remove reposync 4.4

### DIFF
--- a/scheduled-jobs/build/sync-for-ci/Jenkinsfile
+++ b/scheduled-jobs/build/sync-for-ci/Jenkinsfile
@@ -24,7 +24,7 @@ def runFor(group, dir, arch="x86_64") {
 
 @NonCPS
 def sortedVersions() {
-  def disabled = ['4.3', '4.2']
+  def disabled = ['4.4', '4.3', '4.2']
   return commonlib.ocp4Versions.sort(false).findAll { !disabled.contains(it) }
 }
 


### PR DESCRIPTION
BuildVM is running out of disk space again. A more durable slution is in
the works, but until we are so far, taking out reposync for 4.4. This
will gain us around 100GB to work with.

Follow-up of:
https://github.com/openshift/aos-cd-jobs/pull/2479/files
Re-enable ticket:
https://issues.redhat.com/browse/ART-2584