### PR TITLE
Stop building ppc64le for 3.11

### DIFF
--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -135,8 +135,8 @@ ocpReleaseState = [
             "pre-release": [],
         ],
         "3.11": [
-            "release": [ 'x86_64', 'ppc64le' ],
-            "pre-release": [ 's390x', 'aarch64' ],
+            "release": [ 'x86_64' ],
+            "pre-release": [ 'ppc64le', 's390x', 'aarch64' ],
         ],
 ]
 


### PR DESCRIPTION
As per the document
https://access.redhat.com/support/policy/updates/openshift_noncurrent,
POWER for 3.X is EOL after June 2021. This commit removes the ppc64le
architecture from the build targets of 3.11.

See also: https://github.com/openshift/ocp-build-data/pull/961