### PR TITLE
[ART-3281] Require release offset when promoting custom releases

### DIFF
--- a/jobs/build/multi_promote/Jenkinsfile
+++ b/jobs/build/multi_promote/Jenkinsfile
@@ -48,7 +48,7 @@ node {
                     ),
                     string(
                         name: 'RELEASE_OFFSET',
-                        description: 'Integer. Do not specify for hotfix and non-stream assembly. If offset is X for 4.5 nightly => Release name is 4.5.X for standard, 4.5.0-rc.X for Release Candidate, 4.5.0-fc.X for Feature Candidate ',
+                        description: 'Integer. Do not specify for standard or candidate assembly. If offset is X for 4.5 nightly => Release name is 4.5.X for standard, 4.5.0-rc.X for Release Candidate, 4.5.0-fc.X for Feature Candidate, 4.5.X-assembly.ASSEMBLY_NAME for custom release',
                         trim: true,
                     ),
                     string(

--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -61,7 +61,7 @@ node {
                     ),
                     string(
                         name: 'RELEASE_OFFSET',
-                        description: 'Integer. Do not specify for assembly or hotfix. If offset is X for 4.5 nightly => Release name is 4.5.X for standard, 4.5.0-rc.X for Release Candidate, 4.5.0-fc.X for Feature Candidate ',
+                        description: 'Integer. Do not specify for standard or candidate assembly. If offset is X for 4.5 nightly => Release name is 4.5.X for standard, 4.5.0-rc.X for Release Candidate, 4.5.0-fc.X for Feature Candidate, 4.5.X-assembly.ASSEMBLY_NAME for custom release',
                         trim: true,
                     ),
                     string(
@@ -244,7 +244,11 @@ node {
             ga_release = true
             break
         case "custom":
-            release_name = "${major}.${minor}.0-assembly.${params.ASSEMBLY}"
+            if (!params.RELEASE_OFFSET) {
+                error("RELEASE_OFFSET is required when promoting a custom release payload.")
+            }
+            release_offset = params.RELEASE_OFFSET.toInteger()
+            release_name = "${major}.${minor}.${release_offset}-assembly.${params.ASSEMBLY}"
             detect_previous = false
             is_4stable_release = false
             CLIENT_TYPE = 'ocp-dev-preview'  // Trigger beta2 key

--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -245,7 +245,7 @@ node {
             break
         case "custom":
             if (!params.RELEASE_OFFSET) {
-                error("RELEASE_OFFSET is required when promoting a custom release payload.")
+                error("RELEASE_OFFSET is required when promoting a custom release payload. Use 0 if this is not a derivative of any GA named release.")
             }
             release_offset = params.RELEASE_OFFSET.toInteger()
             release_name = "${major}.${minor}.${release_offset}-assembly.${params.ASSEMBLY}"


### PR DESCRIPTION
RELEASE_OFFSET in the promote job becomes required when promoting custom release payloads. '0' is accepted if the user is crafting a custom release unrelated to any GA release. The offset is used in the custom release name; e.g. 4.7.<RELEASE_OFFSET>-assembly.<ASSEMBLY_NAME>.