### PR TITLE
[ART-3056] Don't fail if there are no bundles to build

### DIFF
--- a/jobs/build/olm_bundle/olm_bundles.groovy
+++ b/jobs/build/olm_bundle/olm_bundles.groovy
@@ -17,7 +17,7 @@ def elliott(cmd) {
  * Return the brew package name of all OLM operators present in <params.BUILD_VERSION>
  */
 def get_olm_operators() {
-    doozer('olm-bundle:list-olm-operators').split("\n")
+    doozer('olm-bundle:list-olm-operators').split("\n").findAll { !it.isEmpty() }
 }
 
 /*


### PR DESCRIPTION
https://github.com/openshift/aos-cd-jobs/pull/2654/files got reverted because Sid found out that the sanitize function was replacing `\n` and breaking the job.