### PR TITLE
[ART-3331] Decouple mirror files from imagestream files in build-sync

### DIFF
--- a/jobs/build/build-sync/build.groovy
+++ b/jobs/build/build-sync/build.groovy
@@ -114,8 +114,8 @@ def backupAllImageStreams() {
 def buildSyncApplyImageStreams() {
     echo("Updating ImageStream's")
     def failures = []
-    for ( String key: mirroringKeys ) {
-        def isFile = "${mirrorWorking}/image_stream.${key}.yaml"
+    def isFiles = findFiles(glob: '"${mirrorWorking}/image_stream.*.yaml').collect{ it.path }
+    for ( String isFile: isFiles ) {
         def imageStream = readYaml file: isFile
         def theStream = imageStream.metadata.name
         def namespace = imageStream.metadata.namespace
@@ -146,8 +146,8 @@ def buildSyncApplyImageStreams() {
                 continue
             }
             echo("IS `.metadata.resourceVersion` has not updated, it should have updated. Please use the debug info above to report this issue")
-            currentBuild.description += "\nImageStream update failed for ${key}"
-            failures << key
+            currentBuild.description += "\nImageStream update failed for ${isFile}"
+            failures << isFile
         }
     }
     if (failures) {

--- a/jobs/build/build-sync/build.groovy
+++ b/jobs/build/build-sync/build.groovy
@@ -114,7 +114,7 @@ def backupAllImageStreams() {
 def buildSyncApplyImageStreams() {
     echo("Updating ImageStream's")
     def failures = []
-    def isFiles = findFiles(glob: '"${mirrorWorking}/image_stream.*.yaml').collect{ it.path }
+    def isFiles = findFiles(glob: "MIRROR_working/image_stream.*.yaml").collect{ it.path }
     for ( String isFile: isFiles ) {
         def imageStream = readYaml file: isFile
         def theStream = imageStream.metadata.name


### PR DESCRIPTION
The new assembly logic only generates a single mirroring list for each arch instead of one for public & private. The pipeline previously used mirroring files as a queue to determine which imagestream filenames to apply. This PR decouples the two and applies any imagestream file that `gen-payload` creates.