### PR TITLE
[ART-2678] Fix opm binary location for OCP 4.6 on promote job

### DIFF
--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -418,15 +418,10 @@ function extract_opm() {
 
     MAJOR=$(echo "$VERSION" | cut -d . -f 1)
     MINOR=$(echo "$VERSION" | cut -d . -f 2)
-    if [ "$MAJOR" -eq 4 ] && [ "$MINOR" -le 6 ]; then
-        PREFIX=/usr/bin
-    else  # for 4.7+, opm binaries are at /usr/bin/registry/
-        PREFIX=/usr/bin/registry
-    fi
 
     PATH_ARGS=()
     for binary in ${BINARIES[@]}; do
-        PATH_ARGS+=(--path "$PREFIX/$binary:$OUTDIR")
+        PATH_ARGS+=(--path "/usr/bin/registry/$binary:$OUTDIR")
     done
 
     GOTRACEBACK=all oc -v5 image extract --confirm --only-files "${PATH_ARGS[@]}" -- "$OPERATOR_REGISTRY"


### PR DESCRIPTION
*this PR only solves part of the problem reported in [ART-2678](https://issues.redhat.com/browse/ART-2678), i'll create another PR later wrapping the binary extraction in a retry loop or something along those lines.
*UPDATE:* retry follow up #2527 