### PR TITLE
[ART-2752] add alert when all images build failed in ocp4

### DIFF
--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -148,15 +148,38 @@ node {
                 }
 
                 stage("update dist-git") { build.stageUpdateDistgit() }
-                stage("build images") { build.stageBuildImages() }
+                stage("build images") {
+                    build.stageBuildImages()
+                    branch=build.version.branch
+                    imagelist=build.buildPlan.imagesIncluded.split(',')
+                    for (i = 0; i < imagelist.size(); i++) {
+                        out = commonlib.shell(
+                            returnStdout: true,
+                            script: "brew list-tagged --latest-n=2 --quiet ${branch} | grep ${imagelist[i]} | grep .p0 | wc -l"
+                        )
+                        builds = commonlib.shell(
+                            returnStdout: true,
+                            script: "brew list-tagged --latest-n=2 --quiet ${branch}| grep ${imagelist[i]} | cut -d ' ' -f 1"
+                        )
+                        if (out.contains("1")){
+                            slacklib.to(commonlib.extractMajorMinorVersion(params.BUILD_VERSION)).say("""
+                                *:alert:(test message) we may catch a newly-embargoed build ${imagelist[i]} in ocp4 build*
+the two recents builds are:
+${builds}
+                            """)
+                        }
+                    }
+                }
             }
             lock("mirroring-rpms-lock-${params.BUILD_VERSION}") {
                 stage("mirror RPMs") { build.stageMirrorRpms() }
             }
-            stage("sync images") { build.stageSyncImages() }
-            stage("push qe quay images") { build.stagePushQEImages() }
-            stage("sweep") {
-                buildlib.sweep(params.BUILD_VERSION)
+            if (!buildlib.allImagebuildfailed){
+                stage("sync images") { build.stageSyncImages() }
+                stage("push qe quay images") { build.stagePushQEImages() }
+                stage("sweep") {
+                    buildlib.sweep(params.BUILD_VERSION)
+                }
             }
         }
         stage("report success") { build.stageReportSuccess() }

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -148,28 +148,7 @@ node {
                 }
 
                 stage("update dist-git") { build.stageUpdateDistgit() }
-                stage("build images") {
-                    build.stageBuildImages()
-                    branch=build.version.branch
-                    imagelist=build.buildPlan.imagesIncluded.split(',')
-                    for (i = 0; i < imagelist.size(); i++) {
-                        out = commonlib.shell(
-                            returnStdout: true,
-                            script: "brew list-tagged --latest-n=2 --quiet ${branch} | grep ${imagelist[i]} | grep .p0 | wc -l"
-                        )
-                        builds = commonlib.shell(
-                            returnStdout: true,
-                            script: "brew list-tagged --latest-n=2 --quiet ${branch}| grep ${imagelist[i]} | cut -d ' ' -f 1"
-                        )
-                        if (out.contains("1")){
-                            slacklib.to(commonlib.extractMajorMinorVersion(params.BUILD_VERSION)).say("""
-                                *:alert:(test message) we may catch a newly-embargoed build ${imagelist[i]} in ocp4 build*
-the two recents builds are:
-${builds}
-                            """)
-                        }
-                    }
-                }
+                stage("build images") { build.stageBuildImages() }
             }
             lock("mirroring-rpms-lock-${params.BUILD_VERSION}") {
                 stage("mirror RPMs") { build.stageMirrorRpms() }

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -348,7 +348,7 @@ def stageBuildImages() {
         def r = buildlib.determine_build_failure_ratio(recordLog)
         if (r.failed == r.total) {
             allImagebuildfailed = true
-            failed_message = ""
+            failed_messages = ""
             for (i = 0; i < failed_images.size(); i++) {
                 failed_messages += "${failed_images[i]}:${failed_map[failed_images[i]]['task_url']}\n"
             }


### PR DESCRIPTION
if all images build failed then send an alert to sclack and skip the following steps
such error messages like:
```
:warning: All of 4 image builds failed in ocp4 job
openshift-enterprise-pod:https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=36484036
ironic:https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=36484064
ose-installer:https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=36484070
ose-installer-artifacts:n/a
```