### PR TITLE
[ART-3069] olm_bundle job assembly awareness

### DIFF
--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -255,12 +255,22 @@ node {
 
             stage('sync images') {
                 if (params.SCRATCH || !any_images_to_build) { return }  // no point
-                if (majorVersion == 4) {
+                if (majorVersion >= 4) {
+                    def record_log = buildlib.parse_record_log(doozer_working)
+                    def records = record_log.get('build', [])
+                    def operator_nvrs = []
+                    for (record in records) {
+                        if (record["has_olm_bundle"] != '1' || record['status'] != '0' || !record["nvrs"]) {
+                            continue
+                        }
+                        operator_nvrs << record["nvrs"].split(",")[0]
+                    }
                     buildlib.sync_images(
                         majorVersion,
                         minorVersion,
                         "aos-team-art@redhat.com", // "reply to"
-                        currentBuild.number
+                        params.ASSEMBLY,
+                        operator_nvrs,
                     )
                 }
             }

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -467,15 +467,22 @@ def stageSyncImages() {
         echo "No built images to sync."
         return
     }
-    if(buildPlan.dryRun) {
-        echo "Not syncing images in a dry run."
-        return
+
+    def record_log = buildlib.parse_record_log(doozerWorking)
+    def records = record_log.get('build', [])
+    def operator_nvrs = []
+    for (record in records) {
+        if (record["has_olm_bundle"] != '1' || record['status'] != '0' || !record["nvrs"]) {
+            continue
+        }
+        operator_nvrs << record["nvrs"].split(",")[0]
     }
     buildlib.sync_images(
         version.major,
         version.minor,
         "aos-team-art@redhat.com",
-        currentBuild.number
+        params.ASSEMBLY,
+        operator_nvrs,
     )
 }
 

--- a/jobs/build/olm_bundle/olm_bundles.groovy
+++ b/jobs/build/olm_bundle/olm_bundles.groovy
@@ -3,39 +3,35 @@ commonlib = buildlib.commonlib
 slacklib = commonlib.slacklib
 
 doozer_working = "${WORKSPACE}/doozer_working"
+elliott_working = "${WORKSPACE}/elliott_working"
 buildlib.cleanWorkdir(doozer_working)
-
-def doozer(cmd) {
-    buildlib.doozer("--working-dir ${doozer_working} -g openshift-${params.BUILD_VERSION} ${cmd}", [capture: true])
-}
-
-def elliott(cmd) {
-    buildlib.elliott("-g openshift-${params.BUILD_VERSION} ${cmd}", [capture: true])
-}
+buildlib.cleanWorkdir(elliott_working)
+doozer_opts = "--working-dir ${doozer_working} -g openshift-${params.BUILD_VERSION}"
+elliott_opts = "--working-dir ${elliott_working} -g openshift-${params.BUILD_VERSION}"
 
 /*
  * Return the brew package name of all OLM operators present in <params.BUILD_VERSION>
  */
 def get_olm_operators() {
-    doozer('olm-bundle:list-olm-operators').split("\n").findAll { !it.isEmpty() }
+    buildlib.doozer("${doozer_opts} olm-bundle:list-olm-operators", [capture: true]).split("\n").findAll { !it.isEmpty() }
 }
 
 /*
  * Make sure 2 advisories belong to the same group that is given
  */
 def validate_advisories(advisory1, advisory2, group) {
-    def adv1_str = elliott("get ${advisory1}")
-    def adv2_str = elliott("get ${advisory2}")
+    def adv1_str = buildlib.elliott("${elliott_opts} get ${advisory1}", [capture: true])
+    def adv2_str = buildlib.elliott("${elliott_opts} get ${advisory2}", [capture: true])
     echo adv1_str
     echo adv2_str
-    
+
     // validate advisory1 string contains group(4.7)
     adv1 = adv1_str.split()
     index = adv1.findIndexOf { it.contains(group) }
     if (index == -1) {
         error("Group ${group} not found in advisory ${advisory1} data. Exiting")
     }
-    
+
     // validate the version of advisory1(4.7.4) is in advisory2 string
     version = adv1[index]
     if (!adv2_str.contains(version)) {
@@ -47,39 +43,52 @@ def validate_advisories(advisory1, advisory2, group) {
  * Return list of OLM Operator NVRs attached to given <advisory>
  */
 def get_builds_from_advisory(advisory) {
-    def json = elliott("get --json - ${advisory}")
+    def json = buildlib.elliott("${elliott_opts} get --json - ${advisory}", [capture: true])
     readJSON(text: json).errata_builds.values().flatten()
 }
 
 /*
- * Return the latest build of given <packages> for <tag>
- */
-def get_latest_builds(packages) {
-    if (!packages) { return [] }
-    def tag = "rhaos-${params.BUILD_VERSION}-rhel-8-candidate"
-    commonlib.shell(
-        script: "brew --quiet latest-build ${tag} ${packages.join(' ')}",
-        returnAll: true
-    ).stdout.split("\n").collect { it.split(" ")[0] }
-}
-
-/*
- * Build corresponding bundle containers for given <operator_nvrs>
+ * Build corresponding bundle containers for given operators
+ * :param only: list of operator distgit names to include in the build
+ * :param exclude: list of operator distgit names to exclude from the build
+ * :param operator_nvrs: only build bundles for given <operator_nvrs>
  * Return a list of built <bundle_nvrs>
  */
-def build_bundles(operator_nvrs) {
-    doozer("olm-bundle:rebase-and-build ${operator_nvrs.join(' ')} ${params.FORCE_BUILD ? '--force' : ''}").split("\n")
+def build_bundles(String[] only, String[] exclude, String[] operator_nvrs) {
+    def cmd = ""
+    if (only)
+        cmd += " --images=${only.join(',')}"
+    if (exclude)
+        cmd += " --exclude=${exclude.join(',')}"
+    cmd += " olm-bundle:rebase-and-build"
+    if (params.FORCE_BUILD)
+        cmd += " --force"
+    if (params.DRY_RUN)
+        cmd += " --dry-run"
+    cmd += " -- "
+    cmd += operator_nvrs.join(' ')
+    buildlib.doozer("${doozer_opts} ${cmd}")
+    def record_log = buildlib.parse_record_log(doozer_working)
+    def records = record_log.get('build_olm_bundle', [])
+    def bundle_nvrs = []
+    for (record in records) {
+        if (record['status'] != '0') {
+            throw new Exception("record.log includes unexpected build_olm_bundle record with error message: ${record['message']}")
+        }
+        bundle_nvrs << record["bundle_nvr"]
+    }
+    return bundle_nvrs
 }
 
 /*
  * Attach given <bundle_nvrs> to <advisory>
  */
 def attach_bundles_to_advisory(bundle_nvrs, advisory) {
-    elliott("change-state -s NEW_FILES -a ${advisory} ${params.DRY_RUN ? '--noop' : ''}")
+    buildlib.elliott("${elliott_opts} change-state -s NEW_FILES -a ${advisory} ${params.DRY_RUN ? '--noop' : ''}")
     flags = bundle_nvrs.collect { "--build ${it}" }.join(' ')
-    elliott("""find-builds -k image ${flags} ${params.DRY_RUN ? '' : "--attach ${advisory}"}""")
+    buildlib.elliott("""${elliott_opts} find-builds -k image ${flags} ${params.DRY_RUN ? '' : "--attach ${advisory}"}""")
     sleep(30) // wait for ET validations to be complete
-    elliott("change-state -s QE -a ${advisory} ${params.DRY_RUN ? '--noop' : ''}")
+    buildlib.elliott("${elliott_opts} change-state -s QE -a ${advisory} ${params.DRY_RUN ? '--noop' : ''}")
 }
 
 /*


### PR DESCRIPTION
1. Add `ASSEMBLY` and `OPERATOR_NVRS` parameters to `olm_bundle` job.
2. `ocp4`, `custom`, and `rebuild` jobs automatically call `olm_bundle` job to prebuild bundles for operator NVRs that they just built. We don't have to wait for release artists to pin the operator NVRs to the assembly.
3. Manually run `olm_bundle` job with `ASSEMBLY` will build bundles for operators that are currently selected by the assembly.
4. Improve troubleshooting capability by not capturing stdout/stderr for Doozer and Elliott.

Requires https://github.com/openshift/doozer/pull/498