### PR TITLE
[ART-2459] Add operator-sdk_sync job

### DIFF
--- a/jobs/build/operator-sdk_sync/Jenkinsfile
+++ b/jobs/build/operator-sdk_sync/Jenkinsfile
@@ -26,7 +26,6 @@ pipeline {
                          "<li>v4.7.0-202101261648.p0</li>" +
                          "<li>v4.7.0</li>" +
                          "<li>v4.7</li>" +
-                         "<li>latest</li>" +
                          "</ul>",
             defaultValue: '',
             trim: true,

--- a/jobs/build/operator-sdk_sync/Jenkinsfile
+++ b/jobs/build/operator-sdk_sync/Jenkinsfile
@@ -1,0 +1,85 @@
+node {
+    checkout scm
+    commonlib = load('pipeline-scripts/commonlib.groovy')
+    commonlib.describeJob("operator-sdk_sync", """
+        <h2>Sync operator-sdk to mirror</h2>
+        <b>Timing</b>: Manually, upon request. Expected to happen once every y-stream and
+        sporadically on z-stream releases.
+    """)
+    imagePath = 'registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-operator-sdk'
+}
+
+pipeline {
+    agent any
+
+    options {
+        disableResume()
+        skipDefaultCheckout()
+    }
+
+    parameters {
+        string(
+            name: 'BUILD_TAG',
+            description: "Build of ose-operator-sdk from which the contents should be extracted.<br/>" +
+                         "Examples:<br/>" +
+                         "<ul>" +
+                         "<li>v4.7.0-202101261648.p0</li>" +
+                         "<li>v4.7.0</li>" +
+                         "<li>v4.7</li>" +
+                         "<li>latest</li>" +
+                         "</ul>",
+            defaultValue: '',
+            trim: true,
+        )
+        string(
+            name: 'VERSION',
+            description: 'Release version (name of directories published in the mirror)',
+            defaultValue: '',
+            trim: true,
+        )
+    }
+
+    stages {
+        stage('pre-flight') {
+            steps {
+                script {
+                    if (!params.BUILD_TAG) {
+                        error 'BUILD_TAG must be specified'
+                    }
+                    if (!params.VERSION) {
+                        error 'VERSION must be specified'
+                    }
+                    currentBuild.displayName = "${params.VERSION}"
+                    currentBuild.description = "${params.BUILD_TAG}"
+                }
+            }
+        }
+        stage('extract binaries') {
+            steps {
+                script {
+                    def manifestList = readJSON(
+                        text: sh(
+                            script: "skopeo inspect --raw docker://${imagePath}:${params.BUILD_TAG}",
+                            returnStdout: true,
+                        )
+                    ).manifests
+                    manifestList.each {
+                        sh "rm -rf ./${params.VERSION} && mkdir ./${params.VERSION}"
+
+                        dir("./${params.VERSION}") {
+                            sh "oc image extract ${imagePath}@${it.digest} --path /usr/local/bin/operator-sdk:. --confirm"
+                            sh "chmod +x operator-sdk"
+                        }
+
+                        def arch = it.platform.architecture == 'amd64' ? 'x86_64' : it.platform.architecture
+                        sshagent(['aos-cd-test']) {
+                            sh "scp -r ${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/${arch}/clients/operator-sdk/"
+                            sh "ssh use-mirror-upload.ops.rhcloud.com -- ln --symbolic --force --no-dereference ${params.VERSION} /srv/pub/openshift-v4/${arch}/clients/operator-sdk/latest"
+                            sh "ssh use-mirror-upload.ops.rhcloud.com -- /usr/local/bin/push.pub.sh openshift-v4/${arch}/clients/operator-sdk -v"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
New sync job for `operator-sdk` client.

![Screenshot from 2021-01-28 13-45-26](https://user-images.githubusercontent.com/190616/106141556-8fb27200-6170-11eb-9a0b-77f4f7ca90a1.png)

```
use-mirror-upload:/srv/pub/openshift-v4
$ ls -lsh x86_64/clients/operator-sdk/
total 0
0 drwxr-xr-x. 2 jenkins_aos_cd_bot jenkins_aos_cd_bot 25 Jan 28 07:48 4.7.0
0 lrwxrwxrwx. 1 jenkins_aos_cd_bot jenkins_aos_cd_bot  5 Jan 28 07:49 latest -> 4.7.0

use-mirror-upload:/srv/pub/openshift-v4
$ ls -lsh x86_64/clients/operator-sdk/4.7.0
total 65M
65M -rwxr-x--x. 1 jenkins_aos_cd_bot jenkins_aos_cd_bot 65M Jan 28 07:49 operator-sdk
```
```
use-mirror-upload:/srv/pub/openshift-v4
$ ls -lsh s390x/clients/operator-sdk/
total 0
0 drwxr-xr-x. 2 jenkins_aos_cd_bot jenkins_aos_cd_bot 25 Jan 28 07:49 4.7.0
0 lrwxrwxrwx. 1 jenkins_aos_cd_bot jenkins_aos_cd_bot  5 Jan 28 07:49 latest -> 4.7.0

use-mirror-upload:/srv/pub/openshift-v4
$ ls -lsh s390x/clients/operator-sdk/4.7.0
total 64M
64M -rwxr-x--x. 1 jenkins_aos_cd_bot jenkins_aos_cd_bot 64M Jan 28 07:49 operator-sdk
```
```
use-mirror-upload:/srv/pub/openshift-v4
$ ls -lsh ppc64le/clients/operator-sdk/
total 0
0 drwxr-xr-x. 2 jenkins_aos_cd_bot jenkins_aos_cd_bot 25 Jan 28 07:49 4.7.0
0 lrwxrwxrwx. 1 jenkins_aos_cd_bot jenkins_aos_cd_bot  5 Jan 28 07:49 latest -> 4.7.0

use-mirror-upload:/srv/pub/openshift-v4
$ ls -lsh ppc64le/clients/operator-sdk/4.7.0
total 62M
62M -rwxr-x--x. 1 jenkins_aos_cd_bot jenkins_aos_cd_bot 62M Jan 28 07:49 operator-sdk
```