### PR TITLE
fix ssh call error

### DIFF
--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -432,7 +432,7 @@ def stageMirrorRpms() {
     //  Now we have a plashet named after the original on the mirror. QE wants a 'latest' link there.
     commonlib.shell("ssh -tt ${openshift_mirror_user}@${openshift_mirror_bastion} \"cd ${destBaseDir}; ln -sfn ${rpmMirror.plashetDirName} latest\"")
     //  Because the mirrors are always low on space, delete all but the lastest 4 plashets
-    commonlib.shell("ssh -tt ${openshift_mirror_user}@${openshift_mirror_bastion} \"cd ${destBaseDir};  rm -rf `ls | grep '4.*' | sort | tac | tail -n +5` \"")
+    commonlib.shell("ssh ${openshift_mirror_user}@${openshift_mirror_bastion} \"ls ${destBaseDir} | grep '4.*' | sort | tac | tail -n +5 | xargs rm -rf \"")
     //  For historical reasons, all puddles were linked to from 'all' directory as well.
     commonlib.shell("ssh ${openshift_mirror_user}@${openshift_mirror_bastion} -- ln -sfn ${destBaseDir}/${rpmMirror.plashetDirName} /srv/enterprise/all/${version.stream}/${rpmMirror.plashetDirName}")
     // Also establish latest link


### PR DESCRIPTION
after debug I found  \`  ( Backtick character ) is the root cause which in this case it executed on jenkins vm not on mirror. Try to use another way without  \` and -tt

```
[jenkins@buildvm ~]$ ssh -tt jenkins_aos_cd_bot@use-mirror-upload.ops.rhcloud.com "cd /srv/enterprise/enterprise-4.8;  rm -rf `ls | grep '4.*' | sort | tac | tail -n +5` "
bash: line 1: base-art-latest-imagestream-4.2.yaml: command not found
bash: line 2: base-art-latest-imagestream-4.1.yaml~: command not found
bash: line 3: base-art-latest-imagestream-4.1.yaml: command not found
bash: line 4: base-art-latest-imagestream-4.0.yaml: command not found
bash: line 5: art-1634-test: command not found
Connection to use-mirror-upload.ops.rhcloud.com closed.
```