### PR TITLE
[ART-3149] Build jenkins{,-2-plugins} without disabling the firewall

### DIFF
--- a/hacks/iptables/buildvm-scripts/known-networks.txt
+++ b/hacks/iptables/buildvm-scripts/known-networks.txt
@@ -232,3 +232,6 @@
 96.6.42.179
 23.208.140.80
 23.208.140.34
+
+# https://ftp.belnet.be / jenkins{,-2-plugins} archives
+193.190.0.0/15

--- a/hacks/update-jenkins-plugins/collect-jenkins-plugins.sh
+++ b/hacks/update-jenkins-plugins/collect-jenkins-plugins.sh
@@ -100,11 +100,8 @@ get_plugin() {
     plugin=$(echo "${plugin_line}:" | cut -d : -f 1)
     plugin_version=$(echo "${plugin_line}:" | cut -d : -f 2)
 
-    if [ -z "${plugin_version}" -o "${plugin_version}" == "latest" ]; then
-        plugin_url="https://updates.jenkins-ci.org/latest/${plugin}.hpi"
-    else
-        plugin_url="https://updates.jenkins-ci.org/download/plugins/${plugin}/${plugin_version}/${plugin}.hpi"
-    fi
+    plugin_url="https://ftp.belnet.be/pub/jenkins/plugins/${plugin}/${plugin_version}/${plugin}.hpi"
+
     tmp_hpi_file="${tmp_hpis_dir}/${plugin}.hpi"
 
     echo "Downloading plugin: ${plugin_url}"

--- a/jobs/devex/jenkins-bump-version/bump-jenkins.sh
+++ b/jobs/devex/jenkins-bump-version/bump-jenkins.sh
@@ -42,15 +42,18 @@ setup_dist_git() {
 
 # download jenkins war
 prep_jenkins_war() {
-    wget https://updates.jenkins-ci.org/download/war/${VERSION}/jenkins.war
+    wget --no-verbose https://ftp.belnet.be/pub/jenkins/war-stable/${VERSION}/jenkins.war
+    wget --no-verbose https://ftp.belnet.be/pub/jenkins/war-stable/${VERSION}/jenkins.war.sha256
+    sha256sum --check jenkins.war.sha256
     mv jenkins.war jenkins.${UVERSION}.war
+    rm jenkins.war.sha256
 }
 
 # update changelog
 update_dist_git () {
   if [ ! -f *.spec ]; then
-        # Get the spec and supporting files from a prior release
-        git pull --no-edit --allow-unrelated-histories origin rhaos-3.7-rhel-7
+      echo "No .spec file found. Exiting.">/dev/stderr
+      exit 1
   fi
   REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt rhpkg new-sources jenkins.${UVERSION}.war
   $SCRIPTS_DIR/rpm-bump-version.sh "${UVERSION}"

--- a/jobs/devex/jenkins-bump-version/bump-jenkins.sh
+++ b/jobs/devex/jenkins-bump-version/bump-jenkins.sh
@@ -42,6 +42,7 @@ setup_dist_git() {
 
 # download jenkins war
 prep_jenkins_war() {
+    set -eu
     wget --no-verbose https://ftp.belnet.be/pub/jenkins/war-stable/${VERSION}/jenkins.war
     wget --no-verbose https://ftp.belnet.be/pub/jenkins/war-stable/${VERSION}/jenkins.war.sha256
     sha256sum --check jenkins.war.sha256


### PR DESCRIPTION
This opens the firewall to https://ftp.belnet.be and uses that rather than updates.jenkins-ci.org.

Test runs:
- [jenkins](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/jdelft-aos-cd-jobs/job/devex%252Fjenkins-bump-version/4/console)
- [jenkins-2-plugins](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/jdelft-aos-cd-jobs/job/devex%252Fjenkins-plugins/2/console)