### PR TITLE
Make dropping work more reliably

### DIFF
--- a/jobs/build/drop_advisories/Jenkinsfile
+++ b/jobs/build/drop_advisories/Jenkinsfile
@@ -42,7 +42,10 @@ node {
     for(adv in advisory_list) {
         res = commonlib.shell(
             returnAll: true,
-            script: "${buildlib.ELLIOTT_BIN} advisory-drop ${adv}",
+            script: """
+              ${buildlib.ELLIOTT_BIN} change-state --state NEW_FILES --advisory ${adv}
+              ${buildlib.ELLIOTT_BIN} advisory-drop ${adv}
+            """,
         )
         print(res)
     }


### PR DESCRIPTION
Change state to NEW_FILES, otherwise there'll be an error.