### PR TITLE
Add skip attach cve flaws flag to promote

### DIFF
--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -123,6 +123,11 @@ node {
                             ].join('\n'),
                     ),
                     booleanParam(
+                        name: 'SKIP_ATTACH_CVE_FLAWS',
+                        description: 'Skip elliott attach-cve-flaws step',
+                        defaultValue: false,
+                    ),
+                    booleanParam(
                         name: 'SKIP_CINCINNATI_PR_CREATION',
                         description: 'DO NOT USE without team lead approval. This is an unusual option.',
                         defaultValue: false,
@@ -382,6 +387,10 @@ node {
             buildlib.registry_quay_dev_login()
             stage("versions") { release.stageVersions() }
             stage("add cve flaw bugs") {
+                if ( params.SKIP_ATTACH_CVE_FLAWS ) {
+                    echo "skipping attach cve flaws step"
+                    return
+                }
                 if (advisory == -1) {
                     return
                 }


### PR DESCRIPTION
In cases we don't want to run the attach-cve-flaws step, now for example in preparing 4.8 GA advisories. The current logic is incomplete and need fixes. Error on our part would require prodsec to fix stuff for us.

Also detecting ga would be nice, but since we would be promoting 4.8.1, rather it be a manual flag.