### PR TITLE
Update registry to registry.ci.openshift.org

### DIFF
--- a/hacks/iptables/buildvm-scripts/known-networks.txt
+++ b/hacks/iptables/buildvm-scripts/known-networks.txt
@@ -202,6 +202,9 @@
 # registry.svc.ci.openshift.org
 2607:f8b0:4004:0c09:0000:0000:0000:0080/48
 
+# registry.ci.openshift.org
+3.212.234.35
+
 # registry.access.redhat.com
 173.223.75.141/32
 104.69.48.79/32

--- a/sjb/actions/clonerefs.py
+++ b/sjb/actions/clonerefs.py
@@ -13,11 +13,11 @@ _PARAMETER_TEMPLATE = Template("""        <hudson.model.StringParameterDefinitio
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>""")
 
-_GCS_UPLOAD = """docker run -e JOB_SPEC="${JOB_SPEC}" -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+_GCS_UPLOAD = """docker run -e JOB_SPEC="${JOB_SPEC}" -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 """
 
 _CLONEREFS_ACTION_TEMPLATE = Template("""JOB_SPEC="$( jq --compact-output '.buildid |= "'"${BUILD_NUMBER}"'"' <<<"${JOB_SPEC}" )"
-for image in 'registry.svc.ci.openshift.org/ci/clonerefs:latest' 'registry.svc.ci.openshift.org/ci/initupload:latest'; do
+for image in 'registry.ci.openshift.org/ci/clonerefs:latest' 'registry.ci.openshift.org/ci/initupload:latest'; do
     for (( i = 0; i < 5; i++ )); do
         if docker pull "${image}"; then
             break
@@ -25,7 +25,7 @@ for image in 'registry.svc.ci.openshift.org/ci/clonerefs:latest' 'registry.svc.c
     done
 done
 clonerefs_args=${CLONEREFS_ARGS:-{% for repo in repos %}--repo={{repo}} {% endfor %}}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json ${PULL_REFS:+--repo=${REPO_OWNER},${REPO_NAME}=${PULL_REFS}} ${clonerefs_args}
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json ${PULL_REFS:+--repo=${REPO_OWNER},${REPO_NAME}=${PULL_REFS}} ${clonerefs_args}
 {{upload_to_gcs_step}}
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data

--- a/sjb/config/common/test_cases/crio.yml
+++ b/sjb/config/common/test_cases/crio.yml
@@ -139,7 +139,7 @@ post_actions:
       trap 'exit 0' EXIT
       if [[ -n "${JOB_SPEC:-}" ]]; then
         JOB_SPEC="$( jq --compact-output ".buildid |= \"${BUILD_NUMBER}\"" <<<"${JOB_SPEC}" )"
-        sudo docker run -e JOB_SPEC="${JOB_SPEC}" -v "/data:/data:z" registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
+        sudo docker run -e JOB_SPEC="${JOB_SPEC}" -v "/data:/data:z" registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
       fi
 artifacts:
   - /go/src/k8s.io/kubernetes/artifacts

--- a/sjb/config/common/test_cases/minimal.yml
+++ b/sjb/config/common/test_cases/minimal.yml
@@ -58,7 +58,7 @@ post_actions:
       trap 'exit 0' EXIT
       if [[ -n "${JOB_SPEC:-}" ]]; then
         JOB_SPEC="$( jq --compact-output ".buildid |= \"${BUILD_NUMBER}\"" <<<"${JOB_SPEC}" )"
-        docker run -e JOB_SPEC="${JOB_SPEC}" -v "/data:/data:z" registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+        docker run -e JOB_SPEC="${JOB_SPEC}" -v "/data:/data:z" registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
       fi
 artifacts: []
 generated_artifacts:

--- a/sjb/config/common/test_cases/origin.yml
+++ b/sjb/config/common/test_cases/origin.yml
@@ -193,7 +193,7 @@ post_actions:
       trap 'exit 0' EXIT
       if [[ -n "${JOB_SPEC:-}" ]]; then
         JOB_SPEC="$( jq --compact-output ".buildid |= \"${BUILD_NUMBER}\"" <<<"${JOB_SPEC}" )"
-        docker run -e JOB_SPEC="${JOB_SPEC}" -v "/data:/data:z" registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+        docker run -e JOB_SPEC="${JOB_SPEC}" -v "/data:/data:z" registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
       fi
 artifacts:
   - "/data/src/github.com/openshift/origin/_output/scripts"

--- a/sjb/config/common/test_cases/origin_minimal.yml
+++ b/sjb/config/common/test_cases/origin_minimal.yml
@@ -117,7 +117,7 @@ post_actions:
       trap 'exit 0' EXIT
       if [[ -n "${JOB_SPEC:-}" ]]; then
         JOB_SPEC="$( jq --compact-output ".buildid |= \"${BUILD_NUMBER}\"" <<<"${JOB_SPEC}" )"
-        docker run -e JOB_SPEC="${JOB_SPEC}" -v "/data:/data:z" registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+        docker run -e JOB_SPEC="${JOB_SPEC}" -v "/data:/data:z" registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
       fi
 artifacts:
   - "/data/src/github.com/openshift/origin/_output/scripts"

--- a/sjb/config/common/test_cases/origin_release.yml
+++ b/sjb/config/common/test_cases/origin_release.yml
@@ -47,16 +47,16 @@ extensions:
         # all of these jobs will be removed in later releases
         if [[ "${tag}" == "v3.11" ]]; then
           for i in service-serving-cert-signer; do
-            if docker pull "registry.svc.ci.openshift.org/openshift/origin-${tag}:${i}"; then
-              docker tag "registry.svc.ci.openshift.org/openshift/origin-${tag}:${i}" "openshift/origin-${i}:$( cat "${jobs_repo}/ORIGIN_COMMIT" )"
+            if docker pull "registry.ci.openshift.org/openshift/origin-${tag}:${i}"; then
+              docker tag "registry.ci.openshift.org/openshift/origin-${tag}:${i}" "openshift/origin-${i}:$( cat "${jobs_repo}/ORIGIN_COMMIT" )"
             fi
           done
         fi
 
         if [[ "${tag}" == "v4.0" ]]; then
           for i in service-serving-cert-signer docker-builder; do
-            if docker pull "registry.svc.ci.openshift.org/openshift/origin-${tag}:${i}"; then
-              docker tag "registry.svc.ci.openshift.org/openshift/origin-${tag}:${i}" "openshift/origin-${i}:$( cat "${jobs_repo}/ORIGIN_COMMIT" )"
+            if docker pull "registry.ci.openshift.org/openshift/origin-${tag}:${i}"; then
+              docker tag "registry.ci.openshift.org/openshift/origin-${tag}:${i}" "openshift/origin-${i}:$( cat "${jobs_repo}/ORIGIN_COMMIT" )"
             fi
           done
         fi        

--- a/sjb/config/common/test_cases/origin_release_install_azure.yml
+++ b/sjb/config/common/test_cases/origin_release_install_azure.yml
@@ -14,7 +14,7 @@ extensions:
         <div>
         </div>
     - name: "OS_PUSH_BASE_REGISTRY"
-      default_value: "registry.svc.ci.openshift.org/"
+      default_value: "registry.ci.openshift.org/"
     - name: "OS_PUSH_BASE_REPO"
       default_value: "ci-pr-images/"
     - name: "DEBUG_MAIL"
@@ -194,7 +194,7 @@ extensions:
           -e TENANT_ID=$AZURE_TENANT \
           -e SUBSCRIPTION_ID=$AZURE_SUBSCRIPTION_ID \
           -e NAME=$RESOURCE_GROUP \
-          registry.svc.ci.openshift.org/azure/acs-engine-tests:v3.10 make test-openshift
+          registry.ci.openshift.org/azure/acs-engine-tests:v3.10 make test-openshift
         set -o xtrace
 
   post_actions:

--- a/sjb/config/common/test_cases/origin_release_install_azure_310.yml
+++ b/sjb/config/common/test_cases/origin_release_install_azure_310.yml
@@ -14,7 +14,7 @@ extensions:
         <div>
         </div>
     - name: "OS_PUSH_BASE_REGISTRY"
-      default_value: "registry.svc.ci.openshift.org/"
+      default_value: "registry.ci.openshift.org/"
     - name: "OS_PUSH_BASE_REPO"
       default_value: "ci-pr-images/"
     - name: "DEBUG_MAIL"
@@ -194,7 +194,7 @@ extensions:
           -e TENANT_ID=$AZURE_TENANT \
           -e SUBSCRIPTION_ID=$AZURE_SUBSCRIPTION_ID \
           -e NAME=$RESOURCE_GROUP \
-          registry.svc.ci.openshift.org/azure/acs-engine-tests:v3.10 make test-openshift
+          registry.ci.openshift.org/azure/acs-engine-tests:v3.10 make test-openshift
         set -o xtrace
 
   post_actions:

--- a/sjb/config/common/test_cases/origin_release_install_descheduler_gce_39.yml
+++ b/sjb/config/common/test_cases/origin_release_install_descheduler_gce_39.yml
@@ -23,7 +23,7 @@ extensions:
         <div>
         </div>
     - name: "OS_PUSH_BASE_REGISTRY"
-      default_value: "registry.svc.ci.openshift.org/"
+      default_value: "registry.ci.openshift.org/"
     - name: "OS_PUSH_BASE_REPO"
       default_value: "ci-pr-images/"
   actions:

--- a/sjb/config/common/test_cases/origin_release_install_gce_310.yml
+++ b/sjb/config/common/test_cases/origin_release_install_gce_310.yml
@@ -22,7 +22,7 @@ extensions:
         <div>
         </div>
     - name: "OS_PUSH_BASE_REGISTRY"
-      default_value: "registry.svc.ci.openshift.org/"
+      default_value: "registry.ci.openshift.org/"
     - name: "OS_PUSH_BASE_REPO"
       default_value: "ci-pr-images/"
     - name: "ORIGIN_TARGET_BRANCH"

--- a/sjb/config/common/test_cases/origin_release_install_gce_37.yml
+++ b/sjb/config/common/test_cases/origin_release_install_gce_37.yml
@@ -22,7 +22,7 @@ extensions:
         <div>
         </div>
     - name: "OS_PUSH_BASE_REGISTRY"
-      default_value: "registry.svc.ci.openshift.org/"
+      default_value: "registry.ci.openshift.org/"
     - name: "OS_PUSH_BASE_REPO"
       default_value: "ci-pr-images/"
   actions:

--- a/sjb/config/common/test_cases/origin_release_install_gce_38.yml
+++ b/sjb/config/common/test_cases/origin_release_install_gce_38.yml
@@ -22,7 +22,7 @@ extensions:
         <div>
         </div>
     - name: "OS_PUSH_BASE_REGISTRY"
-      default_value: "registry.svc.ci.openshift.org/"
+      default_value: "registry.ci.openshift.org/"
     - name: "OS_PUSH_BASE_REPO"
       default_value: "ci-pr-images/"
   actions:

--- a/sjb/config/common/test_cases/origin_release_install_gce_39.yml
+++ b/sjb/config/common/test_cases/origin_release_install_gce_39.yml
@@ -22,7 +22,7 @@ extensions:
         <div>
         </div>
     - name: "OS_PUSH_BASE_REGISTRY"
-      default_value: "registry.svc.ci.openshift.org/"
+      default_value: "registry.ci.openshift.org/"
     - name: "OS_PUSH_BASE_REPO"
       default_value: "ci-pr-images/"
   actions:

--- a/sjb/config/common/test_cases/origin_release_prepare.yml
+++ b/sjb/config/common/test_cases/origin_release_prepare.yml
@@ -22,7 +22,7 @@ extensions:
         <div>
         </div>
     - name: "OS_PUSH_BASE_REGISTRY"
-      default_value: "registry.svc.ci.openshift.org/"
+      default_value: "registry.ci.openshift.org/"
     - name: "OS_PUSH_BASE_REPO"
       default_value: "ci-pr-images/"
   actions:

--- a/sjb/config/common/test_cases/s2i.yml
+++ b/sjb/config/common/test_cases/s2i.yml
@@ -65,5 +65,5 @@ post_actions:
       trap 'exit 0' EXIT
       if [[ -n "${JOB_SPEC:-}" ]]; then
         JOB_SPEC="$( jq --compact-output ".buildid |= \"${BUILD_NUMBER}\"" <<<"${JOB_SPEC}" )"
-        docker run -e JOB_SPEC="${JOB_SPEC}" -v "/data:/data:z" registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+        docker run -e JOB_SPEC="${JOB_SPEC}" -v "/data:/data:z" registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
       fi

--- a/sjb/config/test_cases/azure_build_node_image_centos.yml
+++ b/sjb/config/test_cases/azure_build_node_image_centos.yml
@@ -106,7 +106,7 @@ actions:
         -e CLIENT_SECRET=$AZURE_SECRET \
         -e TENANT_ID=$AZURE_TENANT \
         -e SUBSCRIPTION_ID=$AZURE_SUBSCRIPTION_ID \
-        registry.svc.ci.openshift.org/azure/acs-engine-tests:v3.10 make test-openshift
+        registry.ci.openshift.org/azure/acs-engine-tests:v3.10 make test-openshift
       set -o xtrace
 
   - type: "script"

--- a/sjb/config/test_cases/azure_build_node_image_centos_310.yml
+++ b/sjb/config/test_cases/azure_build_node_image_centos_310.yml
@@ -109,7 +109,7 @@ actions:
         -e CLIENT_SECRET=$AZURE_SECRET \
         -e TENANT_ID=$AZURE_TENANT \
         -e SUBSCRIPTION_ID=$AZURE_SUBSCRIPTION_ID \
-        registry.svc.ci.openshift.org/azure/acs-engine-tests:v$OPENSHIFT_RELEASE make test-openshift
+        registry.ci.openshift.org/azure/acs-engine-tests:v$OPENSHIFT_RELEASE make test-openshift
       set -o xtrace
 
   - type: "script"

--- a/sjb/config/test_cases/azure_build_node_image_rhel_310.yml
+++ b/sjb/config/test_cases/azure_build_node_image_rhel_310.yml
@@ -113,7 +113,7 @@ actions:
         -e CLIENT_SECRET=$AZURE_SECRET \
         -e TENANT_ID=$AZURE_TENANT \
         -e SUBSCRIPTION_ID=$AZURE_SUBSCRIPTION_ID \
-        registry.svc.ci.openshift.org/azure/acs-engine-tests:v$OPENSHIFT_RELEASE make test-openshift
+        registry.ci.openshift.org/azure/acs-engine-tests:v$OPENSHIFT_RELEASE make test-openshift
       set -o xtrace
 
   - type: "script"

--- a/sjb/config/test_cases/ci-kubernetes-aws-actuator.yml
+++ b/sjb/config/test_cases/ci-kubernetes-aws-actuator.yml
@@ -136,5 +136,5 @@ overrides:
         trap 'exit 0' EXIT
         if [[ -n "${JOB_SPEC:-}" ]]; then
           JOB_SPEC="$( jq --compact-output ".buildid |= \"${BUILD_NUMBER}\"" <<<"${JOB_SPEC}" )"
-          sudo docker run -e JOB_SPEC="${JOB_SPEC}" -v "/data:/data:z" registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json /data/gcs/*
+          sudo docker run -e JOB_SPEC="${JOB_SPEC}" -v "/data:/data:z" registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json /data/gcs/*
         fi

--- a/sjb/config/test_cases/ci-kubernetes-descheduler-e2e-gce.yml
+++ b/sjb/config/test_cases/ci-kubernetes-descheduler-e2e-gce.yml
@@ -83,5 +83,5 @@ overrides:
           JOB_SPEC="$( jq --compact-output ".buildid |= \"${BUILD_NUMBER}\"" <<<"${JOB_SPEC}" )"
           gcloud auth activate-service-account --key-file /data/credentials.json
           gcloud config set project openshift-gce-devel
-          docker run -e JOB_SPEC="${JOB_SPEC}" -v "/data:/data:z" registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+          docker run -e JOB_SPEC="${JOB_SPEC}" -v "/data:/data:z" registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
         fi

--- a/sjb/config/test_cases/ci-kubernetes-machine-api-operator.yml
+++ b/sjb/config/test_cases/ci-kubernetes-machine-api-operator.yml
@@ -82,5 +82,5 @@ overrides:
         trap 'exit 0' EXIT
         if [[ -n "${JOB_SPEC:-}" ]]; then
           JOB_SPEC="$( jq --compact-output ".buildid |= \"${BUILD_NUMBER}\"" <<<"${JOB_SPEC}" )"
-          docker run -e JOB_SPEC="${JOB_SPEC}" -v "/data:/data:z" registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+          docker run -e JOB_SPEC="${JOB_SPEC}" -v "/data:/data:z" registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
         fi

--- a/sjb/config/test_cases/pull-ci-openshift-cluster-api-provider-libvirt-master-e2e.yml
+++ b/sjb/config/test_cases/pull-ci-openshift-cluster-api-provider-libvirt-master-e2e.yml
@@ -83,7 +83,7 @@ extensions:
         ssh libvirtactuator 'sudo systemctl start libvirtd'
 
         # run the e2e
-        MAO_IMAGE=$(docker run registry.svc.ci.openshift.org/openshift/origin-release:v4.0 image machine-api-operator)
+        MAO_IMAGE=$(docker run registry.ci.openshift.org/openshift/origin-release:v4.0 image machine-api-operator)
         ssh libvirtactuator "./machines.test -logtostderr -v 3 -kubeconfig ~/.kube/config -ginkgo.v -machine-manager-image gcr.io/k8s-cluster-api/libvirt-machine-controller:0.0.1 -nodelink-controller-image $MAO_IMAGE -machine-controller-image gcr.io/k8s-cluster-api/libvirt-machine-controller:0.0.1 -libvirt-uri 'qemu+ssh://root@${LIBVIRT_IP}/system?no_verify=1&keyfile=/root/.ssh/actuator.pem/privatekey' -libvirt-pk /libvirt.pem -ssh-user fedora -ssh-key /guest.pem"
   system_journals:
     - systemd-journald.service
@@ -124,5 +124,5 @@ overrides:
         trap 'exit 0' EXIT
         if [[ -n "${JOB_SPEC:-}" ]]; then
           JOB_SPEC="$( jq --compact-output ".buildid |= \"${BUILD_NUMBER}\"" <<<"${JOB_SPEC}" )"
-          sudo docker run -e JOB_SPEC="${JOB_SPEC}" -v "/data:/data:z" registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json /data/gcs/*
+          sudo docker run -e JOB_SPEC="${JOB_SPEC}" -v "/data:/data:z" registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json /data/gcs/*
         fi

--- a/sjb/config/test_cases/push_cluster_operator_images.yml
+++ b/sjb/config/test_cases/push_cluster_operator_images.yml
@@ -25,14 +25,14 @@ extensions:
         sudo chmod a+rw /tmp/.docker/config.json
         export DOCKER_CONFIG=/tmp/.docker
 
-        docker tag cluster-operator:canary registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator:latest
-        docker push registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator:latest
+        docker tag cluster-operator:canary registry.ci.openshift.org/openshift-cluster-operator/cluster-operator:latest
+        docker push registry.ci.openshift.org/openshift-cluster-operator/cluster-operator:latest
 
-        docker tag cluster-operator-ansible:canary registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:latest
-        docker push registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:latest
+        docker tag cluster-operator-ansible:canary registry.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:latest
+        docker push registry.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:latest
 
-        docker tag cluster-operator-ansible:v3.10 registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:v3.10
-        docker push registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:v3.10
+        docker tag cluster-operator-ansible:v3.10 registry.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:v3.10
+        docker push registry.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:v3.10
 
-        docker tag cluster-operator-ansible:v3.9 registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:v3.9
-        docker push registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:v3.9
+        docker tag cluster-operator-ansible:v3.9 registry.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:v3.9
+        docker push registry.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:v3.9

--- a/sjb/generated/ami_build_origin_int_fedora_crio.xml
+++ b/sjb/generated/ami_build_origin_int_fedora_crio.xml
@@ -480,7 +480,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
+  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/ami_build_origin_int_rhel_crio.xml
+++ b/sjb/generated/ami_build_origin_int_rhel_crio.xml
@@ -480,7 +480,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
+  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/ami_validate_origin_int_rhel_base.xml
+++ b/sjb/generated/ami_validate_origin_int_rhel_base.xml
@@ -16,6 +16,65 @@
         <artifactNumToKeep>-1</artifactNumToKeep>
       </strategy>
     </jenkins.model.BuildDiscarderProperty>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>JOB_SPEC</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>buildId</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>BUILD_ID</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>REPO_OWNER</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>REPO_NAME</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>PULL_BASE_REF</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>PULL_BASE_SHA</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>PULL_REFS</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>PULL_NUMBER</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>PULL_PULL_SHA</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>CLONEREFS_ARGS</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
     <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@1.9.0">
       <maxConcurrentPerNode>0</maxConcurrentPerNode>
       <maxConcurrentTotal>0</maxConcurrentTotal>
@@ -62,6 +121,61 @@ SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &a
 
 oct image_not_ready --os &#34;rhel&#34; --stage &#34;base&#34; --provider &#34;aws&#34;
 oct provision remote all-in-one --os &#34;rhel&#34; --stage &#34;base&#34; --provider &#34;aws&#34; --discrete-ssh-config --name &#34;${JOB_NAME}_${BUILD_NUMBER}&#34; --launch-unready</command>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
+          <command>#!/bin/bash
+SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: FORWARD GCS CREDENTIALS TO REMOTE HOST ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: FORWARD GCS CREDENTIALS TO REMOTE HOST [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
+                break
+            fi
+        done</command>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
+          <command>#!/bin/bash
+SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: FORWARD PARAMETERS TO THE REMOTE HOST ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: FORWARD PARAMETERS TO THE REMOTE HOST [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel sudo chmod o+rw /etc/environment
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;JOB_SPEC=${JOB_SPEC:-}&#39; &gt;&gt; /etc/environment&#34;
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;buildId=${buildId:-}&#39; &gt;&gt; /etc/environment&#34;
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;BUILD_ID=${BUILD_ID:-}&#39; &gt;&gt; /etc/environment&#34;
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;REPO_OWNER=${REPO_OWNER:-}&#39; &gt;&gt; /etc/environment&#34;
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;REPO_NAME=${REPO_NAME:-}&#39; &gt;&gt; /etc/environment&#34;
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;PULL_BASE_REF=${PULL_BASE_REF:-}&#39; &gt;&gt; /etc/environment&#34;
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;PULL_BASE_SHA=${PULL_BASE_SHA:-}&#39; &gt;&gt; /etc/environment&#34;
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;PULL_REFS=${PULL_REFS:-}&#39; &gt;&gt; /etc/environment&#34;
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;PULL_NUMBER=${PULL_NUMBER:-}&#39; &gt;&gt; /etc/environment&#34;
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;PULL_PULL_SHA=${PULL_PULL_SHA:-}&#39; &gt;&gt; /etc/environment&#34;
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;JOB_SPEC=${JOB_SPEC:-}&#39; &gt;&gt; /etc/environment&#34;
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;BUILD_NUMBER=${BUILD_NUMBER:-}&#39; &gt;&gt; /etc/environment&#34;
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config openshiftdevel &#34;echo &#39;CLONEREFS_ARGS=${CLONEREFS_ARGS:-}&#39; &gt;&gt; /etc/environment&#34;
+</command>
+        </hudson.tasks.Shell>
+        <hudson.tasks.Shell>
+          <command>#!/bin/bash
+SCRIPT_START_TIME=&#34;$( date +%s )&#34; &amp;&amp; export SCRIPT_START_TIME &amp;&amp; echo &#34;########## STARTING STAGE: SYNC REPOSITORIES ##########&#34; &amp;&amp; trap &#39;export status=FAILURE&#39; ERR &amp;&amp; trap &#39;set +o xtrace; SCRIPT_END_TIME=&#34;$( date +%s )&#34;; ELAPSED_TIME=&#34;$(( SCRIPT_END_TIME - SCRIPT_START_TIME ))&#34;; echo &#34;########## FINISHED STAGE: ${status:-SUCCESS}: SYNC REPOSITORIES [$( printf &#34;%02dh %02dm %02ds&#34; &#34;$(( ELAPSED_TIME/3600 ))&#34; &#34;$(( (ELAPSED_TIME%3600)/60 ))&#34; &#34;$(( ELAPSED_TIME%60 ))&#34; )] ##########&#34;&#39; EXIT &amp;&amp; set -o errexit -o nounset -o pipefail -o xtrace &amp;&amp; if [[ -s &#34;${WORKSPACE}/activate&#34; ]]; then source &#34;${WORKSPACE}/activate&#34;; fi
+script=&#34;$( mktemp )&#34;
+cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
+#!/bin/bash
+set -o errexit -o nounset -o pipefail -o xtrace
+cd &#34;\${HOME}&#34;
+JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
+    for (( i = 0; i &lt; 5; i++ )); do
+        if docker pull &#34;\${image}&#34;; then
+            break
+        fi
+    done
+done
+clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.11 }
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+
+sudo chmod -R a+rwX /data
+sudo chown -R origin:origin-git /data
+SCRIPT
+chmod +x &#34;${script}&#34;
+scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
+ssh -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config -t openshiftdevel &#34;bash -l -c \&#34;timeout 14400 ${script}\&#34;&#34; </command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/azure_build_base_image_centos.xml
+++ b/sjb/generated/azure_build_base_image_centos.xml
@@ -163,7 +163,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -171,8 +171,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data

--- a/sjb/generated/azure_build_base_image_rhel.xml
+++ b/sjb/generated/azure_build_base_image_rhel.xml
@@ -163,7 +163,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -171,8 +171,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data

--- a/sjb/generated/azure_build_node_image_centos.xml
+++ b/sjb/generated/azure_build_node_image_centos.xml
@@ -163,7 +163,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -171,8 +171,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -276,7 +276,7 @@ docker run --rm -v \${PWD}:/go/src/github.com/Azure/acs-engine:z \
   -e CLIENT_SECRET=\$AZURE_SECRET \
   -e TENANT_ID=\$AZURE_TENANT \
   -e SUBSCRIPTION_ID=\$AZURE_SUBSCRIPTION_ID \
-  registry.svc.ci.openshift.org/azure/acs-engine-tests:v3.10 make test-openshift
+  registry.ci.openshift.org/azure/acs-engine-tests:v3.10 make test-openshift
 set -o xtrace
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/azure_build_node_image_centos_310.xml
+++ b/sjb/generated/azure_build_node_image_centos_310.xml
@@ -168,7 +168,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -176,8 +176,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.10 --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -282,7 +282,7 @@ docker run --rm -v \${PWD}:/go/src/github.com/Azure/acs-engine:z \
   -e CLIENT_SECRET=\$AZURE_SECRET \
   -e TENANT_ID=\$AZURE_TENANT \
   -e SUBSCRIPTION_ID=\$AZURE_SUBSCRIPTION_ID \
-  registry.svc.ci.openshift.org/azure/acs-engine-tests:v\$OPENSHIFT_RELEASE make test-openshift
+  registry.ci.openshift.org/azure/acs-engine-tests:v\$OPENSHIFT_RELEASE make test-openshift
 set -o xtrace
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/azure_build_node_image_rhel.xml
+++ b/sjb/generated/azure_build_node_image_rhel.xml
@@ -168,7 +168,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -176,8 +176,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data

--- a/sjb/generated/azure_build_node_image_rhel_310.xml
+++ b/sjb/generated/azure_build_node_image_rhel_310.xml
@@ -168,7 +168,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -176,8 +176,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.10 --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -286,7 +286,7 @@ docker run --rm -v \${PWD}:/go/src/github.com/Azure/acs-engine:z \
   -e CLIENT_SECRET=\$AZURE_SECRET \
   -e TENANT_ID=\$AZURE_TENANT \
   -e SUBSCRIPTION_ID=\$AZURE_SUBSCRIPTION_ID \
-  registry.svc.ci.openshift.org/azure/acs-engine-tests:v\$OPENSHIFT_RELEASE make test-openshift
+  registry.ci.openshift.org/azure/acs-engine-tests:v\$OPENSHIFT_RELEASE make test-openshift
 set -o xtrace
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/ci-kubernetes-aws-actuator.xml
+++ b/sjb/generated/ci-kubernetes-aws-actuator.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -505,7 +505,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json /data/gcs/*
+  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/ci-kubernetes-conformance-node-e2e-containerized-rhel.xml
+++ b/sjb/generated/ci-kubernetes-conformance-node-e2e-containerized-rhel.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data

--- a/sjb/generated/ci-kubernetes-conformance-node-e2e-rhel.xml
+++ b/sjb/generated/ci-kubernetes-conformance-node-e2e-rhel.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data

--- a/sjb/generated/ci-kubernetes-descheduler-e2e-gce.xml
+++ b/sjb/generated/ci-kubernetes-descheduler-e2e-gce.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -432,7 +432,7 @@ if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
   gcloud auth activate-service-account --key-file /data/credentials.json
   gcloud config set project openshift-gce-devel
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/ci-kubernetes-machine-api-operator.xml
+++ b/sjb/generated/ci-kubernetes-machine-api-operator.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -409,7 +409,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/pull-ci-openshift-cluster-api-actuator-pkg-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-cluster-api-actuator-pkg-master-e2e.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,cluster-api-provider-kubemark=master --repo=openshift,machine-api-operator=master --repo=openshift,cluster-autoscaler-operator=master --repo=openshift,kubernetes-autoscaler=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -529,7 +529,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/pull-ci-openshift-cluster-api-provider-kubemark-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-cluster-api-provider-kubemark-master-e2e.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,machine-api-operator=master --repo=openshift,cluster-autoscaler-operator=master --repo=openshift,kubernetes-autoscaler=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -522,7 +522,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/pull-ci-openshift-cluster-api-provider-libvirt-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-cluster-api-provider-libvirt-master-e2e.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -291,7 +291,7 @@ ssh libvirtactuator &#39;sudo systemctl status libvirtd&#39;
 ssh libvirtactuator &#39;sudo systemctl start libvirtd&#39;
 
 # run the e2e
-MAO_IMAGE=\$(docker run registry.svc.ci.openshift.org/openshift/origin-release:v4.0 image machine-api-operator)
+MAO_IMAGE=\$(docker run registry.ci.openshift.org/openshift/origin-release:v4.0 image machine-api-operator)
 ssh libvirtactuator &#34;./machines.test -logtostderr -v 3 -kubeconfig ~/.kube/config -ginkgo.v -machine-manager-image gcr.io/k8s-cluster-api/libvirt-machine-controller:0.0.1 -nodelink-controller-image \$MAO_IMAGE -machine-controller-image gcr.io/k8s-cluster-api/libvirt-machine-controller:0.0.1 -libvirt-uri &#39;qemu+ssh://root@\${LIBVIRT_IP}/system?no_verify=1&amp;keyfile=/root/.ssh/actuator.pem/privatekey&#39; -libvirt-pk /libvirt.pem -ssh-user fedora -ssh-key /guest.pem&#34;
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -463,7 +463,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json /data/gcs/*
+  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/pull-ci-openshift-cluster-autoscaler-operator-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-cluster-autoscaler-operator-master-e2e.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,cluster-api-provider-kubemark=master --repo=openshift,machine-api-operator=master --repo=openshift,kubernetes-autoscaler=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -520,7 +520,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/pull-ci-openshift-kubernetes-autoscaler-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-kubernetes-autoscaler-master-e2e.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,cluster-api-provider-kubemark=master --repo=openshift,machine-api-operator=master --repo=openshift,cluster-autoscaler-operator=master --repo=openshift,cluster-api-actuator-pkg=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -521,7 +521,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/pull-ci-openshift-machine-api-operator-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-machine-api-operator-master-e2e.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,cluster-api-provider-kubemark=master --repo=openshift,cluster-autoscaler-operator=master --repo=openshift,kubernetes-autoscaler=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -521,7 +521,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/push_cluster_operator_images.xml
+++ b/sjb/generated/push_cluster_operator_images.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -343,17 +343,17 @@ cd &#34;\${GOPATH}/src/github.com/openshift/cluster-operator&#34;
 sudo chmod a+rw /tmp/.docker/config.json
 export DOCKER_CONFIG=/tmp/.docker
 
-docker tag cluster-operator:canary registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator:latest
-docker push registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator:latest
+docker tag cluster-operator:canary registry.ci.openshift.org/openshift-cluster-operator/cluster-operator:latest
+docker push registry.ci.openshift.org/openshift-cluster-operator/cluster-operator:latest
 
-docker tag cluster-operator-ansible:canary registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:latest
-docker push registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:latest
+docker tag cluster-operator-ansible:canary registry.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:latest
+docker push registry.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:latest
 
-docker tag cluster-operator-ansible:v3.10 registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:v3.10
-docker push registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:v3.10
+docker tag cluster-operator-ansible:v3.10 registry.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:v3.10
+docker push registry.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:v3.10
 
-docker tag cluster-operator-ansible:v3.9 registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:v3.9
-docker push registry.svc.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:v3.9
+docker tag cluster-operator-ansible:v3.9 registry.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:v3.9
+docker push registry.ci.openshift.org/openshift-cluster-operator/cluster-operator-ansible:v3.9
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -499,7 +499,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/push_jenkins_images.xml
+++ b/sjb/generated/push_jenkins_images.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -431,7 +431,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/push_origin_aggregated_logging_release.xml
+++ b/sjb/generated/push_origin_aggregated_logging_release.xml
@@ -153,7 +153,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -161,8 +161,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data

--- a/sjb/generated/push_origin_metrics_release.xml
+++ b/sjb/generated/push_origin_metrics_release.xml
@@ -153,7 +153,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -161,8 +161,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data

--- a/sjb/generated/push_origin_metrics_release_310.xml
+++ b/sjb/generated/push_origin_metrics_release_310.xml
@@ -153,7 +153,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -161,8 +161,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data

--- a/sjb/generated/push_origin_release.xml
+++ b/sjb/generated/push_origin_release.xml
@@ -163,7 +163,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -171,8 +171,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master --repo=openshift,aos-cd-jobs=master --repo=openshift,release=master --repo=openshift,service-catalog=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -331,16 +331,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -632,7 +632,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/push_origin_release_310.xml
+++ b/sjb/generated/push_origin_release_310.xml
@@ -163,7 +163,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -171,8 +171,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.10 --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,aos-cd-jobs=master --repo=openshift,release=master --repo=openshift,service-catalog=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -331,16 +331,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -695,7 +695,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/push_origin_release_36.xml
+++ b/sjb/generated/push_origin_release_36.xml
@@ -163,7 +163,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -171,8 +171,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -331,16 +331,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -557,7 +557,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/push_origin_release_37.xml
+++ b/sjb/generated/push_origin_release_37.xml
@@ -163,7 +163,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -171,8 +171,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -331,16 +331,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -557,7 +557,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/push_origin_release_38.xml
+++ b/sjb/generated/push_origin_release_38.xml
@@ -163,7 +163,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -171,8 +171,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.8 --repo=openshift,image-registry=release-3.8 --repo=openshift,origin-web-console-server=release-3.8 --repo=openshift,aos-cd-jobs=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -331,16 +331,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -632,7 +632,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/push_origin_release_39.xml
+++ b/sjb/generated/push_origin_release_39.xml
@@ -163,7 +163,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -171,8 +171,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.9 --repo=openshift,image-registry=release-3.9 --repo=openshift,kubernetes-metrics-server=release-3.9 --repo=openshift,origin-web-console-server=release-3.9 --repo=openshift,aos-cd-jobs=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -331,16 +331,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -663,7 +663,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/push_wildfly_images.xml
+++ b/sjb/generated/push_wildfly_images.xml
@@ -159,7 +159,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -167,8 +167,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,source-to-image=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -339,7 +339,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_cluster_operator_e2e.xml
+++ b/sjb/generated/test_branch_cluster_operator_e2e.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -537,7 +537,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_cluster_operator_unit.xml
+++ b/sjb/generated/test_branch_cluster_operator_unit.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -438,7 +438,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_crio_e2e_features_fedora.xml
+++ b/sjb/generated/test_branch_crio_e2e_features_fedora.xml
@@ -447,7 +447,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
+  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_crio_e2e_features_rhel.xml
+++ b/sjb/generated/test_branch_crio_e2e_features_rhel.xml
@@ -447,7 +447,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
+  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_crio_e2e_fedora.xml
+++ b/sjb/generated/test_branch_crio_e2e_fedora.xml
@@ -447,7 +447,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
+  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_crio_e2e_rhel.xml
+++ b/sjb/generated/test_branch_crio_e2e_rhel.xml
@@ -447,7 +447,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
+  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_image_registry_integration.xml
+++ b/sjb/generated/test_branch_image_registry_integration.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -432,7 +432,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_image_registry_unit.xml
+++ b/sjb/generated/test_branch_image_registry_unit.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -424,7 +424,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_jenkins_client_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_client_plugin.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.11 --repo=openshift,aos-cd-jobs=master --repo=openshift,origin=release-3.11 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -796,7 +796,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_jenkins_images.xml
+++ b/sjb/generated/test_branch_jenkins_images.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -362,7 +362,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_openshift_login_plugin.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.11 --repo=openshift,aos-cd-jobs=master --repo=openshift,origin=release-3.11 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -796,7 +796,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_jenkins_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_plugin.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.11 --repo=openshift,aos-cd-jobs=master --repo=openshift,origin=release-3.11 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -796,7 +796,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_jenkins_sync_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_sync_plugin.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.11 --repo=openshift,aos-cd-jobs=master --repo=openshift,origin=release-3.11 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -796,7 +796,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_kubernetes_metrics_server_unit.xml
+++ b/sjb/generated/test_branch_kubernetes_metrics_server_unit.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -424,7 +424,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_online_console_extensions.xml
+++ b/sjb/generated/test_branch_online_console_extensions.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -424,7 +424,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_online_hibernation_unit.xml
+++ b/sjb/generated/test_branch_online_hibernation_unit.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -424,7 +424,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_azure.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_azure.xml
@@ -39,7 +39,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -196,7 +196,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -204,8 +204,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=master --repo=openshift,aos-cd-jobs=master --repo=openshift,service-catalog=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -364,16 +364,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -650,7 +650,7 @@ docker run --rm -v \${PWD}:/go/src/github.com/Azure/acs-engine:z \
   -e TENANT_ID=\$AZURE_TENANT \
   -e SUBSCRIPTION_ID=\$AZURE_SUBSCRIPTION_ID \
   -e NAME=\$RESOURCE_GROUP \
-  registry.svc.ci.openshift.org/azure/acs-engine-tests:v3.10 make test-openshift
+  registry.ci.openshift.org/azure/acs-engine-tests:v3.10 make test-openshift
 set -o xtrace
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -811,7 +811,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_azure_310.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_azure_310.xml
@@ -39,7 +39,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -196,7 +196,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -204,8 +204,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.10 --repo=openshift,aos-cd-jobs=master --repo=openshift,service-catalog=release-3.10 --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -364,16 +364,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -713,7 +713,7 @@ docker run --rm -v \${PWD}:/go/src/github.com/Azure/acs-engine:z \
   -e TENANT_ID=\$AZURE_TENANT \
   -e SUBSCRIPTION_ID=\$AZURE_SUBSCRIPTION_ID \
   -e NAME=\$RESOURCE_GROUP \
-  registry.svc.ci.openshift.org/azure/acs-engine-tests:v3.10 make test-openshift
+  registry.ci.openshift.org/azure/acs-engine-tests:v3.10 make test-openshift
 set -o xtrace
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -874,7 +874,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce.xml
@@ -44,7 +44,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -201,7 +201,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -209,8 +209,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master --repo=openshift,aos-cd-jobs=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -369,16 +369,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -901,7 +901,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_310.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_310.xml
@@ -44,7 +44,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -206,7 +206,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -214,8 +214,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.10 --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,aos-cd-jobs=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -374,16 +374,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -906,7 +906,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_37.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_37.xml
@@ -44,7 +44,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -201,7 +201,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -209,8 +209,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.7 --repo=openshift,aos-cd-jobs=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -369,16 +369,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -841,7 +841,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_39.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_39.xml
@@ -44,7 +44,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -201,7 +201,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -209,8 +209,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.9 --repo=openshift,image-registry=release-3.9 --repo=openshift,kubernetes-metrics-server=release-3.9 --repo=openshift,origin-web-console-server=release-3.9 --repo=openshift,aos-cd-jobs=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -369,16 +369,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -947,7 +947,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_logging.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=master --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,origin-aggregated-logging=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -871,7 +871,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_logging_310.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.10 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,origin-aggregated-logging=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -910,7 +910,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_logging_311.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_311.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.11 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.11 --repo=openshift,origin-aggregated-logging=release-3.11 --repo=openshift,kubernetes-metrics-server=release-3.11 --repo=openshift,origin-web-console-server=release-3.11 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -871,7 +871,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=master --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,origin-aggregated-logging=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -881,7 +881,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file_310.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.10 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,origin-aggregated-logging=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -920,7 +920,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file_311.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file_311.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.11 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.11 --repo=openshift,origin-aggregated-logging=release-3.11 --repo=openshift,kubernetes-metrics-server=release-3.11 --repo=openshift,origin-web-console-server=release-3.11 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -881,7 +881,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_aggregated_logging_json_file.xml
+++ b/sjb/generated/test_branch_origin_aggregated_logging_json_file.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=master --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,openshift-ansible=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -881,7 +881,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_aggregated_logging_json_file_310.xml
+++ b/sjb/generated/test_branch_origin_aggregated_logging_json_file_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.10 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,openshift-ansible=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -920,7 +920,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_aggregated_logging_json_file_311.xml
+++ b/sjb/generated/test_branch_origin_aggregated_logging_json_file_311.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.11 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.11 --repo=openshift,openshift-ansible=release-3.11 --repo=openshift,kubernetes-metrics-server=release-3.11 --repo=openshift,origin-web-console-server=release-3.11 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -881,7 +881,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_check.xml
+++ b/sjb/generated/test_branch_origin_check.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -443,7 +443,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_check_310.xml
+++ b/sjb/generated/test_branch_origin_check_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -443,7 +443,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_cmd.xml
+++ b/sjb/generated/test_branch_origin_cmd.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -424,7 +424,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_cmd_310.xml
+++ b/sjb/generated/test_branch_origin_cmd_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -424,7 +424,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_cross.xml
+++ b/sjb/generated/test_branch_origin_cross.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -441,7 +441,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_cross_310.xml
+++ b/sjb/generated/test_branch_origin_cross_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -441,7 +441,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_end_to_end.xml
+++ b/sjb/generated/test_branch_origin_end_to_end.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -542,7 +542,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_end_to_end_310.xml
+++ b/sjb/generated/test_branch_origin_end_to_end_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,image-registry=release-3.10 --repo=openshift,openshift-ansible=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,service-catalog=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -606,7 +606,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_end_to_end_311.xml
+++ b/sjb/generated/test_branch_origin_end_to_end_311.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.11 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -543,7 +543,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_builds_310.xml
+++ b/sjb/generated/test_branch_origin_extended_builds_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,image-registry=release-3.10 --repo=openshift,openshift-ansible=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,service-catalog=release-3.10 --repo=openshift,aos-cd-jobs=master --repo=openshift,origin=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -817,7 +817,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_builds_311.xml
+++ b/sjb/generated/test_branch_origin_extended_builds_311.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=master --repo=openshift,aos-cd-jobs=master --repo=openshift,origin=release-3.11 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -780,7 +780,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_clusterup.xml
+++ b/sjb/generated/test_branch_origin_extended_clusterup.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -425,7 +425,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_clusterup_310.xml
+++ b/sjb/generated/test_branch_origin_extended_clusterup_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -425,7 +425,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_azure.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_azure.xml
@@ -39,7 +39,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -196,7 +196,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -204,8 +204,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -364,16 +364,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -650,7 +650,7 @@ docker run --rm -v \${PWD}:/go/src/github.com/Azure/acs-engine:z \
   -e TENANT_ID=\$AZURE_TENANT \
   -e SUBSCRIPTION_ID=\$AZURE_SUBSCRIPTION_ID \
   -e NAME=\$RESOURCE_GROUP \
-  registry.svc.ci.openshift.org/azure/acs-engine-tests:v3.10 make test-openshift
+  registry.ci.openshift.org/azure/acs-engine-tests:v3.10 make test-openshift
 set -o xtrace
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -811,7 +811,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_azure_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_azure_310.xml
@@ -39,7 +39,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -196,7 +196,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -204,8 +204,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,image-registry=release-3.10 --repo=openshift,openshift-ansible=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,service-catalog=release-3.10 --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -364,16 +364,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -713,7 +713,7 @@ docker run --rm -v \${PWD}:/go/src/github.com/Azure/acs-engine:z \
   -e TENANT_ID=\$AZURE_TENANT \
   -e SUBSCRIPTION_ID=\$AZURE_SUBSCRIPTION_ID \
   -e NAME=\$RESOURCE_GROUP \
-  registry.svc.ci.openshift.org/azure/acs-engine-tests:v3.10 make test-openshift
+  registry.ci.openshift.org/azure/acs-engine-tests:v3.10 make test-openshift
 set -o xtrace
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -874,7 +874,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_crio.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,openshift-ansible=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -776,7 +776,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_crio_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_crio_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,openshift-ansible=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -776,7 +776,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_crio_rpm.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_crio_rpm.xml
@@ -884,7 +884,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_crio_rpm_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_crio_rpm_310.xml
@@ -884,7 +884,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce.xml
@@ -50,7 +50,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -197,7 +197,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -205,8 +205,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master --repo=openshift,aos-cd-jobs=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -365,16 +365,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -863,7 +863,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_gce_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce_310.xml
@@ -50,7 +50,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -202,7 +202,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -210,8 +210,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.10 --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,aos-cd-jobs=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -370,16 +370,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -868,7 +868,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_gce_37.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce_37.xml
@@ -50,7 +50,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -197,7 +197,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -205,8 +205,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.9 --repo=openshift,aos-cd-jobs=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -365,16 +365,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -785,7 +785,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_gce_38.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce_38.xml
@@ -50,7 +50,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -197,7 +197,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -205,8 +205,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.9 --repo=openshift,image-registry=release-3.8 --repo=openshift,origin-web-console-server=release-3.8 --repo=openshift,aos-cd-jobs=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -365,16 +365,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -860,7 +860,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_gce_39.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce_39.xml
@@ -50,7 +50,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -197,7 +197,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -205,8 +205,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.9 --repo=openshift,image-registry=release-3.9 --repo=openshift,kubernetes-metrics-server=release-3.9 --repo=openshift,origin-web-console-server=release-3.9 --repo=openshift,aos-cd-jobs=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -365,16 +365,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -891,7 +891,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install-release-3.11.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install-release-3.11.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.11 --repo=openshift,aos-cd-jobs=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -780,7 +780,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=master --repo=openshift,aos-cd-jobs=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -780,7 +780,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,image-registry=release-3.10 --repo=openshift,openshift-ansible=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,service-catalog=release-3.10 --repo=openshift,aos-cd-jobs=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -817,7 +817,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_311.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_311.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.11 --repo=openshift,aos-cd-jobs=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -780,7 +780,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_36.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_36.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.6 --repo=openshift,aos-cd-jobs=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -722,7 +722,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_37.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_37.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.7 --repo=openshift,aos-cd-jobs=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -722,7 +722,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_38.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_38.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -769,7 +769,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_39.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_39.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,image-registry=release-3.9 --repo=openshift,openshift-ansible=release-3.9 --repo=openshift,kubernetes-metrics-server=release-3.9 --repo=openshift,origin-web-console-server=release-3.9 --repo=openshift,aos-cd-jobs=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -787,7 +787,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_containerized.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_containerized.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -696,7 +696,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_containerized_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_containerized_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -696,7 +696,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_in_tree.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_in_tree.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -628,7 +628,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_in_tree_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_in_tree_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -628,7 +628,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
@@ -163,7 +163,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -171,8 +171,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,openshift-ansible=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -346,16 +346,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -809,7 +809,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_system_containers_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_system_containers_310.xml
@@ -163,7 +163,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -171,8 +171,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,openshift-ansible=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -346,16 +346,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -846,7 +846,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,openshift-ansible=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -776,7 +776,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,openshift-ansible=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -776,7 +776,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -734,7 +734,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -734,7 +734,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -825,7 +825,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -825,7 +825,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_k8s.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_k8s.xml
@@ -50,7 +50,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -202,7 +202,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -210,8 +210,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=master --repo=openshift,openshift-ansible=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master --repo=openshift,aos-cd-jobs=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -370,16 +370,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -858,7 +858,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_k8s_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_k8s_310.xml
@@ -50,7 +50,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -207,7 +207,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -215,8 +215,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.10 --repo=openshift,openshift-ansible=release-3.10 --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,aos-cd-jobs=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -375,16 +375,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -863,7 +863,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_k8s_39.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_k8s_39.xml
@@ -50,7 +50,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -202,7 +202,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -210,8 +210,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.9 --repo=openshift,openshift-ansible=release-3.9 --repo=openshift,image-registry=release-3.9 --repo=openshift,kubernetes-metrics-server=release-3.9 --repo=openshift,origin-web-console-server=release-3.9 --repo=openshift,aos-cd-jobs=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -370,16 +370,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -904,7 +904,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_gssapi.xml
+++ b/sjb/generated/test_branch_origin_extended_gssapi.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -541,7 +541,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_gssapi_310.xml
+++ b/sjb/generated/test_branch_origin_extended_gssapi_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -604,7 +604,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_image_ecosystem_310.xml
+++ b/sjb/generated/test_branch_origin_extended_image_ecosystem_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,image-registry=release-3.10 --repo=openshift,openshift-ansible=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,service-catalog=release-3.10 --repo=openshift,aos-cd-jobs=master --repo=openshift,origin=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -817,7 +817,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_image_ecosystem_311.xml
+++ b/sjb/generated/test_branch_origin_extended_image_ecosystem_311.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.11 --repo=openshift,aos-cd-jobs=master --repo=openshift,origin=release-3.11 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -780,7 +780,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_image_registry_310.xml
+++ b/sjb/generated/test_branch_origin_extended_image_registry_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,image-registry=release-3.10 --repo=openshift,openshift-ansible=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,service-catalog=release-3.10 --repo=openshift,aos-cd-jobs=master --repo=openshift,origin=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -817,7 +817,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_ldap_groups.xml
+++ b/sjb/generated/test_branch_origin_extended_ldap_groups.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -541,7 +541,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_ldap_groups_310.xml
+++ b/sjb/generated/test_branch_origin_extended_ldap_groups_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -604,7 +604,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_networking.xml
+++ b/sjb/generated/test_branch_origin_extended_networking.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -499,7 +499,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_networking_310.xml
+++ b/sjb/generated/test_branch_origin_extended_networking_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -499,7 +499,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_integration.xml
+++ b/sjb/generated/test_branch_origin_integration.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -424,7 +424,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_integration_310.xml
+++ b/sjb/generated/test_branch_origin_integration_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -424,7 +424,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_service_catalog.xml
+++ b/sjb/generated/test_branch_origin_service_catalog.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -620,7 +620,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_service_catalog_310.xml
+++ b/sjb/generated/test_branch_origin_service_catalog_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -618,7 +618,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_unit.xml
+++ b/sjb/generated/test_branch_origin_unit.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -424,7 +424,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_unit_310.xml
+++ b/sjb/generated/test_branch_origin_unit_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -424,7 +424,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_verify.xml
+++ b/sjb/generated/test_branch_origin_verify.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -444,7 +444,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_verify_310.xml
+++ b/sjb/generated/test_branch_origin_verify_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -444,7 +444,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_web_console.xml
+++ b/sjb/generated/test_branch_origin_web_console.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -476,7 +476,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_web_console_310.xml
+++ b/sjb/generated/test_branch_origin_web_console_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -476,7 +476,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_web_console_311.xml
+++ b/sjb/generated/test_branch_origin_web_console_311.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -496,7 +496,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_web_console_39.xml
+++ b/sjb/generated/test_branch_origin_web_console_39.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -476,7 +476,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_web_console_server_check.xml
+++ b/sjb/generated/test_branch_origin_web_console_server_check.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -424,7 +424,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_web_console_server_e2e.xml
+++ b/sjb/generated/test_branch_origin_web_console_server_e2e.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -440,7 +440,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_ovn_kubernetes_unit.xml
+++ b/sjb/generated/test_branch_ovn_kubernetes_unit.xml
@@ -450,7 +450,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
+  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_wildfly_images.xml
+++ b/sjb/generated/test_branch_wildfly_images.xml
@@ -160,7 +160,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -168,8 +168,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,source-to-image=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -286,7 +286,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_origin_device_manager_plugin_gpu.xml
+++ b/sjb/generated/test_origin_device_manager_plugin_gpu.xml
@@ -160,7 +160,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -168,8 +168,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=master --repo=openshift,aos-cd-jobs=master --repo=zvonkok,openshift-ansible=zvonkok-gpu-origin }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -328,16 +328,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -790,7 +790,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_cluster_operator_e2e.xml
+++ b/sjb/generated/test_pull_request_cluster_operator_e2e.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -537,7 +537,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_cluster_operator_unit.xml
+++ b/sjb/generated/test_pull_request_cluster_operator_unit.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -438,7 +438,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_crio_ami_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_ami_fedora.xml
@@ -507,7 +507,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
+  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_crio_ami_rhel.xml
+++ b/sjb/generated/test_pull_request_crio_ami_rhel.xml
@@ -507,7 +507,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
+  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_crio_critest_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_critest_fedora.xml
@@ -455,7 +455,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
+  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_crio_critest_rhel.xml
+++ b/sjb/generated/test_pull_request_crio_critest_rhel.xml
@@ -455,7 +455,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
+  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_crio_e2e_crun_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_e2e_crun_fedora.xml
@@ -471,7 +471,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
+  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_crio_e2e_crun_fedora_cgroupv2.xml
+++ b/sjb/generated/test_pull_request_crio_e2e_crun_fedora_cgroupv2.xml
@@ -471,7 +471,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
+  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_crio_e2e_features_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_e2e_features_fedora.xml
@@ -455,7 +455,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
+  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_crio_e2e_features_rhel.xml
+++ b/sjb/generated/test_pull_request_crio_e2e_features_rhel.xml
@@ -455,7 +455,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
+  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_crio_e2e_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_e2e_fedora.xml
@@ -456,7 +456,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
+  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_crio_e2e_rhel.xml
+++ b/sjb/generated/test_pull_request_crio_e2e_rhel.xml
@@ -456,7 +456,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
+  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_crio_integration_crun_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_integration_crun_fedora.xml
@@ -471,7 +471,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
+  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_crio_integration_crun_fedora_cgroupv2.xml
+++ b/sjb/generated/test_pull_request_crio_integration_crun_fedora_cgroupv2.xml
@@ -471,7 +471,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
+  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_crio_integration_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_integration_fedora.xml
@@ -456,7 +456,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
+  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_crio_integration_kata_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_integration_kata_fedora.xml
@@ -471,7 +471,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
+  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_crio_integration_rhel.xml
+++ b/sjb/generated/test_pull_request_crio_integration_rhel.xml
@@ -456,7 +456,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
+  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_descheduler_gce_39.xml
+++ b/sjb/generated/test_pull_request_descheduler_gce_39.xml
@@ -50,7 +50,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -192,7 +192,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -200,8 +200,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.9 --repo=openshift,image-registry=release-3.9 --repo=openshift,kubernetes-metrics-server=release-3.9 --repo=openshift,origin-web-console-server=release-3.9 --repo=openshift,aos-cd-jobs=master --repo=openshift,release=master --repo=openshift,origin=release-3.9 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -360,16 +360,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -904,7 +904,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_image_registry_integration.xml
+++ b/sjb/generated/test_pull_request_image_registry_integration.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -432,7 +432,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_image_registry_unit.xml
+++ b/sjb/generated/test_pull_request_image_registry_unit.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -424,7 +424,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_jenkins_client_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_client_plugin.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.11 --repo=openshift,aos-cd-jobs=master --repo=openshift,origin=release-3.11 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -796,7 +796,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_jenkins_images.xml
+++ b/sjb/generated/test_pull_request_jenkins_images.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -362,7 +362,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_openshift_login_plugin.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.11 --repo=openshift,aos-cd-jobs=master --repo=openshift,origin=release-3.11 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -796,7 +796,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_jenkins_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_plugin.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.11 --repo=openshift,aos-cd-jobs=master --repo=openshift,origin=release-3.11 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -796,7 +796,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_jenkins_sync_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_sync_plugin.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.11 --repo=openshift,aos-cd-jobs=master --repo=openshift,origin=release-3.11 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -796,7 +796,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_kubernetes_metrics_server_unit.xml
+++ b/sjb/generated/test_pull_request_kubernetes_metrics_server_unit.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -424,7 +424,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_online_console_extensions.xml
+++ b/sjb/generated/test_pull_request_online_console_extensions.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -424,7 +424,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_online_hibernation_unit.xml
+++ b/sjb/generated/test_pull_request_online_hibernation_unit.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -424,7 +424,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_azure.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_azure.xml
@@ -39,7 +39,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -196,7 +196,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -204,8 +204,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=master --repo=openshift,aos-cd-jobs=master --repo=openshift,service-catalog=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -364,16 +364,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -650,7 +650,7 @@ docker run --rm -v \${PWD}:/go/src/github.com/Azure/acs-engine:z \
   -e TENANT_ID=\$AZURE_TENANT \
   -e SUBSCRIPTION_ID=\$AZURE_SUBSCRIPTION_ID \
   -e NAME=\$RESOURCE_GROUP \
-  registry.svc.ci.openshift.org/azure/acs-engine-tests:v3.10 make test-openshift
+  registry.ci.openshift.org/azure/acs-engine-tests:v3.10 make test-openshift
 set -o xtrace
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -811,7 +811,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_azure_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_azure_310.xml
@@ -39,7 +39,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -196,7 +196,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -204,8 +204,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.10 --repo=openshift,aos-cd-jobs=master --repo=openshift,service-catalog=release-3.10 --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -364,16 +364,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -713,7 +713,7 @@ docker run --rm -v \${PWD}:/go/src/github.com/Azure/acs-engine:z \
   -e TENANT_ID=\$AZURE_TENANT \
   -e SUBSCRIPTION_ID=\$AZURE_SUBSCRIPTION_ID \
   -e NAME=\$RESOURCE_GROUP \
-  registry.svc.ci.openshift.org/azure/acs-engine-tests:v3.10 make test-openshift
+  registry.ci.openshift.org/azure/acs-engine-tests:v3.10 make test-openshift
 set -o xtrace
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -874,7 +874,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce.xml
@@ -44,7 +44,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -196,7 +196,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -204,8 +204,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=master --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -364,16 +364,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -844,7 +844,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_310.xml
@@ -44,7 +44,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -201,7 +201,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -209,8 +209,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.10 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -369,16 +369,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -849,7 +849,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_37.xml
@@ -44,7 +44,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -196,7 +196,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -204,8 +204,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.7 --repo=openshift,aos-cd-jobs=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -364,16 +364,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -784,7 +784,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_39.xml
@@ -44,7 +44,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -196,7 +196,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -204,8 +204,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.9 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.9 --repo=openshift,kubernetes-metrics-server=release-3.9 --repo=openshift,origin-web-console-server=release-3.9 --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -364,16 +364,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -890,7 +890,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha.xml
@@ -39,7 +39,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -196,7 +196,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -204,8 +204,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=master --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -364,16 +364,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -844,7 +844,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha_310.xml
@@ -39,7 +39,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -201,7 +201,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -209,8 +209,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.10 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -369,16 +369,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -849,7 +849,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha_39.xml
@@ -39,7 +39,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -196,7 +196,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -204,8 +204,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.9 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.9 --repo=openshift,kubernetes-metrics-server=release-3.9 --repo=openshift,origin-web-console-server=release-3.9 --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -364,16 +364,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -890,7 +890,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install-release-3.11.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install-release-3.11.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.11 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.11 --repo=openshift,kubernetes-metrics-server=release-3.11 --repo=openshift,origin-web-console-server=release-3.11 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -780,7 +780,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=master --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -780,7 +780,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.10 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -817,7 +817,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -696,7 +696,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -696,7 +696,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -776,7 +776,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -776,7 +776,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio_rpm.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio_rpm.xml
@@ -937,7 +937,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio_rpm_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio_rpm_310.xml
@@ -937,7 +937,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_in_tree.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_in_tree.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -628,7 +628,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_in_tree_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_in_tree_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -628,7 +628,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_36.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.6 --repo=openshift,aos-cd-jobs=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -780,7 +780,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_37.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.7 --repo=openshift,aos-cd-jobs=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -780,7 +780,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_39.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.9 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.9 --repo=openshift,kubernetes-metrics-server=release-3.9 --repo=openshift,origin-web-console-server=release-3.9 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -780,7 +780,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
@@ -163,7 +163,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -171,8 +171,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=master --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -346,16 +346,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -809,7 +809,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_310.xml
@@ -163,7 +163,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -171,8 +171,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.10 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -346,16 +346,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -846,7 +846,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_36.xml
@@ -163,7 +163,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -171,8 +171,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.6 --repo=openshift,aos-cd-jobs=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -346,16 +346,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -809,7 +809,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_37.xml
@@ -163,7 +163,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -171,8 +171,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.7 --repo=openshift,aos-cd-jobs=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -346,16 +346,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -809,7 +809,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_39.xml
@@ -163,7 +163,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -171,8 +171,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.9 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.9 --repo=openshift,kubernetes-metrics-server=release-3.9 --repo=openshift,origin-web-console-server=release-3.9 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -346,16 +346,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -809,7 +809,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -776,7 +776,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -776,7 +776,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -734,7 +734,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -734,7 +734,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -825,7 +825,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -825,7 +825,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=master --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -790,7 +790,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.10 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -827,7 +827,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_install_upgrade_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_install_upgrade_gce.xml
@@ -39,7 +39,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -201,7 +201,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -209,8 +209,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=master --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -369,16 +369,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -886,7 +886,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_install_upgrade_gce_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_install_upgrade_gce_310.xml
@@ -39,7 +39,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -201,7 +201,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -209,8 +209,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.10 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -369,16 +369,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -886,7 +886,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_launch_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_launch_gce.xml
@@ -50,7 +50,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -192,7 +192,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -200,8 +200,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=master --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -360,16 +360,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -856,7 +856,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_launch_gce_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_launch_gce_310.xml
@@ -50,7 +50,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -197,7 +197,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -205,8 +205,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.10 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -365,16 +365,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -861,7 +861,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_logging-release-3.11.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging-release-3.11.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.11 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.11 --repo=openshift,origin-aggregated-logging=release-3.11 --repo=openshift,kubernetes-metrics-server=release-3.11 --repo=openshift,origin-web-console-server=release-3.11 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -871,7 +871,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_logging.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=master --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,origin-aggregated-logging=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -871,7 +871,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.10 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,origin-aggregated-logging=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -910,7 +910,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_311.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_311.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.11 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.11 --repo=openshift,origin-aggregated-logging=release-3.11 --repo=openshift,kubernetes-metrics-server=release-3.11 --repo=openshift,origin-web-console-server=release-3.11 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -871,7 +871,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_36.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.6 --repo=openshift,aos-cd-jobs=master --repo=openshift,origin-aggregated-logging=release-3.6 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -871,7 +871,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_37.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.7 --repo=openshift,aos-cd-jobs=master --repo=openshift,origin-aggregated-logging=release-3.7 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -871,7 +871,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_39.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.9 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.9 --repo=openshift,origin-aggregated-logging=release-3.9 --repo=openshift,kubernetes-metrics-server=release-3.9 --repo=openshift,origin-web-console-server=release-3.9 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -871,7 +871,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_tox.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_tox.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -471,7 +471,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_tox_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_tox_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -471,7 +471,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_service_catalog.xml
+++ b/sjb/generated/test_pull_request_openshift_service_catalog.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -620,7 +620,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_service_catalog_310.xml
+++ b/sjb/generated/test_pull_request_openshift_service_catalog_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -618,7 +618,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_service_catalog_311.xml
+++ b/sjb/generated/test_pull_request_openshift_service_catalog_311.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.11 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -620,7 +620,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald-release-3.11.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald-release-3.11.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.11 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.11 --repo=openshift,openshift-ansible=release-3.11 --repo=openshift,kubernetes-metrics-server=release-3.11 --repo=openshift,origin-web-console-server=release-3.11 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -873,7 +873,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=master --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,openshift-ansible=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -873,7 +873,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_310.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.10 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,openshift-ansible=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -912,7 +912,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_36.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_36.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.6 --repo=openshift,aos-cd-jobs=master --repo=openshift,openshift-ansible=release-3.6 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -873,7 +873,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_37.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_37.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.7 --repo=openshift,aos-cd-jobs=master --repo=openshift,openshift-ansible=release-3.7 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -873,7 +873,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_39.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_39.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.9 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.9 --repo=openshift,openshift-ansible=release-3.9 --repo=openshift,kubernetes-metrics-server=release-3.9 --repo=openshift,origin-web-console-server=release-3.9 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -873,7 +873,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file-release-3.11.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file-release-3.11.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.11 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.11 --repo=openshift,openshift-ansible=release-3.11 --repo=openshift,kubernetes-metrics-server=release-3.11 --repo=openshift,origin-web-console-server=release-3.11 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -881,7 +881,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=master --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,openshift-ansible=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -881,7 +881,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_310.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.10 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,openshift-ansible=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -920,7 +920,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_36.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_36.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.6 --repo=openshift,aos-cd-jobs=master --repo=openshift,openshift-ansible=release-3.6 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -881,7 +881,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_37.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_37.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,origin=release-3.7 --repo=openshift,openshift-ansible=release-3.7 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -881,7 +881,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_39.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_39.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,origin=release-3.9 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.9 --repo=openshift,openshift-ansible=release-3.9 --repo=openshift,kubernetes-metrics-server=release-3.9 --repo=openshift,origin-web-console-server=release-3.9 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -341,16 +341,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -881,7 +881,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_cmd.xml
+++ b/sjb/generated/test_pull_request_origin_cmd.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -424,7 +424,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_cmd_310.xml
+++ b/sjb/generated/test_pull_request_origin_cmd_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -424,7 +424,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_cross.xml
+++ b/sjb/generated/test_pull_request_origin_cross.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -424,7 +424,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_cross_310.xml
+++ b/sjb/generated/test_pull_request_origin_cross_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -424,7 +424,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_end_to_end.xml
+++ b/sjb/generated/test_pull_request_origin_end_to_end.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -542,7 +542,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_end_to_end_310.xml
+++ b/sjb/generated/test_pull_request_origin_end_to_end_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,image-registry=release-3.10 --repo=openshift,openshift-ansible=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,service-catalog=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -606,7 +606,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_end_to_end_311.xml
+++ b/sjb/generated/test_pull_request_origin_end_to_end_311.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.11 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -543,7 +543,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_builds_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_builds_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,image-registry=release-3.10 --repo=openshift,openshift-ansible=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,service-catalog=release-3.10 --repo=openshift,aos-cd-jobs=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -817,7 +817,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_builds_311.xml
+++ b/sjb/generated/test_pull_request_origin_extended_builds_311.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.11 --repo=openshift,aos-cd-jobs=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -780,7 +780,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_clusterup-release-3.11.xml
+++ b/sjb/generated/test_pull_request_origin_extended_clusterup-release-3.11.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -499,7 +499,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_clusterup.xml
+++ b/sjb/generated/test_pull_request_origin_extended_clusterup.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -499,7 +499,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_clusterup_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_clusterup_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -499,7 +499,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_azure.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_azure.xml
@@ -39,7 +39,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -196,7 +196,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -204,8 +204,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -364,16 +364,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -650,7 +650,7 @@ docker run --rm -v \${PWD}:/go/src/github.com/Azure/acs-engine:z \
   -e TENANT_ID=\$AZURE_TENANT \
   -e SUBSCRIPTION_ID=\$AZURE_SUBSCRIPTION_ID \
   -e NAME=\$RESOURCE_GROUP \
-  registry.svc.ci.openshift.org/azure/acs-engine-tests:v3.10 make test-openshift
+  registry.ci.openshift.org/azure/acs-engine-tests:v3.10 make test-openshift
 set -o xtrace
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -811,7 +811,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_azure_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_azure_310.xml
@@ -39,7 +39,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -196,7 +196,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -204,8 +204,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,image-registry=release-3.10 --repo=openshift,openshift-ansible=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,service-catalog=release-3.10 --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -364,16 +364,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -713,7 +713,7 @@ docker run --rm -v \${PWD}:/go/src/github.com/Azure/acs-engine:z \
   -e TENANT_ID=\$AZURE_TENANT \
   -e SUBSCRIPTION_ID=\$AZURE_SUBSCRIPTION_ID \
   -e NAME=\$RESOURCE_GROUP \
-  registry.svc.ci.openshift.org/azure/acs-engine-tests:v3.10 make test-openshift
+  registry.ci.openshift.org/azure/acs-engine-tests:v3.10 make test-openshift
 set -o xtrace
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -874,7 +874,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,openshift-ansible=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -776,7 +776,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_crio_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_crio_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,openshift-ansible=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -776,7 +776,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_crio_rpm.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_crio_rpm.xml
@@ -884,7 +884,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_crio_rpm_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_crio_rpm_310.xml
@@ -884,7 +884,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
@@ -44,7 +44,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -196,7 +196,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -204,8 +204,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=master --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -364,16 +364,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -844,7 +844,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce_310.xml
@@ -44,7 +44,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -201,7 +201,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -209,8 +209,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.10 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -369,16 +369,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -849,7 +849,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce_37.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce_37.xml
@@ -44,7 +44,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -196,7 +196,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -204,8 +204,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.9 --repo=openshift,aos-cd-jobs=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -364,16 +364,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -784,7 +784,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce_39.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce_39.xml
@@ -44,7 +44,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -196,7 +196,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -204,8 +204,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.9 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.9 --repo=openshift,kubernetes-metrics-server=release-3.9 --repo=openshift,origin-web-console-server=release-3.9 --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -364,16 +364,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -890,7 +890,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install-release-3.11.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install-release-3.11.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.11 --repo=openshift,aos-cd-jobs=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -780,7 +780,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=master --repo=openshift,aos-cd-jobs=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -780,7 +780,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,image-registry=release-3.10 --repo=openshift,openshift-ansible=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,service-catalog=release-3.10 --repo=openshift,aos-cd-jobs=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -817,7 +817,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_36.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_36.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.6 --repo=openshift,aos-cd-jobs=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -722,7 +722,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_37.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_37.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.7 --repo=openshift,aos-cd-jobs=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -722,7 +722,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_38.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_38.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.8 --repo=openshift,aos-cd-jobs=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -769,7 +769,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_39.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_39.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.9 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.9 --repo=openshift,kubernetes-metrics-server=release-3.9 --repo=openshift,origin-web-console-server=release-3.9 --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -780,7 +780,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,openshift-ansible=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -776,7 +776,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_update_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_update_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,openshift-ansible=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -776,7 +776,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_k8s.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_k8s.xml
@@ -50,7 +50,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -197,7 +197,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -205,8 +205,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=master --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -365,16 +365,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -845,7 +845,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_k8s_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_k8s_310.xml
@@ -50,7 +50,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -202,7 +202,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -210,8 +210,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.10 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -370,16 +370,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -850,7 +850,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_gssapi.xml
+++ b/sjb/generated/test_pull_request_origin_extended_gssapi.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -541,7 +541,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_gssapi_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_gssapi_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,image-registry=release-3.10 --repo=openshift,openshift-ansible=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,service-catalog=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -604,7 +604,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_image_ecosystem_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_ecosystem_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,image-registry=release-3.10 --repo=openshift,openshift-ansible=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,service-catalog=release-3.10 --repo=openshift,aos-cd-jobs=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -817,7 +817,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_image_ecosystem_311.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_ecosystem_311.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.11 --repo=openshift,aos-cd-jobs=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -780,7 +780,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_image_registry-release-3.11.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_registry-release-3.11.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.11 --repo=openshift,aos-cd-jobs=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -780,7 +780,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_image_registry_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_registry_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,image-registry=release-3.10 --repo=openshift,openshift-ansible=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,service-catalog=release-3.10 --repo=openshift,aos-cd-jobs=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -817,7 +817,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_ldap_groups.xml
+++ b/sjb/generated/test_pull_request_origin_extended_ldap_groups.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -541,7 +541,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_ldap_groups_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_ldap_groups_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,image-registry=release-3.10 --repo=openshift,openshift-ansible=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,service-catalog=release-3.10 }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -604,7 +604,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_networking.xml
+++ b/sjb/generated/test_pull_request_origin_extended_networking.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -499,7 +499,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_networking_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_networking_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -326,16 +326,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -499,7 +499,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_integration.xml
+++ b/sjb/generated/test_pull_request_origin_integration.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -424,7 +424,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_integration_310.xml
+++ b/sjb/generated/test_pull_request_origin_integration_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -424,7 +424,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_launch_gce.xml
+++ b/sjb/generated/test_pull_request_origin_launch_gce.xml
@@ -50,7 +50,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -192,7 +192,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -200,8 +200,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=master --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=master --repo=openshift,kubernetes-metrics-server=master --repo=openshift,origin-web-console-server=master --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -360,16 +360,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -856,7 +856,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_launch_gce_310.xml
+++ b/sjb/generated/test_pull_request_origin_launch_gce_310.xml
@@ -50,7 +50,7 @@ See also:
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REGISTRY</name>
           <description>None</description>
-          <defaultValue>registry.svc.ci.openshift.org/</defaultValue>
+          <defaultValue>registry.ci.openshift.org/</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OS_PUSH_BASE_REPO</name>
@@ -197,7 +197,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -205,8 +205,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,openshift-ansible=release-3.10 --repo=openshift,aos-cd-jobs=master --repo=openshift,image-registry=release-3.10 --repo=openshift,kubernetes-metrics-server=release-3.10 --repo=openshift,origin-web-console-server=release-3.10 --repo=openshift,release=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -365,16 +365,16 @@ echo &#34;\${tag}&#34; &gt; &#34;\${jobs_repo}/ORIGIN_TAG&#34;
 # all of these jobs will be removed in later releases
 if [[ &#34;\${tag}&#34; == &#34;v3.11&#34; ]]; then
   for i in service-serving-cert-signer; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi
 
 if [[ &#34;\${tag}&#34; == &#34;v4.0&#34; ]]; then
   for i in service-serving-cert-signer docker-builder; do
-    if docker pull &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
-      docker tag &#34;registry.svc.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
+    if docker pull &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34;; then
+      docker tag &#34;registry.ci.openshift.org/openshift/origin-\${tag}:\${i}&#34; &#34;openshift/origin-\${i}:\$( cat &#34;\${jobs_repo}/ORIGIN_COMMIT&#34; )&#34;
     fi
   done
 fi        
@@ -861,7 +861,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_service_catalog.xml
+++ b/sjb/generated/test_pull_request_origin_service_catalog.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -620,7 +620,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_service_catalog_310.xml
+++ b/sjb/generated/test_pull_request_origin_service_catalog_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -618,7 +618,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_service_catalog_39.xml
+++ b/sjb/generated/test_pull_request_origin_service_catalog_39.xml
@@ -658,7 +658,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_unit.xml
+++ b/sjb/generated/test_pull_request_origin_unit.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -424,7 +424,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_unit_310.xml
+++ b/sjb/generated/test_pull_request_origin_unit_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -424,7 +424,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_verify.xml
+++ b/sjb/generated/test_pull_request_origin_verify.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -444,7 +444,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_verify_310.xml
+++ b/sjb/generated/test_pull_request_origin_verify_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -444,7 +444,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_web_console.xml
+++ b/sjb/generated/test_pull_request_origin_web_console.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -476,7 +476,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_web_console_310.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_310.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -476,7 +476,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_web_console_311.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_311.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -496,7 +496,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_web_console_39.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_39.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -476,7 +476,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_web_console_server_check.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_server_check.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -424,7 +424,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_web_console_server_e2e.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_server_e2e.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -440,7 +440,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_ovn_kubernetes_rhel.xml
+++ b/sjb/generated/test_pull_request_ovn_kubernetes_rhel.xml
@@ -416,7 +416,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
+  sudo docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-federated-results --gcs-credentials-file=/data/credentials.json /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_s2i_master.xml
+++ b/sjb/generated/test_pull_request_s2i_master.xml
@@ -158,7 +158,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -166,8 +166,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:-}
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -379,7 +379,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_wildfly_images.xml
+++ b/sjb/generated/test_pull_request_wildfly_images.xml
@@ -160,7 +160,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${HOME}&#34;
 JOB_SPEC=&#34;\$( jq --compact-output &#39;.buildid |= &#34;&#39;&#34;\${BUILD_NUMBER}&#34;&#39;&#34;&#39; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.svc.ci.openshift.org/ci/initupload:latest&#39;; do
+for image in &#39;registry.ci.openshift.org/ci/clonerefs:latest&#39; &#39;registry.ci.openshift.org/ci/initupload:latest&#39;; do
     for (( i = 0; i &lt; 5; i++ )); do
         if docker pull &#34;\${image}&#34;; then
             break
@@ -168,8 +168,8 @@ for image in &#39;registry.svc.ci.openshift.org/ci/clonerefs:latest&#39; &#39;re
     done
 done
 clonerefs_args=\${CLONEREFS_ARGS:---repo=openshift,source-to-image=master }
-docker run -v /data:/data:z registry.svc.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
-docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.svc.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
+docker run -v /data:/data:z registry.ci.openshift.org/ci/clonerefs:latest --src-root=/data --log=/data/clone.json \${PULL_REFS:+--repo=\${REPO_OWNER},\${REPO_NAME}=\${PULL_REFS}} \${clonerefs_args}
+docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v /data:/data:z registry.ci.openshift.org/ci/initupload:latest --clone-log=/data/clone.json --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin
 
 sudo chmod -R a+rwX /data
 sudo chown -R origin:origin-git /data
@@ -286,7 +286,7 @@ cd &#34;\${HOME}&#34;
 trap &#39;exit 0&#39; EXIT
 if [[ -n &#34;\${JOB_SPEC:-}&#34; ]]; then
   JOB_SPEC=&#34;\$( jq --compact-output &#34;.buildid |= \&#34;\${BUILD_NUMBER}\&#34;&#34; &lt;&lt;&lt;&#34;\${JOB_SPEC}&#34; )&#34;
-  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.svc.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
+  docker run -e JOB_SPEC=&#34;\${JOB_SPEC}&#34; -v &#34;/data:/data:z&#34; registry.ci.openshift.org/ci/gcsupload:latest --dry-run=false --gcs-path=gs://origin-ci-test --gcs-credentials-file=/data/credentials.json --path-strategy=single --default-org=openshift --default-repo=origin /data/gcs/*
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;


### PR DESCRIPTION
registry.svc.ci.openshift.org was deprecated a while ago and no longer
works. This commit updates it to registry.ci.openshift.org.