### PR TITLE
Update to use UMB brokers 03/04

### DIFF
--- a/jobs/signing/sign-artifacts/umb_producer.py
+++ b/jobs/signing/sign-artifacts/umb_producer.py
@@ -19,20 +19,20 @@ logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 ######################################################################
 URLS = {
     'dev': (
-        'amqps://messaging-devops-broker01.dev1.ext.devlab.redhat.com:5671',
-        'amqps://messaging-devops-broker02.dev1.ext.devlab.redhat.com:5671',
+        'amqps://messaging-devops-broker03.dev1.ext.devlab.redhat.com:5671',
+        'amqps://messaging-devops-broker04.dev1.ext.devlab.redhat.com:5671',
     ),
     'qa': (
-        'amqps://messaging-devops-broker01.web.qa.ext.phx1.redhat.com:5671',
-        'amqps://messaging-devops-broker02.web.qa.ext.phx1.redhat.com:5671',
+        'amqps://messaging-devops-broker03.web.qa.ext.phx1.redhat.com:5671',
+        'amqps://messaging-devops-broker04.web.qa.ext.phx1.redhat.com:5671',
     ),
     'stage': (
-        'amqps://messaging-devops-broker01.web.stage.ext.phx2.redhat.com:5671',
-        'amqps://messaging-devops-broker02.web.stage.ext.phx2.redhat.com:5671',
+        'amqps://messaging-devops-broker03.web.stage.ext.phx2.redhat.com:5671',
+        'amqps://messaging-devops-broker04.web.stage.ext.phx2.redhat.com:5671',
     ),
     'prod': (
-        'amqps://messaging-devops-broker01.web.prod.ext.phx2.redhat.com:5671',
-        'amqps://messaging-devops-broker02.web.prod.ext.phx2.redhat.com:5671',
+        'amqps://messaging-devops-broker03.web.prod.ext.phx2.redhat.com:5671',
+        'amqps://messaging-devops-broker04.web.prod.ext.phx2.redhat.com:5671',
     ),
 
 }


### PR DESCRIPTION
This is a workaround UMB issue affecting us communicating with the radas signing service.
UMB is not replicating messages across brokers, and Radas and pub have moved to brokers 03/04.