### PR TITLE
parallel the download process

### DIFF
--- a/hacks/refine-candidate/download-logs.sh
+++ b/hacks/refine-candidate/download-logs.sh
@@ -8,12 +8,16 @@ if [[ -z "$TAG" ]]; then
     exit 1
 fi
 
-for build in $(brew list-tagged --quiet --latest $TAG | awk '{print $1}' | grep -E '(apb|container)-v?[0-9]'); do
+for build in $(brew list-tagged --quiet --latest $TAG | awk '{print $1}' | grep -E '(apb|container)-v?[0-9]');
+do
+    {
         task=$(brew buildinfo $build | grep Extra: | sed -n  's/.*container_koji_task_id...\([0-9]\+\).*/\1/p')
         if [ -z "$task" ]; then
                 echo "Could not find task for: $build"
         else
                 brew download-logs -r $task
         fi
+    }&
 done
-
+wait
+echo "done"


### PR DESCRIPTION
an other way is to use brew watch-logs to grep installing log instead of download all the log files.
