### PR TITLE
cmd test: avoid using dockerhub

### DIFF
--- a/sjb/config/test_cases/test_branch_origin_cmd.yml
+++ b/sjb/config/test_cases/test_branch_origin_cmd.yml
@@ -8,4 +8,4 @@ extensions:
       title: "run test-cmd"
       repository: "origin"
       script: |-
-        OS_BUILD_ENV_DOCKER_ARGS='-v /tmp/etcd:/tmp/openshift/test-cmd/etcd' OS_TMPFS_REQUIRED=true OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_PRESERVE=_output/scripts OS_BUILD_ENV_TMP_VOLUME='/tmp' hack/env JUNIT_REPORT='true' make test-cmd -k
+        OS_BUILD_ENV_DOCKER_ARGS='-v /tmp/etcd:/tmp/openshift/test-cmd/etcd' OS_TMPFS_REQUIRED=true OS_BUILD_ENV_PULL_IMAGE=true OS_BUILD_ENV_IMAGE=registry.ci.openshift.org/openshift/release:golang-1.10 OS_BUILD_ENV_PRESERVE=_output/scripts OS_BUILD_ENV_TMP_VOLUME='/tmp' hack/env JUNIT_REPORT='true' make test-cmd -k


### PR DESCRIPTION
golang-1.10 image is uploaded to CI registry, so we should use it to avoid hitting ratelimits