### PR TITLE
Promote job - Upgrade test message fixes

### DIFF
--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -352,7 +352,7 @@ node {
                     return
                 }
                 try {  // don't let a slack outage break the job at this point
-                    def modeOptions = [ 'aws', 'gcp', 'azure' ]
+                    def modeOptions = [ 'aws', 'gcp', 'azure,mirror' ]
                     def testIndex = 0
                     def testLines = []
                     for ( String from_release : previousList) {
@@ -366,7 +366,7 @@ node {
                         return
                     }
                     slackChannel.say("Hi @release-artists . A new release is ready and needs some upgrade tests to be triggered. "
-                        + "Please open a chat with @cluster-bot and issue each of these lines individually:\n${testLines.join('\n')}")
+                        + "Please open a chat with @cluster-bot and issue each of these lines individually. Note: mirror variant is broken for upgrade tests at this time, just use 'azure' instead.\n${testLines.join('\n')}")
                 } catch(ex) {
                     echo "slack notification failed: ${ex}"
                 }

--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -300,7 +300,8 @@ node {
                     }
                 }
             }
-            previousList = previousList.toList().unique()
+            previousList = previousList.toList().unique().sort()
+            Collections.reverse(previousList)
             echo "previousList is ${previousList}"
 
             // must be able to access remote registry for verification
@@ -343,10 +344,11 @@ node {
                     echo "Don't request upgrade tests because SKIP_PAYLOAD_CREATION option is checked."
                     return
                 }
-                if (direct_release_nightly || !is_4stable_release) {
-                    // For a hotfix, there is speed is our goal. Assume testing has already been done.
+                if (direct_release_nightly || !is_4stable_release || arch != 'x86_64') {
+                    // For a hotfix, speed is our goal. Assume testing has already been done.
                     // For an FC, we are so early in the release cycle that non-default upgrade tests are
                     // only noise.
+                    // Skip for non x64 arches because we don't test for that.
                     return
                 }
                 try {  // don't let a slack outage break the job at this point

--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -352,7 +352,7 @@ node {
                     return
                 }
                 try {  // don't let a slack outage break the job at this point
-                    def modeOptions = [ 'aws', 'gcp', 'azure,mirror' ]
+                    def modeOptions = [ 'aws', 'gcp', 'azure' ]
                     def testIndex = 0
                     def testLines = []
                     for ( String from_release : previousList) {

--- a/jobs/build/release/Jenkinsfile
+++ b/jobs/build/release/Jenkinsfile
@@ -318,7 +318,7 @@ node {
                     return
                 }
                 try {  // don't let a slack outage break the job at this point
-                    def modeOptions = [ 'aws', 'gcp', 'azure,mirror' ]
+                    def modeOptions = [ 'aws', 'gcp', 'azure' ]
                     def testIndex = 0
                     def testLines = []
                     for ( String from_release : previousList) {

--- a/jobs/build/release/Jenkinsfile
+++ b/jobs/build/release/Jenkinsfile
@@ -318,7 +318,7 @@ node {
                     return
                 }
                 try {  // don't let a slack outage break the job at this point
-                    def modeOptions = [ 'aws', 'gcp', 'azure' ]
+                    def modeOptions = [ 'aws', 'gcp', 'azure,mirror' ]
                     def testIndex = 0
                     def testLines = []
                     for ( String from_release : previousList) {
@@ -332,7 +332,7 @@ node {
                         return
                     }
                     slackChannel.say("Hi @release-artists . A new release is ready and needs some upgrade tests to be triggered. "
-                        + "Please open a chat with @cluster-bot and issue each of these lines individually:\n${testLines.join('\n')}")
+                        + "Please open a chat with @cluster-bot and issue each of these lines individually. Note: mirror variant is broken for upgrade tests at this time, just use 'azure' instead.:\n${testLines.join('\n')}")
                 } catch(ex) {
                     echo "slack notification failed: ${ex}"
                 }


### PR DESCRIPTION
## Summary
- Do not print "upgrade test" slack message for non-x64 arches
- Print sorted list of upgrade versions from most recent ones
- Add comment to not use "mirror" variant with upgrade tests since it's broken possibly - https://coreos.slack.com/archives/CBN38N3MW/p1612989185114600?thread_ts=1612969025.078300&cid=CBN38N3MW

## Test run
[hack job url]