### PR TITLE
[ART-3056] Don't fail if there are no bundles to build

### DIFF
--- a/jobs/build/olm_bundle/olm_bundles.groovy
+++ b/jobs/build/olm_bundle/olm_bundles.groovy
@@ -17,7 +17,7 @@ def elliott(cmd) {
  * Return the brew package name of all OLM operators present in <params.BUILD_VERSION>
  */
 def get_olm_operators() {
-    doozer('olm-bundle:list-olm-operators').split("\n")
+    commonlib.sanitizeInvisible(doozer('olm-bundle:list-olm-operators')).split("\n").findAll { !it.isEmpty() }
 }
 
 /*


### PR DESCRIPTION
The pipeline already counts with stage conditions to prevent failure when there is nothing to be built, but they were beeing fooled by an odd behavior when splitting by `\n`:
```
groovy:000> doozer_output = "".split()
===> []
groovy:000> doozer_output.size()
===> 0
groovy:000> doozer_output = "".split("\n")
===> []
groovy:000> doozer_output.size()
===> 1
groovy:000>
```

So the list wasn't _technically_ empty, and consequentially the stage conditions weren't being met.