### PR TITLE
[ART-3110] Add assembly parameters to promote job

### DIFF
--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -1,4 +1,5 @@
 #!/usr/bin/groovy
+import java.net.URLEncoder
 
 commonlib = load("pipeline-scripts/commonlib.groovy")
 commonlib.initialize()
@@ -1538,6 +1539,20 @@ def get_owners(doozerOpts, images, rpms=[]) {
             """, [capture: true]
         )
     return yamlData
+}
+
+def get_releases_config(String group) {
+    def r = httpRequest(
+        url: "https://raw.githubusercontent.com/openshift/ocp-build-data/${URLEncoder.encode(group, 'utf-8')}/releases.yml",
+        httpMode: 'GET',
+        timeout: 30,
+        validResponseCodes: '200:404',
+    )
+    if (r.status == 200)
+        return readYaml(text: r.content)
+    if (r.status == 404)
+        return null
+    error("Unable to get releases config: HTTP Error ${r.status}")
 }
 
 this.setup_venv()


### PR DESCRIPTION
 - Support promoting releases by specifying the name of assemblies instead of nightlies. To keep backward compatibility, promoting releases for stream assembliy still requires specifying nightlies.
- Releases names are derived from assembly names. For standard releases, release name is the assembly name; For custom releases, release name is `X.Y.0-assembly.ASSEMBLY_NAME`.
- If nightlies are not defined in assembly config `basis.reference_releases`, release images will be created by `oc adm release new --from-image-stream X.Y-art-assembly-ASSEMBLY_NAME[-ARCH]`.
- Don't create Cincinnati PRs for custom releases.
- Don't check for blocker bugs for FCs, RCs, and custom releases.
- Update `multi_promote` job to accommodate the `promote` job change.
- Update `multi_promote` job to eliminate the hardcoded arch list. The arch list should be retrieved from `commonlib.ocpReleaseState`.

Test builds:
- custom release x86_64 (without reference_releases): https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/yuxzhu/job/build_promote/61/
- custom release s390x (without reference_releases): https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/yuxzhu/job/build_promote/64/
- custom release ppc64le (without reference_releases): https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/yuxzhu/job/build_promote/60/
- 4.7.21 ppc64le (with reference_releases, dry run): https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/yuxzhu/job/build_promote/57/

Note: Promoting FC or RC releases using assemblies is not supported.