### PR TITLE
art-3078: Add create text only advisory

### DIFF
--- a/jobs/build/advisories/Jenkinsfile
+++ b/jobs/build/advisories/Jenkinsfile
@@ -97,6 +97,42 @@ node {
                             ].join(","),
                             trim: true
                         ),
+                        booleanParam(
+                            name: 'TEXT_ONLY',
+                            description: 'Create one text only advisory, the following params should modified manually if this is true',
+                            defaultValue: false,
+                        ),
+                        string(
+                            name: 'SYNOPIS'
+                            description: 'Synopsis value for text only advisory',
+                            defaultVale: "OpenShift Container Platform 4.7.z notification of delayed upgrade path to 4.8"
+                        ),
+                        string(
+                            name: 'TOPIC'
+                            description: 'Topic value for text only advisory',
+                            defaultVale: "Upgrading from Red Hat OpenShift Container Platform version 4.7.z to version 4.8 is not currently available."
+                        ),
+                        string(
+                            name: 'DESCRIPTION'
+                            description: 'Description value for text only advisory',
+                            defaultVale: "Red Hat has discovered an issue in OpenShift Container Platform 4.7.17 that provides sufficient cause for Red Hat to not support installations of, or upgrades to, version 4.7.17:\n\nhttps://bugzilla.redhat.com/show_bug.cgi?id=1973006\n\nFor more information, see https://access.redhat.com/solutions/6131081\n\nThe delayed availability of this upgrade path does not affect the support of clusters as documented in the OpenShift Container Platform version life cycle policy, and Red Hat will provide supported update paths as soon as possible. \n\nYou can view the OpenShift Container Platform life cycle policy at https://access.redhat.com/support/policy/updates/openshift\n\nFor more information about upgrade paths and recommendations, see https://docs.openshift.com/container-platform/4.6/updating/updating-cluster-between-minor.html#upgrade-version-paths"
+                        ),
+                        string(
+                            name: 'SOLUTION'
+                            description: 'Solution value for text only advisory',
+                            defaultVale: "eneral Guidance:\n\nAll OpenShift Container Platform 4.6 users are advised to upgrade to the next version when it is available in the appropriate release channel. To check for currently recommended updates, use the OpenShift Console or the CLI oc command. \n\nOutside of a cluster, view the currently recommended upgrade paths with the Red Hat OpenShift Container Platform Update Graph tool
+                            https://access.redhat.com/labs/ocpupgradegraph/update_channel\nInstructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.6/updating/updating-cluster-between-minor.html#understanding-upgrade-channels_updating-cluster-between-minor"
+                        ),
+                        string(
+                            name: 'BUGTITLE'
+                            description: 'Bug title value for the bug used in text only advisory',
+                            defaultVale: "No upgrade edge available from 4.6.32 to 4.7"
+                        ),
+                        string(
+                            name: 'BUGDESCRIPTION'
+                            description: 'Bug description value for the bug used in text only advisory',
+                            defaultVale: "Description of problem:\nUpgrading from Red Hat OpenShift Container Platform version 4.7.z to version 4.8 is not currently available.\nCustomers would have to upgrade to 4.7.z or later to upgrade to 4.8 version."
+                        ),
                         commonlib.mockParam(),
                     ]
                 ],
@@ -114,11 +150,15 @@ node {
                 buildlib.kinit()
             }
             stage("create advisories") {
-                lib.create_advisory("image")
-                lib.create_advisory("rpm")
-                if (major > 3) {
-                    lib.create_advisory("extras")
-                    lib.create_advisory("metadata")
+                if (params.TEXT_ONLY) {
+                    lib.create_textonly()
+                } else {
+                    lib.create_advisory("image")
+                    lib.create_advisory("rpm")
+                    if (major > 3) {
+                        lib.create_advisory("extras")
+                        lib.create_advisory("metadata")
+                    }
                 }
             }
 
@@ -135,7 +175,7 @@ node {
                         draft << "- ${it.key}: https://errata.devel.redhat.com/advisory/${it.value}"
                     }
                     body = draft.join('\n')
-                    if (params.DRY_RUN) {
+                    if (params.DRY_RUN || params.TEXT_ONLY) {
                         out = "DRY RUN mode, email did not send to ${params.LIVE_ID_MAIL_LIST}\n\n subject: Live IDs for ${params.VERSION}\n\n body: ${body}"
                         echo "out: ${out}"
                     } else {
@@ -150,42 +190,48 @@ node {
             }
             sshagent(["openshift-bot"]) {
                 stage("commit new advisories to ocp-build-data") {
-                    def edit = [
-                        "rm -rf ocp-build-data",
-                        "git clone --single-branch --branch openshift-${params.VERSION} git@github.com:openshift/ocp-build-data.git",
-                        "cd ocp-build-data"
-                    ]
-                    for (advisory in lib.ADVISORIES) {
-                        edit << "sed -Ei 's/^  ${advisory.key}: [0-9]+\$/  ${advisory.key}: ${advisory.value}/' group.yml"
-                    }
-                    commit = [
-                        "git diff",
-                        "git add .",
-                        "git commit -m 'Update advisories on group.yml'",
-                        "git push origin openshift-${params.VERSION}",
-                    ]
+                    if (params.TEXT_ONLY != True) {
+                        def edit = [
+                            "rm -rf ocp-build-data",
+                            "git clone --single-branch --branch openshift-${params.VERSION} git@github.com:openshift/ocp-build-data.git",
+                            "cd ocp-build-data"
+                        ]
+                        for (advisory in lib.ADVISORIES) {
+                            edit << "sed -Ei 's/^  ${advisory.key}: [0-9]+\$/  ${advisory.key}: ${advisory.value}/' group.yml"
+                        }
+                        commit = [
+                            "git diff",
+                            "git add .",
+                            "git commit -m 'Update advisories on group.yml'",
+                            "git push origin openshift-${params.VERSION}",
+                        ]
 
-                    cmd = (edit << commit).flatten().join('\n')
+                        cmd = (edit << commit).flatten().join('\n')
 
-                    echo "shell cmd: ${cmd}"
-                    if (params.DRY_RUN) {
-                        out = "DRY RUN mode, command did not run"
+                        echo "shell cmd: ${cmd}"
+                        if (params.DRY_RUN) {
+                            out = "DRY RUN mode, command did not run"
+                        } else {
+                            out = commonlib.shell(
+                                returnStdout: true,
+                                script: cmd
+                            )
+                        }
+                        echo "out: ${out}"
                     } else {
-                        out = commonlib.shell(
-                            returnStdout: true,
-                            script: cmd
-                        )
+                        echo "skip commit text only advisory to ocp-build-data"
                     }
-                    echo "out: ${out}"
                 }
             }
 
             stage("add placeholder bugs to advisories") {
-                lib.ADVISORIES.each {
-                    if (it.key == "rpm" && major == 3) { return }
-                    if (it.key == "image" && major > 3) { return }
-                    if (it.key.contains('rhsa')) { return }
-                    lib.create_placeholder(it.key)
+                if (params.TEXT_ONLY != True) {
+                    lib.ADVISORIES.each {
+                        if (it.key == "rpm" && major == 3) { return }
+                        if (it.key == "image" && major > 3) { return }
+                        if (it.key.contains('rhsa')) { return }
+                        lib.create_placeholder(it.key)
+                    }
                 }
             }
 

--- a/jobs/build/advisories/Jenkinsfile
+++ b/jobs/build/advisories/Jenkinsfile
@@ -175,7 +175,7 @@ node {
                         draft << "- ${it.key}: https://errata.devel.redhat.com/advisory/${it.value}"
                     }
                     body = draft.join('\n')
-                    if (params.DRY_RUN || params.TEXT_ONLY) {
+                    if (params.DRY_RUN) {
                         out = "DRY RUN mode, email did not send to ${params.LIVE_ID_MAIL_LIST}\n\n subject: Live IDs for ${params.VERSION}\n\n body: ${body}"
                         echo "out: ${out}"
                     } else {

--- a/jobs/build/advisories/advisories.groovy
+++ b/jobs/build/advisories/advisories.groovy
@@ -67,4 +67,32 @@ def create_placeholder(kind) {
     echo "out: ${out}"
 }
 
+def create_textonly() {
+  cmd = [
+      "--group openshift-${params.VERSION}",
+      "create-textonly",
+      "--synopsis ${params.SYNOPIS}",
+      "--topic ${params.TOPIC}",
+      "--description ${params.DESCRIPTION}",
+      "--solution ${params.SOLUTION}",
+      "--bugtitle ${params.BUGTITLE}",
+      "--bugdescription ${params.BUGDESCRIPTION}",
+      "--assigned-to ${params.ASSIGNED_TO}",
+      "--manager ${params.MANAGER}",
+      "--package-owner ${params.PACKAGE_OWNER}"
+  ].join(' ')
+  if (params.DATE != null) {
+      create_cmd += " --date ${params.DATE}"
+  }
+  echo "elliott cmd: ${cmd}"
+  if (params.DRY_RUN) {
+      out = "DRY RUN mode, command did not run"
+  } else {
+      out = buildlib.elliott(cmd, [capture: true])
+      advisory_id = buildlib.extractAdvisoryId(out)
+      currentBuild.description += "Text only advisory:  https://errata.devel.redhat.com/advisory/${advisory_id}<br />"
+  }
+  echo "out: ${out}"
+}
+
 return this

--- a/jobs/build/advisories/advisories.groovy
+++ b/jobs/build/advisories/advisories.groovy
@@ -36,7 +36,7 @@ def create_advisory(name) {
         "--package-owner ${params.PACKAGE_OWNER}"
     ].join(" ")
 
-    if (params.DATE != null) {
+    if (params.DATE) {
         create_cmd += " --date ${params.DATE}"
     }
     if (params.DRY_RUN != true) {
@@ -81,7 +81,7 @@ def create_textonly() {
       "--manager ${params.MANAGER}",
       "--package-owner ${params.PACKAGE_OWNER}"
   ].join(' ')
-  if (params.DATE != null) {
+  if (params.DATE) {
       create_cmd += " --date ${params.DATE}"
   }
   echo "elliott cmd: ${cmd}"


### PR DESCRIPTION
Extend advisory job to be able to used create text only advisory if needed, need to pass through all required parameters for advisory creation and related bug creation, because each use cases are different, don't have a template to use without modification but the default value have a basic instance of what needed, some minor version changes need human to check and confirm.