### PR TITLE
Blocker bug check retry 

### DIFF
--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -212,7 +212,7 @@ node {
             group = "openshift-${major}.${minor}"
             
             commonlib.retryAbort("Waiting for Blocker Bugs to be resolved", taskThread, 
-                                    "Blocker Bugs found for release. Do not proceed until confirmation from ARTists/bug owners that it is okay to proceed. If the bugs are not blockers, coordinate to remove the blocker+ flag on the bug(s). RETRY when blocker(s) is finally resolved.") {
+                                    "Blocker Bugs found for release; do not proceed without resolving. See https://github.com/openshift/art-docs/blob/master/4.y.z-stream.md#handling-blocker-bugs") {
                 release.stageCheckBlockerBug(group)
             }
         }

--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -210,45 +210,10 @@ node {
         
         stage("Check for Blocker Bugs") {
             group = "openshift-${major}.${minor}"
-            blocker_bugs = commonlib.shell(
-                returnStdout: true,
-                script: "${buildlib.ELLIOTT_BIN} -g ${group} find-bugs --mode blocker --report"
-            ).trim()
-
-            echo blocker_bugs
             
-            found = true
-            try {
-                pattern = ~"Found ([0-9]+) bugs"
-                match = blocker_bugs =~ pattern
-                match.find()
-                found = (match[0][1] != '0')
-            } catch(ex) {
-                echo "Please check for blocker bug output"
-            }
-            
-            if (found) {
-                msg = "Blocker bugs found! Prompting ARTist for confirmation"
-                echo msg
-                taskThread.say(msg)
-                commonlib.inputRequired(taskThread) {
-                    def resp = input(
-                        message: "Blocker Bugs found. Do not proceed until confirmation from ARTists/bug owners that it is okay to proceed. If the bugs are not blockers, coordinate to remove the blocker+ flag on the bug(s)",
-                        parameters: [
-                            booleanParam(
-                                defaultValue: false,
-                                description: "Check this checkbox only if you're sure you want to proceed with pending release blocker bugs. Ask #forum-release on slack if you are not sure.",
-                                name: 'IGNORE_BLOCKER_BUGS',
-                            ),
-                        ]
-                    )
-                    if (!resp) {
-                        currentBuild.result = 'ABORTED'
-                        error('Aborting because release blocker bugs found.')
-                    }
-                }
-            } else {
-                echo "No blocker bugs found. Proceeding"
+            commonlib.retryAbort("Waiting for Blocker Bugs to be resolved", taskThread, 
+                                    "Blocker Bugs found for release. Do not proceed until confirmation from ARTists/bug owners that it is okay to proceed. If the bugs are not blockers, coordinate to remove the blocker+ flag on the bug(s). RETRY when blocker(s) is finally resolved.") {
+                release.stageCheckBlockerBug(group)
             }
         }
         

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -336,6 +336,28 @@ def Map stageWaitForStable(String releaseStream, String releaseName) {
     }
 }
 
+def stageCheckBlockerBug(group){
+    blocker_bugs = commonlib.shell(
+        returnStdout: true,
+        script: "${buildlib.ELLIOTT_BIN} -g ${group} find-bugs --mode blocker --report"
+    ).trim()
+
+    echo blocker_bugs
+    
+    found = true
+    try {
+        pattern = ~"Found ([0-9]+) bugs"
+        match = blocker_bugs =~ pattern
+        match.find()
+        found = (match[0][1] != '0')
+    } catch(ex) {
+        error("Could not parse Blocker bug output. Please check for blocker bug output")
+    }
+    if (found) {
+        error('Blocker Bugs found! Aborting.')
+    }
+}
+
 def stageGetReleaseInfo(quay_url, release_tag){
     def cmd = "GOTRACEBACK=all ${oc_cmd} adm release info --pullspecs ${quay_url}:${release_tag}"
 


### PR DESCRIPTION
This enhances the blocker bug check in the promote job. Currently there is no option to retry check, once blocker bugs are found, which results in aborting the release or proceeding anyway. This uses the retryAbort method which we use for example, in checking for stable release in RC, to provide similar functionality.

todo: untested code. Do a test run.