### PR TITLE
[ART-2945] ocp4 & custom: create plashets under assembly specific loc…

### DIFF
--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -48,6 +48,12 @@ node {
                         trim: true,
                     ),
                     string(
+                        name: 'ASSEMBLY',
+                        description: 'The name of an assembly to rebase & build for. If assemblies are not enabled in group.yml, this parameter will be ignored',
+                        defaultValue: "stream",
+                        trim: true,
+                    ),
+                    string(
                         name: 'DOOZER_DATA_PATH',
                         description: 'ocp-build-data fork to use (e.g. test customizations on your own fork)',
                         defaultValue: "https://github.com/openshift/ocp-build-data",
@@ -143,6 +149,9 @@ node {
     def exclude_images = commonlib.cleanCommaList(params.EXCLUDE_IMAGES)
     def rpms = commonlib.cleanCommaList(params.RPMS)
 
+    if (params.ASSEMBLY && params.ASSEMBLY != 'stream' && buildlib.doozer("${doozerOpts} config:read-group --default=False assemblies.enabled", [capture: true]).trim() != 'True') {
+        error("ASSEMBLY cannot be set to '${params.ASSEMBLY}' because assemblies are not enabled in ocp-build-data.")
+    }
 
     currentBuild.displayName = "#${currentBuild.number} - ${version}-${release}"
 

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -13,7 +13,7 @@ node {
 
         In typical usage, scans for changes that could affect package or image
         builds and rebuilds the affected components.  Creates new plashets if
-        the automation is not frozen or if there are RPMs that are built in this run, 
+        the automation is not frozen or if there are RPMs that are built in this run,
         and runs other jobs to sync builds to nightlies, create
         operator metadata, and sweep bugs and builds into advisories.
 
@@ -40,6 +40,12 @@ node {
                         name: 'NEW_VERSION',
                         description: '(Optional) version for build instead of most recent\nor "+" to bump most recent version',
                         defaultValue: "",
+                        trim: true,
+                    ),
+                    string(
+                        name: 'ASSEMBLY',
+                        description: 'The name of an assembly to rebase & build for. If assemblies are not enabled in group.yml, this parameter will be ignored',
+                        defaultValue: "stream",
                         trim: true,
                     ),
                     booleanParam(

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -49,7 +49,7 @@ def initialize() {
     version.stream = params.BUILD_VERSION.trim()
     doozerOpts += " --group 'openshift-${version.stream}'"
 
-    if (params.ASSEMBLY && params.ASSEMBLY != 'stream' && buildlib.doozer("${doozerOpts} config:read-group --default=False assemblies.enabled", [capture: true]).trim() != 'True') {
+    if (params.ASSEMBLY != 'stream' && buildlib.doozer("${doozerOpts} config:read-group --default=False assemblies.enabled", [capture: true]).trim() != 'True') {
         error("ASSEMBLY cannot be set to '${params.ASSEMBLY}' because assemblies are not enabled in ocp-build-data.")
     }
 

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -48,6 +48,11 @@ def initialize() {
 
     version.stream = params.BUILD_VERSION.trim()
     doozerOpts += " --group 'openshift-${version.stream}'"
+
+    if (params.ASSEMBLY && params.ASSEMBLY != 'stream' && buildlib.doozer("${doozerOpts} config:read-group --default=False assemblies.enabled", [capture: true]).trim() != 'True') {
+        error("ASSEMBLY cannot be set to '${params.ASSEMBLY}' because assemblies are not enabled in ocp-build-data.")
+    }
+
     version.branch = buildlib.getGroupBranch(doozerOpts)
     version << determineBuildVersion(version.stream, version.branch)
 
@@ -386,6 +391,10 @@ ${failed_messages}
  * required for bare metal installs.
  */
 def stageMirrorRpms() {
+    if (params.ASSEMBLY && params.ASSEMBLY != 'stream') {
+        echo "No need to mirror rpms for non-stream assembly."
+        return
+    }
     if (!rpmMirror.localPlashetPath) {
         echo "No updated RPMs to mirror."
         return


### PR DESCRIPTION
…ations

- Adds `ASSEMBLY` parameter to override the default assembly value (`stream`).
- If assemblies are enabled, plashets should be created under assembly specific locations.
- If `assembly == 'stream'`, legacy `building[-embaroged]` symlink will be updated to point to the new symlink.
- Only sync rpms to mirror if assemblies are disabled or `assembly == "stream"`.

Test builds (with this PR, https://github.com/openshift/aos-cd-jobs/pull/2637, and https://github.com/openshift/doozer/pull/425 merged into my fork)
- ocp4 build for 4.8 with assembly == "stream": https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/yuxzhu/job/aos-cd-jobs/job/build%252Focp4/34/console
- ocp4 build for 4.8 with assembly == "test":  https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/yuxzhu/job/aos-cd-jobs/job/build%252Focp4/35/console
- custom build for 4.9 with assembly == "stream": https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/yuxzhu/job/aos-cd-jobs/job/build%252Fcustom/21/console
- custom build for 4.5 with assembly == "stream" (assemblies disabled): https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/yuxzhu/job/aos-cd-jobs/job/build%252Fcustom/22/console
- custom build for 4.5 with assembly == "test" (assemblies disabled, build error is expected): 
https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/yuxzhu/job/aos-cd-jobs/job/build%252Fcustom/23/console