### PR TITLE
Optionally update "latest" symlink on operator-sdk sync

### DIFF
--- a/jobs/build/operator-sdk_sync/Jenkinsfile
+++ b/jobs/build/operator-sdk_sync/Jenkinsfile
@@ -41,6 +41,11 @@ pipeline {
             defaultValue: '',
             trim: true,
         )
+        booleanParam(
+            name: 'UPDATE_LATEST_SYMLINK',
+            description: 'You just want to update "latest" on the highest 4.x version',
+            defaultValue: true,
+        )
     }
 
     stages {
@@ -132,7 +137,9 @@ pipeline {
                             sshagent(['aos-cd-test']) {
                                 sh "ssh use-mirror-upload.ops.rhcloud.com -- mkdir -p /srv/pub/openshift-v4/${arch}/clients/operator-sdk/${params.OCP_VERSION}"
                                 sh "rsync -av --no-g --progress *.tar.gz use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/${arch}/clients/operator-sdk/${params.OCP_VERSION}/"
-                                sh "ssh use-mirror-upload.ops.rhcloud.com -- ln --symbolic --force --no-dereference ${params.OCP_VERSION} /srv/pub/openshift-v4/${arch}/clients/operator-sdk/latest"
+                                if (params.UPDATE_LATEST_SYMLINK) {
+                                    sh "ssh use-mirror-upload.ops.rhcloud.com -- ln --symbolic --force --no-dereference ${params.OCP_VERSION} /srv/pub/openshift-v4/${arch}/clients/operator-sdk/latest"
+                                }
                                 sh "ssh use-mirror-upload.ops.rhcloud.com -- /usr/local/bin/push.pub.sh openshift-v4/${arch}/clients/operator-sdk -v"
                             }
                         }

--- a/jobs/build/operator-sdk_sync/README.md
+++ b/jobs/build/operator-sdk_sync/README.md
@@ -25,6 +25,11 @@ Examples:
 - v4.7.0
 - v4.7
 
+### UPDATE_LATEST_SYMLINK
+
+Point "latest" symlink to version being published.
+Usually, you'll only want to do that on the highest 4.x version.
+
 ## Known issues
 
 ### Job reports as 'SUCCESS' but sync to one of the mirrors failed


### PR DESCRIPTION
we'll usually do it for 4.8 on Mondays, then 4.7 on Tuesdays, but we want to keep "latest" pointing to the latest 4.8, not the latest 4.7 we published later.