### PR TITLE
[ART-2877] Create build/butane_sync job

### DIFF
--- a/jobs/build/butane_sync/Jenkinsfile
+++ b/jobs/build/butane_sync/Jenkinsfile
@@ -1,0 +1,128 @@
+node {
+    checkout scm
+    commonlib = load("pipeline-scripts/commonlib.groovy")
+    commonlib.describeJob("butane_sync", """
+        ------------------------------
+        Sync Butane binaries to mirror
+        ------------------------------
+        Sync butane binaries to mirror.openshift.com.
+        (formerly the Fedora CoreOS Config Transpiler, FCCT)
+
+        http://mirror.openshift.com/pub/openshift-v4/clients/butane/
+
+        Timing: This is only ever run by humans, upon request.
+    """)
+}
+
+pipeline {
+    agent any
+    options { disableResume() }
+
+    parameters {
+        string(
+            name: "NVR",
+            description: "NVR of the brew build from which binaries should be extracted.<br/>" +
+                         "Example: butane-0.11.0-3.rhaos4.8.el8",
+            defaultValue: "",
+            trim: true,
+        )
+        string(
+            name: "VERSION",
+            description: "Under which directory to place the binaries.<br/>" +
+                         "Example: v0.11.0",
+            defaultValue: "",
+            trim: true,
+        )
+    }
+
+    stages {
+        stage("validate params") {
+            steps {
+                script {
+                    if (!params.NVR) {
+                        error "NVR must be specified"
+                    }
+                    if (!params.VERSION) {
+                        error "VERSION must be specified"
+                    }
+                }
+            }
+        }
+        stage("download build") {
+            steps {
+                script {
+                    commonlib.shell(
+                        script: """
+                        rm -rf ./${params.VERSION}
+                        mkdir -p ./${params.VERSION}
+                        cd ./${params.VERSION}
+                        brew download-build ${params.NVR}
+                        tree
+                        """
+                    )
+                }
+            }
+        }
+        stage("extract binaries") {
+            steps {
+                dir("./${params.VERSION}") {
+                    script {
+                        commonlib.shell(
+                            script: """
+                            rpm2cpio *.aarch64.rpm | cpio -idm ./usr/bin/butane
+                            mv ./usr/bin/butane ./butane-aarch64
+                            rm -rf *.aarch64.rpm ./usr
+                            """
+                        )
+                        commonlib.shell(
+                            script: """
+                            rpm2cpio *.noarch.rpm | cpio -idm ./usr/share/butane-redistributable/*
+                            mv ./usr/share/butane-redistributable/* .
+                            rm -rf *.noarch.rpm ./usr
+                            """
+                        )
+                        commonlib.shell(
+                            script: """
+                            rpm2cpio *.ppc64le.rpm | cpio -idm ./usr/bin/butane
+                            mv ./usr/bin/butane ./butane-ppc64le
+                            rm -rf *.ppc64le.rpm ./usr
+                            """
+                        )
+                        commonlib.shell(
+                            script: """
+                            rpm2cpio *.s390x.rpm | cpio -idm ./usr/bin/butane
+                            mv ./usr/bin/butane ./butane-s390x
+                            rm -rf *.s390x.rpm ./usr
+                            """
+                        )
+                        commonlib.shell(
+                            script: """
+                            rpm2cpio *.x86_64.rpm | cpio -idm ./usr/bin/butane
+                            mv ./usr/bin/butane ./butane-amd64
+                            ln -s ./butane-amd64 ./butane
+                            rm -rf *.x86_64.rpm ./usr
+                            """
+                        )
+                    }
+                    sh "rm *.src.rpm"
+                }
+            }
+        }
+        stage("calculate shasum") {
+            steps {
+                sh "cd ./${params.VERSION} && sha256sum * > sha256sum.txt"
+            }
+        }
+        stage("sync to mirror") {
+            steps {
+                sh "tree ./${params.VERSION} && cat ./${params.VERSION}/sha256sum.txt"
+                sshagent(["aos-cd-test"]) {
+                    sh "ssh use-mirror-upload.ops.rhcloud.com -- mkdir -p /srv/pub/openshift-v4/clients/butane"
+                    sh "scp -r./ ${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/clients/butane/"
+                    sh "ssh use-mirror-upload.ops.rhcloud.com -- ln --symbolic --force --no-dereference ${params.VERSION} /srv/pub/openshift-v4/clients/butane/latest"
+                    sh "ssh use-mirror-upload.ops.rhcloud.com -- /usr/local/bin/push.pub.sh openshift-v4/clients/butane -v"
+                }
+            }
+        }
+    }
+}

--- a/jobs/build/butane_sync/README.md
+++ b/jobs/build/butane_sync/README.md
@@ -1,0 +1,26 @@
+# butane_sync
+
+## Purpose
+
+Sync butane binaries to mirror.openshift.com.
+(formerly the Fedora CoreOS Config Transpiler, FCCT)
+
+<http://mirror.openshift.com/pub/openshift-v4/clients/butane/>
+
+## Timing
+
+Manually, upon request.
+
+## Parameters
+
+### NVR
+
+NVR of the brew build from which binaries should be extracted.
+Example: [butane-0.11.0-3.rhaos4.8.el8][]
+
+### VERSION
+
+Under which directory to place the binaries.
+Example: v0.11.0
+
+[butane-0.11.0-3.rhaos4.8.el8]: https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1592689]

--- a/jobs/build/butane_sync/README.md
+++ b/jobs/build/butane_sync/README.md
@@ -24,3 +24,56 @@ Under which directory to place the binaries.
 Example: v0.11.0
 
 [butane-0.11.0-3.rhaos4.8.el8]: https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1592689]
+
+### How does it work?
+
+This job performs the following steps:
+
+1. download all RPMs from a given brew build
+2. extract the binaries from each RPM, appending the corresponding arch to each filename
+3. create a `butane` symlink, pointing to the `butane-amd64` binary
+4. calculate the shasum of each binary
+5. sync them to https://mirror.openshift.com/pub/openshift-v4/clients/butane/, under a directory named
+by the given version name.
+
+### Example
+
+Running the job with the following parameters:
+
+* **NVR:** "butane-0.11.0-3.rhaos4.8.el8"
+* **VERSION:** "v0.11.0"
+
+Will download all RPMs from butane-0.11.0-3.rhaos4.8.el8:
+
+    ├── butane-0.11.0-3.rhaos4.8.el8.aarch64.rpm
+    ├── butane-0.11.0-3.rhaos4.8.el8.ppc64le.rpm
+    ├── butane-0.11.0-3.rhaos4.8.el8.s390x.rpm
+    ├── butane-0.11.0-3.rhaos4.8.el8.src.rpm
+    ├── butane-0.11.0-3.rhaos4.8.el8.x86_64.rpm
+    └── butane-redistributable-0.11.0-3.rhaos4.8.el8.noarch.rpm
+
+Extract binaries from RPMs
+
+    rpm2cpio <rpm> | cpio -idm ./usr/bin/butane
+
+**NOTE:** `darwin-amd64` and `windows-amd64` are obtained from the redistributable "noarch" RPM;
+Example: butane-redistributable-0.11.0-3.rhaos4.8.el8.noarch.rpm
+
+    $ rpm -qlp butane-redistributable-0.11.0-3.rhaos4.8.el8.noarch.rpm
+    /usr/share/butane-redistributable
+    /usr/share/butane-redistributable/butane-darwin-amd64
+    /usr/share/butane-redistributable/butane-windows-amd64.exe
+    /usr/share/licenses/butane-redistributable
+    /usr/share/licenses/butane-redistributable/LICENSE
+
+The final result is published under a directory called v.0.11.0 with the following contents:
+
+    ./v0.11.0
+    ├── butane -> ./butane-amd64
+    ├── butane-aarch64
+    ├── butane-amd64
+    ├── butane-darwin-amd64
+    ├── butane-ppc64le
+    ├── butane-s390x
+    ├── butane-windows-amd64.exe
+    └── sha256sum.txt


### PR DESCRIPTION
Create a new sync job, called `butane_sync`, so we can start shipping [butane](https://coreos.github.io/butane/) binaries for OCP 4.8 GA.

Request: [ART-2877](https://issues.redhat.com/browse/ART-2877)

### How does it work?

This job performs the following steps:
1. download all RPMs from a given brew build
2. extract the binaries from each RPM, appending the corresponding arch to each filename
3. create a `butane` symlink, pointing to the `butane-amd64` binary
4. calculate the shasum of each binary
5. sync them to <https://mirror.openshift.com/pub/openshift-v4/clients/butane/>, under a directory named by the given version name.

### Example

Running the job with the following parameters:
- **NVR:** "butane-0.11.0-3.rhaos4.8.el8"
- **VERSION:** "v0.11.0"

Will download all RPMs from [butane-0.11.0-3.rhaos4.8.el8](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1592689):
```
├── butane-0.11.0-3.rhaos4.8.el8.aarch64.rpm
├── butane-0.11.0-3.rhaos4.8.el8.ppc64le.rpm
├── butane-0.11.0-3.rhaos4.8.el8.s390x.rpm
├── butane-0.11.0-3.rhaos4.8.el8.src.rpm
├── butane-0.11.0-3.rhaos4.8.el8.x86_64.rpm
└── butane-redistributable-0.11.0-3.rhaos4.8.el8.noarch.rpm
```

Extract binaries from RPMs
```
rpm2cpio <rpm> | cpio -idm ./usr/bin/butane
```
**NOTE:** `darwin-amd64` and `windows-amd64` are obtained from the redistributable "noarch" RPM; Example: [butane-redistributable-0.11.0-3.rhaos4.8.el8.noarch.rpm](https://brewweb.engineering.redhat.com/brew/rpminfo?rpmID=9667312)
```
$ rpm -qlp butane-redistributable-0.11.0-3.rhaos4.8.el8.noarch.rpm
/usr/share/butane-redistributable
/usr/share/butane-redistributable/butane-darwin-amd64
/usr/share/butane-redistributable/butane-windows-amd64.exe
/usr/share/licenses/butane-redistributable
/usr/share/licenses/butane-redistributable/LICENSE
```

The final result is published under a directory called `v.0.11.0` with the following contents:
```
./v0.11.0
├── butane -> ./butane-amd64
├── butane-aarch64
├── butane-amd64
├── butane-darwin-amd64
├── butane-ppc64le
├── butane-s390x
├── butane-windows-amd64.exe
└── sha256sum.txt
```

### More info

We'll probably just run this for real close to 4.8 GA, but you can see it "in action" under my `hack` dir; it does everything except the last step (sync to mirror)
https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/talessio-aos-cd-jobs/job/ART-2877-hack/23/console