### PR TITLE
operator-sdk_sync: provide versionless symlinks

### DIFF
--- a/jobs/build/operator-sdk_sync/Jenkinsfile
+++ b/jobs/build/operator-sdk_sync/Jenkinsfile
@@ -100,6 +100,7 @@ pipeline {
 
                             def tarballFilename = "operator-sdk-${sdkVersion}-linux-${it.arch}.tar.gz"
                             sh "tar --create --preserve-order --gzip --verbose --file ${tarballFilename} ./operator-sdk"
+                            sh "ln -s ${tarballFilename} operator-sdk-linux-${it.arch}.tar.gz"
                             sh "rm -f ./operator-sdk"
 
                             // Extract darwin binaries
@@ -108,6 +109,7 @@ pipeline {
                                 sh "chmod +x operator-sdk"
                                 tarballFilename = "operator-sdk-${sdkVersion}-darwin-${it.arch}.tar.gz"
                                 sh "tar --create --preserve-order --gzip --verbose --file ${tarballFilename} ./operator-sdk"
+                                sh "ln -s ${tarballFilename} operator-sdk-darwin-${it.arch}.tar.gz"
                                 sh "rm -f ./operator-sdk"
                             }
 
@@ -126,7 +128,7 @@ pipeline {
                         dir("./${arch}") {
                             sshagent(['aos-cd-test']) {
                                 sh "ssh use-mirror-upload.ops.rhcloud.com -- mkdir -p /srv/pub/openshift-v4/${arch}/clients/operator-sdk/${params.OCP_VERSION}"
-                                sh "scp -- *.tar.gz use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/${arch}/clients/operator-sdk/${params.OCP_VERSION}"
+                                sh "rsync -av --no-g --progress -e \"ssh -o StrictHostKeyChecking=no\" *.tar.gz use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/${arch}/clients/operator-sdk/${params.OCP_VERSION}/"
                                 sh "ssh use-mirror-upload.ops.rhcloud.com -- ln --symbolic --force --no-dereference ${params.OCP_VERSION} /srv/pub/openshift-v4/${arch}/clients/operator-sdk/latest"
                                 sh "ssh use-mirror-upload.ops.rhcloud.com -- /usr/local/bin/push.pub.sh openshift-v4/${arch}/clients/operator-sdk -v"
                             }


### PR DESCRIPTION
This is necessary for creating reliable download links on
cloud.redhat.com/openshift/downloads.

Please verify this works as intended, as I am not an ARTist.
