### PR TITLE
[ART-2459] Update operator-sdk_sync job

### DIFF
--- a/jobs/build/operator-sdk_sync/README.md
+++ b/jobs/build/operator-sdk_sync/README.md
@@ -1,0 +1,39 @@
+# operator-sdk_sync
+
+## Purpose
+
+Sync operator-sdk binaries to mirror.openshift.com.
+
+## Timing
+
+Manually, upon request. Expected to happen once every y-stream and sporadically on z-stream releases.
+
+## Parameters
+
+### OCP_VERSION
+
+Under which directory to place the binaries.
+Examples:
+- 4.7.0
+- 4.7.0-rc.0
+
+### BUILD_TAG
+
+Build of ose-operator-sdk from which the contents should be extracted.
+Examples:
+- v4.7.0-202101261648.p0
+- v4.7.0
+- v4.7
+
+## Known issues
+
+### Job reports as 'SUCCESS' but sync to one of the mirrors failed
+
+    [BEGIN] /usr/local/bin/push.pub.sh openshift-v4/ppc64le/clients/operator-sdk -v 2021-02-09 08:02:07
+    [1] 08:37:07 [SUCCESS] mirror_sync@use-mirror2.ops.rhcloud.com
+    [2] 08:37:07 [SUCCESS] mirror_sync@use-mirror1.ops.rhcloud.com
+    [3] 08:37:08 [FAILURE] mirror_sync@use-mirror7.ops.rhcloud.com Exited with error code 12
+    Statuses: [0, 0, 12]
+
+Try again, otherwise open a ticket to OHSS.
+Example: <https://issues.redhat.com/browse/OHSS-2099>.


### PR DESCRIPTION
Follow up of https://github.com/openshift/aos-cd-jobs/pull/2520

Extracts `operator-sdk` version to name the tarballs, and creates the following structure:

```
$ for arch in x86_64 s390x ppc64le; do ls /srv/pub/openshift-v4/${arch}/clients/operator-sdk/4.7.0-rc.0 ; done
operator-sdk-v1.3.0-ocp-linux-x86_64.tar.gz
operator-sdk-v1.3.0-ocp-linux-s390x.tar.gz
operator-sdk-v1.3.0-ocp-linux-ppc64le.tar.gz
```

Open question to @jmrodri: It is still unclear to me from where we should extract the `darwin` binaries.