### PR TITLE
aarch64 enablement

### DIFF
--- a/build-scripts/use-mirror/set-v4-client-latest.sh
+++ b/build-scripts/use-mirror/set-v4-client-latest.sh
@@ -23,7 +23,7 @@ set -u
 RELEASE=$1    # e.g. 4.2.0 or 4.3.0-0.nightly-2019-11-08-080321
 CLIENT_TYPE=$2   # e.g. ocp or ocp-dev-preview
 LINK_NAME=$3   # e.g. latest
-ARCHES="${4:-x86_64}"  # e.g. "x86_64 ppc64le s390x"  OR  "all" to detect arches automatically
+ARCHES="${4:-x86_64}"  # e.g. "x86_64 ppc64le s390x aarch64"  OR  "all" to detect arches automatically
 
 BASE_DIR="/srv/pub/openshift-v4"
 
@@ -124,10 +124,11 @@ for arch in ${ARCHES}; do
 
     if [[ ! -z "$USE_CHANNEL" ]]; then
         qarch="${arch}"
-        if [[ "${qarch}" == "x86_64" ]]; then
-            # Graph uses go arch names; translate from brew arch names
-            qarch="amd64"
-        fi
+        # Graph uses go arch names; translate from brew arch names
+        case "${qarch}" in
+            x86_64) qarch="amd64" ;;
+            aarch64) qarch="arm64" ;;
+        esac
         CHANNEL_RELEASES=$(curl -sH 'Accept:application/json' "https://api.openshift.com/api/upgrades_info/v1/graph?channel=${USE_CHANNEL}&arch=${qarch}" | jq '.nodes[].version' -r)
         if [[ -z "$CHANNEL_RELEASES" ]]; then
             echo "No versions current detected in ${USE_CHANNEL} for arch ${qarch} ; No ${LINK_NAME} will be set"

--- a/jobs/build/build-sync/build.groovy
+++ b/jobs/build/build-sync/build.groovy
@@ -89,7 +89,7 @@ def buildSyncMirrorImages() {
 }
 
 def backupAllImageStreams() {
-    def allNameSpaces = ["ocp", "ocp-priv", "ocp-s390x", "ocp-s390x-priv", "ocp-ppc64le", "ocp-ppc64le-priv"]
+    def allNameSpaces = ["ocp", "ocp-priv", "ocp-s390x", "ocp-s390x-priv", "ocp-ppc64le", "ocp-ppc64le-priv", "ocp-arm64", "ocp-arm64-priv"]
     for (ns in allNameSpaces) {
         def yaml = buildlib.oc("--kubeconfig ${buildlib.ciKubeconfig} get is -n ${ns} -o yaml", [capture: true])
         writeFile file:"${ns}.backup.yaml", text: yaml

--- a/jobs/build/coreos-installer_sync/extract.sh
+++ b/jobs/build/coreos-installer_sync/extract.sh
@@ -11,7 +11,10 @@ if [[ -n "${3-}" ]]; then
   rm -rf keep/
   mkdir keep/
   for arch in $ARCHES; do
-    [[ "$arch" == "amd64" ]] && arch=x86_64
+    case "$arch" in
+      amd64) arch=x86_64 ;;
+      arm64) arch=aarch64 ;;
+    esac
     mv *.$arch.rpm keep/
   done
   rm *.rpm
@@ -23,7 +26,7 @@ rm -rf "$VERSION"
 mkdir "$VERSION"
 
 for rpm in *.rpm; do
-  arch="$(awk -F'[.]' '{a = $(NF-1); print a=="x86_64" ? "amd64" : a}' <<<"$rpm")"
+  arch="$(awk -F'[.]' '{a = $(NF-1); print a=="x86_64" ? "amd64" : a=="aarch64" ? "arm64" : a}' <<<"$rpm")"
   rpm2cpio "${rpm}" | cpio -idm --quiet ./usr/bin/coreos-installer
   mv usr/bin/coreos-installer "$VERSION/coreos-installer_$arch"
 done

--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -136,7 +136,9 @@ node {
         version = buildlib.determineBuildVersion(params.BUILD_VERSION, buildlib.getGroupBranch(doozerOpts), params.VERSION)
         release = params.RELEASE.trim() ?: buildlib.defaultReleaseFor(params.BUILD_VERSION)
     }
-    def repo_type = "signed" // was: params.SIGNED ? "signed" : "unsigned"
+    // If any arch is ready for GA, use signed repos for all (plashets will sign everything).
+    def repo_type = commonlib.ocpReleaseState[params.BUILD_VERSION]['release'] ? 'signed' : 'unsigned'
+
     def images = commonlib.cleanCommaList(params.IMAGES)
     def exclude_images = commonlib.cleanCommaList(params.EXCLUDE_IMAGES)
     def rpms = commonlib.cleanCommaList(params.RPMS)

--- a/jobs/build/oc_sync/publish-clients-from-payload.sh
+++ b/jobs/build/oc_sync/publish-clients-from-payload.sh
@@ -22,6 +22,8 @@ ARCH=$(skopeo inspect docker://${PULL_SPEC} --config | jq .architecture -r)
 
 if [[ "${ARCH}" == "amd64" ]]; then
     ARCH="x86_64"
+elif [[ "${ARCH}" == "arm64" ]]; then
+    ARCH="aarch64"
 fi
 
 OC_MIRROR_DIR="/srv/pub/openshift-v4/${ARCH}/clients/${CLIENT_TYPE}"

--- a/jobs/build/operator-sdk_sync/Jenkinsfile
+++ b/jobs/build/operator-sdk_sync/Jenkinsfile
@@ -68,7 +68,9 @@ pipeline {
                     ).manifests.each {
                         // We want x86_64 to be the first in the list, as that will be used to extract the
                         // Operator SDK version, which is used while naming the files.
-                        def sdkArch = it.platform.architecture == 'amd64' ? 'x86_64' : it.platform.architecture
+                        def sdkArch = it.platform.architecture == 'amd64' ? 'x86_64' :
+                                      it.platform.architecture == 'arm64' ? 'aarch64' :
+                                      it.platform.architecture
                         def data = [arch: sdkArch, digest: it.digest]
                         println("data: ${data}")
 

--- a/jobs/build/operator-sdk_sync/Jenkinsfile
+++ b/jobs/build/operator-sdk_sync/Jenkinsfile
@@ -68,9 +68,7 @@ pipeline {
                     ).manifests.each {
                         // We want x86_64 to be the first in the list, as that will be used to extract the
                         // Operator SDK version, which is used while naming the files.
-                        def sdkArch = it.platform.architecture == 'amd64' ? 'x86_64' :
-                                      it.platform.architecture == 'arm64' ? 'aarch64' :
-                                      it.platform.architecture
+                        def sdkArch = commonlib.brewArchForGoArch(it.platform.architecture)
                         def data = [arch: sdkArch, digest: it.digest]
                         println("data: ${data}")
 

--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -55,6 +55,7 @@ node {
                                 'x86_64',
                                 's390x',
                                 'ppc64le',
+                                'aarch64',
                             ].join('\n'),
                     ),
                     string(
@@ -664,7 +665,7 @@ node {
 
         dry_subject = ""
         if (params.DRY_RUN) { dry_subject = "[DRY RUN] "}
-        releaseArch = arch == "x86_64" ? "amd64" : "${arch}"
+        releaseArch = arch == "x86_64" ? "amd64" : arch == "aarch64" ? "arm64" : "${arch}"
         commonlib.email(
             to: "${params.MAIL_LIST_SUCCESS}",
             replyTo: "aos-team-art@redhat.com",

--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -50,13 +50,7 @@ node {
                     choice(
                         name: 'ARCH',
                         description: 'The architecture for the release. Use "auto" for promoting nightlies. ARCH must be specified when re-promoting an RC."',
-                        choices: [
-                                'auto',
-                                'x86_64',
-                                's390x',
-                                'ppc64le',
-                                'aarch64',
-                            ].join('\n'),
+                        choices: (['auto'] + commonlib.brewArches).join('\n'),
                     ),
                     string(
                         name: 'RELEASE_OFFSET',
@@ -665,7 +659,7 @@ node {
 
         dry_subject = ""
         if (params.DRY_RUN) { dry_subject = "[DRY RUN] "}
-        releaseArch = arch == "x86_64" ? "amd64" : arch == "aarch64" ? "arm64" : "${arch}"
+        releaseArch = commonlib.goArchForBrewArch(arch)
         commonlib.email(
             to: "${params.MAIL_LIST_SUCCESS}",
             replyTo: "aos-team-art@redhat.com",

--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -238,18 +238,18 @@ node {
     slackChannel = slacklib.to(FROM_RELEASE_TAG)
     slackChannel.task("Public release prep for: ${FROM_RELEASE_TAG}${ params.DRY_RUN ? ' (DRY RUN)' : ''}") {
         taskThread ->
-        
+
         stage("Check for Blocker Bugs") {
             if (params.RELEASE_TYPE.startsWith('3.')) {
                 echo "Skip Blocker Bug check for FCs"
                 return
             }
-            commonlib.retrySkipAbort("Waiting for Blocker Bugs to be resolved", taskThread, 
+            commonlib.retrySkipAbort("Waiting for Blocker Bugs to be resolved", taskThread,
                                     "Blocker Bugs found for release; do not proceed without resolving. See https://github.com/openshift/art-docs/blob/master/4.y.z-stream.md#handling-blocker-bugs") {
                 release.stageCheckBlockerBug(group)
             }
         }
-        
+
         sshagent(['aos-cd-test']) {
             release_info = ""
             name = release_name
@@ -561,7 +561,7 @@ node {
                     echo "Skipping rhcos sync"
                     return
                 }
-                
+
                 suffix = release.getArchPrivSuffix(arch, false)
                 tag = params.FROM_RELEASE_TAG
 
@@ -573,7 +573,7 @@ node {
                 print("RHCOS build: $rhcos_build")
 
                 rhcos_mirror_prefix = is_prerelease ? "pre-release" : "$major.$minor"
-                
+
                 sync_params = [
                     buildlib.param('String','BUILD_VERSION', "$major.$minor"),
                     buildlib.param('String','NAME', release_name),

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -545,6 +545,8 @@ def getReleaseControllerURL(releaseStreamName) {
         arch = "s390x" // e.g. -s390x
     } else if ('ppc64le' in streamNameComponents) {
         arch = "ppc64le"
+    } else if ('arm64' in streamNameComponents) {
+        arch = "arm64"
     }
     return "https://${arch}.ocp.releases.ci.openshift.org"
 }

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -20,6 +20,36 @@ eusVersions = [
     "4.10",
 ]
 
+// some of our systems refer to golang's chosen architecture nomenclature;
+// most use brew's nomenclature or similar. translate.
+brewArches = ["x86_64", "s390x", "ppc64le", "aarch64"]
+brewArchSuffixes = ["", "-s390x", "-ppc64le", "-aarch64"]
+goArches = ["amd64", "s390x", "ppc64le", "arm64"]
+goArchSuffixes = ["", "-s390x", "-ppc64le", "-arm64"]
+def goArchForBrewArch(String brewArch) {
+    if (brewArch in goArches) return brewArch  // allow to already be a go arch, just keep same
+    if (brewArch in brewArches)
+        return goArches[brewArches.findIndexOf {it == brewArch}]
+    error("no such brew arch '${brewArch}' - cannot translate to golang arch")
+}
+def brewArchForGoArch(String goArch) {
+    // some of our systems refer to golang's chosen nomenclature; translate to what we use in brew
+    if (goArch in brewArches) return goArch  // allow to already be a brew arch, just keep same
+    if (goArch in goArches)
+        return brewArches[goArches.findIndexOf {it == goArch}]
+    error("no such golang arch '${goArch}' - cannot translate to brew arch")
+}
+// imagestreams and file names often began without consideration for multi-arch and then
+// added a suffix everywhere to accommodate arches (but kept the legacy location for x86).
+def brewSuffixForArch(String arch) {
+    arch = brewArchForGoArch(arch)  // translate either incoming arch style
+    return brewArchSuffixes[brewArches.findIndexOf {it == arch}]
+}
+def goSuffixForArch(String arch) {
+    arch = goArchForBrewArch(arch)  // translate either incoming arch style
+    return goArchSuffixes[goArches.findIndexOf {it == arch}]
+}
+
 /**
  * Why is ocpReleaseState needed?
  *
@@ -499,12 +529,21 @@ def extractMajorMinorVersionNumbers(String version) {
     Returns the architecture name extracted from a release name.
     Only known architecture names are recognized, defaulting to `defaultArch`.
     e.g.
-        "4.4.0-0.nightly-ppc64le-2019-11-06-041852" => "ppc64le"
-        "4.4.0-0.nightly-s390x-2019-11-06-041852" => "s390x"
-        "4.4.0-0.nightly-2019-11-06-041852" => "x86_64"
+        "4.8.0-0.nightly-2021-01-06-041852" => "amd64"
+        "4.8.0-0.nightly-ppc64le-2021-01-06-041852" => "ppc64le"
+        "4.8.0-0.nightly-s390x-2021-01-06-041852" => "s390x"
+        "4.8.0-0.nightly-arm64-2021-06-06-041852" => "arm64"
 */
+def extractGoArchFromReleaseName(String release, String defaultArch='amd64') {
+    archs = goArches + brewArches  // should normally be go but we can identify either safely
+    for(arch in goArches) {
+        if(arch in release.split('-')) defaultArch = arch
+    }
+    return goArchForBrewArch(defaultArch)
+}
 def extractArchFromReleaseName(String release, String defaultArch='x86_64') {
-    return (release =~ /(x86_64|ppc64le|s390x)?$/)[0][1] ?: defaultArch
+    // get the *brew* arch from release name which is go arch nomenclature
+    return brewArchForGoArch(extractGoArchFromReleaseName(release, goArchForBrewArch(defaultArch)))
 }
 
 /**
@@ -541,12 +580,9 @@ def canLock(lockName, timeout_seconds=10) {
 def getReleaseControllerURL(releaseStreamName) {
     def arch = 'amd64'
     def streamNameComponents = releaseStreamName.split('-') // e.g. ['4', 'stable', 's390x']  or [ '4', 'stable' ]
-    if ('s390x' in streamNameComponents) {
-        arch = "s390x" // e.g. -s390x
-    } else if ('ppc64le' in streamNameComponents) {
-        arch = "ppc64le"
-    } else if ('arm64' in streamNameComponents) {
-        arch = "arm64"
+    for(goArch in goArches) {
+        if (goArch in streamNameComponents)
+            arch = goArch
     }
     return "https://${arch}.ocp.releases.ci.openshift.org"
 }

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -162,7 +162,7 @@ Map stageValidation(String quay_url, String dest_release_tag, int advisory = 0, 
 }
 
 def getArchPrivSuffix(arch, priv) {
-    def suffix = arch == "x86_64" ? "" : "-${arch}"
+    def suffix = arch == "x86_64" ? "" : arch == "aarch64" ? "-arm64" : "-${arch}"
     if (priv)
         suffix <<= '-priv'
     return suffix

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -162,7 +162,7 @@ Map stageValidation(String quay_url, String dest_release_tag, int advisory = 0, 
 }
 
 def getArchPrivSuffix(arch, priv) {
-    def suffix = arch == "x86_64" ? "" : arch == "aarch64" ? "-arm64" : "-${arch}"
+    def suffix = commonlib.goSuffixForArch(arch)  // expect golang in release-controller land
     if (priv)
         suffix <<= '-priv'
     return suffix

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -57,8 +57,9 @@ class PrepareReleasePipeline:
             else:
                 arch = "x86_64"
             if ":" not in nightly:
-                # prepend pullsepc URL to nightly name
-                arch_suffix = "" if arch == "x86_64" else "-" + arch
+                # prepend pullspec URL to nightly name
+                # TODO: proper translation facility between brew and go arch nomenclature
+                arch_suffix = "" if arch == "x86_64" else "-amd64" if arch == "aarch64" else "-" + arch
                 nightly = f"registry.ci.openshift.org/ocp{arch_suffix}/release{arch_suffix}:{nightly}"
             self.candidate_nightlies[arch] = nightly
         self.elliott_working_dir = self.working_dir / "elliott-working"

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -52,6 +52,8 @@ class PrepareReleasePipeline:
                 arch = "s390x"
             elif "ppc64le" in nightly:
                 arch = "ppc64le"
+            elif "arm64" in nightly:
+                arch = "aarch64"
             else:
                 arch = "x86_64"
             if ":" not in nightly:

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -59,7 +59,7 @@ class PrepareReleasePipeline:
             if ":" not in nightly:
                 # prepend pullspec URL to nightly name
                 # TODO: proper translation facility between brew and go arch nomenclature
-                arch_suffix = "" if arch == "x86_64" else "-amd64" if arch == "aarch64" else "-" + arch
+                arch_suffix = "" if arch == "x86_64" else "-arm64" if arch == "aarch64" else "-" + arch
                 nightly = f"registry.ci.openshift.org/ocp{arch_suffix}/release{arch_suffix}:{nightly}"
             self.candidate_nightlies[arch] = nightly
         self.elliott_working_dir = self.working_dir / "elliott-working"

--- a/scheduled-jobs/build/poll-payload/Jenkinsfile
+++ b/scheduled-jobs/build/poll-payload/Jenkinsfile
@@ -14,6 +14,7 @@ import groovy.json.JsonOutput
     "4.8.0-0.nightly": this.&startPreReleaseJob,
     "4.8.0-0.nightly-s390x": this.&startPreReleaseJob,
     "4.8.0-0.nightly-ppc64le": this.&startPreReleaseJob,
+    "4.8.0-0.nightly-aarch64": this.&startPreReleaseJob,
 ]
 
 def startPreReleaseJob(String releaseStream, Map latestRelease, Map previousRelease) {

--- a/scheduled-jobs/build/poll-payload/Jenkinsfile
+++ b/scheduled-jobs/build/poll-payload/Jenkinsfile
@@ -14,7 +14,7 @@ import groovy.json.JsonOutput
     "4.8.0-0.nightly": this.&startPreReleaseJob,
     "4.8.0-0.nightly-s390x": this.&startPreReleaseJob,
     "4.8.0-0.nightly-ppc64le": this.&startPreReleaseJob,
-    "4.8.0-0.nightly-aarch64": this.&startPreReleaseJob,
+    // "4.8.0-0.nightly-arm64": this.&startPreReleaseJob, // uncomment once these exist
 ]
 
 def startPreReleaseJob(String releaseStream, Map latestRelease, Map previousRelease) {


### PR DESCRIPTION
Adding on to [yaakov's PR here](https://github.com/openshift/aos-cd-jobs/pull/2610):

> Until now, x86_64/amd64 was the only enabled architecture with differing
> nomenclatures. However, aarch64/arm64 has the same issue, which
> accounts for most of the complications in adding it.

I'm still reviewing and looking carefully at what's affected here... I think there's a doozer piece too, but this is close.