### PR TITLE
WIP: Enable aarch64

### DIFF
--- a/build-scripts/use-mirror/set-v4-client-latest.sh
+++ b/build-scripts/use-mirror/set-v4-client-latest.sh
@@ -23,7 +23,7 @@ set -u
 RELEASE=$1    # e.g. 4.2.0 or 4.3.0-0.nightly-2019-11-08-080321
 CLIENT_TYPE=$2   # e.g. ocp or ocp-dev-preview
 LINK_NAME=$3   # e.g. latest
-ARCHES="${4:-x86_64}"  # e.g. "x86_64 ppc64le s390x"  OR  "all" to detect arches automatically
+ARCHES="${4:-x86_64}"  # e.g. "x86_64 ppc64le s390x aarch64"  OR  "all" to detect arches automatically
 
 BASE_DIR="/srv/pub/openshift-v4"
 
@@ -124,10 +124,11 @@ for arch in ${ARCHES}; do
 
     if [[ ! -z "$USE_CHANNEL" ]]; then
         qarch="${arch}"
-        if [[ "${qarch}" == "x86_64" ]]; then
-            # Graph uses go arch names; translate from brew arch names
-            qarch="amd64"
-        fi
+        # Graph uses go arch names; translate from brew arch names
+        case "${qarch}" in
+            x86_64) qarch="amd64" ;;
+            aarch64) qarch="arm64" ;;
+        esac
         CHANNEL_RELEASES=$(curl -sH 'Accept:application/json' "https://api.openshift.com/api/upgrades_info/v1/graph?channel=${USE_CHANNEL}&arch=${qarch}" | jq '.nodes[].version' -r)
         if [[ -z "$CHANNEL_RELEASES" ]]; then
             echo "No versions current detected in ${USE_CHANNEL} for arch ${qarch} ; No ${LINK_NAME} will be set"

--- a/jobs/build/coreos-installer_sync/extract.sh
+++ b/jobs/build/coreos-installer_sync/extract.sh
@@ -11,7 +11,10 @@ if [[ -n "${3-}" ]]; then
   rm -rf keep/
   mkdir keep/
   for arch in $ARCHES; do
-    [[ "$arch" == "amd64" ]] && arch=x86_64
+    case "$arch" in
+      amd64) arch=x86_64 ;;
+      arm64) arch=aarch64 ;;
+    esac
     mv *.$arch.rpm keep/
   done
   rm *.rpm
@@ -23,7 +26,7 @@ rm -rf "$VERSION"
 mkdir "$VERSION"
 
 for rpm in *.rpm; do
-  arch="$(awk -F'[.]' '{a = $(NF-1); print a=="x86_64" ? "amd64" : a}' <<<"$rpm")"
+  arch="$(awk -F'[.]' '{a = $(NF-1); print a=="x86_64" ? "amd64" : a=="aarch64" ? "arm64" : a}' <<<"$rpm")"
   rpm2cpio "${rpm}" | cpio -idm --quiet ./usr/bin/coreos-installer
   mv usr/bin/coreos-installer "$VERSION/coreos-installer_$arch"
 done

--- a/jobs/build/oc_sync/publish-clients-from-payload.sh
+++ b/jobs/build/oc_sync/publish-clients-from-payload.sh
@@ -22,6 +22,8 @@ ARCH=$(skopeo inspect docker://${PULL_SPEC} --config | jq .architecture -r)
 
 if [[ "${ARCH}" == "amd64" ]]; then
     ARCH="x86_64"
+elif [[ "${ARCH}" == "arm64" ]]; then
+    ARCH="aarch64"
 fi
 
 OC_MIRROR_DIR="/srv/pub/openshift-v4/${ARCH}/clients/${CLIENT_TYPE}"

--- a/jobs/build/operator-sdk_sync/Jenkinsfile
+++ b/jobs/build/operator-sdk_sync/Jenkinsfile
@@ -68,7 +68,9 @@ pipeline {
                     ).manifests.each {
                         // We want x86_64 to be the first in the list, as that will be used to extract the
                         // Operator SDK version, which is used while naming the files.
-                        def sdkArch = it.platform.architecture == 'amd64' ? 'x86_64' : it.platform.architecture
+                        def sdkArch = it.platform.architecture == 'amd64' ? 'x86_64' :
+                                      it.platform.architecture == 'arm64' ? 'aarch64' :
+                                      it.platform.architecture
                         def data = [arch: sdkArch, digest: it.digest]
                         println("data: ${data}")
 

--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -55,6 +55,7 @@ node {
                                 'x86_64',
                                 's390x',
                                 'ppc64le',
+                                'aarch64',
                             ].join('\n'),
                     ),
                     string(
@@ -562,7 +563,7 @@ node {
 
         dry_subject = ""
         if (params.DRY_RUN) { dry_subject = "[DRY RUN] "}
-        releaseArch = arch == "x86_64" ? "amd64" : "${arch}"
+        releaseArch = arch == "x86_64" ? "amd64" : arch == "aarch64" ? "arm64" : "${arch}"
         commonlib.email(
             to: "${params.MAIL_LIST_SUCCESS}",
             replyTo: "aos-team-art@redhat.com",

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -535,6 +535,8 @@ def getReleaseControllerURL(releaseStreamName) {
         arch = "s390x" // e.g. -s390x
     } else if ('ppc64le' in streamNameComponents) {
         arch = "ppc64le"
+    } else if ('arm64' in streamNameComponents) {
+        arch = "arm64"
     }
     return "https://${arch}.ocp.releases.ci.openshift.org"
 }

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -162,7 +162,7 @@ Map stageValidation(String quay_url, String dest_release_tag, int advisory = 0, 
 }
 
 def getArchPrivSuffix(arch, priv) {
-    def suffix = arch == "x86_64" ? "" : "-${arch}"
+    def suffix = arch == "x86_64" ? "" : arch == "aarch64" ? "-arm64" : "-${arch}"
     if (priv)
         suffix <<= '-priv'
     return suffix

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -52,6 +52,8 @@ class PrepareReleasePipeline:
                 arch = "s390x"
             elif "ppc64le" in nightly:
                 arch = "ppc64le"
+            elif "arm64" in nightly:
+                arch = "aarch64"
             else:
                 arch = "x86_64"
             if ":" not in nightly:

--- a/scheduled-jobs/build/poll-payload/Jenkinsfile
+++ b/scheduled-jobs/build/poll-payload/Jenkinsfile
@@ -14,6 +14,7 @@ import groovy.json.JsonOutput
     "4.8.0-0.nightly": this.&startPreReleaseJob,
     "4.8.0-0.nightly-s390x": this.&startPreReleaseJob,
     "4.8.0-0.nightly-ppc64le": this.&startPreReleaseJob,
+    "4.8.0-0.nightly-aarch64": this.&startPreReleaseJob,
 ]
 
 def startPreReleaseJob(String releaseStream, Map latestRelease, Map previousRelease) {


### PR DESCRIPTION
Until now, x86_64/amd64 was the only enabled architecture with differing 
nomenclatures.  However, aarch64/arm64 has the same issue, which 
accounts for most of the complications in adding it.

Please check this carefully for mistakes and missing pieces.  There are 
some things that probably need to be in place first before this can be 
merged.

/cc @sosiouxme
