### PR TITLE
ART-2389: sync opm to mirror

### DIFF
--- a/jobs/build/oc_sync/publish-clients-from-payload.sh
+++ b/jobs/build/oc_sync/publish-clients-from-payload.sh
@@ -1,12 +1,22 @@
 #!/bin/bash
-set -eux
+set -euo pipefail
 export MOBY_DISABLE_PIGZ=true
+
+if [ $# -lt 4 ]; then
+    echo "Usage: $0 WORKSPACE VERSION CLIENT_TYPE PULL_SPEC" >&2
+    exit 1
+fi
+
 WORKSPACE=$1
 VERSION=$2
 CLIENT_TYPE=$3
 PULL_SPEC=$4
 
-ARCH=$(skopeo inspect docker://${PULL_SPEC} -config | jq .architecture -r)
+
+GOTRACEBACK=all oc version --client
+
+ARCH=$(skopeo inspect docker://${PULL_SPEC} --config | jq .architecture -r)
+
 if [[ "${ARCH}" == "amd64" ]]; then
     ARCH="x86_64"
 fi
@@ -24,44 +34,99 @@ else
     echo "Fetching OCP clients from payload ${VERSION}"
 fi
 
-TMPDIR=${WORKSPACE}/tools
-mkdir -p "${TMPDIR}"
-cd ${TMPDIR}
+function extract_tools() {
+    OUTDIR=$1
+    mkdir -p ${OUTDIR}
 
-OUTDIR=${TMPDIR}/${VERSION}
-mkdir -p ${OUTDIR}
-pushd ${OUTDIR}
+    #extract all release assests
+    GOTRACEBACK=all oc adm release extract --tools --command-os=* ${PULL_SPEC} --to=${OUTDIR}
 
-#extract all release assests
-GOTRACEBACK=all oc version
-GOTRACEBACK=all oc adm release extract --tools --command-os=* ${PULL_SPEC} --to=${OUTDIR}
+    pushd ${OUTDIR}
+    # External consumers want a link they can rely on.. e.g. .../latest/openshift-client-linux.tgz .
+    # So whatever we extract, remove the version specific info and make a symlink with that name.
+    for f in *.tar.gz *.bz *.zip *.tgz ; do
 
+        # Is this already a link?
+        if [[ -L "$f" ]]; then
+            continue
+        fi
 
-# External consumers want a link they can rely on.. e.g. .../latest/openshift-client-linux.tgz .
-# So whatever we extract, remove the version specific info and make a symlink with that name.
-for f in *.tar.gz *.bz *.zip *.tgz ; do
+        # example file names:
+        #  - openshift-client-linux-4.3.0-0.nightly-2019-12-06-161135.tar.gz
+        #  - openshift-client-mac-4.3.0-0.nightly-2019-12-06-161135.tar.gz
+        #  - openshift-install-mac-4.3.0-0.nightly-2019-12-06-161135.tar.gz
+        #  - openshift-client-linux-4.1.9.tar.gz
+        #  - openshift-install-mac-4.3.0-0.nightly-s390x-2020-01-06-081137.tar.gz
+        #  ...
+        # So, match, and store in a group, any non-digit up to the point we find -DIGIT. Ignore everything else
+        # until we match (and store in a group) one of the valid file extensions.
+        if [[ "$f" =~ ^([^0-9]+)-[0-9].*(tar.gz|tgz|bz|zip)$ ]]; then
+            # Create a symlink like openshift-client-linux.tgz => openshift-client-linux-4.3.0-0.nightly-2019-12-06-161135.tar.gz
+            ln -sfn "$f" "${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+        fi
+    done
+    popd
+}
 
-    # Is this already a link?
-    if [[ -L "$f" ]]; then
-        continue
+function extract_opm() {
+    OUTDIR=$1
+    mkdir -p "${OUTDIR}"
+    OPERATOR_REGISTRY=$(oc adm release info --image-for operator-registry "$PULL_SPEC")
+    # extract opm binaries
+    BINARIES=(opm)
+    PLATFORMS=(linux)
+    if [ "$ARCH" == "x86_64" ]; then  # For x86_64, we have binaries for macOS and Windows
+        BINARIES+=(darwin-amd64-opm windows-amd64-opm)
+        PLATFORMS+=(mac windows)
     fi
 
-    # example file names:
-    #  - openshift-client-linux-4.3.0-0.nightly-2019-12-06-161135.tar.gz
-    #  - openshift-client-mac-4.3.0-0.nightly-2019-12-06-161135.tar.gz
-    #  - openshift-install-mac-4.3.0-0.nightly-2019-12-06-161135.tar.gz
-    #  - openshift-client-linux-4.1.9.tar.gz
-    #  - openshift-install-mac-4.3.0-0.nightly-s390x-2020-01-06-081137.tar.gz
-    #  ...
-    # So, match, and store in a group, any non-digit up to the point we find -DIGIT. Ignore everything else
-    # until we match (and store in a group) one of the valid file extensions.
-    if [[ "$f" =~ ^([^0-9]+)-[0-9].*(tar.gz|tgz|bz|zip)$ ]]; then
-        # Create a symlink like openshift-client-linux.tgz => openshift-client-linux-4.3.0-0.nightly-2019-12-06-161135.tar.gz
-        ln -sfn "$f" "${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+    MAJOR=$(echo "$VERSION" | cut -d . -f 1)
+    MINOR=$(echo "$VERSION" | cut -d . -f 2)
+    if [ "$MAJOR" -eq 4 ] && [ "$MINOR" -le 6 ]; then
+        PREFIX=/usr/bin
+    else  # for 4.7+, opm binaries are at /usr/bin/registry/
+        PREFIX=/usr/bin/registry
     fi
-done
 
-popd
+    PATH_ARGS=()
+    for binary in ${BINARIES[@]}; do
+        PATH_ARGS+=(--path "$PREFIX/$binary:$OUTDIR")
+    done
+
+    GOTRACEBACK=all oc image extract --confirm --only-files "${PATH_ARGS[@]}" -- "$OPERATOR_REGISTRY"
+
+    # Compress binaries into tar.gz files and calculate sha256 digests
+    pushd "$OUTDIR"
+    for idx in ${!BINARIES[@]}; do
+        binary=${BINARIES[idx]}
+        platform=${PLATFORMS[idx]}
+        chmod +x "$binary"
+        tar -czvf "opm-$platform-$VERSION.tar.gz" "$binary"
+        rm "$binary"
+        ln -sf "opm-$platform-$VERSION.tar.gz" "opm-$platform.tar.gz"
+        sha256sum "opm-$platform-$VERSION.tar.gz" >> sha256sum.txt
+    done
+    popd
+}
+
+case "$CLIENT_TYPE" in
+ocp|ocp-dev-preview)
+    OUTDIR=${WORKSPACE}/tools/${VERSION}
+    extract_tools "$OUTDIR"
+    extract_opm "$OUTDIR"
+    tree "$OUTDIR"
+    cat "$OUTDIR"/sha256sum.txt
+    ;;
+*)
+    >&2 echo "Unknown CLIENT_TYPE: $CLIENT_TYPE"
+    exit 1
+    ;;
+esac
+
+if [ "${DRY_RUN:-0}" -ne 0 ]; then
+    >&2 echo "[DRY RUN] Don't actually sync things to mirror."
+    exit 0
+fi
 
 #sync to use-mirror-upload
 rsync \

--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -482,7 +482,7 @@ node {
 
             buildlib.registry_quay_dev_login()  // chances are, earlier auth has expired
 
-            stage("mirror tools") {
+            stage("mirror binaries") {
                 retry(3) {
                     release.stagePublishClient(quay_url, dest_release_tag, release_name, arch, CLIENT_TYPE)
                 }

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -371,9 +371,8 @@ def stagePublishClient(quay_url, from_release_tag, release_name, arch, client_ty
     def tools_extract_cmd = "MOBY_DISABLE_PIGZ=true GOTRACEBACK=all oc adm release extract --tools --command-os='*' -n ocp " +
                                 " --to=${CLIENT_MIRROR_DIR} --from ${quay_url}:${from_release_tag}"
 
-    if (!params.DRY_RUN) {
-        commonlib.shell(script: tools_extract_cmd)
-        commonlib.shell("cd ${CLIENT_MIRROR_DIR}\n" + '''
+    commonlib.shell(script: tools_extract_cmd)
+    commonlib.shell("cd ${CLIENT_MIRROR_DIR}\n" + '''
 # External consumers want a link they can rely on.. e.g. .../latest/openshift-client-linux.tgz .
 # So whatever we extract, remove the version specific info and make a symlink with that name.
 for f in *.tar.gz *.bz *.zip *.tgz ; do
@@ -397,10 +396,55 @@ for f in *.tar.gz *.bz *.zip *.tgz ; do
         ln -sfn "$f" "${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
     fi
 done
+    ''')
+    withEnv(["OUTDIR=$CLIENT_MIRROR_DIR", "PULL_SPEC=${quay_url}:${from_release_tag}", "ARCH=$arch", "VERSION=$release_name"]){
+        commonlib.shell('''
+function extract_opm() {
+    OUTDIR=$1
+    mkdir -p "${OUTDIR}"
+    OPERATOR_REGISTRY=$(oc adm release info --image-for operator-registry "$PULL_SPEC")
+    # extract opm binaries
+    BINARIES=(opm)
+    PLATFORMS=(linux)
+    if [ "$ARCH" == "x86_64" ]; then  # For x86_64, we have binaries for macOS and Windows
+        BINARIES+=(darwin-amd64-opm windows-amd64-opm)
+        PLATFORMS+=(mac windows)
+    fi
+
+    MAJOR=$(echo "$VERSION" | cut -d . -f 1)
+    MINOR=$(echo "$VERSION" | cut -d . -f 2)
+    if [ "$MAJOR" -eq 4 ] && [ "$MINOR" -le 6 ]; then
+        PREFIX=/usr/bin
+    else  # for 4.7+, opm binaries are at /usr/bin/registry/
+        PREFIX=/usr/bin/registry
+    fi
+
+    PATH_ARGS=()
+    for binary in ${BINARIES[@]}; do
+        PATH_ARGS+=(--path "$PREFIX/$binary:$OUTDIR")
+    done
+
+    GOTRACEBACK=all oc -v5 image extract --confirm --only-files "${PATH_ARGS[@]}" -- "$OPERATOR_REGISTRY"
+
+    # Compress binaries into tar.gz files and calculate sha256 digests
+    pushd "$OUTDIR"
+    for idx in ${!BINARIES[@]}; do
+        binary=${BINARIES[idx]}
+        platform=${PLATFORMS[idx]}
+        chmod +x "$binary"
+        tar -czvf "opm-$platform-$VERSION.tar.gz" "$binary"
+        rm "$binary"
+        ln -sf "opm-$platform-$VERSION.tar.gz" "opm-$platform.tar.gz"
+        sha256sum "opm-$platform-$VERSION.tar.gz" >> sha256sum.txt
+    done
+    popd
+}
+extract_opm "$OUTDIR"
         ''')
-    } else {
-        echo "Would have run: ${tools_extract_cmd}"
     }
+
+    sh "tree $CLIENT_MIRROR_DIR"
+    sh "cat $CLIENT_MIRROR_DIR/sha256sum.txt"
 
     // DO NOT use --delete. We only built a part of openshift-v4 locally and don't want to remove
     // anything on the mirror.


### PR DESCRIPTION
Extract and mirror opm binaries to mirror, store their sha256 digests to sha256sum.txt as well to get signed.

Tested with following hack jobs:

promote:
https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/yuxzhu/job/aos-cd-jobs/job/build%252Fpromote/7/

oc_sync:
- 4.7.0-fc.3 x86_64: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/yuxzhu/job/aos-cd-jobs/job/build%252Foc_sync/10/
- 4.6.12 s390x: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/yuxzhu/job/aos-cd-jobs/job/build%252Foc_sync/9/
- 4.6.12 x86_64: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/yuxzhu/job/aos-cd-jobs/job/build%252Foc_sync/8/