### PR TITLE
ART-2913 Multi Promote Job

### DIFF
--- a/jobs/build/multi_promote/Jenkinsfile
+++ b/jobs/build/multi_promote/Jenkinsfile
@@ -43,7 +43,6 @@ node {
                         description: 'Integer. Do not specify for hotfix. If offset is X for 4.5 nightly => Release name is 4.5.X for standard, 4.5.0-rc.X for Release Candidate, 4.5.0-fc.X for Feature Candidate ',
                         trim: true,
                     ),
-                    commonlib.suppressEmailParam(),
                     commonlib.dryrunParam('Take no actions. Note: still notifies and runs signing job (which fails)'),
                     commonlib.mockParam(),
                 ]
@@ -64,29 +63,63 @@ node {
     }
     s390x_index = nightly_list.findIndexOf { it.contains("s390x") }
     power_index = nightly_list.findIndexOf { it.contains("ppc64le") }
-    if (s390x_index == -1 || power_index == -1) {
+    x86_index = nightly_list.findIndexOf { !it.contains("s390x") && !it.contains("ppc64le") }
+    if (s390x_index == -1 || power_index == -1 || x86_index == -1) {
         error("Something doesn't seem right. Job expects 3 nightlies of each arch")
     }
-    
-    // setup common job params
-    commonparams = [
-        buildlib.param('Choice', 'RELEASE_TYPE', params.RELEASE_TYPE)
-        buildlib.param('String', 'RELEASE_OFFSET', params.RELEASE_OFFSET)
-        booleanParam(name: 'DRY_RUN', value: params.DRY_RUN)
+
+    common_params = [
+        buildlib.param('String','RELEASE_TYPE', params.RELEASE_TYPE),
+        buildlib.param('String','RELEASE_OFFSET', params.RELEASE_OFFSET),
+        buildlib.param('String','ADVISORY', ""),
+        booleanParam(name: 'DRY_RUN', value: params.DRY_RUN),
         booleanParam(name: 'MOCK', value: params.MOCK)
     ]
 
-    // trigger jobs
-    for (nightly in nightly_list) {
-        build(
-            job: 'build%2Fpromote',
-            propagate: true,
-            parameters: [
-                buildlib.param('String', 'FROM_RELEASE_TAG', nightly),
-                commonparams,
-            ]
-        )
-        currentBuild.description += "<br>triggered build: ${version}"        
-    }
+    parallel(
+        "x86_64": {
+            stage("x86_64") {
+                def params = common_params.clone()
+                nightly = nightly_list[x86_index]
+                params << buildlib.param('String','FROM_RELEASE_TAG', nightly)
+                
+                build(
+                    job: '/aos-cd-builds/build%2Fpromote',
+                    propagate: false,
+                    parameters: params
+                )
+                currentBuild.description += "<br>triggered promote: ${nightly}"
+            }
+        },
+        "s390x": {
+            stage("s390x") {
+                def params = common_params.clone()
+                nightly = nightly_list[s390x_index]
+                params << buildlib.param('String','FROM_RELEASE_TAG', nightly)
+                
+                build(
+                    job: '/aos-cd-builds/build%2Fpromote',
+                    propagate: false,
+                    parameters: params
+                )
+                currentBuild.description += "<br>triggered promote: ${nightly}"
+            }
+        },
+        "ppc64le": {
+            stage("ppc64le") {
+                def params = common_params.clone()
+                nightly = nightly_list[power_index]
+                params << buildlib.param('String','FROM_RELEASE_TAG', nightly)
+                
+                build(
+                    job: '/aos-cd-builds/build%2Fpromote',
+                    propagate: false,
+                    parameters: params
+                )
+                currentBuild.description += "<br>triggered promote: ${nightly}"
+            }
+        }
+    )
+    
     buildlib.cleanWorkspace()
 }

--- a/jobs/build/multi_promote/Jenkinsfile
+++ b/jobs/build/multi_promote/Jenkinsfile
@@ -1,0 +1,92 @@
+#!/usr/bin/env groovy
+
+node {
+    checkout scm
+    def buildlib = load("pipeline-scripts/buildlib.groovy")
+    def commonlib = buildlib.commonlib
+    commonlib.describeJob("multi_promote", """
+        <h2>Kick off multiple promote jobs for selected nightlies</h2>
+    """)
+
+
+    def doozer_working = "${WORKSPACE}/doozer_working"
+
+    // Expose properties for a parameterized build
+    properties(
+        [
+            buildDiscarder(
+                logRotator(
+                    artifactDaysToKeepStr: '7',
+                    daysToKeepStr: '7'
+                )
+            ),
+            [
+                $class: 'ParametersDefinitionProperty',
+                parameterDefinitions: [
+                    choice(
+                        name: 'RELEASE_TYPE',
+                        description: 'Select [1. Standard Release] unless discussed with team lead',
+                        choices: [
+                                '1. Standard Release (Named, Signed, Previous, All Channels)',
+                                '2. Release Candidate (Named, Signed, Previous, Candidate Channel)',
+                                '3. Feature Candidate (Named, Signed - rpms may not be, Previous, Candidate Channel)',
+                                '4. Hotfix (No name, Signed, No Previous, All Channels)',
+                            ].join('\n'),
+                    ),
+                    string(
+                        name: "NIGHTLIES",
+                        description: "List of proposed nightlies for each arch, separated by comma",
+                        trim: true
+                    ),
+                    string(
+                        name: 'RELEASE_OFFSET',
+                        description: 'Integer. Do not specify for hotfix. If offset is X for 4.5 nightly => Release name is 4.5.X for standard, 4.5.0-rc.X for Release Candidate, 4.5.0-fc.X for Feature Candidate ',
+                        trim: true,
+                    ),
+                    commonlib.suppressEmailParam(),
+                    commonlib.dryrunParam('Take no actions. Note: still notifies and runs signing job (which fails)'),
+                    commonlib.mockParam(),
+                ]
+            ],
+        ]
+    )
+
+    commonlib.checkMock()
+
+    // some basic validations
+    if (!params.NIGHTLIES) {
+        error("You must provide a list of proposed nightlies.")
+    }
+    
+    nightly_list = params.NIGHTLIES.split("[,\\s]+")
+    if (nightly_list.size() != 3) {
+        error("Something doesn't seem right. Job expects 3 nightlies of each arch")
+    }
+    s390x_index = nightly_list.findIndexOf { it.contains("s390x") }
+    power_index = nightly_list.findIndexOf { it.contains("ppc64le") }
+    if (s390x_index == -1 || power_index == -1) {
+        error("Something doesn't seem right. Job expects 3 nightlies of each arch")
+    }
+    
+    // setup common job params
+    commonparams = [
+        buildlib.param('Choice', 'RELEASE_TYPE', params.RELEASE_TYPE)
+        buildlib.param('String', 'RELEASE_OFFSET', params.RELEASE_OFFSET)
+        booleanParam(name: 'DRY_RUN', value: params.DRY_RUN)
+        booleanParam(name: 'MOCK', value: params.MOCK)
+    ]
+
+    // trigger jobs
+    for (nightly in nightly_list) {
+        build(
+            job: 'build%2Fpromote',
+            propagate: true,
+            parameters: [
+                buildlib.param('String', 'FROM_RELEASE_TAG', nightly),
+                commonparams,
+            ]
+        )
+        currentBuild.description += "<br>triggered build: ${version}"        
+    }
+    buildlib.cleanWorkspace()
+}

--- a/jobs/build/multi_promote/README.md
+++ b/jobs/build/multi_promote/README.md
@@ -1,0 +1,92 @@
+# Multi Promote Job
+
+## Description
+
+Promote multiple nightlies as release payloads. Supports different release types.
+
+## Purpose
+
+This is a wrapper job for triggering multiple Promote jobs, for each architecture
+to create release payloads for a single release. 
+
+See [Promote job Readme](../promote/README.md) as the canonical source and documentation
+for what Promote job does.
+
+## Timing
+
+This job is run manually per the release schedule. It requires nightlies for
+all arches to be ready, to be given as input. 
+
+Promotion should wait for QE to have a chance to review, and should not occur
+if there are blockers outstanding for a release.
+
+## Parameters
+
+See [Standard Parameters](/jobs/README.md#standard-parameters).
+
+
+### NIGHTLIES
+
+A list of 3 nightlies (one per arch - x86_64, s390x, ppc64le) comma separated.
+
+A nightly would be a release tag to pull from (e.g. 4.6.0-0.nightly-s390x-2020-11-06-181325).
+These nightlies should be listed as `Accepted` in the release-controllers: \[
+  [x86\_64](https://amd64.ocp.releases.ci.openshift.org/) |
+  [s390x](https://s390x.ocp.releases.ci.openshift.org/) |
+  [ppc64le](https://ppc64le.ocp.releases.ci.openshift.org/)
+  \]
+
+### RELEASE\_TYPE
+
+This specifies what type of release to publish for customer use. Releases may be:
+
+* **named** (given a different name from their source release image)
+* Built with **signed** RPMs
+* Upgrade targets (by specifying **previous** releases that can upgrade to them)
+* Destined for various Cincinnati **channels**
+
+The types are:
+
+**1. Standard Release (Named, Signed, Previous, All Channels)**
+
+This is what we use the job for most of the time - GA and z-stream releases.
+
+**2. Release Candidate (Named, Signed, Previous, Candidate Channel)**
+
+Release candidates are intended to be actual candidates for being released
+as-is at a minor version GA. As such, they should have populated advisories
+that are valid to ship. These are pretty much ART practice runs for the real
+GA.
+
+**3. Feature Candidate (Named, Signed - rpms may not be, Previous, Candidate Channel)**
+
+Feature candidates enable customers/partners/developers to try out the features
+coming in a new minor version, as well as upgrades. These are crucial to enable
+the ecosystem to discover bugs as well.
+
+FCs begin after feature freeze and continue regularly until we are ready for a
+release candidate (hopefully, at code freeze). From ART's perspective they are
+simply renamed nightlies and should not use signed RPMs or even have
+advisories. However, these are entered in Cincinnati candidate channels to
+enable exercising upgrades normally.
+
+**4. Hotfix (No name, Signed, No Previous, All Channels)**
+
+A hotfix is basically a nightly that gets added to Cincinnati channels. It is
+used to solve an acute customer problem and intended only to be used until the
+next z-stream release. It is added to channels only to enable the customer to
+upgrade *away* from it in a supported fashion (they must do a "force" ugprade
+*to* it in the first place).
+
+### RELEASE\_OFFSET
+
+Releases are distinguished from others in the same minor version only by an integer offset.
+This offset (call it X) is used to construct the release name depending on the release type:
+
+1. Standard Release: `4.y.X`
+2. Release Candidate: `4.y.0-rc.X`
+3. Feature Candidate: `4.y.0-fc.X`
+4. Hotfix: do not specify an offset; the name of the nightly is re-used.
+
+## Known issues
+As of right now (May 4th 2021) the job expects 3 nightlies always (for s390x, ppc64le and x86). In the future we want to fix this by varying for release type/version, and for supporting more arches. - [see this comment](https://github.com/openshift/aos-cd-jobs/pull/2606#discussion_r625391662) for details.


### PR DESCRIPTION
## Summary

https://issues.redhat.com/browse/ART-2913

This is a new wrapper job to trigger multiple promote jobs in parallel for the 3 arches. The usecase is being able to promote all 3 nightlies from one job, something we sorely need :) It doesn't have the advanced params of promote job, in which case ARTist should use the promote job itself. Wanted to keep this pretty basic.

## Test Run
https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Fmulti_promote/15/console