### PR TITLE
Skip RHCOS AMI sync for arches other than x64

### DIFF
--- a/jobs/build/rhcos_sync/Jenkinsfile
+++ b/jobs/build/rhcos_sync/Jenkinsfile
@@ -107,18 +107,20 @@ node {
             buildvm job: ${commonlib.buildURL('console')}
             """)
         }
+        
+        // only run for x86_64 since no AMIs for other arches        
         // only sync AMI to ROSA Marketplace account when no custom sync list is defined
-        if ( params.SYNC_LIST == "" ) {
+        if ( params.SYNC_LIST == "" && params.ARCH == "x86_64") {
             stage("Mirror ROSA AMIs") {
                 withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'artjenkins_rhcos_rosa_marketplace_production', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                     build.rhcosSyncROSA()
                 }
             }
-        }
-        stage("Slack notification to release channel") {
-            slacklib.to(params.BUILD_VERSION).say("""
-            *:heavy_check_mark: rosa_sync (${params.NAME}) successful*
-            """)
+            stage("Slack notification to release channel") {
+                slacklib.to(params.BUILD_VERSION).say("""
+                *:heavy_check_mark: rosa_sync (${params.NAME}) successful*
+                """)
+            }
         }
     } catch ( err ) {
         slacklib.to(params.BUILD_VERSION).say("""


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-2630