### PR TITLE
ART-3003 Promote and Multi promote enhancements

### DIFF
--- a/jobs/build/multi_promote/Jenkinsfile
+++ b/jobs/build/multi_promote/Jenkinsfile
@@ -43,6 +43,22 @@ node {
                         description: 'Integer. Do not specify for hotfix. If offset is X for 4.5 nightly => Release name is 4.5.X for standard, 4.5.0-rc.X for Release Candidate, 4.5.0-fc.X for Feature Candidate ',
                         trim: true,
                     ),
+                    string(
+                        name: 'IN_FLIGHT_PREV',
+                        description: 'This is the in flight release version of previous minor version of OCP. Leave blank to be prompted later in the job. Used to fill upgrade suggestions.',
+                        defaultValue: false,
+                        trim: true,
+                    ),
+                    choice(
+                        name: 'RESUME_FROM',
+                        description: 'Select stage to resume from. Useful to execute remaining steps in the case of a failed promote job.',
+                        choices: [
+                                '0. The beginning',
+                                '1. Mirror binaries',
+                                '2. Signing',
+                                '3. Cincinnati PRs',
+                            ].join('\n'),
+                    ),
                     commonlib.dryrunParam('Take no actions. Note: still notifies and runs signing job (which fails)'),
                     commonlib.mockParam(),
                 ]
@@ -70,7 +86,8 @@ node {
 
     common_params = [
         buildlib.param('String','RELEASE_TYPE', params.RELEASE_TYPE),
-        buildlib.param('String','RELEASE_OFFSET', params.RELEASE_OFFSET),
+        buildlib.param('String','IN_FLIGHT_PREV', params.IN_FLIGHT_PREV),
+        buildlib.param('String','RESUME_FROM', params.RESUME_FROM),
         buildlib.param('String','ADVISORY', ""),
         booleanParam(name: 'DRY_RUN', value: params.DRY_RUN),
         booleanParam(name: 'MOCK', value: params.MOCK)

--- a/jobs/build/multi_promote/Jenkinsfile
+++ b/jobs/build/multi_promote/Jenkinsfile
@@ -45,8 +45,8 @@ node {
                     ),
                     string(
                         name: 'IN_FLIGHT_PREV',
-                        description: 'This is the in flight release version of previous minor version of OCP. Leave blank to be prompted later in the job. Used to fill upgrade suggestions.',
-                        defaultValue: false,
+                        description: 'This is the in flight release version of previous minor version of OCP. Leave blank to be prompted later in the job. "skip" to indicate that there is no such release in flight. Used to fill upgrade suggestions.',
+                        defaultValue: "",
                         trim: true,
                     ),
                     choice(
@@ -74,30 +74,28 @@ node {
     }
     
     nightly_list = params.NIGHTLIES.split("[,\\s]+")
-    if (nightly_list.size() != 3) {
-        error("Something doesn't seem right. Job expects 3 nightlies of each arch")
-    }
     s390x_index = nightly_list.findIndexOf { it.contains("s390x") }
     power_index = nightly_list.findIndexOf { it.contains("ppc64le") }
     x86_index = nightly_list.findIndexOf { !it.contains("s390x") && !it.contains("ppc64le") }
     if (s390x_index == -1 || power_index == -1 || x86_index == -1) {
         def resp = input(
-            message: "Something doesn't seem right. Job expects 3 nightlies of each arch. Do you still want to proceed?",
+            message: "Something doesn't seem right. Job expects 3 nightlies of each arch. Do you still want to proceed with given nightlies $nightly_list ?",
             parameters: [
                 booleanParam(
-                    defaultValue: false,
-                    description: "This is release ${release_name}. What release is in flight for the previous minor release 4.${prevMinor}?",
                     name: 'PROCEED',
+                    defaultValue: false,
+                    description: "Are you sure to proceed with the given nightlies?"
                 )
             ]
         )
-        if (!resp.PROCEED) {
+        if (!resp) {
             error("Aborting.")
         }
     }
 
     common_params = [
         buildlib.param('String','RELEASE_TYPE', params.RELEASE_TYPE),
+        buildlib.param('String','RELEASE_OFFSET', params.RELEASE_OFFSET),
         buildlib.param('String','IN_FLIGHT_PREV', params.IN_FLIGHT_PREV),
         buildlib.param('String','RESUME_FROM', params.RESUME_FROM),
         buildlib.param('String','ADVISORY', ""),
@@ -110,44 +108,50 @@ node {
     parallel(
         "x86_64": {
             stage("x86_64") {
-                def params = common_params.clone()
-                nightly = nightly_list[x86_index]
-                params << buildlib.param('String','FROM_RELEASE_TAG', nightly)
-                
-                build(
-                    job: promote_job_location,
-                    propagate: false,
-                    parameters: params
-                )
-                currentBuild.description += "<br>triggered promote: ${nightly}"
+                if (x86_index != -1) {
+                    def params = common_params.clone()
+                    nightly = nightly_list[x86_index]
+                    params << buildlib.param('String','FROM_RELEASE_TAG', nightly)
+                    
+                    build(
+                        job: promote_job_location,
+                        propagate: false,
+                        parameters: params
+                    )
+                    currentBuild.description += "<br>triggered promote: ${nightly}"
+                }
             }
         },
         "s390x": {
             stage("s390x") {
-                def params = common_params.clone()
-                nightly = nightly_list[s390x_index]
-                params << buildlib.param('String','FROM_RELEASE_TAG', nightly)
-                
-                build(
-                    job: promote_job_location,
-                    propagate: false,
-                    parameters: params
-                )
-                currentBuild.description += "<br>triggered promote: ${nightly}"
+                if (s390x_index != -1) {
+                    def params = common_params.clone()
+                    nightly = nightly_list[s390x_index]
+                    params << buildlib.param('String','FROM_RELEASE_TAG', nightly)
+                    
+                    build(
+                        job: promote_job_location,
+                        propagate: false,
+                        parameters: params
+                    )
+                    currentBuild.description += "<br>triggered promote: ${nightly}"    
+                }
             }
         },
         "ppc64le": {
             stage("ppc64le") {
-                def params = common_params.clone()
-                nightly = nightly_list[power_index]
-                params << buildlib.param('String','FROM_RELEASE_TAG', nightly)
-                
-                build(
-                    job: promote_job_location,
-                    propagate: false,
-                    parameters: params
-                )
-                currentBuild.description += "<br>triggered promote: ${nightly}"
+                if (power_index != -1) {
+                    def params = common_params.clone()
+                    nightly = nightly_list[power_index]
+                    params << buildlib.param('String','FROM_RELEASE_TAG', nightly)
+                    
+                    build(
+                        job: promote_job_location,
+                        propagate: false,
+                        parameters: params
+                    )
+                    currentBuild.description += "<br>triggered promote: ${nightly}"
+                }
             }
         }
     )

--- a/jobs/build/multi_promote/Jenkinsfile
+++ b/jobs/build/multi_promote/Jenkinsfile
@@ -81,7 +81,19 @@ node {
     power_index = nightly_list.findIndexOf { it.contains("ppc64le") }
     x86_index = nightly_list.findIndexOf { !it.contains("s390x") && !it.contains("ppc64le") }
     if (s390x_index == -1 || power_index == -1 || x86_index == -1) {
-        error("Something doesn't seem right. Job expects 3 nightlies of each arch")
+        def resp = input(
+            message: "Something doesn't seem right. Job expects 3 nightlies of each arch. Do you still want to proceed?",
+            parameters: [
+                booleanParam(
+                    defaultValue: false,
+                    description: "This is release ${release_name}. What release is in flight for the previous minor release 4.${prevMinor}?",
+                    name: 'PROCEED',
+                )
+            ]
+        )
+        if (!resp.PROCEED) {
+            error("Aborting.")
+        }
     }
 
     common_params = [

--- a/jobs/build/multi_promote/Jenkinsfile
+++ b/jobs/build/multi_promote/Jenkinsfile
@@ -105,6 +105,8 @@ node {
         booleanParam(name: 'MOCK', value: params.MOCK)
     ]
 
+    promote_job_location = 'build%2Fpromote'
+
     parallel(
         "x86_64": {
             stage("x86_64") {
@@ -113,7 +115,7 @@ node {
                 params << buildlib.param('String','FROM_RELEASE_TAG', nightly)
                 
                 build(
-                    job: '/aos-cd-builds/build%2Fpromote',
+                    job: promote_job_location,
                     propagate: false,
                     parameters: params
                 )
@@ -127,7 +129,7 @@ node {
                 params << buildlib.param('String','FROM_RELEASE_TAG', nightly)
                 
                 build(
-                    job: '/aos-cd-builds/build%2Fpromote',
+                    job: promote_job_location,
                     propagate: false,
                     parameters: params
                 )
@@ -141,7 +143,7 @@ node {
                 params << buildlib.param('String','FROM_RELEASE_TAG', nightly)
                 
                 build(
-                    job: '/aos-cd-builds/build%2Fpromote',
+                    job: promote_job_location,
                     propagate: false,
                     parameters: params
                 )

--- a/jobs/build/multi_promote/README.md
+++ b/jobs/build/multi_promote/README.md
@@ -88,5 +88,26 @@ This offset (call it X) is used to construct the release name depending on the r
 3. Feature Candidate: `4.y.0-fc.X`
 4. Hotfix: do not specify an offset; the name of the nightly is re-used.
 
+### IN\_FLIGHT\_PREV
+
+This is used to specify the previous minor version release that is being prepared/promoted
+in the same week. Usually we would have 2-3 releases, e.g. 4.7.13 and 4.6.31 being prepared
+in the week. While promoting 4.7.13, this field would have the value 4.6.31.
+
+If you leave it as blank, you will be prompted later in the job for the input also with the 
+suggested previous releases.
+
+### RESUME\_FROM
+
+**Warning: This would start multiple promote jobs with the given stage. Make sure all previous promote jobs failed on the same stage. Otherwise use the standalone promote job**
+
+Sometimes promote jobs fail either because of an outage or due to a network error,
+or due to some other reason. This param lets you specify a stage to start a promote
+job from.
+
+If you're unsure about the stage previous promote failed or which stage to resume from, 
+it's a good idea to consult other ARTists and read the code since this is an 
+advanced param :)
+
 ## Known issues
 As of right now (May 4th 2021) the job expects 3 nightlies always (for s390x, ppc64le and x86). In the future we want to fix this by varying for release type/version, and for supporting more arches. - [see this comment](https://github.com/openshift/aos-cd-jobs/pull/2606#discussion_r625391662) for details.

--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -334,10 +334,8 @@ node {
                         in_flight_prev_required = false
                     } else if (params.IN_FLIGHT_PREV) {
                         in_flight_prev = params.IN_FLIGHT_PREV.trim()
-                        pattern = /$major\.$prevMinor\.(\d+)/
-                        match = in_flight_prev =~ pattern
-                        match.find()
-                        if (match.size() == 1) {
+                        valid = release.validateInFlightPrevVersion(in_flight_prev, major, prevMinor)
+                        if (valid) {
                             print("Proceeding with given in_flight_prev: $in_flight_prev")
                             in_flight_prev_required = false
                         } else {

--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -81,8 +81,8 @@ node {
                     ),
                     string(
                         name: 'IN_FLIGHT_PREV',
-                        description: 'This is the in flight release version of previous minor version of OCP. Leave blank to be prompted later in the job. Used to fill upgrade suggestions.',
-                        defaultValue: false,
+                        description: 'This is the in flight release version of previous minor version of OCP. Leave blank to be prompted later in the job. "skip" to indicate that there is no such release in flight. Used to fill upgrade suggestions.',
+                        defaultValue: "",
                         trim: true,
                     ),
                     booleanParam(

--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -329,9 +329,12 @@ node {
 
                     prevMinor = minor - 1
                     in_flight_prev_required = true
-                    if (params.IN_FLIGHT_PREV) {
+                    if (params.IN_FLIGHT_PREV.toUpperCase() == 'SKIP') {
+                        print("Skipping asking for in_flight_prev")
+                        in_flight_prev_required = false
+                    } else if (params.IN_FLIGHT_PREV) {
                         in_flight_prev = params.IN_FLIGHT_PREV.trim()
-                        pattern = /4\.$prevMinor\.(\d+)/
+                        pattern = /$major\.$prevMinor\.(\d+)/
                         match = in_flight_prev =~ pattern
                         match.find()
                         if (match.size() == 1) {
@@ -361,9 +364,9 @@ node {
                             )    
                         }
                         in_flight_prev = resp.IN_FLIGHT_PREV
+                        suggest_previous = resp.SUGGESTED
                     }
-                    
-                    previousList = commonlib.parseList(resp.SUGGESTED) + commonlib.parseList(in_flight_prev)
+                    previousList = commonlib.parseList(suggest_previous) + commonlib.parseList(in_flight_prev)
                 }
             }
             previousList = previousList.toList().unique().sort()

--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -622,7 +622,7 @@ node {
                     echo "Not a stable release, not sending message over bus"
                     return
                 }
-                if (params.DRY_DRUN) {
+                if (params.DRY_RUN) {
                     echo "DRY_RUN: Not sending release message"
                     return
                 }

--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -595,7 +595,7 @@ node {
                 rhcos_build =  commonlib.shell(
                     returnStdout: true,
                     script: cmd
-                )
+                ).trim()
                 print("RHCOS build: $rhcos_build")
 
                 rhcos_mirror_prefix = is_prerelease ? "pre-release" : "$major.$minor"

--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -79,6 +79,12 @@ node {
                         defaultValue: "auto",
                         trim: true,
                     ),
+                    string(
+                        name: 'IN_FLIGHT_PREV',
+                        description: 'This is the in flight release version of previous minor version of OCP. Leave blank to be prompted later in the job. Used to fill upgrade suggestions.',
+                        defaultValue: false,
+                        trim: true,
+                    ),
                     booleanParam(
                         name: 'PERMIT_PAYLOAD_OVERWRITE',
                         description: 'DO NOT USE without team lead approval. Allows the pipeline to overwrite an existing payload in quay.',
@@ -322,25 +328,42 @@ node {
                     }
 
                     prevMinor = minor - 1
-                    commonlib.inputRequired(taskThread) {
-                        def resp = input(
-                            message: "${acquire_failure}What PREVIOUS releases should be included in ${release_name} (arch: ${arch})?",
-                            parameters: [
-                                string(
-                                    defaultValue: "4.${prevMinor}.?",
-                                    description: "This is release ${release_name}. What release is in flight for the previous minor release 4.${prevMinor}?",
-                                    name: 'IN_FLIGHT_PREV',
-                                ),
-                                string(
-                                    defaultValue: "${suggest_previous}",
-                                    description: (acquire_failure?acquire_failure:"Doozer thinks these are the other releases to include.") + " Edit as necessary (comma delimited).",
-                                    name: 'SUGGESTED',
-                                ),
-                            ]
-                        )
+                    in_flight_prev_required = true
+                    if (params.IN_FLIGHT_PREV) {
+                        in_flight_prev = params.IN_FLIGHT_PREV.trim()
+                        pattern = /4\.$prevMinor\.(\d+)/
+                        match = in_flight_prev =~ pattern
+                        match.find()
+                        if (match.size() == 1) {
+                            print("Proceeding with given in_flight_prev: $in_flight_prev")
+                            in_flight_prev_required = false
+                        } else {
+                            print("Error validating given in_flight_prev: $in_flight_prev . Asking for manual input")
+                        }
+                    } 
 
-                        previousList = commonlib.parseList(resp.SUGGESTED) + commonlib.parseList(resp.IN_FLIGHT_PREV)
+                    if (in_flight_prev_required) {
+                        commonlib.inputRequired(taskThread) {
+                            def resp = input(
+                                message: "${acquire_failure}What PREVIOUS releases should be included in ${release_name} (arch: ${arch})?",
+                                parameters: [
+                                    string(
+                                        defaultValue: "4.${prevMinor}.?",
+                                        description: "This is release ${release_name}. What release is in flight for the previous minor release 4.${prevMinor}?",
+                                        name: 'IN_FLIGHT_PREV',
+                                    ),
+                                    string(
+                                        defaultValue: "${suggest_previous}",
+                                        description: (acquire_failure?acquire_failure:"Doozer thinks these are the other releases to include.") + " Edit as necessary (comma delimited).",
+                                        name: 'SUGGESTED',
+                                    ),
+                                ]
+                            )    
+                        }
+                        in_flight_prev = resp.IN_FLIGHT_PREV
                     }
+                    
+                    previousList = commonlib.parseList(resp.SUGGESTED) + commonlib.parseList(in_flight_prev)
                 }
             }
             previousList = previousList.toList().unique().sort()

--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -306,71 +306,73 @@ node {
                 }
             }
 
-            previousList = commonlib.parseList(params.PREVIOUS)
-            if ( params.PREVIOUS.trim() == 'auto' && !skip.PAYLOAD_CREATION) {
-                taskThread.task('Gather PREVIOUS for release') {
+            stage("get upgrade edges") {
+                previousList = commonlib.parseList(params.PREVIOUS)
+                if ( params.PREVIOUS.trim() == 'auto' && !skip.PAYLOAD_CREATION) {
+                    taskThread.task('Gather PREVIOUS for release') {
 
-                    if (!detect_previous) {
-                        // Hotfixes don't get a PREVIOUS by default since we don't
-                        // want customers upgrading to it unintentionally.
-                        previousList = []
-                        return
-                    }
+                        if (!detect_previous) {
+                            // Hotfixes don't get a PREVIOUS by default since we don't
+                            // want customers upgrading to it unintentionally.
+                            previousList = []
+                            return
+                        }
 
-                    def acquire_failure = ''
-                    def suggest_previous = ''
-                    try {
-                        suggest_previous = buildlib.doozer("release:calc-previous -a ${arch} --version ${release_name}", [capture: true])
-                        echo "Doozer suggested: ${suggest_previous}"
-                    } catch ( cincy_down ) {
-                        acquire_failure = '****Doozer was not able to acquire data from Cincinnati. Inputs will need to be determined manually****. '
-                        echo acquire_failure
-                    }
+                        def acquire_failure = ''
+                        def suggest_previous = ''
+                        try {
+                            suggest_previous = buildlib.doozer("release:calc-previous -a ${arch} --version ${release_name}", [capture: true])
+                            echo "Doozer suggested: ${suggest_previous}"
+                        } catch ( cincy_down ) {
+                            acquire_failure = '****Doozer was not able to acquire data from Cincinnati. Inputs will need to be determined manually****. '
+                            echo acquire_failure
+                        }
 
-                    prevMinor = minor - 1
-                    in_flight_prev_required = true
-                    if (params.IN_FLIGHT_PREV.toUpperCase() == 'SKIP') {
-                        print("Skipping asking for in_flight_prev")
-                        in_flight_prev_required = false
-                    } else if (params.IN_FLIGHT_PREV) {
-                        in_flight_prev = params.IN_FLIGHT_PREV.trim()
-                        valid = release.validateInFlightPrevVersion(in_flight_prev, major, prevMinor)
-                        if (valid) {
-                            print("Proceeding with given in_flight_prev: $in_flight_prev")
+                        prevMinor = minor - 1
+                        in_flight_prev_required = true
+                        if (params.IN_FLIGHT_PREV.toUpperCase() == 'SKIP') {
+                            print("Skipping asking for in_flight_prev")
                             in_flight_prev_required = false
-                        } else {
-                            print("Error validating given in_flight_prev: $in_flight_prev . Asking for manual input")
-                        }
-                    } 
+                        } else if (params.IN_FLIGHT_PREV) {
+                            in_flight_prev = params.IN_FLIGHT_PREV.trim()
+                            valid = release.validateInFlightPrevVersion(in_flight_prev, major, prevMinor)
+                            if (valid) {
+                                print("Proceeding with given in_flight_prev: $in_flight_prev")
+                                in_flight_prev_required = false
+                            } else {
+                                print("Error validating given in_flight_prev: $in_flight_prev . Asking for manual input")
+                            }
+                        } 
 
-                    if (in_flight_prev_required) {
-                        commonlib.inputRequired(taskThread) {
-                            def resp = input(
-                                message: "${acquire_failure}What PREVIOUS releases should be included in ${release_name} (arch: ${arch})?",
-                                parameters: [
-                                    string(
-                                        defaultValue: "4.${prevMinor}.?",
-                                        description: "This is release ${release_name}. What release is in flight for the previous minor release 4.${prevMinor}?",
-                                        name: 'IN_FLIGHT_PREV',
-                                    ),
-                                    string(
-                                        defaultValue: "${suggest_previous}",
-                                        description: (acquire_failure?acquire_failure:"Doozer thinks these are the other releases to include.") + " Edit as necessary (comma delimited).",
-                                        name: 'SUGGESTED',
-                                    ),
-                                ]
-                            )    
+                        if (in_flight_prev_required) {
+                            commonlib.inputRequired(taskThread) {
+                                def resp = input(
+                                    message: "${acquire_failure}What PREVIOUS releases should be included in ${release_name} (arch: ${arch})?",
+                                    parameters: [
+                                        string(
+                                            defaultValue: "4.${prevMinor}.?",
+                                            description: "This is release ${release_name}. What release is in flight for the previous minor release 4.${prevMinor}?",
+                                            name: 'IN_FLIGHT_PREV',
+                                        ),
+                                        string(
+                                            defaultValue: "${suggest_previous}",
+                                            description: (acquire_failure?acquire_failure:"Doozer thinks these are the other releases to include.") + " Edit as necessary (comma delimited).",
+                                            name: 'SUGGESTED',
+                                        ),
+                                    ]
+                                )    
+                            }
+                            in_flight_prev = resp.IN_FLIGHT_PREV
+                            suggest_previous = resp.SUGGESTED
                         }
-                        in_flight_prev = resp.IN_FLIGHT_PREV
-                        suggest_previous = resp.SUGGESTED
+                        previousList = commonlib.parseList(suggest_previous) + commonlib.parseList(in_flight_prev)
                     }
-                    previousList = commonlib.parseList(suggest_previous) + commonlib.parseList(in_flight_prev)
                 }
+                previousList = previousList.toList().unique().sort()
+                Collections.reverse(previousList)
+                echo "previousList is ${previousList}"
             }
-            previousList = previousList.toList().unique().sort()
-            Collections.reverse(previousList)
-            echo "previousList is ${previousList}"
-
+            
             // must be able to access remote registry for verification
             buildlib.registry_quay_dev_login()
             stage("versions") { release.stageVersions() }

--- a/jobs/build/promote/README.md
+++ b/jobs/build/promote/README.md
@@ -166,6 +166,15 @@ for instructions on how to fill this field.
 Once we have `releases.yml` automation this should go away entirely in favor of
 determining the releases from our configuration.
 
+### IN\_FLIGHT\_PREV
+
+This is used to specify the previous minor version release that is being prepared/promoted
+in the same week. Usually we would have 2-3 releases, e.g. 4.7.13 and 4.6.31 being prepared
+in the week. While promoting 4.7.13, this field would have the value 4.6.31.
+
+If you leave it as blank, you will be prompted later in the job for the input also with the 
+suggested previous releases.
+
 ### PERMIT\_PAYLOAD\_OVERWRITE
 
 **DO NOT USE** without discussing with your team or pillar lead for approval.
@@ -192,6 +201,16 @@ automated incremental builds for this version.
 Usually we want to do this to allow builds to begin after the release is
 promoted; set to "No" only if you know of a reason why we want to keep the
 version closed to further builds.
+
+### RESUME\_FROM
+
+Sometimes promote job fail either because of an outage or due to a network error,
+or due to some other reason. This param lets you specify a stage to start a promote
+job from.
+
+If you're unsure about the stage previous promote failed or which stage to resume from, 
+it's a good idea to consult other ARTists and read the code since this is an 
+advanced param :)
 
 ### SKIP\_CINCINNATI\_PR\_CREATION
 

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -370,6 +370,16 @@ def stageCheckBlockerBug(group){
     }
 }
 
+def validateInFlightPrevVersion(in_flight_prev, major, prevMinor) {
+    pattern = /$major\.$prevMinor\.(\d+)/
+    match = in_flight_prev =~ pattern
+    match.find()
+    if (match.size() == 1) {
+        return true
+    }
+    return false
+}
+
 def stageGetReleaseInfo(quay_url, release_tag){
     def cmd = "GOTRACEBACK=all ${oc_cmd} adm release info --pullspecs ${quay_url}:${release_tag}"
 


### PR DESCRIPTION
- Have a "in_flight_prev" param on promote job which if specified correctly does not prompt artist for input.
- Have multi_promote job include params
    - "resume_from" 
    - "in_flight_prev" 

Test job runs
- https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Fpromote/34/parameters/ (with in_flight_prev)
- https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Fmulti_promote/ (with in_flight_prev and selective nightlies with confirmation prompt)