### PR TITLE
ART-2936 Drop advisories job

### DIFF
--- a/jobs/build/drop_advisories/Jenkinsfile
+++ b/jobs/build/drop_advisories/Jenkinsfile
@@ -37,7 +37,7 @@ node {
         error("You must provide one or more advisories.")
     }
     
-    advisory_list = params.ADVISORIES.split("[,\\s]+")
+    advisory_list = commonlib.parseList(params.ADVISORIES)
     
     for(adv in advisory_list) {
         res = commonlib.shell(

--- a/jobs/build/drop_advisories/Jenkinsfile
+++ b/jobs/build/drop_advisories/Jenkinsfile
@@ -1,0 +1,51 @@
+#!/usr/bin/env groovy
+
+node {
+    checkout scm
+    def buildlib = load("pipeline-scripts/buildlib.groovy")
+    def commonlib = buildlib.commonlib
+    commonlib.describeJob("drop_advisories", """
+        <h2>Runs elliott drop-advisory command for one or more advisories</h2>
+    """)
+
+    // Expose properties for a parameterized build
+    properties(
+        [
+            buildDiscarder(
+                logRotator(
+                    artifactDaysToKeepStr: '7',
+                    daysToKeepStr: '7'
+                )
+            ),
+            [
+                $class: 'ParametersDefinitionProperty',
+                parameterDefinitions: [
+                    string(
+                        name: 'ADVISORIES',
+                        description: 'One or more advisories to drop, comma separated',
+                        trim: true
+                    ),
+                    commonlib.mockParam(),
+                ]
+            ],
+        ]
+    )
+
+    commonlib.checkMock()
+
+    if (!params.ADVISORIES) {
+        error("You must provide one or more advisories.")
+    }
+    
+    advisory_list = params.ADVISORIES.split("[,\\s]+")
+    
+    for(adv in advisory_list) {
+        res = commonlib.shell(
+            returnAll: true,
+            script: "${buildlib.ELLIOTT_BIN} advisory-drop ${adv}",
+        )
+        print(res)
+    }
+        
+    buildlib.cleanWorkspace()
+}

--- a/jobs/build/drop_advisories/README.md
+++ b/jobs/build/drop_advisories/README.md
@@ -9,7 +9,7 @@ Drop (mark as not shipping) one or more advisories in ErrataTool. Runs elliott c
 Sometimes we need to drop advisories, in cases like
 - No updated builds found for shipping - in which case we don't need that advisory.
   - when no rpm builds are found, we drop rpm advisory
-  - when no "extras" operator build found, then we drop image and metadata advisories.
+  - when no "extras" operator build found, then we drop extras and metadata advisories.
 - Release as a whole is dropped due to some blocker.
 - Duplicate advisories created by error (this has happened!)
 

--- a/jobs/build/drop_advisories/README.md
+++ b/jobs/build/drop_advisories/README.md
@@ -1,0 +1,28 @@
+# Drop Advisories Job
+
+## Description
+
+Drop (mark as not shipping) one or more advisories in ErrataTool. Runs elliott command of the same name.
+
+## Purpose
+
+Sometimes we need to drop advisories, in cases like
+- No updated builds found for shipping - in which case we don't need that advisory.
+  - when no rpm builds are found, we drop rpm advisory
+  - when no "extras" operator build found, then we drop image and metadata advisories.
+- Release as a whole is dropped due to some blocker.
+- Duplicate advisories created by error (this has happened!)
+
+Previously in case an ARTist wants to drop advisories, we would find somebody higher up to drop it, or manually run elliott from buildvm. This is a wrapper job that runs `elliott advisory-drop` with buildvm privileged credentials.
+
+## Timing
+
+When an ARTist realizes advisory(s) need to be dropped.
+
+## Parameters
+
+See [Standard Parameters](/jobs/README.md#standard-parameters).
+
+### ADVISORIES
+
+A list of one or more ErrataTool advisories numbers (e.g 66039), comma separated.


### PR DESCRIPTION
A job to drop advisories from buildvm. Much needed so we don't have to hunt people down when we have advisories to drop

Test run 
- https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Fdrop_advisories/2/console