### PR TITLE
Ensure that all client s3 syncs are arch specific

### DIFF
--- a/build-scripts/use-mirror/rhcossync.sh
+++ b/build-scripts/use-mirror/rhcossync.sh
@@ -19,7 +19,7 @@ function usage() {
 usage: ${0} [OPTIONS]
 
 This script will create directories under
-https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/{--PREFIX}/{--VERSION}/
+https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/{--PREFIX}/{--VERSION}/
 containing the items provided in --synclist as well as a sha256sum.txt
 file generated from those items.
 

--- a/hacks/rhel-7-deps-mirroring/README.MD
+++ b/hacks/rhel-7-deps-mirroring/README.MD
@@ -7,13 +7,13 @@ On buildvm (adjust 4.7 to reflect current release):
 
 This will create a directory `4.7-beta` in the current directory 
  
-`$ scp -r 4.7-beta/ use-mirror-upload:/srv/pub/openshift-v4/dependencies/rpms/4.7-beta`
+`$ scp -r 4.7-beta/ use-mirror-upload:/srv/pub/openshift-v4/x86_64/dependencies/rpms/4.7-beta`
 
 This will populate the files on the mirror.
 
 `$ ssh use-mirror-upload`
 ```
-use-mirror-upload$ cd /srv/pub/openshift-v4/dependencies/rpms/4.7-beta
+use-mirror-upload$ cd /srv/pub/openshift-v4/x86_64/dependencies/rpms/4.7-beta
 use-mirror-upload$ createrepo --database `pwd`
-use-mirror-upload$ /usr/local/bin/push.pub.sh openshift-v4/dependencies/rpms/4.7-beta -v
+use-mirror-upload$ /usr/local/bin/push.pub.sh openshift-v4/x86_64/dependencies/rpms/4.7-beta -v
 ```

--- a/jobs/build/butane_sync/Jenkinsfile
+++ b/jobs/build/butane_sync/Jenkinsfile
@@ -8,7 +8,7 @@ node {
         Sync butane binaries to mirror.openshift.com.
         (formerly the Fedora CoreOS Config Transpiler, FCCT)
 
-        http://mirror.openshift.com/pub/openshift-v4/clients/butane/
+        http://mirror.openshift.com/pub/openshift-v4/x86_64/clients/butane/
 
         Timing: This is only ever run by humans, upon request.
     """)
@@ -116,13 +116,13 @@ pipeline {
         stage("sync to mirror") {
             steps {
                 sh "tree ./${params.VERSION} && cat ./${params.VERSION}/sha256sum.txt"
-                commonlib.syncDirToS3Mirror("./${params.VERSION}/", "/pub/openshift-v4/clients/butane/${params.VERSION}/")
-                commonlib.syncDirToS3Mirror("./${params.VERSION}/", "/pub/openshift-v4/clients/butane/latest/")
+                commonlib.syncDirToS3Mirror("./${params.VERSION}/", "/pub/openshift-v4/x86_64/clients/butane/${params.VERSION}/")
+                commonlib.syncDirToS3Mirror("./${params.VERSION}/", "/pub/openshift-v4/x86_64/clients/butane/latest/")
                 sshagent(["aos-cd-test"]) {
-                    sh "ssh use-mirror-upload.ops.rhcloud.com -- mkdir -p /srv/pub/openshift-v4/clients/butane"
-                    sh "scp -r ./${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/clients/butane/"
-                    sh "ssh use-mirror-upload.ops.rhcloud.com -- ln --symbolic --force --no-dereference ${params.VERSION} /srv/pub/openshift-v4/clients/butane/latest"
-                    sh "ssh use-mirror-upload.ops.rhcloud.com -- /usr/local/bin/push.pub.sh openshift-v4/clients/butane -v"
+                    sh "ssh use-mirror-upload.ops.rhcloud.com -- mkdir -p /srv/pub/openshift-v4/x86_64/clients/butane"
+                    sh "scp -r ./${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/x86_64/clients/butane/"
+                    sh "ssh use-mirror-upload.ops.rhcloud.com -- ln --symbolic --force --no-dereference ${params.VERSION} /srv/pub/openshift-v4/x86_64/clients/butane/latest"
+                    sh "ssh use-mirror-upload.ops.rhcloud.com -- /usr/local/bin/push.pub.sh openshift-v4/x86_64/clients/butane -v"
                 }
             }
         }

--- a/jobs/build/butane_sync/README.md
+++ b/jobs/build/butane_sync/README.md
@@ -5,7 +5,7 @@
 Sync butane binaries to mirror.openshift.com.
 (formerly the Fedora CoreOS Config Transpiler, FCCT)
 
-<http://mirror.openshift.com/pub/openshift-v4/clients/butane/>
+<http://mirror.openshift.com/pub/openshift-v4/x86_64/clients/butane/>
 
 ## Timing
 
@@ -33,7 +33,7 @@ This job performs the following steps:
 2. extract the binaries from each RPM, appending the corresponding arch to each filename
 3. create a `butane` symlink, pointing to the `butane-amd64` binary
 4. calculate the shasum of each binary
-5. sync them to https://mirror.openshift.com/pub/openshift-v4/clients/butane/, under a directory named
+5. sync them to https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/butane/, under a directory named
 by the given version name.
 
 ### Example

--- a/jobs/build/camel-k_sync/Jenkinsfile
+++ b/jobs/build/camel-k_sync/Jenkinsfile
@@ -5,7 +5,7 @@ node {
         -----------------------------
         Sync Camel-K client to mirror
         -----------------------------
-        http://mirror.openshift.com/pub/openshift-v4/clients/camel-k/
+        http://mirror.openshift.com/pub/openshift-v4/x86_64/clients/camel-k/
 
         Timing: This is only ever run by humans, upon request.
     """)
@@ -80,13 +80,13 @@ pipeline {
         }
         stage("Sync to mirror") {
             steps {
-                commonlib.syncDirToS3Mirror("./${params.VERSION}/", "/pub/openshift-v4/clients/camel-k/${params.VERSION}/")
-                commonlib.syncDirToS3Mirror("./${params.VERSION}/", "/pub/openshift-v4/clients/camel-k/latest/")
+                commonlib.syncDirToS3Mirror("./${params.VERSION}/", "/pub/openshift-v4/x86_64/clients/camel-k/${params.VERSION}/")
+                commonlib.syncDirToS3Mirror("./${params.VERSION}/", "/pub/openshift-v4/x86_64/clients/camel-k/latest/")
 
                 sshagent(['aos-cd-test']) {
-                    sh "scp -r ${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/clients/camel-k/"
-                    sh "ssh use-mirror-upload.ops.rhcloud.com -- ln --symbolic --force --no-dereference ${params.VERSION} /srv/pub/openshift-v4/clients/camel-k/latest"
-                    sh "ssh use-mirror-upload.ops.rhcloud.com -- /usr/local/bin/push.pub.sh openshift-v4/clients/camel-k -v"
+                    sh "scp -r ${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/x86_64/clients/camel-k/"
+                    sh "ssh use-mirror-upload.ops.rhcloud.com -- ln --symbolic --force --no-dereference ${params.VERSION} /srv/pub/openshift-v4/x86_64/clients/camel-k/latest"
+                    sh "ssh use-mirror-upload.ops.rhcloud.com -- /usr/local/bin/push.pub.sh openshift-v4/x86_64/clients/camel-k -v"
                 }
             }
         }

--- a/jobs/build/coreos-installer_sync/Jenkinsfile
+++ b/jobs/build/coreos-installer_sync/Jenkinsfile
@@ -6,7 +6,7 @@ node {
 
     commonlib.describeJob("coreos-installer_sync", """
         <h2>Sync contents of the coreos-installer RPM to mirror</h2>
-        http://mirror.openshift.com/pub/openshift-v4/clients/coreos-installer/
+        http://mirror.openshift.com/pub/openshift-v4/x86_64/clients/coreos-installer/
 
         Timing: This is only ever run by humans, upon request.
     """)
@@ -85,7 +85,7 @@ node {
 
     stage("Sync to mirror") {
         def mirror = "use-mirror-upload.ops.rhcloud.com"
-        def dir = "/srv/pub/openshift-v4/clients/coreos-installer"
+        def dir = "/srv/pub/openshift-v4/x86_64/clients/coreos-installer"
 
         if (params.DRY_RUN) {
             commonlib.shell(
@@ -97,8 +97,8 @@ node {
             return
         }
 
-        commonlib.syncDirToS3Mirror("${workdir}/${params.VERSION}/", "/pub/openshift-v4/clients/coreos-installer/${params.VERSION}/")
-        commonlib.syncDirToS3Mirror("${workdir}/${params.VERSION}/", "/pub/openshift-v4/clients/coreos-installer/latest/")
+        commonlib.syncDirToS3Mirror("${workdir}/${params.VERSION}/", "/pub/openshift-v4/x86_64/clients/coreos-installer/${params.VERSION}/")
+        commonlib.syncDirToS3Mirror("${workdir}/${params.VERSION}/", "/pub/openshift-v4/x86_64/clients/coreos-installer/latest/")
 
         sshagent(['aos-cd-test']) {
             commonlib.shell(
@@ -109,7 +109,7 @@ node {
                     scp -r ${params.VERSION} ${mirror}:${dir}/${params.VERSION}
                     ssh ${mirror} ln --symbolic --force --no-dereference ${params.VERSION} ${dir}/latest
                     ssh ${mirror} tree ${dir}
-                    ssh ${mirror} /usr/local/bin/push.pub.sh openshift-v4/clients/coreos-installer -v
+                    ssh ${mirror} /usr/local/bin/push.pub.sh openshift-v4/x86_64/clients/coreos-installer -v
                 """
             )
         }

--- a/jobs/build/crc/Jenkinsfile
+++ b/jobs/build/crc/Jenkinsfile
@@ -6,7 +6,7 @@ node {
         -----------------------------------
         Sync Code Ready Container to mirror
         -----------------------------------
-        http://mirror.openshift.com/pub/openshift-v4/clients/crc/
+        http://mirror.openshift.com/pub/openshift-v4/x86_64/clients/crc/
 
         Timing: This is only ever run by humans, upon request.
     """)
@@ -57,13 +57,13 @@ pipeline {
             steps {
                 sh "tree ${params.VERSION}"
                 script {
-                    commonlib.syncDirToS3Mirror("./${params.VERSION}/", "/pub/openshift-v4/clients/crc/${params.VERSION}/")
-                    commonlib.syncDirToS3Mirror("./${params.VERSION}/", "/pub/openshift-v4/clients/crc/latest/")
+                    commonlib.syncDirToS3Mirror("./${params.VERSION}/", "/pub/openshift-v4/x86_64/clients/crc/${params.VERSION}/")
+                    commonlib.syncDirToS3Mirror("./${params.VERSION}/", "/pub/openshift-v4/x86_64/clients/crc/latest/")
                 }
                 sshagent(['aos-cd-test']) {
-                    sh "scp -r ${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/clients/crc/"
-                    sh "ssh use-mirror-upload.ops.rhcloud.com -- ln --symbolic --force --no-dereference ${params.VERSION} /srv/pub/openshift-v4/clients/crc/latest"
-                    sh "ssh use-mirror-upload.ops.rhcloud.com -- /usr/local/bin/push.pub.sh openshift-v4/clients/crc -v"
+                    sh "scp -r ${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/x86_64/clients/crc/"
+                    sh "ssh use-mirror-upload.ops.rhcloud.com -- ln --symbolic --force --no-dereference ${params.VERSION} /srv/pub/openshift-v4/x86_64/clients/crc/latest"
+                    sh "ssh use-mirror-upload.ops.rhcloud.com -- /usr/local/bin/push.pub.sh openshift-v4/x86_64/clients/crc -v"
                 }
             }
         }

--- a/jobs/build/helm_sync/Jenkinsfile
+++ b/jobs/build/helm_sync/Jenkinsfile
@@ -5,7 +5,7 @@ node {
         --------------------------
         Sync Helm client to mirror
         --------------------------
-        http://mirror.openshift.com/pub/openshift-v4/clients/helm/
+        http://mirror.openshift.com/pub/openshift-v4/x86_64/clients/helm/
 
         Timing: This is only ever run by humans, upon request.
     """)
@@ -58,13 +58,13 @@ pipeline {
         stage("Sync to mirror") {
             steps {
                 sh "tree ${params.VERSION}"
-                commonlib.syncDirToS3Mirror("${params.VERSION}/", "/pub/openshift-v4/clients/helm/${params.VERSION}/")
-                commonlib.syncDirToS3Mirror("${params.VERSION}/", "/pub/openshift-v4/clients/helm/latest/")
+                commonlib.syncDirToS3Mirror("${params.VERSION}/", "/pub/openshift-v4/x86_64/clients/helm/${params.VERSION}/")
+                commonlib.syncDirToS3Mirror("${params.VERSION}/", "/pub/openshift-v4/x86_64/clients/helm/latest/")
 
                 sshagent(['aos-cd-test']) {
-                    sh "scp -r ${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/clients/helm/"
-                    sh "ssh use-mirror-upload.ops.rhcloud.com -- ln --symbolic --force --no-dereference ${params.VERSION} /srv/pub/openshift-v4/clients/helm/latest"
-                    sh "ssh use-mirror-upload.ops.rhcloud.com -- /usr/local/bin/push.pub.sh openshift-v4/clients/helm -v"
+                    sh "scp -r ${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/x86_64/clients/helm/"
+                    sh "ssh use-mirror-upload.ops.rhcloud.com -- ln --symbolic --force --no-dereference ${params.VERSION} /srv/pub/openshift-v4/x86_64/clients/helm/latest"
+                    sh "ssh use-mirror-upload.ops.rhcloud.com -- /usr/local/bin/push.pub.sh openshift-v4/x86_64/clients/helm -v"
                 }
             }
         }

--- a/jobs/build/kam_sync/Jenkinsfile
+++ b/jobs/build/kam_sync/Jenkinsfile
@@ -5,7 +5,7 @@ node {
         -----------------------------------
         Sync OpenShift kam client to mirror
         -----------------------------------
-        http://mirror.openshift.com/pub/openshift-v4/clients/kam/
+        http://mirror.openshift.com/pub/openshift-v4/x86_64/clients/kam/
 
         Timing: This is only ever run by humans, upon request.
     """)
@@ -55,13 +55,13 @@ pipeline {
         stage("Sync to mirror") {
             steps {
                 sh "tree ${params.VERSION}"
-                commonlib.syncDirToS3Mirror("${params.VERSION}/", "/pub/openshift-v4/clients/kam/${params.VERSION}/")
-                commonlib.syncDirToS3Mirror("${params.VERSION}/", "/pub/openshift-v4/clients/kam/latest/")
+                commonlib.syncDirToS3Mirror("${params.VERSION}/", "/pub/openshift-v4/x86_64/clients/kam/${params.VERSION}/")
+                commonlib.syncDirToS3Mirror("${params.VERSION}/", "/pub/openshift-v4/x86_64/clients/kam/latest/")
 
                 sshagent(['aos-cd-test']) {
-                    sh "scp -r ${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/clients/kam/"
-                    sh "ssh use-mirror-upload.ops.rhcloud.com -- ln --symbolic --force --no-dereference ${params.VERSION} /srv/pub/openshift-v4/clients/kam/latest"
-                    sh "ssh use-mirror-upload.ops.rhcloud.com -- /usr/local/bin/push.pub.sh openshift-v4/clients/kam -v"
+                    sh "scp -r ${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/x86_64/clients/kam/"
+                    sh "ssh use-mirror-upload.ops.rhcloud.com -- ln --symbolic --force --no-dereference ${params.VERSION} /srv/pub/openshift-v4/x86_64/clients/kam/latest"
+                    sh "ssh use-mirror-upload.ops.rhcloud.com -- /usr/local/bin/push.pub.sh openshift-v4/x86_64/clients/kam -v"
                 }
             }
         }

--- a/jobs/build/kn_sync/Jenkinsfile
+++ b/jobs/build/kn_sync/Jenkinsfile
@@ -5,7 +5,7 @@ node {
         ----------------------------------------------
         Sync the knative (serverless) client to mirror
         ----------------------------------------------
-        http://mirror.openshift.com/pub/openshift-v4/clients/serverless/
+        http://mirror.openshift.com/pub/openshift-v4/x86_64/clients/serverless/
 
         Timing: This is only ever run by humans, upon request.
     """)
@@ -63,13 +63,13 @@ pipeline {
         stage("Sync to mirror") {
             steps {
                 sh "tree ${params.VERSION}"
-                commonlib.syncDirToS3Mirror("${params.VERSION}/", "/pub/openshift-v4/clients/serverless/${params.VERSION}/")
-                commonlib.syncDirToS3Mirror("${params.VERSION}/", "/pub/openshift-v4/clients/serverless/latest/")
+                commonlib.syncDirToS3Mirror("${params.VERSION}/", "/pub/openshift-v4/x86_64/clients/serverless/${params.VERSION}/")
+                commonlib.syncDirToS3Mirror("${params.VERSION}/", "/pub/openshift-v4/x86_64/clients/serverless/latest/")
 
                 sshagent(['aos-cd-test']) {
-                    sh "scp -r ${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/clients/serverless/"
-                    sh "ssh use-mirror-upload.ops.rhcloud.com -- ln --symbolic --force --no-dereference ${params.VERSION} /srv/pub/openshift-v4/clients/serverless/latest"
-                    sh "ssh use-mirror-upload.ops.rhcloud.com -- /usr/local/bin/push.pub.sh openshift-v4/clients/serverless -v"
+                    sh "scp -r ${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/x86_64/clients/serverless/"
+                    sh "ssh use-mirror-upload.ops.rhcloud.com -- ln --symbolic --force --no-dereference ${params.VERSION} /srv/pub/openshift-v4/x86_64/clients/serverless/latest"
+                    sh "ssh use-mirror-upload.ops.rhcloud.com -- /usr/local/bin/push.pub.sh openshift-v4/x86_64/clients/serverless -v"
                 }
             }
         }

--- a/jobs/build/oc_sync/Jenkinsfile
+++ b/jobs/build/oc_sync/Jenkinsfile
@@ -9,8 +9,8 @@ node {
     commonlib.describeJob("oc_sync", """
         <h2>Sync the oc, installer, and opm clients to mirror</h2>
         Extracts the clients from the payload cli-artifacts and operator-registry images and publishes them to
-        <a href="http://mirror.openshift.com/pub/openshift-v4/clients/ocp" target="_blank">the mirror</a>
-        or <a href="http://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview" target="_blank">ocp-dev-preview</a>
+        <a href="http://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp" target="_blank">the mirror</a>
+        or <a href="http://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp-dev-preview" target="_blank">ocp-dev-preview</a>
 
         <b>Timing</b>: This is only ever run by humans, typically when the release job
         fails somehow. Normally the release job syncs these clients itself.

--- a/jobs/build/odo_sync/Jenkinsfile
+++ b/jobs/build/odo_sync/Jenkinsfile
@@ -5,7 +5,7 @@ node {
         ----------------------------------
         Sync OpenShift Do client to mirror
         ----------------------------------
-        http://mirror.openshift.com/pub/openshift-v4/clients/odo/
+        http://mirror.openshift.com/pub/openshift-v4/x86_64/clients/odo/
 
         Timing: This is only ever run by humans, upon request.
     """)
@@ -55,13 +55,13 @@ pipeline {
         stage("Sync to mirror") {
             steps {
                 sh "tree ${params.VERSION}"
-                commonlib.syncDirToS3Mirror("${params.VERSION}/", "/pub/openshift-v4/clients/odo/${params.VERSION}/")
-                commonlib.syncDirToS3Mirror("${params.VERSION}/", "/pub/openshift-v4/clients/odo/latest/")
+                commonlib.syncDirToS3Mirror("${params.VERSION}/", "/pub/openshift-v4/x86_64/clients/odo/${params.VERSION}/")
+                commonlib.syncDirToS3Mirror("${params.VERSION}/", "/pub/openshift-v4/x86_64/clients/odo/latest/")
 
                 sshagent(['aos-cd-test']) {
-                    sh "scp -r ${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/clients/odo/"
-                    sh "ssh use-mirror-upload.ops.rhcloud.com -- ln --symbolic --force --no-dereference ${params.VERSION} /srv/pub/openshift-v4/clients/odo/latest"
-                    sh "ssh use-mirror-upload.ops.rhcloud.com -- /usr/local/bin/push.pub.sh openshift-v4/clients/odo -v"
+                    sh "scp -r ${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/x86_64/clients/odo/"
+                    sh "ssh use-mirror-upload.ops.rhcloud.com -- ln --symbolic --force --no-dereference ${params.VERSION} /srv/pub/openshift-v4/x86_64/clients/odo/latest"
+                    sh "ssh use-mirror-upload.ops.rhcloud.com -- /usr/local/bin/push.pub.sh openshift-v4/x86_64/clients/odo -v"
                 }
             }
         }

--- a/jobs/build/publish-rpms/Jenkinsfile
+++ b/jobs/build/publish-rpms/Jenkinsfile
@@ -36,7 +36,7 @@ node {
     commonlib.checkMock()
 
     version = params.BUILD_VERSION
-    path = "openshift-v4/dependencies/rpms/${version}-beta"
+    path = "openshift-v4/x86_64/dependencies/rpms/${version}-beta"
     mirror_dir = "/srv/pub/${path}"
     withCredentials([aws(credentialsId: 's3-art-srv-enterprise', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
         commonlib.shell(

--- a/jobs/build/publish-rpms/README.md
+++ b/jobs/build/publish-rpms/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This job will publish the dependent RPMs to mirror location under https://mirror.openshift.com/pub/openshift-v4/dependencies/rpms/<4.y-beta>
+This job will publish the dependent RPMs to mirror location under https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rpms/<4.y-beta>
 So that we can test out pre-GA versions on RHEL 7 workers
 
 ## Timing

--- a/jobs/build/rosa_sync/Jenkinsfile
+++ b/jobs/build/rosa_sync/Jenkinsfile
@@ -6,7 +6,7 @@ node {
         ------------------------------------------------------
         Sync ROSA (Red Hat OpenShift Service on AWS) to mirror
         ------------------------------------------------------
-        http://mirror.openshift.com/pub/openshift-v4/clients/rosa_sync/
+        http://mirror.openshift.com/pub/openshift-v4/x86_64/clients/rosa_sync/
 
         Timing: This is only ever run by humans, upon request.
     """)
@@ -62,9 +62,9 @@ pipeline {
                 }
 
                 sshagent(['aos-cd-test']) {
-                    sh "scp -r ${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/clients/rosa/"
-                    sh "ssh use-mirror-upload.ops.rhcloud.com -- ln --symbolic --force --no-dereference ${params.VERSION} /srv/pub/openshift-v4/clients/rosa/latest"
-                    sh "ssh use-mirror-upload.ops.rhcloud.com -- /usr/local/bin/push.pub.sh openshift-v4/clients/rosa -v"
+                    sh "scp -r ${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/x86_64/clients/rosa/"
+                    sh "ssh use-mirror-upload.ops.rhcloud.com -- ln --symbolic --force --no-dereference ${params.VERSION} /srv/pub/openshift-v4/x86_64/clients/rosa/latest"
+                    sh "ssh use-mirror-upload.ops.rhcloud.com -- /usr/local/bin/push.pub.sh openshift-v4/x86_64/clients/rosa -v"
                 }
             }
         }

--- a/jobs/build/tkn_sync/Jenkinsfile
+++ b/jobs/build/tkn_sync/Jenkinsfile
@@ -7,7 +7,7 @@ node {
         -----------------------------------------------
         Sync the Tekton pipeline client (tkn) to mirror
         -----------------------------------------------
-        http://mirror.openshift.com/pub/openshift-v4/clients/pipeline/
+        http://mirror.openshift.com/pub/openshift-v4/x86_64/clients/pipeline/
         Timing: Run manually by request.
     """)
 }
@@ -33,8 +33,8 @@ pipeline {
                         error 'TKN_VERSION must be specified'
                     }
                     target_version = params.TKN_VERSION.split("-")[0]
-                    target_dir = "/srv/pub/openshift-v4/clients/pipeline/${target_version}"
-                    s3_target_dir = "/pub/openshift-v4/clients/pipeline/${target_version}"
+                    target_dir = "/srv/pub/openshift-v4/x86_64/clients/pipeline/${target_version}"
+                    s3_target_dir = "/pub/openshift-v4/x86_64/clients/pipeline/${target_version}"
                 }
             }
         }
@@ -43,7 +43,7 @@ pipeline {
             steps {
                 sh "tree /mnt/redhat/staging-cds/developer/openshift-pipelines-client/${params.TKN_VERSION}/signed/all ; cat /mnt/redhat/staging-cds/developer/openshift-pipelines-client/${params.TKN_VERSION}/signed/all/sha256sum.txt"
                 syncDirToS3Mirror.syncDirToS3Mirror("/mnt/redhat/staging-cds/developer/openshift-pipelines-client/${params.TKN_VERSION}/signed/all/", "${s3_target_dir}/" )
-                syncDirToS3Mirror.syncDirToS3Mirror("/mnt/redhat/staging-cds/developer/openshift-pipelines-client/${params.TKN_VERSION}/signed/all/", "/pub/openshift-v4/clients/pipeline/latest/" )
+                syncDirToS3Mirror.syncDirToS3Mirror("/mnt/redhat/staging-cds/developer/openshift-pipelines-client/${params.TKN_VERSION}/signed/all/", "/pub/openshift-v4/x86_64/clients/pipeline/latest/" )
 
                 sshagent(['aos-cd-test']) {
                     sh "tree /mnt/redhat/staging-cds/developer/openshift-pipelines-client/${params.TKN_VERSION}/signed/all"
@@ -52,8 +52,8 @@ pipeline {
                     sh "ssh use-mirror-upload rm --recursive --force --verbose ${target_dir}"
                     sh "ssh use-mirror-upload mkdir -p ${target_dir}"
                     sh "scp -r /mnt/redhat/staging-cds/developer/openshift-pipelines-client/${params.TKN_VERSION}/signed/all/* use-mirror-upload:${target_dir}"
-                    sh "ssh use-mirror-upload ln --symbolic --force --no-dereference ${target_dir} /srv/pub/openshift-v4/clients/pipeline/latest"
-                    sh "ssh use-mirror-upload /usr/local/bin/push.pub.sh openshift-v4/clients/pipeline -v"
+                    sh "ssh use-mirror-upload ln --symbolic --force --no-dereference ${target_dir} /srv/pub/openshift-v4/x86_64/clients/pipeline/latest"
+                    sh "ssh use-mirror-upload /usr/local/bin/push.pub.sh openshift-v4/x86_64/clients/pipeline -v"
                 }
             }
         }

--- a/jobs/signing/sign-artifacts/Jenkinsfile
+++ b/jobs/signing/sign-artifacts/Jenkinsfile
@@ -259,7 +259,7 @@ node {
                         // the signed artifact is 'signature-1'
                         //
                         // 2) A message digest (sha256sum.txt) is mirrored to
-                        // https://mirror.openshift.com/pub/openshift-v4/clients/
+                        // https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/
                         // using this directory structure:
                         //
                         // ocp/
@@ -342,11 +342,11 @@ node {
                         // just received the sha256sum.txt.gpg file for openshift
                         // release 4.1.0-rc.5. We will mirror this file to:
                         //
-                        // https://mirror.openshift.com/pub/openshift-v4/clients/
+                        // https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/
                         //  --> ocp/
                         //  ----> `.artifacts.name`/
                         //  ------> sha256sum.txt.gpg
-                        //  ==> https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.1.0-rc.5/sha256sum.txt.gpg
+                        //  ==> https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.1.0-rc.5/sha256sum.txt.gpg
 
                         sshagent(["openshift-bot"]) {
                             withCredentials([aws(credentialsId: 's3-art-srv-enterprise', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {

--- a/tekton-pipelines/images/artcd/Dockerfile
+++ b/tekton-pipelines/images/artcd/Dockerfile
@@ -30,7 +30,7 @@ RUN dnf install -y python36-devel \
 
 # install oc
 ARG OC_VERSION=latest
-RUN wget -O /tmp/openshift-client-linux-"$OC_VERSION".tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/"$OC_VERSION"/openshift-client-linux.tar.gz \
+RUN wget -O /tmp/openshift-client-linux-"$OC_VERSION".tar.gz https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/"$OC_VERSION"/openshift-client-linux.tar.gz \
   && tar -C /usr/local/bin -xzf  /tmp/openshift-client-linux-"$OC_VERSION".tar.gz oc kubectl \
   && rm /tmp/openshift-client-linux-"$OC_VERSION".tar.gz
 


### PR DESCRIPTION
For the s3 backed mirror, copying things to openshift-v4/clients, openshift-v4/dependencies, and a few more will not affect what content is available to end users. This is because those directories are dynamically redirected to openshift-v4/x86_64/clients, openshift-v4/dependencies, ... 
The redirection is performed here: https://github.com/openshift/aos-cd-jobs/blob/f893dcf1b507d85469f8589cfa07d96d9106d813/hacks/s3_art-srv-enterprise/cloudfront_function_art-srv-request-basic-auth.js#L31 .

This PR changes code to both copy to the arch qualified locations of the existing mirror as well as the arch qualified location on the s3 mirror. It will also raise an error if commonlib is asked to copy content to one of the virtual locations. 