### PR TITLE
WIP: Promote validations report and don't fail early

### DIFF
--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -102,8 +102,9 @@ Map stageValidation(String quay_url, String dest_release_tag, int advisory = 0, 
     echo "Verifying advisory ${advisoryInfo.id} (https://errata.engineering.redhat.com/advisory/${advisoryInfo.id}) status"
     if (advisoryInfo.status != 'QE' && permitAnyAdvisoryState == false) {
         error("🚫 Advisory ${advisoryInfo.id} is not in QE state.")
+    } else {
+        echo "✅ Advisory ${advisoryInfo.id} is in ${advisoryInfo.status} state."
     }
-    echo "✅ Advisory ${advisoryInfo.id} is in ${advisoryInfo.status} state."
 
     // Extract live ID from advisory info
     // Examples:


### PR DESCRIPTION
There are several promote validations we run, some of them are independent, some of them are dependent. When a validation fails, it shouldn't block other validations from being run, so we get a report at the end. Then the ARTist can fix/retry/skip/abort as needed