### PR TITLE
[ART-3174] Support promoting FCs and RCs using assemblies

### DIFF
--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -249,6 +249,11 @@ node {
             is_4stable_release = false
             CLIENT_TYPE = 'ocp-dev-preview'  // Trigger beta2 key
             break
+        case "candidate":
+            is_prerelease = true
+            release_name = "${major}.${minor}.0-${params.ASSEMBLY}"
+            CLIENT_TYPE = 'ocp-dev-preview'  // Trigger beta2 key
+            break
         default:
             error("Unsupported release type $release_type")
         }


### PR DESCRIPTION
Release name will be `${major}.${minor}.0-${ASSEMBLY}` where `ASSEMBLY` is `fc.#` or `rc.#`.