### PR TITLE
sync-for-ci-ironic: double versions in prevalidation plashet

### DIFF
--- a/scheduled-jobs/build/sync-for-ci-ironic/Jenkinsfile
+++ b/scheduled-jobs/build/sync-for-ci-ironic/Jenkinsfile
@@ -44,6 +44,7 @@ node() {
                 plashet_arch_args,
                 "from-tags", // plashet mode of operation => build from brew tags
                 "--brew-tag ${prevalidation_tag_name} NOT_APPLICABLE",  // product name is not required since we aren't signing
+                "--include-previous", // enable both pinning and non-pinning for pre-validation
         ].join(' '))
 
         echo "Synchronizing plashet for ${prevalidation_tag_name}"


### PR DESCRIPTION
[per slack convo](https://coreos.slack.com/archives/C01LM2R1R4G/p1618243269206100?thread_ts=1617972459.202200&cid=C01LM2R1R4G) this was only needed for prevalidation testing, so I just enabled it for all in that tag. Would need to be more specific in the regular ocp repo sync.