### PR TITLE
Supply assembly argument to all doozer invocations

### DIFF
--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -130,7 +130,7 @@ def doozer(cmd, opts=[:]){
             return commonlib.shell(
                     returnStdout: opts.capture ?: false,
                     alwaysArchive: opts.capture ?: false,
-                    script: "doozer ${cleanWhitespace(cmd)}")
+                    script: "doozer --assembly stream ${cleanWhitespace(cmd)}")
         }
     }
 }


### PR DESCRIPTION
Requires https://github.com/openshift/doozer/pull/408 .
Casts a broad net and includes assembly in every doozer invocation. This will be refined later.