### PR TITLE
[ART-2873] Productionize beta:rpms:rebase-and-build

### DIFF
--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -155,7 +155,7 @@ node {
                     currentBuild.description = "building RPM(s): ${rpms}\n"
                     command = doozerOpts
                     if (rpms) { command += "-r '${rpms}' " }
-                    command += "beta:rpms:rebase-and-build --version ${version} --release '${release}' ${params.SCRATCH ? '--scratch' : ''} "
+                    command += "rpms:rebase-and-build --version ${version} --release '${release}' ${params.SCRATCH ? '--scratch' : ''} "
 
                     def buildRpms = { ->
                         buildlib.doozer command

--- a/jobs/build/ocp3/Jenkinsfile
+++ b/jobs/build/ocp3/Jenkinsfile
@@ -638,7 +638,7 @@ node {
                 buildlib.doozer """
                     ${doozerOpts}
                     --source ose ${OSE_DIR}
-                    beta:rpms:rebase-and-build --version v${NEW_VERSION}
+                    rpms:rebase-and-build --version v${NEW_VERSION}
                     --release ${NEW_RELEASE}
                 """
             }

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -257,7 +257,7 @@ def stageBuildRpms() {
         """
         ${doozerOpts}
         ${includeExclude "rpms", buildPlan.rpmsIncluded, buildPlan.rpmsExcluded}
-        beta:rpms:rebase-and-build --version v${version.full}
+        rpms:rebase-and-build --version v${version.full}
         --release '${version.release}'
         """
 


### PR DESCRIPTION
Removes the beta: prefix.

Requires https://github.com/openshift/doozer/pull/394.