### PR TITLE
Resume from mirror artifacts

### DIFF
--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -116,7 +116,7 @@ node {
                         description: 'Select stage to resume from. Useful to execute remaining steps in the case of a failed promote job.',
                         choices: [
                                 'Not Applicable',
-                                'Mirror binaries',
+                                '1. Mirror binaries',
                             ].join('\n'),
                     ),
                     booleanParam(
@@ -180,11 +180,16 @@ node {
     is_4stable_release = true
     next_is_prerelease = false
 
-    if (params.RESUME_FROM == "Mirror binaries") { // skip stages before mirror binaries
-        params.SKIP_PAYLOAD_CREATION = true
-        params.SKIP_VERIFY_BUGS = true
+    // copy job params into normal vars, since params is an immutable map
+    SKIP_PAYLOAD_CREATION = params.SKIP_PAYLOAD_CREATION
+    SKIP_VERIFY_BUGS = params.SKIP_VERIFY_BUGS
+    SKIP_IMAGE_LIST = params.SKIP_IMAGE_LIST
+
+    if (params.RESUME_FROM.startsWith('1.')) { // skip stages before mirror binaries
+        SKIP_PAYLOAD_CREATION = true
+        SKIP_VERIFY_BUGS = true
         SKIP_TAG_STABLE = true
-        params.SKIP_IMAGE_LIST = true
+        SKIP_IMAGE_LIST = true
     }
     
     release_offset = params.RELEASE_OFFSET?params.RELEASE_OFFSET.toInteger():0
@@ -254,7 +259,7 @@ node {
                 currentBuild.displayName += " (dry-run)"
                 currentBuild.description += "[DRY RUN]"
             }
-            if (params.SKIP_PAYLOAD_CREATION) {
+            if (SKIP_PAYLOAD_CREATION) {
                 currentBuild.displayName += " (skip payload creation)"
                 currentBuild.description += "[SKIP PAYLOAD CREATION]"
             }
@@ -283,7 +288,7 @@ node {
             }
 
             previousList = commonlib.parseList(params.PREVIOUS)
-            if ( params.PREVIOUS.trim() == 'auto' && !params.SKIP_PAYLOAD_CREATION) {
+            if ( params.PREVIOUS.trim() == 'auto' && !SKIP_PAYLOAD_CREATION) {
                 taskThread.task('Gather PREVIOUS for release') {
 
                     if (!detect_previous) {
@@ -341,15 +346,15 @@ node {
                     errata_url = ''
                     return
                 }
-                skipVerifyBugs = !ga_release || next_is_prerelease || params.SKIP_VERIFY_BUGS
+                skipVerifyBugs = !ga_release || next_is_prerelease || SKIP_VERIFY_BUGS
                 commonlib.retryAbort("Validating release", taskThread, "Error running release validation") {
-                    def retval = release.stageValidation(quay_url, dest_release_tag, advisory, params.PERMIT_PAYLOAD_OVERWRITE, params.PERMIT_ALL_ADVISORY_STATES, params.FROM_RELEASE_TAG, arch, skipVerifyBugs, params.SKIP_PAYLOAD_CREATION)
+                    def retval = release.stageValidation(quay_url, dest_release_tag, advisory, params.PERMIT_PAYLOAD_OVERWRITE, params.PERMIT_ALL_ADVISORY_STATES, params.FROM_RELEASE_TAG, arch, skipVerifyBugs, SKIP_PAYLOAD_CREATION)
                     advisory = advisory ?: retval.advisoryInfo.id
                     errata_url = retval.errataUrl
                 }
             }
             stage("build payload") {
-                if (params.SKIP_PAYLOAD_CREATION) {
+                if (SKIP_PAYLOAD_CREATION) {
                     echo "Don't actually create the payload because SKIP_PAYLOAD_CREATION is checked."
                     return
                 }
@@ -369,7 +374,7 @@ node {
             }
 
             stage("request upgrade tests") {
-                if (params.SKIP_PAYLOAD_CREATION) {
+                if (SKIP_PAYLOAD_CREATION) {
                     echo "Don't request upgrade tests because SKIP_PAYLOAD_CREATION option is checked."
                     return
                 }
@@ -486,7 +491,7 @@ node {
                     echo "Skipping image list for dummy advisory."
                     return
                 }
-                if (params.SKIP_IMAGE_LIST) {
+                if (SKIP_IMAGE_LIST) {
                     currentBuild.description += "[No image list]"
                     return
                 }
@@ -532,7 +537,7 @@ node {
             }
 
             stage("sign artifacts") {
-                if (params.SKIP_PAYLOAD_CREATION) {
+                if (SKIP_PAYLOAD_CREATION) {
                     payloadDigest = release.getPayloadDigest(quay_url, dest_release_tag)
                 }
                 commonlib.retrySkipAbort("Signing artifacts", taskThread, "Error running signing job") {

--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -181,19 +181,19 @@ node {
     next_is_prerelease = false
 
     // copy job params into normal vars, since params is an immutable map
-    Boolean SKIP_PAYLOAD_CREATION = params.SKIP_PAYLOAD_CREATION
-    Boolean SKIP_VERIFY_BUGS = params.SKIP_VERIFY_BUGS
-    Boolean SKIP_IMAGE_LIST = params.SKIP_IMAGE_LIST
-
-    // set unset vars to default value
-    Boolean SKIP_TAG_STABLE = false
-
+    def skip = [
+        PAYLOAD_CREATION: params.SKIP_PAYLOAD_CREATION,
+        VERIFY_BUGS: params.SKIP_VERIFY_BUGS,
+        IMAGE_LIST: params.SKIP_IMAGE_LIST,
+        TAG_STABLE: false
+    ]
+    
     // skip stages before mirror binaries
     if (params.RESUME_FROM.startsWith('1.')) {
-        SKIP_PAYLOAD_CREATION = true
-        SKIP_VERIFY_BUGS = true
-        SKIP_TAG_STABLE = true
-        SKIP_IMAGE_LIST = true
+        skip.PAYLOAD_CREATION = true
+        skip.VERIFY_BUGS = true
+        skip.TAG_STABLE = true
+        skip.IMAGE_LIST = true
     }
     
     release_offset = params.RELEASE_OFFSET?params.RELEASE_OFFSET.toInteger():0
@@ -263,7 +263,7 @@ node {
                 currentBuild.displayName += " (dry-run)"
                 currentBuild.description += "[DRY RUN]"
             }
-            if (SKIP_PAYLOAD_CREATION) {
+            if (skip.PAYLOAD_CREATION) {
                 currentBuild.displayName += " (skip payload creation)"
                 currentBuild.description += "[SKIP PAYLOAD CREATION]"
             }
@@ -292,7 +292,7 @@ node {
             }
 
             previousList = commonlib.parseList(params.PREVIOUS)
-            if ( params.PREVIOUS.trim() == 'auto' && !SKIP_PAYLOAD_CREATION) {
+            if ( params.PREVIOUS.trim() == 'auto' && !skip.PAYLOAD_CREATION) {
                 taskThread.task('Gather PREVIOUS for release') {
 
                     if (!detect_previous) {
@@ -350,16 +350,16 @@ node {
                     errata_url = ''
                     return
                 }
-                skipVerifyBugs = !ga_release || next_is_prerelease || SKIP_VERIFY_BUGS
+                skipVerifyBugs = !ga_release || next_is_prerelease || skip.VERIFY_BUGS
                 commonlib.retryAbort("Validating release", taskThread, "Error running release validation") {
-                    def retval = release.stageValidation(quay_url, dest_release_tag, advisory, params.PERMIT_PAYLOAD_OVERWRITE, params.PERMIT_ALL_ADVISORY_STATES, params.FROM_RELEASE_TAG, arch, skipVerifyBugs, SKIP_PAYLOAD_CREATION)
+                    def retval = release.stageValidation(quay_url, dest_release_tag, advisory, params.PERMIT_PAYLOAD_OVERWRITE, params.PERMIT_ALL_ADVISORY_STATES, params.FROM_RELEASE_TAG, arch, skipVerifyBugs, skip.PAYLOAD_CREATION)
                     advisory = advisory ?: retval.advisoryInfo.id
                     errata_url = retval.errataUrl
                 }
             }
             stage("build payload") {
-                if (SKIP_PAYLOAD_CREATION) {
-                    echo "Don't actually create the payload because SKIP_PAYLOAD_CREATION is checked."
+                if (skip.PAYLOAD_CREATION) {
+                    echo "Don't actually create the payload because SKIP_PAYLOAD_CREATION is set."
                     return
                 }
                 release.stageGenPayload(quay_url, release_name, dest_release_tag, from_release_tag, description, previousList.join(','), errata_url)
@@ -378,8 +378,8 @@ node {
             }
 
             stage("request upgrade tests") {
-                if (SKIP_PAYLOAD_CREATION) {
-                    echo "Don't request upgrade tests because SKIP_PAYLOAD_CREATION option is checked."
+                if (skip.PAYLOAD_CREATION) {
+                    echo "Don't request upgrade tests because SKIP_PAYLOAD_CREATION flag is set."
                     return
                 }
                 if (direct_release_nightly || !is_4stable_release || arch != 'x86_64') {
@@ -495,7 +495,7 @@ node {
                     echo "Skipping image list for dummy advisory."
                     return
                 }
-                if (SKIP_IMAGE_LIST) {
+                if (skip.IMAGE_LIST) {
                     currentBuild.description += "[No image list]"
                     return
                 }
@@ -541,7 +541,7 @@ node {
             }
 
             stage("sign artifacts") {
-                if (SKIP_PAYLOAD_CREATION) {
+                if (skip.PAYLOAD_CREATION) {
                     payloadDigest = release.getPayloadDigest(quay_url, dest_release_tag)
                 }
                 commonlib.retrySkipAbort("Signing artifacts", taskThread, "Error running signing job") {

--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -181,11 +181,15 @@ node {
     next_is_prerelease = false
 
     // copy job params into normal vars, since params is an immutable map
-    SKIP_PAYLOAD_CREATION = params.SKIP_PAYLOAD_CREATION
-    SKIP_VERIFY_BUGS = params.SKIP_VERIFY_BUGS
-    SKIP_IMAGE_LIST = params.SKIP_IMAGE_LIST
+    Boolean SKIP_PAYLOAD_CREATION = params.SKIP_PAYLOAD_CREATION
+    Boolean SKIP_VERIFY_BUGS = params.SKIP_VERIFY_BUGS
+    Boolean SKIP_IMAGE_LIST = params.SKIP_IMAGE_LIST
 
-    if (params.RESUME_FROM.startsWith('1.')) { // skip stages before mirror binaries
+    // set unset vars to default value
+    Boolean SKIP_TAG_STABLE = false
+
+    // skip stages before mirror binaries
+    if (params.RESUME_FROM.startsWith('1.')) {
         SKIP_PAYLOAD_CREATION = true
         SKIP_VERIFY_BUGS = true
         SKIP_TAG_STABLE = true

--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -566,7 +566,7 @@ node {
                 if (arch == 'x86_64' || params.OPEN_NON_X86_PR ) {
                     commonlib.retrySkipAbort('Open Cincinnati PRs', taskThread) {
                         build(
-                                job: 'build%2Fcincinnati-prs',  propagate: true,
+                                job: '/aos-cd-builds/build%2Fcincinnati-prs',  propagate: true,
                                 parameters: [
                                     buildlib.param('String', 'RELEASE_NAME', release_name),
                                     buildlib.param('String', 'ADVISORY_NUM', "${advisory}"),

--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -357,8 +357,8 @@ node {
             }
 
             stage("tag stable") {
-                if (params.SKIP_TAG_STABLE) {
-                    echo "Do not tag stable because SKIP_TAG_STABLE is checked."
+                if (SKIP_TAG_STABLE) {
+                    echo "Do not tag stable because SKIP_TAG_STABLE is set."
                     return
                 }
                 if (!is_4stable_release) {

--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -111,6 +111,14 @@ node {
                             'No',
                         ].join('\n'),
                     ),
+                    choice(
+                        name: 'RESUME_FROM',
+                        description: 'Select stage to resume from. Useful to execute remaining steps in the case of a failed promote job.',
+                        choices: [
+                                'Not Applicable',
+                                'Mirror binaries',
+                            ].join('\n'),
+                    ),
                     booleanParam(
                         name: 'SKIP_CINCINNATI_PR_CREATION',
                         description: 'DO NOT USE without team lead approval. This is an unusual option.',
@@ -172,6 +180,13 @@ node {
     is_4stable_release = true
     next_is_prerelease = false
 
+    if (params.RESUME_FROM == "Mirror binaries") { // skip stages before mirror binaries
+        params.SKIP_PAYLOAD_CREATION = true
+        params.SKIP_VERIFY_BUGS = true
+        SKIP_TAG_STABLE = true
+        params.SKIP_IMAGE_LIST = true
+    }
+    
     release_offset = params.RELEASE_OFFSET?params.RELEASE_OFFSET.toInteger():0
     def (major, minor) = commonlib.extractMajorMinorVersionNumbers(params.FROM_RELEASE_TAG)
 
@@ -342,6 +357,10 @@ node {
             }
 
             stage("tag stable") {
+                if (params.SKIP_TAG_STABLE) {
+                    echo "Do not tag stable because SKIP_TAG_STABLE is checked."
+                    return
+                }
                 if (!is_4stable_release) {
                     // Something like a hotfix should not go into 4-stable in the release controller
                     return


### PR DESCRIPTION
This was hacky way to accomplish what I wanted to - which was running remaining steps for 3 failed promote jobs, which failed at the mirror binaries stage.

But the general idea is to have all the different stages in a dropdown, to resume from. Implementation wise I'm thinking of storing the stages in an ordered list/map of some kind and then setting previous stage skip variables in an automated fashion. Ideas/feedback welcome