### PR TITLE
Revert "keep check=False"

### DIFF
--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -316,10 +316,7 @@ class PrepareReleasePipeline:
         if self.dry_run:
             cmd.append("--dry-run")
         _LOGGER.debug("Running command: %s", cmd)
-
-        # keep check=False so we don't abort
-        subprocess.run(cmd, check=False, universal_newlines=True, cwd=self.working_dir)
-
+        subprocess.run(cmd, check=True, universal_newlines=True, cwd=self.working_dir)
 
     def sweep_builds(
         self, kind: str, advisory: int, only_payload=False, only_non_payload=False
@@ -338,10 +335,7 @@ class PrepareReleasePipeline:
         if not self.dry_run:
             cmd.append(f"--attach={advisory}")
         _LOGGER.debug("Running command: %s", cmd)
-
-        # keep check=False so we don't abort
-        subprocess.run(cmd, check=False, universal_newlines=True, cwd=self.working_dir)
-
+        subprocess.run(cmd, check=True, universal_newlines=True, cwd=self.working_dir)
 
     def change_advisory_state(self, advisory: int, state: str):
         cmd = [


### PR DESCRIPTION
This reverts commit 36791e1298522fe502b9d6e42d3f182007c43ca0.

Errors shouldn't be ignored. We trust the status of prepare-release job so that if it finishes with success, we know everything is fine. I know if prepare-release fails it’s hard to run again, but that issue will gone when we finish the assemblies work.