### PR TITLE
promote: Don't run verify-payload for null

### DIFF
--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -127,7 +127,7 @@ Map stageValidation(String quay_url, String dest_release_tag, int advisory = 0, 
     }
 
     slackChannel = slacklib.to(version)
-    if (arch == 'amd64' || arch == 'x86_64') {
+    if (nightly && (arch == 'amd64' || arch == 'x86_64')) {
         echo "Verifying payload"
         res = commonlib.shell(
                 returnAll: true,


### PR DESCRIPTION
When promoting an assembly and that assembly doesn't have reference nightlies, don't run `verify-payload`.