### PR TITLE
ART-3091: Adds "rebuild" job

### DIFF
--- a/.devcontainer/brewkoji.conf
+++ b/.devcontainer/brewkoji.conf
@@ -10,4 +10,3 @@ weburl = https://brewweb.engineering.redhat.com/brew
 topurl = http://download.devel.redhat.com/brewroot
 use_fast_upload = yes
 anon_retry = yes
-serverca = /etc/pki/brew/legacy.crt

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,6 @@
 		// This will ignore your local shell user setting for Linux since shells like zsh are typically
 		// not in base container images. You can also update this to an specific shell to ensure VS Code
 		// uses the right one for terminals and tasks. For example, /bin/bash (or /bin/ash for Alpine).
-		"terminal.integrated.shell.linux": "/bin/bash",
 		"python.pythonPath": "/usr/bin/python3",
 		"python.linting.pylintEnabled": false,
 		"python.linting.flake8Enabled": true,
@@ -34,7 +33,7 @@
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
 	// Uncomment the next line to run commands after the container is created - for example installing git.
-	"postCreateCommand": "sudo chown -R dev: /workspaces/aos-cd-jobs-working /home/dev/",
+	"postCreateCommand": "sudo chown -R dev: /workspaces/ && pip3 install --user -r ./pyartcd/requirements-dev.txt -e ./pyartcd",
 	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ms-python.vscode-pylance",

--- a/.devcontainer/doozer.settings.yaml
+++ b/.devcontainer/doozer.settings.yaml
@@ -1,5 +1,5 @@
 #Persistent working directory to use
-working_dir: /workspaces/aos-cd-jobs-working/elliott-working/doozer-working
+working_dir: /workspaces/aos-cd-jobs-working/doozer-working
 
 #Git URL or File Path to build data
 data_path: https://github.com/openshift/ocp-build-data.git

--- a/config/artcd.toml
+++ b/config/artcd.toml
@@ -1,22 +1,25 @@
 [advisory]
-assigned_to="openshift-qe-errata@redhat.com"
-manager="vlaad@redhat.com"
-package_owner="lmeyer@redhat.com"
+assigned_to = "openshift-qe-errata@redhat.com"
+manager = "vlaad@redhat.com"
+package_owner = "lmeyer@redhat.com"
 
 [build_config]
-ocp_build_data_repo_push_url="git@github.com:openshift/ocp-build-data.git"
+# ocp_build_data_url = "https://github.com/openshift/ocp-build-data.git"
+ocp_build_data_repo_push_url = "git@github.com:openshift/ocp-build-data.git"
 
 [email]
-smtp_server="smtp.corp.redhat.com"
-from="aos-art-automation@redhat.com"
-reply_to="aos-team-art@redhat.com"
-cc=["aos-team-art@redhat.com"]
-live_id_request_recipients=["openshift-ccs@redhat.com"]
-prepare_release_notification_recipients=["multi-arch-zstream-testing@redhat.com", "aos-qe@redhat.com"]
+smtp_server = "smtp.corp.redhat.com"
+from = "aos-art-automation@redhat.com"
+reply_to = "aos-team-art@redhat.com"
+cc = ["aos-team-art@redhat.com"]
+live_id_request_recipients = ["openshift-ccs@redhat.com"]
+prepare_release_notification_recipients = [
+    "multi-arch-zstream-testing@redhat.com",
+    "aos-qe@redhat.com",
+]
 
 [jira]
-url="https://issues.redhat.com"
-
+url = "https://issues.redhat.com"
 [jira.templates]
-ocp4="OCPPLAN-4756"
-ocp3="OCPPLAN-1373"
+ocp4 = "OCPPLAN-4756"
+ocp3 = "OCPPLAN-1373"

--- a/jobs/build/rebuild/Jenkinsfile
+++ b/jobs/build/rebuild/Jenkinsfile
@@ -1,0 +1,119 @@
+node {
+    wrap([$class: "BuildUser"]) {
+        checkout scm
+        def buildlib = load("pipeline-scripts/buildlib.groovy")
+        def commonlib = buildlib.commonlib
+
+        commonlib.describeJob("rebuild", """
+            <h2>Rebuild an image, rpm, or RHCOS for an assembly.</h2>
+            <h3>This job is used to patch one or more images with an updated RPM dependency or upstream code commit</h3>
+        """)
+
+        properties(
+            [
+                disableResume(),
+                buildDiscarder(
+                    logRotator(
+                        artifactDaysToKeepStr: "",
+                        artifactNumToKeepStr: "",
+                        daysToKeepStr: "",
+                        numToKeepStr: "")),
+                [
+                    $class: "ParametersDefinitionProperty",
+                    parameterDefinitions: [
+                        commonlib.ocpVersionParam('BUILD_VERSION', '4'),
+                        string(
+                            name: "ASSEMBLY",
+                            description: "The name of an assembly to rebase & build for. e.g. 4.9.1",
+                            trim: true
+                        ),
+                        choice(
+                            name: 'TYPE',
+                            description: 'image or rpm or rhcos',
+                            choices: [
+                                    'image',
+                                    'rpm',
+                                    'rhcos',
+                                ].join('\n'),
+                        ),
+                        string(
+                            name: "DISTGIT_KEY",
+                            description: "(Optional) The name of a component to rebase & build for. e.g. openshift-enterprise-cli; leave this empty when rebuilding rhcos",
+                            defaultValue: "",
+                            trim: true
+                        ),
+                        booleanParam(
+                            name: "DRY_RUN",
+                            description: "Take no action, just echo what the job would have done.",
+                            defaultValue: false
+                        ),
+                        commonlib.mockParam(),
+                    ]
+                ],
+            ]
+        )   // Please update README.md if modifying parameter names or semantics
+
+        commonlib.checkMock()
+        stage("initialize") {
+            buildlib.initialize()
+            buildlib.registry_quay_dev_login()
+            if (params.DRY_RUN) {
+                currentBuild.displayName += " - [DRY RUN]"
+            }
+            currentBuild.displayName += " - $params.ASSEMBLY - $params.TYPE - ${params.DISTGIT_KEY?: '(N/A)'}"
+            commonlib.shell(script: "pip install -e ./pyartcd")
+        }
+        stage ("Notify release channel") {
+            if (params.DRY_RUN) {
+                return
+            }
+            slackChannel = slacklib.to(params.BUILD_VERSION)
+            slackChannel.say(":construction: Rebuilding $params.TYPE $params.DISTGIT_KEY for assembly $params.ASSEMBLY :construction:")
+        }
+
+        stage("rebuild") {
+            sh "mkdir -p ./artcd_working"
+            def cmd = [
+                "artcd",
+                "-vv",
+                "--working-dir=./artcd_working",
+                "--config", "./config/artcd.toml",
+            ]
+
+            if (params.DRY_RUN) {
+                cmd << "--dry-run"
+            }
+            cmd += [
+                "rebuild",
+                "-g", "openshift-$params.BUILD_VERSION",
+                "--assembly", params.ASSEMBLY,
+                "--type", params.TYPE
+            ]
+            if (params.DISTGIT_KEY) {
+                cmd << "--component"
+                cmd << params.DISTGIT_KEY
+            }
+            sshagent(["openshift-bot"]) {
+                echo "Will run ${cmd}"
+                lock("github-activity-lock-${params.BUILD_VERSION}") {
+                    commonlib.shell(script: cmd.join(' '))
+                }
+            }
+        }
+        stage("save artifacts") {
+            commonlib.safeArchiveArtifacts([
+                "artcd_working/email/**",
+                "artcd_working/**/*.json",
+                "artcd_working/**/*.log",
+            ])
+        }
+        stage ("Notify release channel") {
+            if (params.DRY_RUN) {
+                return
+            }
+            slackChannel = slacklib.to(params.BUILD_VERSION)
+            slackChannel.say("Hi @release-artists , rebuilding $params.TYPE $params.DISTGIT_KEY for assembly $params.ASSEMBLY is done. Please check instructions in the build log for the next step.")
+        }
+        buildlib.cleanWorkspace()
+    }
+}

--- a/pyartcd/artcd
+++ b/pyartcd/artcd
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+from pyartcd.__main__ import main
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/pyartcd/pyartcd/__main__.py
+++ b/pyartcd/pyartcd/__main__.py
@@ -1,0 +1,7 @@
+from typing import Optional, Sequence
+from pyartcd.cli import cli
+from pyartcd.pipelines import rebuild
+
+
+def main(args: Optional[Sequence[str]] = None):
+    cli()

--- a/pyartcd/pyartcd/cli.py
+++ b/pyartcd/pyartcd/cli.py
@@ -1,0 +1,51 @@
+import asyncio
+from functools import update_wrapper
+import logging
+from pathlib import Path
+from typing import Optional
+
+import click
+
+from pyartcd.runtime import Runtime
+
+pass_runtime = click.make_pass_decorator(Runtime)
+
+
+def click_coroutine(f):
+    """ A wrapper to allow to use asyncio with click.
+    https://github.com/pallets/click/issues/85
+    """
+    f = asyncio.coroutine(f)
+
+    def wrapper(*args, **kwargs):
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(f(*args, **kwargs))
+    return update_wrapper(wrapper, f)
+
+
+# ============================================================================
+# GLOBAL OPTIONS: parameters for all commands
+# ============================================================================
+@click.group(context_settings=dict(help_option_names=['-h', '--help']))
+@click.option("--config", "-c", metavar='PATH',
+              help="Configuration file ('~/.config/artcd.toml' by default)")
+@click.option("--working-dir", "-C", metavar='PATH', default=None,
+              help="Existing directory in which file operations should be performed (current directory by default)")
+@click.option("--dry-run", is_flag=True,
+              help="don't actually execute the pipeline; just print what would be done")
+@click.option("--verbosity", "-v", count=True,
+              help="[MULTIPLE] increase output verbosity")
+@click.pass_context
+def cli(ctx: click.Context, config: Optional[str], working_dir: Optional[str], dry_run: bool, verbosity: int):
+    config_filename = config or Path("~/.config/artcd.toml").expanduser()
+    working_dir = working_dir or Path.cwd()
+    # configure logging
+    if not verbosity:
+        logging.basicConfig(level=logging.WARNING)
+    elif verbosity == 1:
+        logging.basicConfig(level=logging.INFO)
+    elif verbosity >= 2:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        raise ValueError(f"Invalid verbosity {verbosity}")
+    ctx.obj = Runtime.from_config_file(config_filename, working_dir=Path(working_dir), dry_run=dry_run)

--- a/pyartcd/pyartcd/constants.py
+++ b/pyartcd/pyartcd/constants.py
@@ -1,0 +1,3 @@
+PLASHET_REMOTE_URL = "http://download.eng.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets"
+PLASHET_REMOTE_HOST = "ocp-build@rcm-guest.app.eng.bos.redhat.com"
+PLASHET_REMOTE_BASE_DIR = "/mnt/rcm-guest/puddles/RHAOS/plashets"

--- a/pyartcd/pyartcd/exectools.py
+++ b/pyartcd/pyartcd/exectools.py
@@ -1,0 +1,94 @@
+import asyncio
+import contextvars
+import functools
+import logging
+import shlex
+from typing import List, Tuple, Union
+
+logger = logging.getLogger(__name__)
+
+
+async def to_thread(func, *args, **kwargs):
+    """Asynchronously run function *func* in a separate thread.
+
+    This function is a backport of asyncio.to_thread from Python 3.9.
+
+    Any *args and **kwargs supplied for this function are directly passed
+    to *func*. Also, the current :class:`contextvars.Context` is propogated,
+    allowing context variables from the main thread to be accessed in the
+    separate thread.
+
+    Return a coroutine that can be awaited to get the eventual result of *func*.
+    """
+    loop = asyncio.get_event_loop()
+    ctx = contextvars.copy_context()
+    func_call = functools.partial(ctx.run, func, *args, **kwargs)
+    return await loop.run_in_executor(None, func_call)
+
+
+def limit_concurrency(limit=5):
+    """A decorator to limit the number of parallel tasks with asyncio.
+
+    It should be noted that when the decorator function is executed, the created Semaphore is bound to the default event loop.
+    https://stackoverflow.com/a/66289885
+    """
+    # use asyncio.BoundedSemaphore(5) instead of Semaphore to prevent accidentally increasing the original limit (stackoverflow.com/a/48971158/6687477)
+    sem = asyncio.BoundedSemaphore(limit)
+
+    def executor(func):
+        @functools.wraps(func)
+        async def wrapper(*args, **kwargs):
+            async with sem:
+                return await func(*args, **kwargs)
+
+        return wrapper
+
+    return executor
+
+
+async def cmd_gather_async(cmd: Union[List[str], str], check: bool = True, **kwargs) -> Tuple[int, str, str]:
+    """ Runs a command asynchronously and returns rc,stdout,stderr as a tuple
+    :param cmd <string|list>: A shell command
+    :param check: If check is True and the exit code was non-zero, it raises a ChildProcessError
+    :param kwargs: Other arguments passing to asyncio.subprocess.create_subprocess_exec
+    :return: rc,stdout,stderr
+    """
+    if isinstance(cmd, str):
+        cmd_list = shlex.split(cmd)
+    else:
+        cmd_list = cmd
+    logger.debug("Executing:cmd_gather_async %s", cmd_list)
+    proc = await asyncio.subprocess.create_subprocess_exec(cmd_list[0], *cmd_list[1:], stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, **kwargs)
+    stdout, stderr = await proc.communicate()
+    stdout = stdout.decode()
+    stderr = stderr.decode()
+    if proc.returncode != 0:
+        msg = f"Process {cmd_list!r} exited with {proc.returncode}\nstdout>>{stdout}<<\nstderr>>{stderr}<<\n"
+        if check:
+            raise ChildProcessError(msg)
+        else:
+            logger.warning(msg)
+    return proc.returncode, stdout, stderr
+
+
+async def cmd_assert_async(cmd: Union[List[str], str], check: bool = True, **kwargs) -> int:
+    """ Runs a command and optionally raises an exception if the return code of the command indicates failure.
+    :param cmd <string|list>: A shell command
+    :param check: If check is True and the exit code was non-zero, it raises a ChildProcessError
+    :param kwargs: Other arguments passing to asyncio.subprocess.create_subprocess_exec
+    :return: return code of the command
+    """
+    if isinstance(cmd, str):
+        cmd_list = shlex.split(cmd)
+    else:
+        cmd_list = cmd
+    logger.debug("Executing:cmd_assert_async %s", cmd_list)
+    proc = await asyncio.subprocess.create_subprocess_exec(cmd_list[0], *cmd_list[1:], **kwargs)
+    returncode = await proc.wait()
+    if returncode != 0:
+        msg = f"Process {cmd_list!r} exited with {returncode}"
+        if check:
+            raise ChildProcessError(msg)
+        else:
+            logger.warning(msg)
+    return proc.returncode

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -74,7 +74,7 @@ class PrepareReleasePipeline:
 
         _LOGGER.info("Checking Blocker Bugs for release %s...", self.release_name)
         self.check_blockers()
-        
+
         if self.default_advisories:
             advisories = self.get_advisories()
         else:
@@ -169,7 +169,7 @@ class PrepareReleasePipeline:
         match = re.search(r"Found ([0-9]+) bugs", str(result.stdout))
         if match and int(match[1]) != 0:
             _LOGGER.info(f"{int(match[1])} Blocker Bugs found! Make sure to resolve these blocker bugs before proceeding to promote the release.")
-    
+
     def create_advisory(self, type: str, kind: str, impetus: str) -> int:
         create_cmd = [
             "elliott",
@@ -226,9 +226,9 @@ class PrepareReleasePipeline:
                 advisories[key] = int(val)
         except Exception as ex:
             raise ValueError(f"Error parsing advisories from group.yml: {ex}")
-        
+
         return advisories
-    
+
     def save_advisories(self, advisories: Dict[str, int]):
         if not advisories:
             return
@@ -448,7 +448,7 @@ This is the current set of advisories we intend to ship:
             for arch, pullspec in self.candidate_nightlies.items():
                 content += f"- {arch}: {pullspec}\n"
         content += f"\nJIRA ticket: {jira_link}\n"
-        content += f"Note: Advisories are still being prepared, it may take a while before bugs and builds appear.\n"
+        content += "Note: Advisories are still being prepared, it may take a while before bugs and builds appear.\n"
         content += "\nThanks.\n"
         email_dir = self.working_dir / "email"
         self.mail.send_mail(self.config["email"]["prepare_release_notification_recipients"], subject, content, archive_dir=email_dir, dry_run=self.dry_run)

--- a/pyartcd/pyartcd/pipelines/rebuild.py
+++ b/pyartcd/pyartcd/pipelines/rebuild.py
@@ -1,0 +1,520 @@
+import asyncio
+import logging
+import os
+import re
+import shutil
+from datetime import datetime
+from enum import Enum
+from io import TextIOWrapper
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import click
+import yaml
+from pyartcd import constants, exectools
+from pyartcd.cli import cli, click_coroutine, pass_runtime
+from pyartcd.record import parse_record_log
+from pyartcd.runtime import Runtime
+from pyartcd.util import (isolate_el_version_in_branch,
+                          isolate_el_version_in_release)
+
+
+class RebuildType(Enum):
+    IMAGE = 0
+    RPM = 1
+    RHCOS = 2
+
+
+class RebuildPipeline:
+    """ Rebuilds a component for an assembly """
+
+    def __init__(self, runtime: Runtime, group: str, assembly: str,
+                 type: RebuildType, dg_key: str, logger: Optional[logging.Logger] = None):
+        if assembly == "stream":
+            raise ValueError("You may not rebuild a component for 'stream' assembly.")
+        if type in [RebuildType.RPM, RebuildType.IMAGE] and not dg_key:
+            raise ValueError("'dg_key' is required.")
+        elif type == RebuildType.RHCOS and dg_key:
+            raise ValueError("'dg_key' is not supported when rebuilding RHCOS.")
+
+        self.runtime = runtime
+        self.group = group
+        self.assembly = assembly
+        self.type = type
+        self.dg_key = dg_key
+        self.logger = logger or runtime.logger
+
+        # determines OCP version
+        match = re.fullmatch(r"openshift-(\d+).(\d)", group)
+        if not match:
+            raise ValueError(f"Invalid group name: {match}")
+        self._ocp_version = (int(match[1]), int(match[2]))
+
+        # sets environment variables for Doozer
+        self._doozer_env_vars = os.environ.copy()
+        self._doozer_env_vars["DOOZER_WORKING_DIR"] = self.runtime.working_dir / "doozer-working"
+        ocp_build_data_url = self.runtime.config.get("build_config", {}).get("ocp_build_data_url")
+        if ocp_build_data_url:
+            self._doozer_env_vars["DOOZER_DATA_PATH"] = ocp_build_data_url
+
+    async def run(self):
+        timestamp = datetime.utcnow().strftime("%Y%m%d%H%M")
+        release = f"{timestamp}.p?"
+
+        if self.type == RebuildType.RPM:
+            # Rebases and builds the specified rpm
+            nvrs = await self._rebase_and_build_rpm(release)
+            if self.runtime.dry_run:
+                # fake rpm nvrs for dry run
+                nvrs = [
+                    f"foo-0.0.1-{timestamp}.p0.git.1234567.assembly.{self.assembly}.el8",
+                    f"foo-0.0.1-{timestamp}.p0.git.1234567.assembly.{self.assembly}.el7",
+                ]
+        elif self.type == RebuildType.IMAGE:
+            # Determines RHEL version that the image is based on
+            group_config = await self._load_group_config()
+            branch = await self._get_image_distgit_branch(group_config)
+            el_version = isolate_el_version_in_branch(branch)
+            assert isinstance(el_version, int)
+
+            (plashet_a_dir, _, plashet_b_dir, plashet_b_url), _ = await asyncio.gather(
+                # Builds plashet repos
+                self._build_plashets(timestamp, el_version, group_config),
+                # Rebases distgit repo
+                self._rebase_image(release),
+            )
+
+            # Generates rebuild.repo
+            with open(plashet_b_dir / "rebuild.repo", "w") as file:
+                self._generate_repo_file_for_image(file, plashet_a_dir.name, plashet_b_url)
+
+            # Copies plashet repos out to rcm-guest
+            await asyncio.gather(
+                self._copy_plashet_out_to_remote(el_version, plashet_a_dir),
+                self._copy_plashet_out_to_remote(el_version, plashet_b_dir),
+            )
+
+            # Builds image
+            nvrs = await self._build_image(plashet_b_url + "/rebuild.repo")
+            if self.runtime.dry_run:
+                # Fakes image nvrs for dry run
+                nvrs = [
+                    f"foo-container-0.0.1-{timestamp}.p0.git.1234567.assembly.{self.assembly}",
+                ]
+        else:  # self.type == RebuildType.RHCOS:
+            # Builds plashet repos
+            group_config = await self._load_group_config()
+            el_version = 8  # FIXME: Currently RHCOS is based on RHEL8, hardcode RHEL version here
+            plashet_a_dir, plashet_a_url, plashet_b_dir, plashet_b_url = await self._build_plashets(timestamp, el_version, group_config)
+
+            # Generates rebuild.repo
+            with open(plashet_b_dir / "rebuild.repo", "w") as file:
+                self._generate_repo_file_for_rhcos(file, plashet_a_url, plashet_b_url)
+
+            # Copies plashet repos out to rcm-guest
+            await asyncio.gather(
+                self._copy_plashet_out_to_remote(el_version, plashet_a_dir),
+                self._copy_plashet_out_to_remote(el_version, plashet_b_dir),
+            )
+
+            # Prints further instructions
+            click.secho(f"RHCOS build is not triggered by this job. Please manually run the individual rhcos build jobs on the arch-specific rhcos build clusters with the following Plashet repo:\n\t{plashet_b_url}/rebuild.repo", fg="yellow")
+
+        # Prints example schema
+        if self.type in [RebuildType.RPM, RebuildType.IMAGE]:
+            click.secho("Build completes. Please update the assembly schema in releases.yaml to pin the following NVR(s) to the assembly:\n", fg="green")
+            for nvr in nvrs:
+                click.secho(f"\t{nvr}", fg="green")
+            example_schema = self._generate_example_schema(nvrs)
+            click.secho(f"\nExample schema:\n\n{example_schema}", fg="green")
+
+    async def _load_group_config(self):
+        self.logger.info("Loading group config...")
+        cmd = [
+            "doozer",
+            "--group", self.group,
+            "--assembly", self.assembly,
+            "config:read-group",
+            "--yaml",
+        ]
+        _, stdout, _ = await exectools.cmd_gather_async(cmd, env=self._doozer_env_vars)
+        group_config = yaml.safe_load(stdout)
+        return group_config
+
+    async def _build_plashet_from_tags(self, name: str, el_version: int, arches: List[str], signing_advisory: Optional[int]) -> Tuple[Path, str]:
+        self.logger.info("Building plashet A %s for EL%s...", name, el_version)
+        """ Builds Plashet repo with "from-tags"
+        :param name: Plashet repo name
+        :param el_version: RHEL version
+        :param arches: List of arch names
+        :return: (local_path, remote_url)
+        """
+        self.logger.info("Building plashet %s - RHEL %s for assembly %s...", name, el_version, self.assembly)
+        base_dir = self.runtime.working_dir / f"plashets/el{el_version}/{self.assembly}"
+        plashet_dir = base_dir / name
+        if plashet_dir.exists():
+            shutil.rmtree(plashet_dir)
+        base_dir.mkdir(parents=True, exist_ok=True)
+        signing_mode = "signed"  # We assume rpms used in rebuild job should be always signed
+        cmd = [
+            "doozer",
+            "--group", self.group,
+            "--assembly", self.assembly,
+            "config:plashet",
+            "--base-dir", str(base_dir),
+            "--name", name,
+            "--repo-subdir", "os"
+        ]
+        for arch in arches:
+            cmd.extend(["--arch", arch, signing_mode])
+        major, minor = self._ocp_version
+        cmd.extend([
+            "from-tags",
+            "--signing-advisory-id", f"{signing_advisory or 54765}",
+            "--signing-advisory-mode", "clean",
+            "--include-embargoed",
+            "--inherit",
+            "--embargoed-brew-tag", f"rhaos-{major}.{minor}-rhel-{el_version}-embargoed",
+        ])
+        # Currently plashet for-assembly only needs rpms from stream assembly plus those pinned by "is" and group dependencies
+        if el_version >= 8:
+            cmd.extend([
+                "--brew-tag", f"rhaos-{major}.{minor}-rhel-{el_version}-candidate", f"OSE-{major}.{minor}-RHEL-{el_version}",
+            ])
+        else:
+            cmd.extend([
+                "--brew-tag", f"rhaos-{major}.{minor}-rhel-{el_version}-candidate", f"RHEL-{el_version}-OSE-{major}.{minor}",
+            ])
+        if self.runtime.dry_run:
+            self.logger.warning("[Dry run] Would have run %s", cmd)
+        else:
+            await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars)
+
+        remote_url = constants.PLASHET_REMOTE_URL + f"/{major}.{minor}"
+        if el_version >= 8:
+            remote_url += f"-el{el_version}"
+        remote_url += f"/{self.assembly}/{name}"
+        return plashet_dir, remote_url
+
+    async def _build_plashet_for_assembly(self, name: str, el_version: int, arches: List[str], signing_advisory: Optional[int]) -> Tuple[Path, str]:
+        """ Builds Plashet with "for-assembly"
+        :param name: Plashet repo name
+        :param el_version: RHEL version
+        :param arches: List of arch names
+        :return: (local_path, remote_url)
+        """
+        self.logger.info("Building plashet %s for EL%s...", name, el_version)
+        base_dir = self.runtime.working_dir / f"plashets/el{el_version}/{self.assembly}"
+        plashet_dir = base_dir / name
+        if plashet_dir.exists():
+            shutil.rmtree(plashet_dir)
+        base_dir.mkdir(parents=True, exist_ok=True)
+        signing_mode = "signed"  # We assume rpms used in rebuild job should be always signed
+        cmd = [
+            "doozer",
+            "--group", self.group,
+            "--assembly", self.assembly,
+            "config:plashet",
+            "--base-dir", str(base_dir),
+            "--name", name,
+            "--repo-subdir", "os"
+        ]
+        for arch in arches:
+            cmd.extend(["--arch", arch, signing_mode])
+        cmd.extend([
+            "for-assembly",
+            "--signing-advisory-id", f"{signing_advisory or 54765}",
+            "--signing-advisory-mode", "clean",
+            "--el-version", f"{el_version}",
+        ])
+        if self.type == RebuildType.IMAGE:
+            cmd.extend(["--image", self.dg_key])
+        elif self.type == RebuildType.RHCOS:
+            cmd.append("--rhcos")
+        else:
+            raise ValueError("Rebuild type is not IMAGE or RHCOS.")
+        if self.runtime.dry_run:
+            self.logger.warning("[Dry run] Would have run %s", cmd)
+        else:
+            await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars)
+
+        major, minor = self._ocp_version
+        remote_url = constants.PLASHET_REMOTE_URL + f"/{major}.{minor}"
+        if el_version >= 8:
+            remote_url += f"-el{el_version}"
+        remote_url += f"/{self.assembly}/{name}"
+        return plashet_dir, remote_url
+
+    async def _copy_plashet_out_to_remote(self, el_version: int, local_plashet_dir: os.PathLike, symlink_name: Optional[str] = None):
+        """ Copies plashet out to remote host (rcm-guest)
+        """
+        # Make sure the remote base dir exist
+        major, minor = self._ocp_version
+        remote_dir = f"{constants.PLASHET_REMOTE_BASE_DIR}/{major}.{minor}"
+        if el_version >= 8:
+            remote_dir += f"-el{el_version}"
+        remote_dir += f"/{self.assembly}"
+        cmd = [
+            "ssh",
+            constants.PLASHET_REMOTE_HOST,
+            "--",
+            "mkdir",
+            "-p",
+            "--",
+            remote_dir,
+        ]
+        if self.runtime.dry_run:
+            self.logger.warning("[DRY RUN] Would have run %s", cmd)
+        else:
+            await exectools.cmd_assert_async(cmd)
+
+        # Copy local dir to to remote
+        cmd = [
+            "rsync",
+            "-av",
+            "--links",
+            "--progress",
+            "-h",
+            "--no-g",
+            "--omit-dir-times",
+            "--chmod=Dug=rwX,ugo+r",
+            "--perms",
+            "--",
+            f"{local_plashet_dir}",
+            f"{constants.PLASHET_REMOTE_HOST}:{remote_dir}"
+        ]
+        if self.runtime.dry_run:
+            self.logger.warning("[DRY RUN] Would have run %s", cmd)
+        else:
+            await exectools.cmd_assert_async(cmd)
+
+        if symlink_name:
+            # Make a symlink
+            cmd = [
+                "ssh",
+                constants.PLASHET_REMOTE_HOST,
+                "--",
+                "ln",
+                "-sfn",
+                "--",
+                f"{Path(local_plashet_dir).name}",
+                f"{remote_dir}/{symlink_name}",
+            ]
+            if self.runtime.dry_run:
+                self.logger.warning("[DRY RUN] Would have run %s", cmd)
+            else:
+                await exectools.cmd_assert_async(cmd)
+
+    async def _build_plashets(self, timestamp: str, el_version: int, group_config: Dict) -> Tuple[str, str, str, str]:
+        """ Build plashet repos and return the URL to rebuild.repo
+        :return: (plashet_a_dir, plashet_a_url, plashet_b_dir, plashet_b_url)
+        """
+        if self.type == RebuildType.IMAGE:
+            plashet_a_name = f"{self.assembly}-{timestamp}-image-{self.dg_key}-basis"
+            plashet_b_name = f"{self.assembly}-{timestamp}-image-{self.dg_key}-overrides"
+        elif self.type == RebuildType.RHCOS:
+            plashet_a_name = f"{self.assembly}-{timestamp}-rhcos-basis"
+            plashet_b_name = f"{self.assembly}-{timestamp}-rhcos-overrides"
+        else:
+            raise ValueError(f"Building plashets for component type {self.type} is not supported.")
+
+        arches = group_config["arches"]
+        signing_advisory = group_config.get("signing_advisory")
+
+        # Builds plashet-A with "from-tags"
+        plashet_a_dir, plashet_a_url = await self._build_plashet_from_tags(plashet_a_name, el_version, arches, signing_advisory)
+
+        # Builds plashet-B with "for-assembly"
+        plashet_b_dir, plashet_b_url = await self._build_plashet_for_assembly(plashet_b_name, el_version, arches, signing_advisory)
+
+        return plashet_a_dir, plashet_a_url, plashet_b_dir, plashet_b_url
+
+    def _generate_repo_file_for_image(self, file: TextIOWrapper, plashet_a_name: str, plashet_b_url: str):
+        # Copy content of .oit/signed.repo in the distgit repo
+        source_path = Path(self._doozer_env_vars["DOOZER_WORKING_DIR"]) / f"distgits/containers/{self.dg_key}/.oit/signed.repo"
+        content = source_path.read_text()
+        content = content.replace("/building-embargoed/", f"/{plashet_a_name}/")  # Let's not use the symlink
+        file.write(content)
+        file.write("\n")
+        # Generate repo entry for plashet-B
+        file.writelines([
+            "[plashet-rebuild-overrides]\n",
+            "name = plashet-rebuild-overrides\n",
+            f"baseurl = {plashet_b_url}/$basearch/os\n",
+            "enabled = 1\n",
+            "priority = 1\n",  # https://wiki.centos.org/PackageManagement/Yum/Priorities
+            "gpgcheck = 1\n",
+            "gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release\n",
+        ])
+
+    def _generate_repo_file_for_rhcos(self, file: TextIOWrapper, plashet_a_url: str, plashet_b_url: str):
+        # Generate repo entry for plashet-A
+        # See https://gitlab.cee.redhat.com/coreos/redhat-coreos/-/blob/4.7/rhaos.repo
+        file.writelines([
+            "# These repositories are generated by the OpenShift Automated Release Team\n",
+            "# https://issues.redhat.com/browse/ART-3154\n",
+            "\n",
+            "[plashet-rebuild-basis]\n",
+            "name = plashet-rebuild-basis\n",
+            f"baseurl = {plashet_a_url}/$basearch/os\n",
+            "enabled = 1\n",
+            "gpgcheck = 0\n",
+            "exclude=nss-altfiles kernel protobuf\n",
+        ])
+        # Generate repo entry for plashet-B
+        file.writelines([
+            "[plashet-rebuild-overrides]\n",
+            "name = plashet-rebuild-overrides\n",
+            f"baseurl = {plashet_b_url}/$basearch/os\n",
+            "enabled = 1\n",
+            "priority = 1\n",  # https://wiki.centos.org/PackageManagement/Yum/Priorities
+            "gpgcheck = 0\n",
+            "exclude=nss-altfiles kernel protobuf\n",
+        ])
+
+    async def _get_image_distgit_branch(self, group_config: Dict) -> str:
+        self.logger.info("Determining distgit branch for image %s...", self.dg_key)
+        cmd = [
+            "doozer",
+            "--group", self.group,
+            "--assembly", self.assembly,
+            "-i", self.dg_key,
+            "config:print",
+            "--yaml",
+            "--key", "distgit.branch"
+        ]
+        _, stdout, _ = await exectools.cmd_gather_async(cmd, env=self._doozer_env_vars)
+        image_branch = yaml.safe_load(stdout)["images"][self.dg_key] or group_config["branch"]
+        return image_branch
+
+    async def _rebase_image(self, release: str):
+        """ Rebases image
+        :param release: release field for rebase
+        """
+        # rebase
+        major, minor = self._ocp_version
+        version = f"v{major}.{minor}"
+        cmd = [
+            "doozer",
+            "--group", self.group,
+            "--assembly", self.assembly,
+            "--latest-parent-version",
+            "-i", self.dg_key,
+            "images:rebase",
+            "--version", version,
+            "--release", release,
+            "--force-yum-updates",
+            "--message", f"Updating Dockerfile version and release {version}-{release}",
+        ]
+        if not self.runtime.dry_run:
+            cmd.append("--push")
+        await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars)
+
+    async def _build_image(self, repo_url: str) -> List[str]:
+        """ Builds image
+        :param plashet_url: Plashet URL
+        :return: NVRs
+        """
+        # build
+        cmd = [
+            "doozer",
+            "--group", self.group,
+            "--assembly", self.assembly,
+            "--latest-parent-version",
+            "-i", self.dg_key,
+            "images:build",
+            "--repo", repo_url,
+        ]
+        if self.runtime.dry_run:
+            cmd.append("--dry-run")
+
+        await exectools.cmd_assert_async(cmd)
+
+        if self.runtime.dry_run:
+            return []
+        # parse record.log
+        with open(self._doozer_env_vars["DOOZER_WORKING_DIR"] / "record.log", "r") as file:
+            record_log = parse_record_log(file)
+            return record_log["build"][-1]["nvrs"].split(",")
+
+    async def _rebase_and_build_rpm(self, release: str) -> List[str]:
+        """ Rebase and build RPM
+        :param release: release field for rebase
+        :return: NVRs
+        """
+        major, minor = self._ocp_version
+        cmd = [
+            "doozer",
+            "--group", self.group,
+            "--assembly", self.assembly,
+            "-r", self.dg_key,
+            "rpms:rebase-and-build",
+            "--version", f"{major}.{minor}",
+            "--release", release,
+        ]
+        if self.runtime.dry_run:
+            cmd.append("--dry-run")
+        await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars)
+
+        if self.runtime.dry_run:
+            return []
+
+        # parse record.log
+        with open(self._doozer_env_vars["DOOZER_WORKING_DIR"] / "record.log", "r") as file:
+            record_log = parse_record_log(file)
+            return record_log["build_rpm"][-1]["nvrs"].split(",")
+
+    def _generate_example_schema(self, nvrs: List[str]):
+        is_entry = {}
+        if self.type == RebuildType.IMAGE:
+            member_type = "images"
+            is_entry["nvr"] = nvrs[0]
+        elif self.type == RebuildType.RPM:
+            member_type = "rpms"
+            for nvr in nvrs:
+                el_version = isolate_el_version_in_release(nvr)
+                assert el_version is not None
+                is_entry[f"el{el_version}"] = nvr
+        else:
+            raise ValueError(f"Generating example schema for {self.type} is not supported")
+
+        schema = {
+            "releases": {
+                self.assembly: {
+                    "assembly": {
+                        "members": {
+                            member_type: [
+                                {
+                                    "distgit_key": self.dg_key,
+                                    "metadata": {
+                                        "is": is_entry
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        return yaml.safe_dump(schema)
+
+
+@cli.command("rebuild")
+@click.option("-g", "--group", metavar='NAME', required=True,
+              help="The group of components on which to operate. e.g. openshift-4.9")
+@click.option("--assembly", metavar="ASSEMBLY_NAME", required=True,
+              help="The name of an assembly to rebase & build for. e.g. 4.9.1")
+@click.option("--type", metavar="BUILD_TYPE", required=True,
+              type=click.Choice(("rpm", "image", "rhcos")),
+              help="image or rpm or rhcos")
+@click.option("--component", "-c", metavar="DISTGIT_KEY",
+              help="The name of a component to rebase & build for. e.g. openshift-enterprise-cli")
+@pass_runtime
+@click_coroutine
+async def rebuild(runtime: Runtime, group: str, assembly: str, type: str, component: Optional[str]):
+    if type != "rhcos" and not component:
+        raise click.BadParameter(f"'--component' is required for type {type}")
+    elif type == "rhcos" and component:
+        raise click.BadParameter("Option '--component' cannot be used when --type == 'rhcos'")
+    pipeline = RebuildPipeline(runtime, group=group, assembly=assembly, type=RebuildType[type.upper()], dg_key=component)
+    await pipeline.run()

--- a/pyartcd/pyartcd/record.py
+++ b/pyartcd/pyartcd/record.py
@@ -1,0 +1,17 @@
+from typing import Dict, List, Optional, TextIO
+
+
+def parse_record_log(file: TextIO) -> Dict[str, List[Dict[str, Optional[str]]]]:
+    """
+    Parse record.log from Doozer into a dict.
+    The dict will be keyed by the type of operation performed.
+    The values will be a list of dicts. Each of these dicts will contain the attributes for a single recorded operation of the top
+    level key's type.
+    """
+    result = {}
+    for line in file:
+        fields = line.rstrip().split("|")
+        type = fields[0]
+        record = {entry_split[0]: entry_split[1] if len(entry_split) > 1 else None for entry_split in map(lambda entry: entry.split("=", 1), fields[1:]) if entry_split[0]}
+        result.setdefault(type, []).append(record)
+    return result

--- a/pyartcd/pyartcd/runtime.py
+++ b/pyartcd/pyartcd/runtime.py
@@ -1,0 +1,23 @@
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+import toml
+
+
+class Runtime:
+    def __init__(self, config: Dict[str, Any], working_dir: Path, dry_run: bool):
+        self.config = config
+        self.working_dir = working_dir
+        self.dry_run = dry_run
+        self.logger = logging.getLogger()
+
+        # ensures working_dir
+        if not self.working_dir.is_dir():
+            raise IOError(f"Working directory {self.working_dir} doesn't exist.")
+
+    @classmethod
+    def from_config_file(cls, config_filename: Path, working_dir: Path, dry_run: bool):
+        with open(config_filename, "r") as config_file:
+            config_dict = toml.load(config_file)
+        return Runtime(config=config_dict, working_dir=working_dir, dry_run=dry_run)

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -1,0 +1,28 @@
+import re
+from typing import Optional
+
+
+def isolate_el_version_in_release(release: str) -> Optional[int]:
+    """
+    Given a release field, determines whether is contains
+    a RHEL version. If it does, it returns the version value as int.
+    If it is not found, None is returned.
+    """
+    match = re.match(r'.*\.el(\d+)(?:\.+|$)', release)
+    if match:
+        return int(match.group(1))
+
+    return None
+
+
+def isolate_el_version_in_branch(branch_name: str) -> Optional[int]:
+    """
+    Given a distgit branch name, determines whether is contains
+    a RHEL version. If it does, it returns the version value as int.
+    If it is not found, None is returned.
+    """
+    match = re.match(r'.*rhel-(\d+)(?:\.+|$)', branch_name)
+    if match:
+        return int(match.group(1))
+
+    return None

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -21,7 +21,7 @@ def isolate_el_version_in_branch(branch_name: str) -> Optional[int]:
     a RHEL version. If it does, it returns the version value as int.
     If it is not found, None is returned.
     """
-    match = re.match(r'.*rhel-(\d+)(?:\.+|$)', branch_name)
+    match = re.fullmatch(r'.*rhel-(\d+).*', branch_name)
     if match:
         return int(match.group(1))
 

--- a/pyartcd/requirements-dev.txt
+++ b/pyartcd/requirements-dev.txt
@@ -1,2 +1,3 @@
+mock
 pytest
 tox

--- a/pyartcd/requirements.txt
+++ b/pyartcd/requirements.txt
@@ -1,3 +1,4 @@
+click
 Jinja2
 jira
 toml

--- a/pyartcd/setup.py
+++ b/pyartcd/setup.py
@@ -14,11 +14,16 @@ setup(
     author_email="aos-team-art@redhat.com",
     version="0.0.1-dev",
     description="Python based pipeline library for managing and automating Red Hat OpenShift Container Platform releases",
-    url="https://github.com/openshift/aos-cd-jobs",
+    url="https://github.com/openshift/aos-cd-jobs/",
     license="Apache License, Version 2.0",
     packages=find_packages(exclude=["tests", "tests.*"]),
     include_package_data=True,
     install_requires=INSTALL_REQUIRES,
+    entry_points={
+        'console_scripts': [
+            'artcd = pyartcd.__main__:main'
+        ]
+    },
     test_suite='tests',
     dependency_links=[],
     python_requires='>=3.6',

--- a/pyartcd/tests/pipelines/test_rebuild.py
+++ b/pyartcd/tests/pipelines/test_rebuild.py
@@ -1,0 +1,373 @@
+from asyncio import get_event_loop
+from datetime import datetime, timezone
+from io import StringIO
+from pathlib import Path
+from unittest import TestCase
+
+from mock import ANY, AsyncMock, MagicMock, Mock
+from mock.mock import patch
+from pyartcd import constants
+from pyartcd.pipelines.rebuild import RebuildPipeline, RebuildType
+from pyartcd.runtime import Runtime
+
+
+class TestRebuildPipeline(TestCase):
+    @patch("pyartcd.exectools.cmd_gather_async")
+    def test_load_group_config(self, cmd_gather_async: Mock):
+        runtime = MagicMock(dry_run=False)
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.RHCOS, dg_key=None)
+        group_config_content = """
+        key: "value"
+        """
+        cmd_gather_async.return_value = (0, group_config_content, "")
+        actual = get_event_loop().run_until_complete(pipeline._load_group_config())
+        cmd_gather_async.assert_called_once_with(["doozer", "--group", "openshift-4.9", "--assembly", "art0001", "config:read-group", "--yaml"], env=ANY)
+        self.assertEqual(actual["key"], "value")
+
+    @patch("pathlib.Path.mkdir")
+    @patch("pathlib.Path.exists", return_value=True)
+    @patch("shutil.rmtree")
+    @patch("pyartcd.exectools.cmd_assert_async")
+    def test_build_plashet_from_tags(self, cmd_assert_async: Mock, rmtree: Mock, path_exists: Mock, path_mkdir: Mock):
+        runtime = MagicMock(config={"build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"}}, working_dir=Path("/path/to/working"), dry_run=False)
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.RHCOS, dg_key=None)
+        actual = get_event_loop().run_until_complete(pipeline._build_plashet_from_tags("plashet1234", 8, ["x86_64", "s390x"], 12345))
+        expected_local_dir = runtime.working_dir / "plashets/el8/art0001/plashet1234"
+        expected_remote_url = constants.PLASHET_REMOTE_URL + "/4.9-el8/art0001/plashet1234"
+        self.assertEqual(actual, (expected_local_dir, expected_remote_url))
+        path_exists.assert_called_once_with()
+        rmtree.assert_called_once_with(expected_local_dir)
+        path_mkdir.assert_called_once_with(parents=True, exist_ok=True)
+        excepted_doozer_cmd = ["doozer", "--group", "openshift-4.9", "--assembly", "art0001", "config:plashet", "--base-dir", "/path/to/working/plashets/el8/art0001", "--name", "plashet1234", "--repo-subdir", "os", "--arch", "x86_64", "signed", "--arch", "s390x", "signed", "from-tags", "--signing-advisory-id", "12345", "--signing-advisory-mode", "clean", "--include-embargoed", "--inherit", "--embargoed-brew-tag", "rhaos-4.9-rhel-8-embargoed", "--brew-tag", "rhaos-4.9-rhel-8-candidate", "OSE-4.9-RHEL-8"]
+        cmd_assert_async.assert_called_once_with(excepted_doozer_cmd, env=ANY)
+
+    @patch("pathlib.Path.mkdir")
+    @patch("pathlib.Path.exists", return_value=True)
+    @patch("shutil.rmtree")
+    @patch("pyartcd.exectools.cmd_assert_async")
+    def test_build_plashet_for_assembly_rhcos(self, cmd_assert_async: Mock, rmtree: Mock, path_exists: Mock, path_mkdir: Mock):
+        runtime = MagicMock(config={"build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"}}, working_dir=Path("/path/to/working"), dry_run=False)
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.RHCOS, dg_key=None)
+        actual = get_event_loop().run_until_complete(pipeline._build_plashet_for_assembly("plashet1234", 8, ["x86_64", "s390x"], 12345))
+        expected_local_dir = runtime.working_dir / "plashets/el8/art0001/plashet1234"
+        expected_remote_url = constants.PLASHET_REMOTE_URL + "/4.9-el8/art0001/plashet1234"
+        self.assertEqual(actual, (expected_local_dir, expected_remote_url))
+        path_exists.assert_called_once_with()
+        rmtree.assert_called_once_with(expected_local_dir)
+        path_mkdir.assert_called_once_with(parents=True, exist_ok=True)
+        excepted_doozer_cmd = ['doozer', '--group', 'openshift-4.9', '--assembly', 'art0001', 'config:plashet', '--base-dir', '/path/to/working/plashets/el8/art0001', '--name', 'plashet1234', '--repo-subdir', 'os', '--arch', 'x86_64', 'signed', '--arch', 's390x', 'signed', 'for-assembly', '--signing-advisory-id', '12345', '--signing-advisory-mode', 'clean', '--el-version', '8', '--rhcos']
+        cmd_assert_async.assert_called_once_with(excepted_doozer_cmd, env=ANY)
+
+    @patch("pathlib.Path.mkdir")
+    @patch("pathlib.Path.exists", return_value=True)
+    @patch("shutil.rmtree")
+    @patch("pyartcd.exectools.cmd_assert_async")
+    def test_build_plashet_for_assembly_image(self, cmd_assert_async: Mock, rmtree: Mock, path_exists: Mock, path_mkdir: Mock):
+        runtime = MagicMock(config={"build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"}}, working_dir=Path("/path/to/working"), dry_run=False)
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.IMAGE, dg_key="foo")
+        actual = get_event_loop().run_until_complete(pipeline._build_plashet_for_assembly("plashet1234", 8, ["x86_64", "s390x"], 12345))
+        expected_local_dir = runtime.working_dir / "plashets/el8/art0001/plashet1234"
+        expected_remote_url = constants.PLASHET_REMOTE_URL + "/4.9-el8/art0001/plashet1234"
+        self.assertEqual(actual, (expected_local_dir, expected_remote_url))
+        path_exists.assert_called_once_with()
+        rmtree.assert_called_once_with(expected_local_dir)
+        path_mkdir.assert_called_once_with(parents=True, exist_ok=True)
+        excepted_doozer_cmd = ['doozer', '--group', 'openshift-4.9', '--assembly', 'art0001', 'config:plashet', '--base-dir', '/path/to/working/plashets/el8/art0001', '--name', 'plashet1234', '--repo-subdir', 'os', '--arch', 'x86_64', 'signed', '--arch', 's390x', 'signed', 'for-assembly', '--signing-advisory-id', '12345', '--signing-advisory-mode', 'clean', '--el-version', '8', '--image', 'foo']
+        cmd_assert_async.assert_called_once_with(excepted_doozer_cmd, env=ANY)
+
+    @patch("pyartcd.exectools.cmd_assert_async")
+    def test_copy_plashet_out_to_remote(self, cmd_assert_async: Mock):
+        runtime = MagicMock(dry_run=False)
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.RHCOS, dg_key=None)
+        local_plashet_dir = "/path/to/local/plashets/el8/plashet1234"
+        get_event_loop().run_until_complete(pipeline._copy_plashet_out_to_remote(8, local_plashet_dir, "building"))
+        cmd_assert_async.assert_any_call(["ssh", constants.PLASHET_REMOTE_HOST, "--", "mkdir", "-p", "--", "/mnt/rcm-guest/puddles/RHAOS/plashets/4.9-el8/art0001"])
+        cmd_assert_async.assert_any_call(["rsync", "-av", "--links", "--progress", "-h", "--no-g", "--omit-dir-times", "--chmod=Dug=rwX,ugo+r", "--perms", "--", "/path/to/local/plashets/el8/plashet1234", f"{constants.PLASHET_REMOTE_HOST}:{constants.PLASHET_REMOTE_BASE_DIR}/4.9-el8/art0001"])
+        cmd_assert_async.assert_any_call(["ssh", constants.PLASHET_REMOTE_HOST, "--", "ln", "-sfn", "--", "plashet1234", f"{constants.PLASHET_REMOTE_BASE_DIR}/4.9-el8/art0001/building"])
+
+    @patch("pyartcd.pipelines.rebuild.RebuildPipeline._build_plashet_for_assembly")
+    @patch("pyartcd.pipelines.rebuild.RebuildPipeline._build_plashet_from_tags")
+    def test_build_plashets_rhcos(self, _build_plashet_from_tags: AsyncMock, _build_plashet_for_assembly: AsyncMock):
+        runtime = MagicMock(dry_run=False)
+        group_config = {
+            "arches": ["x86_64", "s390x"],
+            "signing_advisory": 12345,
+        }
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.RHCOS, dg_key=None)
+        _build_plashet_from_tags.return_value = (Path("/path/to/local/dir1"), "https://example.com/dir1")
+        _build_plashet_for_assembly.return_value = (Path("/path/to/local/dir2"), "https://example.com/dir2")
+        actual = get_event_loop().run_until_complete(pipeline._build_plashets("202107160000", 8, group_config))
+        _build_plashet_from_tags.assert_called_once_with('art0001-202107160000-rhcos-basis', 8, group_config["arches"], group_config["signing_advisory"])
+        _build_plashet_for_assembly.assert_called_once_with('art0001-202107160000-rhcos-overrides', 8, group_config["arches"], group_config["signing_advisory"])
+        self.assertEqual(actual, (Path("/path/to/local/dir1"), "https://example.com/dir1", Path("/path/to/local/dir2"), "https://example.com/dir2"))
+
+    @patch("pyartcd.pipelines.rebuild.RebuildPipeline._build_plashet_for_assembly")
+    @patch("pyartcd.pipelines.rebuild.RebuildPipeline._build_plashet_from_tags")
+    def test_build_plashets_image(self, _build_plashet_from_tags: AsyncMock, _build_plashet_for_assembly: AsyncMock):
+        runtime = MagicMock(dry_run=False)
+        group_config = {
+            "arches": ["x86_64", "s390x"],
+            "signing_advisory": 12345,
+        }
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.IMAGE, dg_key="foo")
+        _build_plashet_from_tags.return_value = (Path("/path/to/local/dir1"), "https://example.com/dir1")
+        _build_plashet_for_assembly.return_value = (Path("/path/to/local/dir2"), "https://example.com/dir2")
+        actual = get_event_loop().run_until_complete(pipeline._build_plashets("202107160000", 8, group_config))
+        _build_plashet_from_tags.assert_called_once_with('art0001-202107160000-image-foo-basis', 8, group_config["arches"], group_config["signing_advisory"])
+        _build_plashet_for_assembly.assert_called_once_with('art0001-202107160000-image-foo-overrides', 8, group_config["arches"], group_config["signing_advisory"])
+        self.assertEqual(actual, (Path("/path/to/local/dir1"), "https://example.com/dir1", Path("/path/to/local/dir2"), "https://example.com/dir2"))
+
+    @patch("pathlib.Path.read_text")
+    def test_generate_repo_file_for_image(self, read_text: Mock):
+        runtime = MagicMock(dry_run=False)
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.IMAGE, dg_key="foo")
+        read_text.return_value = """
+[rhel-8-server-ose]
+enabled=1
+gpgcheck=0
+baseurl=http://download.eng.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/4.9-el8/art0001/building-embargoed/$basearch/os
+        """.strip()
+        out_file = StringIO()
+        pipeline._generate_repo_file_for_image(out_file, "fake-basis", "https://example.com/plashets/4.9-el8/art0001/fake-overrides")
+        expected = """
+[rhel-8-server-ose]
+enabled=1
+gpgcheck=0
+baseurl=http://download.eng.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/4.9-el8/art0001/fake-basis/$basearch/os
+[plashet-rebuild-overrides]
+name = plashet-rebuild-overrides
+baseurl = https://example.com/plashets/4.9-el8/art0001/fake-overrides/$basearch/os
+enabled = 1
+priority = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+        """.strip()
+        self.assertEqual(out_file.getvalue().strip(), expected)
+
+    def test_generate_repo_file_for_rhcos(self):
+        runtime = MagicMock(dry_run=False)
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.RHCOS, dg_key=None)
+        out_file = StringIO()
+        pipeline._generate_repo_file_for_rhcos(out_file, "fake-basis", "https://example.com/plashets/4.9-el8/art0001/fake-overrides")
+        expected = """
+# These repositories are generated by the OpenShift Automated Release Team
+# https://issues.redhat.com/browse/ART-3154
+
+[plashet-rebuild-basis]
+name = plashet-rebuild-basis
+baseurl = fake-basis/$basearch/os
+enabled = 1
+gpgcheck = 0
+exclude=nss-altfiles kernel protobuf
+[plashet-rebuild-overrides]
+name = plashet-rebuild-overrides
+baseurl = https://example.com/plashets/4.9-el8/art0001/fake-overrides/$basearch/os
+enabled = 1
+priority = 1
+gpgcheck = 0
+exclude=nss-altfiles kernel protobuf
+        """.strip()
+        self.assertEqual(out_file.getvalue().strip(), expected)
+
+    @patch("pyartcd.exectools.cmd_gather_async")
+    def test_get_image_distgit_branch(self, cmd_gather_async: Mock):
+        runtime = MagicMock(dry_run=False)
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.IMAGE, dg_key="foo")
+        group_config = {
+            "branch": "rhaos-4.9-rhel-8",
+        }
+        cmd_gather_async.return_value = (0, """
+images:
+  foo: rhaos-4.9-rhel-7
+        """.strip(), "")
+        actual = get_event_loop().run_until_complete(pipeline._get_image_distgit_branch(group_config))
+        cmd_gather_async.assert_called_once_with(["doozer", "--group", "openshift-4.9", "--assembly", "art0001", "-i", "foo", "config:print", "--yaml", "--key", "distgit.branch"], env=ANY)
+        self.assertEqual(actual, "rhaos-4.9-rhel-7")
+
+        cmd_gather_async.reset_mock()
+        cmd_gather_async.return_value = (0, """
+images:
+  foo: null
+        """.strip(), "")
+        actual = get_event_loop().run_until_complete(pipeline._get_image_distgit_branch(group_config))
+        cmd_gather_async.assert_called_once_with(["doozer", "--group", "openshift-4.9", "--assembly", "art0001", "-i", "foo", "config:print", "--yaml", "--key", "distgit.branch"], env=ANY)
+        self.assertEqual(actual, "rhaos-4.9-rhel-8")
+
+    @patch("pyartcd.exectools.cmd_assert_async")
+    def test_rebase_image(self, cmd_assert_async: Mock):
+        runtime = MagicMock(dry_run=False)
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.IMAGE, dg_key="foo")
+        get_event_loop().run_until_complete(pipeline._rebase_image("202107160000.p?"))
+        excepted_doozer_cmd = ["doozer", "--group", "openshift-4.9", "--assembly", "art0001", "--latest-parent-version", "-i", "foo", "images:rebase", "--version", "v4.9", "--release", "202107160000.p?", "--force-yum-updates", "--message", "Updating Dockerfile version and release v4.9-202107160000.p?", "--push"]
+        cmd_assert_async.assert_called_once_with(excepted_doozer_cmd, env=ANY)
+
+        runtime.dry_run = True
+        cmd_assert_async.reset_mock()
+        get_event_loop().run_until_complete(pipeline._rebase_image("202107160000.p?"))
+        excepted_doozer_cmd = ["doozer", "--group", "openshift-4.9", "--assembly", "art0001", "--latest-parent-version", "-i", "foo", "images:rebase", "--version", "v4.9", "--release", "202107160000.p?", "--force-yum-updates", "--message", "Updating Dockerfile version and release v4.9-202107160000.p?"]
+        cmd_assert_async.assert_called_once_with(excepted_doozer_cmd, env=ANY)
+
+    @patch("builtins.open")
+    @patch("pyartcd.exectools.cmd_assert_async")
+    def test_build_image(self, cmd_assert_async: Mock, open: Mock):
+        runtime = MagicMock(dry_run=False, working_dir=Path("/path/to/working"))
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.IMAGE, dg_key="foo")
+        repo_url = "http://example.com/plashets/4.9-el8/art0001/art0001-image-foo-overrides/rebuild.repo"
+        open.return_value.__enter__.return_value = StringIO("build|nvrs=foo-container-v1.2.3-1.p0.assembly.art0001|")
+        nvrs = get_event_loop().run_until_complete(pipeline._build_image(repo_url))
+        self.assertEqual(nvrs, ["foo-container-v1.2.3-1.p0.assembly.art0001"])
+        excepted_doozer_cmd = ["doozer", "--group", "openshift-4.9", "--assembly", "art0001", "--latest-parent-version", "-i", "foo", "images:build", "--repo", "http://example.com/plashets/4.9-el8/art0001/art0001-image-foo-overrides/rebuild.repo"]
+        cmd_assert_async.assert_called_once_with(excepted_doozer_cmd, env=ANY)
+        open.assert_called_once_with(runtime.working_dir / "doozer-working/record.log", "r")
+
+        runtime.dry_run = True
+        cmd_assert_async.reset_mock()
+        nvrs = get_event_loop().run_until_complete(pipeline._build_image(repo_url))
+        self.assertEqual(nvrs, [])
+        excepted_doozer_cmd = ["doozer", "--group", "openshift-4.9", "--assembly", "art0001", "--latest-parent-version", "-i", "foo", "images:build", "--repo", "http://example.com/plashets/4.9-el8/art0001/art0001-image-foo-overrides/rebuild.repo", "--dry-run"]
+        cmd_assert_async.assert_called_once_with(excepted_doozer_cmd, env=ANY)
+
+    @patch("builtins.open")
+    @patch("pyartcd.exectools.cmd_assert_async")
+    def test_rebase_and_build_rpm(self, cmd_assert_async: Mock, open: Mock):
+        runtime = MagicMock(dry_run=False, working_dir=Path("/path/to/working"))
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.RPM, dg_key="foo")
+        release = "202107160000.p?"
+        open.return_value.__enter__.return_value = StringIO("build_rpm|nvrs=foo-v1.2.3-202107160000.p0.assembly.art0001.el8,foo-v1.2.3-202107160000.p0.assembly.art0001.el7|")
+        nvrs = get_event_loop().run_until_complete(pipeline._rebase_and_build_rpm(release))
+        self.assertEqual(nvrs, ["foo-v1.2.3-202107160000.p0.assembly.art0001.el8", "foo-v1.2.3-202107160000.p0.assembly.art0001.el7"])
+        excepted_doozer_cmd = ["doozer", "--group", "openshift-4.9", "--assembly", "art0001", "-r", "foo", "rpms:rebase-and-build", "--version", "4.9", "--release", release]
+        cmd_assert_async.assert_called_once_with(excepted_doozer_cmd, env=ANY)
+        open.assert_called_once_with(runtime.working_dir / "doozer-working/record.log", "r")
+
+        runtime.dry_run = True
+        cmd_assert_async.reset_mock()
+        nvrs = get_event_loop().run_until_complete(pipeline._rebase_and_build_rpm(release))
+        self.assertEqual(nvrs, [])
+        excepted_doozer_cmd = ["doozer", "--group", "openshift-4.9", "--assembly", "art0001", "-r", "foo", "rpms:rebase-and-build", "--version", "4.9", "--release", release, "--dry-run"]
+        cmd_assert_async.assert_called_once_with(excepted_doozer_cmd, env=ANY)
+
+    def test_generate_example_schema_rpm(self):
+        runtime = MagicMock(dry_run=False)
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.RPM, dg_key="foo")
+        actual = pipeline._generate_example_schema(["foo-v1.2.3-1.el8", "foo-v1.2.3-1.el7"])
+        expected = {
+            "releases": {
+                "art0001": {
+                    "assembly": {
+                        "members": {
+                            "rpms": [{
+                                "distgit_key": "foo",
+                                "metadata": {
+                                    "is": {
+                                        "el8": "foo-v1.2.3-1.el8",
+                                        "el7": "foo-v1.2.3-1.el7",
+                                    }
+                                }
+                            }]
+                        }
+                    }
+                }
+            }
+        }
+        self.assertEqual(actual, expected)
+
+    def test_generate_example_schema_image(self):
+        runtime = MagicMock(dry_run=False)
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.IMAGE, dg_key="foo")
+        actual = pipeline._generate_example_schema(["foo-container-v1.2.3-1"])
+        expected = {
+            "releases": {
+                "art0001": {
+                    "assembly": {
+                        "members": {
+                            "images": [{
+                                "distgit_key": "foo",
+                                "metadata": {
+                                    "is": {
+                                        "nvr": "foo-container-v1.2.3-1",
+                                    }
+                                }
+                            }]
+                        }
+                    }
+                }
+            }
+        }
+        self.assertEqual(actual, expected)
+
+    @patch("pyartcd.pipelines.rebuild.RebuildPipeline._generate_example_schema")
+    @patch("pyartcd.pipelines.rebuild.RebuildPipeline._rebase_and_build_rpm")
+    @patch("pyartcd.pipelines.rebuild.datetime")
+    def test_run_rpm(self, mock_datetime: Mock, _rebase_and_build_rpm: Mock, _generate_example_schema: Mock):
+        mock_datetime.utcnow.return_value = datetime(2021, 7, 16, 0, 0, 0, 0, tzinfo=timezone.utc)
+        runtime = MagicMock(dry_run=False)
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.RPM, dg_key="foo")
+        _rebase_and_build_rpm.return_value = ["foo-v1.2.3-1.el8", "foo-v1.2.3-1.el7"]
+        _generate_example_schema.return_value = {"some_key": "some_value"}
+        get_event_loop().run_until_complete(pipeline.run())
+        _rebase_and_build_rpm.assert_called_once_with("202107160000.p?")
+        _generate_example_schema.assert_called_once_with(_rebase_and_build_rpm.return_value)
+
+    @patch("pyartcd.pipelines.rebuild.RebuildPipeline._generate_example_schema")
+    @patch("pyartcd.pipelines.rebuild.RebuildPipeline._build_image")
+    @patch("pyartcd.pipelines.rebuild.RebuildPipeline._copy_plashet_out_to_remote")
+    @patch("pyartcd.pipelines.rebuild.RebuildPipeline._generate_repo_file_for_image")
+    @patch("pyartcd.pipelines.rebuild.RebuildPipeline._rebase_image")
+    @patch("pyartcd.pipelines.rebuild.RebuildPipeline._build_plashets")
+    @patch("pyartcd.pipelines.rebuild.RebuildPipeline._get_image_distgit_branch")
+    @patch("pyartcd.pipelines.rebuild.RebuildPipeline._load_group_config")
+    @patch("builtins.open")
+    @patch("pyartcd.pipelines.rebuild.datetime")
+    def test_run_image(self, mock_datetime: Mock, open: Mock, _load_group_config: Mock, _get_image_distgit_branch: Mock, _build_plashets: Mock, _rebase_image: Mock,
+                       _generate_repo_file_for_image: Mock, _copy_plashet_out_to_remote: Mock, _build_image: Mock, _generate_example_schema: Mock):
+        mock_datetime.utcnow.return_value = datetime(2021, 7, 16, 0, 0, 0, 0, tzinfo=timezone.utc)
+        timestamp = mock_datetime.utcnow.return_value.strftime("%Y%m%d%H%M")
+        runtime = MagicMock(dry_run=False)
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.IMAGE, dg_key="foo")
+        group_config = {
+            "arches": ["x86_64", "s390x"],
+            "signing_advisory": 12345,
+        }
+        _load_group_config.return_value = group_config
+        _get_image_distgit_branch.return_value = "rhaos-4.9-rhel-8"
+        _build_plashets.return_value = (Path("/path/to/plashet-a"), "http://example.com/plashet-a", Path("/path/to/plashet-b"), "http://example.com/plashet-b")
+        _build_image.return_value = ["foo-container-v1.2.3-1"]
+        _generate_example_schema.return_value = {"some_key": "some_value"}
+        get_event_loop().run_until_complete(pipeline.run())
+        _load_group_config.assert_called_once_with()
+        _get_image_distgit_branch.assert_called_once_with(group_config)
+        _build_plashets.assert_called_once_with(timestamp, 8, group_config)
+        _rebase_image.assert_called_once_with(f"{timestamp}.p?")
+        open.assert_called_once_with(Path("/path/to/plashet-b/rebuild.repo"), "w")
+        _generate_repo_file_for_image.assert_called_once_with(open.return_value.__enter__.return_value, "plashet-a", "http://example.com/plashet-b")
+        _copy_plashet_out_to_remote.assert_any_call(8, Path("/path/to/plashet-a"))
+        _copy_plashet_out_to_remote.assert_any_call(8, Path("/path/to/plashet-b"))
+        _build_image.assert_called_once_with("http://example.com/plashet-b/rebuild.repo")
+        _generate_example_schema.assert_called_once_with(_build_image.return_value)
+
+    @patch("pyartcd.pipelines.rebuild.RebuildPipeline._copy_plashet_out_to_remote")
+    @patch("pyartcd.pipelines.rebuild.RebuildPipeline._generate_repo_file_for_rhcos")
+    @patch("pyartcd.pipelines.rebuild.RebuildPipeline._build_plashets")
+    @patch("pyartcd.pipelines.rebuild.RebuildPipeline._load_group_config")
+    @patch("builtins.open")
+    @patch("pyartcd.pipelines.rebuild.datetime")
+    def test_run_rhcos(self, mock_datetime: Mock, open: Mock, _load_group_config: Mock, _build_plashets: Mock,
+                       _generate_repo_file_for_rhcos: Mock, _copy_plashet_out_to_remote: Mock):
+        mock_datetime.utcnow.return_value = datetime(2021, 7, 16, 0, 0, 0, 0, tzinfo=timezone.utc)
+        timestamp = mock_datetime.utcnow.return_value.strftime("%Y%m%d%H%M")
+        runtime = MagicMock(dry_run=False)
+        pipeline = RebuildPipeline(runtime, group="openshift-4.9", assembly="art0001", type=RebuildType.RHCOS, dg_key=None)
+        group_config = {
+            "arches": ["x86_64", "s390x"],
+            "signing_advisory": 12345,
+        }
+        _load_group_config.return_value = group_config
+        _build_plashets.return_value = (Path("/path/to/plashet-a"), "http://example.com/plashet-a", Path("/path/to/plashet-b"), "http://example.com/plashet-b")
+        get_event_loop().run_until_complete(pipeline.run())
+        _load_group_config.assert_called_once_with()
+        _build_plashets.assert_called_once_with(timestamp, 8, group_config)
+        open.assert_called_once_with(Path("/path/to/plashet-b/rebuild.repo"), "w")
+        _generate_repo_file_for_rhcos.assert_called_once_with(open.return_value.__enter__.return_value, "http://example.com/plashet-a", "http://example.com/plashet-b")
+        _copy_plashet_out_to_remote.assert_any_call(8, Path("/path/to/plashet-a"))
+        _copy_plashet_out_to_remote.assert_any_call(8, Path("/path/to/plashet-b"))

--- a/pyartcd/tests/test_jira.py
+++ b/pyartcd/tests/test_jira.py
@@ -93,7 +93,7 @@ class TestJIRAClient(TestCase):
         ]
 
         mock_jira = mock.MagicMock()
-        mock_jira.create_issues.side_effect = lambda field_list: [{"error":None, "input_fields":fields.copy(), "issue": mock.MagicMock(raw={"fields": fields.copy()})} for fields in field_list]
+        mock_jira.create_issues.side_effect = lambda field_list: [{"error": None, "input_fields": fields.copy(), "issue": mock.MagicMock(raw={"fields": fields.copy()})} for fields in field_list]
         client = JIRAClient(mock_jira)
         client.get_issue = mock.MagicMock(side_effect=lambda key: next(filter(lambda issue: issue.key == key, source_issue.fields.subtasks)))
         client.clone_issue = mock.MagicMock()

--- a/pyartcd/tests/test_record.py
+++ b/pyartcd/tests/test_record.py
@@ -1,0 +1,26 @@
+from io import StringIO
+from unittest import TestCase
+
+from pyartcd.record import parse_record_log
+
+
+class TestRebuildPipeline(TestCase):
+    def test_parse_record_log(self):
+        fake_file = StringIO(
+            "type1|key1=value1|key2=value2|\n"
+            "type2|key3=value3|key4=value4|\n"
+            "type2|key5=value5|\n"
+            "type3\n"
+        )
+        actual = parse_record_log(fake_file)
+        expected = {
+            "type1": [
+                {"key1": "value1", "key2": "value2"},
+            ],
+            "type2": [
+                {"key3": "value3", "key4": "value4"},
+                {"key5": "value5"},
+            ],
+            "type3": [{}],
+        }
+        self.assertEqual(actual, expected)

--- a/pyartcd/tests/test_util.py
+++ b/pyartcd/tests/test_util.py
@@ -1,0 +1,18 @@
+from unittest.case import TestCase
+from pyartcd import util
+
+
+class TestUtil(TestCase):
+    def test_isolate_el_version_in_release(self):
+        self.assertEqual(util.isolate_el_version_in_release('1.2.3-y.p.p1.assembly.4.9.99.el7'), 7)
+        self.assertEqual(util.isolate_el_version_in_release('1.2.3-y.p.p1.assembly.4.9.el7'), 7)
+        self.assertEqual(util.isolate_el_version_in_release('1.2.3-y.p.p1.assembly.art12398.el199'), 199)
+        self.assertEqual(util.isolate_el_version_in_release('1.2.3-y.p.p1.assembly.art12398'), None)
+        self.assertEqual(util.isolate_el_version_in_release('1.2.3-y.p.p1.assembly.4.7.e.8'), None)
+
+    def test_isolate_el_version_in_branch(self):
+        self.assertEqual(util.isolate_el_version_in_branch('rhaos-4.9-rhel-7-candidate'), 7)
+        self.assertEqual(util.isolate_el_version_in_branch('rhaos-4.9-rhel-7-hotfix'), 7)
+        self.assertEqual(util.isolate_el_version_in_branch('rhaos-4.9-rhel-7'), 7)
+        self.assertEqual(util.isolate_el_version_in_branch('rhaos-4.9-rhel-777'), 777)
+        self.assertEqual(util.isolate_el_version_in_branch('rhaos-4.9'), None)

--- a/pyartcd/tox.ini
+++ b/pyartcd/tox.ini
@@ -6,7 +6,7 @@ deps = -rrequirements-dev.txt
 passenv = *
 commands =
     flake8
-    coverage run --branch --source doozerlib -m unittest discover -t . -s tests/
+    coverage run --branch --source pyartcd -m unittest discover -t . -s tests/
     coverage report
 
 [flake8]


### PR DESCRIPTION
This job is used to patch one or more images with an updated RPM
dependency or upstream code commit.

Test builds: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/yuxzhu/job/aos-cd-jobs/job/build%252Frebuild/