### PR TITLE
art-2519: add check upstream step in image_health job

### DIFF
--- a/jobs/scanning/images-health/Jenkinsfile
+++ b/jobs/scanning/images-health/Jenkinsfile
@@ -17,6 +17,17 @@ node() {
                         defaultValue: true,
                         description: "If false, output will only be sent to console"
                     ),
+                    choice(
+                        name: 'ALERT_DATE', 
+                        choices: [
+                            'Monday',
+                            'Tuesday',
+                            'Wednesday', 
+                            'Thursday',
+                            'Friday'
+                        ].join('\n'), 
+                        description: 'In which day check upstream prs'
+                    ),
                     commonlib.mockParam(),
                 ]
             ],
@@ -56,22 +67,35 @@ node() {
             currentBuild.result = "FAILURE"
             throw exception  // gets us a stack trace FWIW
         }
-
+        
+        def week = [1:'Sunday', 2:'Monday', 3:'Tuesday', 4:'Wednesday', 5:'Thursday', 6:'Friday', 7:'Saturday']
         Date today = new Date();
         Calendar c = Calendar.getInstance();
         c.setTime(today);
-        if (c.get(Calendar.DAY_OF_WEEK) == 2 ) {  // to avoid spam message only check once on Mon
-            withCredentials([string(credentialsId: 'openshift-bot-token', variable: 'GIT_TOKEN')]) {
+        if ( week[c.get(Calendar.DAY_OF_WEEK)] == params.ALERT_DATE ) {  // to avoid spam message only check once on Mon
+            withCredentials([string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN')]) {
                 slackChannel = slacklib.to(BUILD_VERSION)
                 try {
-                    report = buildlib.doozer("${doozerOpts} images:upstreampulls", [capture: true]).trim()
+                    report = buildlib.doozer("${doozerOpts} images:streams prs list", [capture: true]).trim()
                     if (report) {
-                        echo "The report:\n${report}"
+                        data = readYaml text: report
+                        text = ""
+                        data.each { email, repo ->
+                            text += "*${email} is a contact for these PRs:*\n"
+                            repos.each { repo, prs ->
+                                prs.each { pr -> text += ":black_small_square:${pr.pr_url}\n" }
+                            }
+                        }
+                        def attachment = [
+                            color: "#f2c744",
+                            blocks: [[type: "section", text: [type: "mrkdwn", text: text]]]
+                        ]
+                        slackChannel.pinAttachment(attachments)
                         if (params.SEND_TO_SLACK) {
-                            slackChannel.say(":scroll: Howdy! Some upstream prs are still open for ${group}\n${report}")
+                            slackChannel.say(":scroll: Howdy! Some alignment prs are still open for ${group}\n", [attachment])
                         }
                     } else {
-                        echo "There are open pr left."
+                        echo "There are no alignment prs left open."
                         if (params.SEND_TO_SLACK) {
                             slackChannel.say(":scroll: All prs are merged for ${group}")
                         }
@@ -82,6 +106,6 @@ node() {
                     throw exception  // gets us a stack trace FWIW
                 }
             }
-
         }
+    }
 }

--- a/jobs/scanning/images-health/Jenkinsfile
+++ b/jobs/scanning/images-health/Jenkinsfile
@@ -1,5 +1,3 @@
-
-
 node() {
     checkout scm
     def buildlib = load("pipeline-scripts/buildlib.groovy")
@@ -58,5 +56,32 @@ node() {
             currentBuild.result = "FAILURE"
             throw exception  // gets us a stack trace FWIW
         }
-    }
+
+        Date today = new Date();
+        Calendar c = Calendar.getInstance();
+        c.setTime(today);
+        if (c.get(Calendar.DAY_OF_WEEK) == 2 ) {  // to avoid spam message only check once on Mon
+            withCredentials([string(credentialsId: 'openshift-bot-token', variable: 'GIT_TOKEN')]) {
+                slackChannel = slacklib.to(BUILD_VERSION)
+                try {
+                    report = buildlib.doozer("${doozerOpts} images:upstreampulls", [capture: true]).trim()
+                    if (report) {
+                        echo "The report:\n${report}"
+                        if (params.SEND_TO_SLACK) {
+                            slackChannel.say(":scroll: Howdy! Some upstream prs are still open for ${group}\n${report}")
+                        }
+                    } else {
+                        echo "There are open pr left."
+                        if (params.SEND_TO_SLACK) {
+                            slackChannel.say(":scroll: All prs are merged for ${group}")
+                        }
+                    }
+                } catch (exception) {
+                    slackChannel.say(":alert: Image health check job failed!\n${BUILD_URL}")
+                    currentBuild.result = "FAILURE"
+                    throw exception  // gets us a stack trace FWIW
+                }
+            }
+
+        }
 }

--- a/scheduled-jobs/scanning/images-health/Jenkinsfile
+++ b/scheduled-jobs/scanning/images-health/Jenkinsfile
@@ -12,6 +12,7 @@ def runFor(version) {
             job: '../scanning/scanning%2Fimages-health',
             parameters: [
                 string(name: 'BUILD_VERSION', value: version),
+                string(name: 'ALERT_DATE', value: 'Monday')
             ],
             propagate: false,
         )


### PR DESCRIPTION
use doozer images sub-command to gather upstream pr report and only check on Monday's health check job to avoid spam message, The mapping of owner and redhat email address is still imperfect so by now not send email by bot.