### PR TITLE
olm_bundles - Validate advisories and group

### DIFF
--- a/jobs/build/olm_bundle/Jenkinsfile
+++ b/jobs/build/olm_bundle/Jenkinsfile
@@ -91,6 +91,14 @@ pipeline {
                 }
             }
         }
+        stage('Make sure advisories belong to a single group') {
+            when {
+                expression { ! params.EXTRAS_ADVISORY.isEmpty() }
+            }
+            steps {
+                olm_bundles.validate_advisories(params.EXTRAS_ADVISORY, params.METADATA_ADVISORY, params.BUILD_VERSION)
+            }
+        }
         stage('Get advisory builds') {
             when {
                 expression { ! params.EXTRAS_ADVISORY.isEmpty() }

--- a/jobs/build/olm_bundle/Jenkinsfile
+++ b/jobs/build/olm_bundle/Jenkinsfile
@@ -96,7 +96,9 @@ pipeline {
                 expression { ! params.EXTRAS_ADVISORY.isEmpty() }
             }
             steps {
-                olm_bundles.validate_advisories(params.EXTRAS_ADVISORY, params.METADATA_ADVISORY, params.BUILD_VERSION)
+                script {
+                    olm_bundles.validate_advisories(params.EXTRAS_ADVISORY, params.METADATA_ADVISORY, params.BUILD_VERSION)
+                }
             }
         }
         stage('Get advisory builds') {

--- a/jobs/build/olm_bundle/olm_bundles.groovy
+++ b/jobs/build/olm_bundle/olm_bundles.groovy
@@ -21,6 +21,18 @@ def get_olm_operators() {
 }
 
 /*
+ * Make sure 2 advisories belong to the same group that is given
+ */
+def validate_advisories(advisory1, advisory2, group) {
+    def advisory1_v = elliott("get ${advisory1}")
+    def advisory2_v = elliott("get ${advisory2}")
+    if !(advisory1_v in advisory2_v && group in advisory2_v) {
+        echo(advisory1_v, advisory2_v, group)
+        error("Inconsistent advisories/group")
+    }
+}
+
+/*
  * Return list of OLM Operator NVRs attached to given <advisory>
  */
 def get_builds_from_advisory(advisory) {

--- a/jobs/build/olm_bundle/olm_bundles.groovy
+++ b/jobs/build/olm_bundle/olm_bundles.groovy
@@ -24,11 +24,22 @@ def get_olm_operators() {
  * Make sure 2 advisories belong to the same group that is given
  */
 def validate_advisories(advisory1, advisory2, group) {
-    def advisory1_v = elliott("get ${advisory1}")
-    def advisory2_v = elliott("get ${advisory2}")
-    if !(advisory1_v in advisory2_v && group in advisory2_v) {
-        echo(advisory1_v, advisory2_v, group)
-        error("Inconsistent advisories/group")
+    def adv1_str = elliott("get ${advisory1}")
+    def adv2_str = elliott("get ${advisory2}")
+    echo adv1_str
+    echo adv2_str
+    
+    // validate advisory1 string contains group(4.7)
+    adv1 = adv1_str.split()
+    index = adv1.findIndexOf { it.contains(group) }
+    if (index == -1) {
+        error("Group ${group} not found in advisory ${advisory1} data. Exiting")
+    }
+    
+    // validate the version of advisory1(4.7.4) is in advisory2 string
+    version = adv1[index]
+    if (!adv2_str.contains(version)) {
+        error("Version mismatch. ${version} not found in advisory ${advisory2} data. Exiting")
     }
 }
 


### PR DESCRIPTION
Idiot proof olm_bundles job so an ARTist knows when he messed up! for [example](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Folm_bundle/4159/parameters/)

Make sure group(4.7) is substring of advisory title version(4.7.4), and both advisory version are exact matches.

Test runs:
- fail case 1 group not found in advisory: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Folm_bundle/6/console
- fail case 2 advisory minor version differ: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Folm_bundle/7/console
- success: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Folm_bundle/9/console