### PR TITLE
Fix a jira clone failure if description is null

### DIFF
--- a/pyartcd/pyartcd/jira.py
+++ b/pyartcd/pyartcd/jira.py
@@ -22,7 +22,7 @@ class JIRAClient:
         new_fields = {
             "project": {"key": fields["project"]["key"]},
             "summary": fields["summary"],
-            "description": fields["description"],
+            "description": fields["description"] or "",
             "issuetype": {"name": fields["issuetype"]["name"]},
             "components": fields.get("components", []).copy(),
             "labels": fields.get("labels", []).copy(),


### PR DESCRIPTION
An error occurs when cloning 3.11 jira subtasks:

```
{'description': 'Operation value must be a string'}
```
This is because some template issues have empty descriptions, which become `null`
when retrieving from the API. But the create issue API doesn't allow null for the description.
Let's just convert it to empty string.