### PR TITLE
Remove `StrictHostKeyChecking=no` from SSH invocations

### DIFF
--- a/build-scripts/rcm-guest/publish-oc-binary.sh
+++ b/build-scripts/rcm-guest/publish-oc-binary.sh
@@ -64,10 +64,10 @@ mkdir "${OUTDIR}/windows"
 zip --quiet --junk-path - windows/oc.exe > "${OUTDIR}/windows/oc.zip"
 rsync \
     -av --delete-after --progress --no-g --omit-dir-times --chmod=Dug=rwX \
-    -e "ssh -l jenkins_aos_cd_bot -o StrictHostKeyChecking=no" \
+    -e "ssh -l jenkins_aos_cd_bot" \
     "${OUTDIR}" \
     use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v3/clients/
-ssh -l jenkins_aos_cd_bot -o StrictHostKeychecking=no \
+ssh -l jenkins_aos_cd_bot \
     use-mirror-upload.ops.rhcloud.com << EOF
         timeout 15m /usr/local/bin/push.pub.sh openshift-v3/clients -v \
         || timeout 5m /usr/local/bin/push.pub.sh openshift-v3/clients -v \

--- a/jobs/build/oc_sync/publish-clients-from-payload.sh
+++ b/jobs/build/oc_sync/publish-clients-from-payload.sh
@@ -28,7 +28,7 @@ fi
 
 OC_MIRROR_DIR="/srv/pub/openshift-v4/${ARCH}/clients/${CLIENT_TYPE}"
 
-SSH_OPTS="-l jenkins_aos_cd_bot -o StrictHostKeychecking=no use-mirror-upload.ops.rhcloud.com"
+SSH_OPTS="-l jenkins_aos_cd_bot use-mirror-upload.ops.rhcloud.com"
 
 #check if already exists
 if ssh ${SSH_OPTS} "[ -d ${OC_MIRROR_DIR}/${VERSION} ]";
@@ -140,7 +140,7 @@ fi
 #sync to use-mirror-upload
 rsync \
     -av --delete-after --progress --no-g --omit-dir-times --chmod=Dug=rwX \
-    -e "ssh -l jenkins_aos_cd_bot -o StrictHostKeyChecking=no" \
+    -e "ssh -l jenkins_aos_cd_bot" \
     "${OUTDIR}" \
     use-mirror-upload.ops.rhcloud.com:${OC_MIRROR_DIR}/
 

--- a/jobs/build/operator-sdk_sync/Jenkinsfile
+++ b/jobs/build/operator-sdk_sync/Jenkinsfile
@@ -128,7 +128,7 @@ pipeline {
                         dir("./${arch}") {
                             sshagent(['aos-cd-test']) {
                                 sh "ssh use-mirror-upload.ops.rhcloud.com -- mkdir -p /srv/pub/openshift-v4/${arch}/clients/operator-sdk/${params.OCP_VERSION}"
-                                sh "rsync -av --no-g --progress -e \"ssh -o StrictHostKeyChecking=no\" *.tar.gz use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/${arch}/clients/operator-sdk/${params.OCP_VERSION}/"
+                                sh "rsync -av --no-g --progress *.tar.gz use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/${arch}/clients/operator-sdk/${params.OCP_VERSION}/"
                                 sh "ssh use-mirror-upload.ops.rhcloud.com -- ln --symbolic --force --no-dereference ${params.OCP_VERSION} /srv/pub/openshift-v4/${arch}/clients/operator-sdk/latest"
                                 sh "ssh use-mirror-upload.ops.rhcloud.com -- /usr/local/bin/push.pub.sh openshift-v4/${arch}/clients/operator-sdk -v"
                             }

--- a/jobs/build/rhcos_sync/build.groovy
+++ b/jobs/build/rhcos_sync/build.groovy
@@ -80,7 +80,7 @@ def rhcosSyncPrintArtifacts() {
 }
 
 def rhcosSyncMirrorArtifacts() {
-    sh("scp -o StrictHostKeychecking=no ${syncList} use-mirror-upload.ops.rhcloud.com:/tmp/")
+    sh("scp ${syncList} use-mirror-upload.ops.rhcloud.com:/tmp/")
     def invokeOpts = "--" +
         " --prefix ${params.RHCOS_MIRROR_PREFIX}" +
         " --arch ${params.ARCH}" +

--- a/jobs/build/sync-for-ci/Jenkinsfile
+++ b/jobs/build/sync-for-ci/Jenkinsfile
@@ -145,7 +145,7 @@ node {
 
                 stage("push to mirror") {
                     sh "ssh -o StrictHostKeyChecking=no ${MIRROR_TARGET} -- mkdir --mode 755 -p ${MIRROR_SYNC_DIR}"
-                    sh "rsync -avzh --copy-links --chmod=a+rwx,g-w,o-w --delete -e \"ssh -o StrictHostKeyChecking=no\" ${LOCAL_SYNC_DIR}/ ${MIRROR_TARGET}:${MIRROR_SYNC_DIR} "
+                    sh "rsync -avzh --copy-links --chmod=a+rwx,g-w,o-w --delete ${LOCAL_SYNC_DIR}/ ${MIRROR_TARGET}:${MIRROR_SYNC_DIR} "
 
                     timeout(time: 2, unit: 'HOURS') {
                         sh "ssh -o StrictHostKeyChecking=no ${MIRROR_TARGET} -- push.enterprise.sh -v ${MIRROR_RELATIVE_REPOSYNC}"

--- a/jobs/signing/sign-artifacts/Jenkinsfile
+++ b/jobs/signing/sign-artifacts/Jenkinsfile
@@ -302,10 +302,10 @@ node {
                         """)
                         sshagent(["openshift-bot"]) {
                             def mirrorReleasePath = (params.ENV == 'stage') ? 'test' : 'release'
-                            sh "rsync -avzh -e \"ssh -o StrictHostKeyChecking=no\" sha256=* ${mirrorTarget}:/srv/pub/openshift-v4/signatures/openshift/${mirrorReleasePath}/"
+                            sh "rsync -avzh sha256=* ${mirrorTarget}:/srv/pub/openshift-v4/signatures/openshift/${mirrorReleasePath}/"
                             if (mirrorReleasePath == 'release') {
-                                sh "rsync -avzh -e \"ssh -o StrictHostKeyChecking=no\" sha256=* ${mirrorTarget}:/srv/pub/openshift-v4/signatures/openshift-release-dev/ocp-release/"
-                                sh "rsync -avzh -e \"ssh -o StrictHostKeyChecking=no\" sha256=* ${mirrorTarget}:/srv/pub/openshift-v4/signatures/openshift-release-dev/ocp-release-nightly/"
+                                sh "rsync -avzh sha256=* ${mirrorTarget}:/srv/pub/openshift-v4/signatures/openshift-release-dev/ocp-release/"
+                                sh "rsync -avzh sha256=* ${mirrorTarget}:/srv/pub/openshift-v4/signatures/openshift-release-dev/ocp-release-nightly/"
                             }
                             mirror_result = buildlib.invoke_on_use_mirror("push.pub.sh", 'openshift-v4/signatures')
                             if (mirror_result.contains("[FAILURE]")) {
@@ -344,7 +344,7 @@ node {
 
                         sshagent(["openshift-bot"]) {
                             def mirrorReleasePath = "openshift-v4/${params.ARCH}/clients/${params.CLIENT_TYPE}/${params.NAME}"
-                            sh "rsync -avzh -e \"ssh -o StrictHostKeyChecking=no\" sha256sum.txt.gpg ${mirrorTarget}:/srv/pub/${mirrorReleasePath}/sha256sum.txt.gpg"
+                            sh "rsync -avzh sha256sum.txt.gpg ${mirrorTarget}:/srv/pub/${mirrorReleasePath}/sha256sum.txt.gpg"
                             mirror_result = buildlib.invoke_on_use_mirror("push.pub.sh", mirrorReleasePath)
                             if (mirror_result.contains("[FAILURE]")) {
                                 echo mirror_result
@@ -356,7 +356,7 @@ node {
                             def name_parts = params.NAME.split('\\.')
                             def nameXY = "${name_parts[0]}.${name_parts[1]}"
                             def mirrorReleasePath = "openshift-v4/${params.ARCH}/dependencies/rhcos/${nameXY}/${params.NAME}"
-                            sh "rsync -avzh -e \"ssh -o StrictHostKeyChecking=no\" sha256sum.txt.gpg ${mirrorTarget}:/srv/pub/${mirrorReleasePath}/sha256sum.txt.gpg"
+                            sh "rsync -avzh sha256sum.txt.gpg ${mirrorTarget}:/srv/pub/${mirrorReleasePath}/sha256sum.txt.gpg"
                             mirror_result = buildlib.invoke_on_use_mirror("push.pub.sh", mirrorReleasePath)
                             if (mirror_result.contains("[FAILURE]")) {
                                 echo mirror_result
@@ -365,8 +365,8 @@ node {
                         }
                     } else if ( params.PRODUCT == 'rhacs' ) {
                         sshagent(["openshift-bot"]) {
-                            sh "rsync -avzh -e \"ssh -o StrictHostKeyChecking=no\" sha256=* ${mirrorTarget}:/srv/pub/rhacs/signatures/rhacs"
-                            sh "rsync -avzh -e \"ssh -o StrictHostKeyChecking=no\" sha256=* ${mirrorTarget}:/srv/pub/rhacs/signatures/rh-acs"
+                            sh "rsync -avzh sha256=* ${mirrorTarget}:/srv/pub/rhacs/signatures/rhacs"
+                            sh "rsync -avzh sha256=* ${mirrorTarget}:/srv/pub/rhacs/signatures/rh-acs"
                             mirror_result = buildlib.invoke_on_use_mirror("push.pub.sh", 'rhacs/signatures')
                             if (mirror_result.contains("[FAILURE]")) {
                                 echo mirror_result

--- a/jobs/signing/sign-rhacs/Jenkinsfile
+++ b/jobs/signing/sign-rhacs/Jenkinsfile
@@ -167,7 +167,7 @@ node {
                         # Touch a file that indicates we have signed for this specific tag; used by rhacs-sigstore scheduled job
                         touch staging/rh-acs/${params.REPO}/${VERSION}
                         cp -a \${fn} staging/rh-acs/${params.REPO}
-                        scp -r -o StrictHostKeychecking=no staging/* ${mirrorTarget}:/srv/pub/rhacs/signatures/
+                        scp -r staging/* ${mirrorTarget}:/srv/pub/rhacs/signatures/
                         """
                         mirror_result = buildlib.invoke_on_use_mirror("push.pub.sh", 'rhacs/signatures')
                         if (mirror_result.contains("[FAILURE]")) {

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -591,7 +591,7 @@ def invoke_on_rcm_guest(git_script_filename, Object... args ) {
 def invoke_on_use_mirror(git_script_filename, Object... args ) {
     return sh(
             returnStdout: true,
-            script: "ssh -o StrictHostKeychecking=no use-mirror-upload.ops.rhcloud.com sh -s ${this.args_to_string(args)} < ${env.WORKSPACE}/build-scripts/use-mirror/${git_script_filename}",
+            script: "ssh use-mirror-upload.ops.rhcloud.com sh -s ${this.args_to_string(args)} < ${env.WORKSPACE}/build-scripts/use-mirror/${git_script_filename}",
     ).trim()
 }
 

--- a/pipeline-scripts/deploylib.groovy
+++ b/pipeline-scripts/deploylib.groovy
@@ -71,7 +71,7 @@ def run( operation_name, opts = [:], capture_stdout=false, interactive_retry=tru
     waitUntil {
         try {
             // -t is necessary for cicd-control.sh to be terminated by Jenkins job terminating ssh early: https://superuser.com/questions/20679/why-does-my-remote-process-still-run-after-killing-an-ssh-session
-            cmd = "ssh -t -o StrictHostKeyChecking=no opsmedic@bastion-nasa-2.ops.openshift.com -- -d ${CLUSTER_GROUP} -c ${CLUSTER_NAME} -o ${operation_name} ${this.map_to_string(opts)}"
+            cmd = "ssh -t opsmedic@bastion-nasa-2.ops.openshift.com -- -d ${CLUSTER_GROUP} -c ${CLUSTER_NAME} -o ${operation_name} ${this.map_to_string(opts)}"
             ansiColor('xterm') {
                 output = sh(
                         returnStdout: capture_stdout,

--- a/scheduled-jobs/build/sync-for-ci-ironic/Jenkinsfile
+++ b/scheduled-jobs/build/sync-for-ci-ironic/Jenkinsfile
@@ -53,12 +53,12 @@ node() {
 
         echo "Synchronizing plashet for ${prevalidation_tag_name}"
 
-        sh "ssh -o StrictHostKeyChecking=no ${MIRROR_TARGET} -- mkdir --mode 755 -p ${MIRROR_SYNC_DIR}" // make ci-ironic if it doesn't exist
-        commonlib.shell "rsync -avzh --copy-links --chmod=a+rwx,g-w,o-w --delete -e \"ssh -o StrictHostKeyChecking=no\" ${baseDir}/${plashetDirName}/ ${MIRROR_TARGET}:${MIRROR_SYNC_DIR}/${plashetDirName} "
+        sh "ssh ${MIRROR_TARGET} -- mkdir --mode 755 -p ${MIRROR_SYNC_DIR}" // make ci-ironic if it doesn't exist
+        commonlib.shell "rsync -avzh --copy-links --chmod=a+rwx,g-w,o-w --delete ${baseDir}/${plashetDirName}/ ${MIRROR_TARGET}:${MIRROR_SYNC_DIR}/${plashetDirName} "
     }
 
     timeout(time: 2, unit: 'HOURS') {
-        sh "ssh -o StrictHostKeyChecking=no ${MIRROR_TARGET} -- push.enterprise.sh -v ${MIRROR_RELATIVE_REPOSYNC}"
+        sh "ssh ${MIRROR_TARGET} -- push.enterprise.sh -v ${MIRROR_RELATIVE_REPOSYNC}"
     }
 
     buildlib.cleanWorkspace()

--- a/scheduled-jobs/build/sync-rhacs/Jenkinsfile
+++ b/scheduled-jobs/build/sync-rhacs/Jenkinsfile
@@ -32,10 +32,10 @@ node() {
         LOCAL_SYNC_DIR="/mnt/workspace/buckets/rhacs-openshift-mirror-src"
 
         sshagent(['openshift-bot']) {
-            sh "ssh -o StrictHostKeyChecking=no ${MIRROR_TARGET} -- mkdir --mode 755 -p ${MIRROR_SYNC_DIR}"
-            sh "rsync -avzh --chmod=a+rwx,g-w,o-w --exclude=signatures--delete -e \"ssh -o StrictHostKeyChecking=no\" ${LOCAL_SYNC_DIR}/ ${MIRROR_TARGET}:${MIRROR_SYNC_DIR} "
+            sh "ssh ${MIRROR_TARGET} -- mkdir --mode 755 -p ${MIRROR_SYNC_DIR}"
+            sh "rsync -avzh --chmod=a+rwx,g-w,o-w --exclude=signatures--delete ${LOCAL_SYNC_DIR}/ ${MIRROR_TARGET}:${MIRROR_SYNC_DIR} "
             timeout(time: 2, unit: 'HOURS') {
-                sh "ssh -o StrictHostKeyChecking=no ${MIRROR_TARGET} -- push.pub.sh -v ${MIRROR_RELATIVE_PATH}"
+                sh "ssh ${MIRROR_TARGET} -- push.pub.sh -v ${MIRROR_RELATIVE_PATH}"
             }
         }
 


### PR DESCRIPTION
It's not needed because our all CI environments has recorded the host key in known_hosts
and we don't really want to risk MIIT attacks.