### PR TITLE
Don't let trailing slash mess up wget

### DIFF
--- a/jobs/build/kn_sync/Jenkinsfile
+++ b/jobs/build/kn_sync/Jenkinsfile
@@ -42,6 +42,9 @@ pipeline {
                     if (!params.VERSION) {
                         error "VERSION must be specified"
                     }
+                    if (!params.SOURCES_LOCATION[-1] != "/") {
+                        error "Location should end with a trailing slash (to not confuse wget)"
+                    }
                 }
             }
         }


### PR DESCRIPTION
If trailing slash isn't added, wget downloads a whole lot more useless files than it should (e.g. "https://download.eng.bos.redhat.com/staging-cds/developer/openshift-serverless-clients/0.21.0-4" should be invalid )
