### PR TITLE
ART-3083 Prepare release - Perform sweep at the end

### DIFF
--- a/jobs/build/prepare-release/Jenkinsfile
+++ b/jobs/build/prepare-release/Jenkinsfile
@@ -75,6 +75,14 @@ node {
             }
             commonlib.shell(script: "pip install -e ./pyartcd")
         }
+        stage ("Notify release channel") {
+            if (params.DRY_RUN) {
+                return
+            }
+            slackChannel = slacklib.to(params.NAME)
+            slackChannel.say(":construction: Preparing release for $params.NAME :construction:")
+        }
+        
         stage("prepare release") {
             def cmd = [
                 "./pyartcd/prepare_release.py",

--- a/jobs/build/prepare-release/Jenkinsfile
+++ b/jobs/build/prepare-release/Jenkinsfile
@@ -69,7 +69,7 @@ node {
             buildlib.initialize()
             buildlib.registry_quay_dev_login()
             def (major, minor) = commonlib.extractMajorMinorVersionNumbers(params.NAME)
-            currentBuild.displayName += " - $major.$minor"
+            currentBuild.displayName += " - $params.NAME"
             if (major >= 4 && !params.NIGHTLIES) {
                 error("For OCP 4 releases, you must provide a list of proposed nightlies.")
             }

--- a/jobs/build/prepare-release/Jenkinsfile
+++ b/jobs/build/prepare-release/Jenkinsfile
@@ -82,7 +82,7 @@ node {
             slackChannel = slacklib.to(params.NAME)
             slackChannel.say(":construction: Preparing release for $params.NAME :construction:")
         }
-        
+
         stage("prepare release") {
             def cmd = [
                 "./pyartcd/prepare_release.py",

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -329,7 +329,10 @@ class PrepareReleasePipeline:
         if self.dry_run:
             cmd.append("--dry-run")
         _LOGGER.debug("Running command: %s", cmd)
-        subprocess.run(cmd, check=True, universal_newlines=True, cwd=self.working_dir)
+
+        # keep check=False so we don't abort
+        subprocess.run(cmd, check=False, universal_newlines=True, cwd=self.working_dir)
+
 
     def sweep_builds(
         self, kind: str, advisory: int, only_payload=False, only_non_payload=False
@@ -348,7 +351,10 @@ class PrepareReleasePipeline:
         if not self.dry_run:
             cmd.append(f"--attach={advisory}")
         _LOGGER.debug("Running command: %s", cmd)
-        subprocess.run(cmd, check=True, universal_newlines=True, cwd=self.working_dir)
+
+        # keep check=False so we don't abort
+        subprocess.run(cmd, check=False, universal_newlines=True, cwd=self.working_dir)
+
 
     def change_advisory_state(self, advisory: int, state: str):
         cmd = [

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -104,6 +104,13 @@ class PrepareReleasePipeline:
             _LOGGER.info("Creating a release JIRA...")
             jira_issues = self.create_release_jira(advisories)
 
+            _LOGGER.info("Sending a notification to QE and multi-arch QE:")
+            if self.dry_run:
+                jira_issue_link = "https://jira.example.com/browse/FOO-1"
+            else:
+                jira_issue_link = jira_issues[0].permalink()
+            self.send_notification_email(advisories, jira_issue_link)
+
             _LOGGER.info("Adding placeholder bugs to the advisories...")
             for kind, advisory in advisories.items():
                 # don't create placeholder bugs for OCP 4 image advisory and OCP 3 rpm advisory
@@ -145,14 +152,6 @@ class PrepareReleasePipeline:
             _LOGGER.info("Verify the swept builds match the nightlies...")
             for _, payload in self.candidate_nightlies.items():
                 self.verify_payload(payload, advisories["image"])
-
-        if not self.default_advisories:
-            _LOGGER.info("Sending a notification to QE and multi-arch QE:")
-            if self.dry_run:
-                jira_issue_link = "https://jira.example.com/browse/FOO-1"
-            else:
-                jira_issue_link = jira_issues[0].permalink()
-            self.send_notification_email(advisories, jira_issue_link)
 
     def check_blockers(self):
         cmd = [

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -124,6 +124,19 @@ class PrepareReleasePipeline:
                     continue
                 self.create_and_attach_placeholder_bug(kind, advisory)
 
+        _LOGGER.info("Adding placeholder bugs to the advisories...")
+        for kind, advisory in advisories.items():
+            # don't create placeholder bugs for OCP 4 image advisory and OCP 3 rpm advisory
+            if (
+                not advisory
+                or self.release_version[0] >= 4
+                and kind == "image"
+                or self.release_version[0] < 4
+                and kind == "rpm"
+            ):
+                continue
+            self.create_and_attach_placeholder_bug(kind, advisory)
+        
         _LOGGER.info("Sweep builds into the the advisories...")
         for kind, advisory in advisories.items():
             if not advisory:

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -124,19 +124,6 @@ class PrepareReleasePipeline:
                     continue
                 self.create_and_attach_placeholder_bug(kind, advisory)
 
-        _LOGGER.info("Adding placeholder bugs to the advisories...")
-        for kind, advisory in advisories.items():
-            # don't create placeholder bugs for OCP 4 image advisory and OCP 3 rpm advisory
-            if (
-                not advisory
-                or self.release_version[0] >= 4
-                and kind == "image"
-                or self.release_version[0] < 4
-                and kind == "rpm"
-            ):
-                continue
-            self.create_and_attach_placeholder_bug(kind, advisory)
-        
         _LOGGER.info("Sweep builds into the the advisories...")
         for kind, advisory in advisories.items():
             if not advisory:
@@ -467,6 +454,7 @@ This is the current set of advisories we intend to ship:
             for arch, pullspec in self.candidate_nightlies.items():
                 content += f"- {arch}: {pullspec}\n"
         content += f"\nJIRA ticket: {jira_link}\n"
+        content += f"Note: Advisories are still being prepared, it may take a while before bugs and builds appear.\n"
         content += "\nThanks.\n"
         email_dir = self.working_dir / "email"
         self.mail.send_mail(self.config["email"]["prepare_release_notification_recipients"], subject, content, archive_dir=email_dir, dry_run=self.dry_run)


### PR DESCRIPTION
Prepare release job sometimes fails due to errors in sweeping bugs/builds. These are considered risky steps. In case of job failure, next steps are performed manually by the artist and sometimes missed (https://coreos.slack.com/archives/CB95J6R4N/p1624464663042000). 

The subsequent steps of sending notification email to qe, and attaching placeholder bugs don't really rely on the success of the sweep. This change is to move sweep at the end, after those steps.