### PR TITLE
Move to app.ci

### DIFF
--- a/scheduled-jobs/build/sync-iib-images/Jenkinsfile.groovy
+++ b/scheduled-jobs/build/sync-iib-images/Jenkinsfile.groovy
@@ -29,7 +29,7 @@ node {
             if (name.startsWith('ose-ptp-operator-metadata') || name.startsWith('ose-ptp-operator-bundle')) {
                 buildlib.registry_quay_dev_login()
                 dest_name = "quay.io/openshift-release-dev/ocp-release-nightly:iib-int-index-cluster-ose-ptp-operator-${ocp_ver}"
-                sh "KUBECONFIG=/home/jenkins/kubeconfigs/art-publish.kubeconfig oc registry login"
+                sh "KUBECONFIG=/home/jenkins/kubeconfigs/art-publish.app.ci.kubeconfig oc registry login"
                 sh "oc image mirror ${idx_image} ${dest_name}"
             }
         } catch (e) {


### PR DESCRIPTION
..and avoid the following [error](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/scheduled-builds/job/mirror-to-iib/129/console):

```
+ KUBECONFIG=/home/jenkins/kubeconfigs/art-publish.kubeconfig
+ oc registry login
info: Using registry public hostname registry.svc.ci.openshift.org
error: unable to check your credentials - pass --skip-check to bypass this error: endpoint "https://registry.svc.ci.openshift.org" does not support v2 API (got 503 Service Unavailable)
```