### PR TITLE
[ART-3329] Change messaging in #forum-release for Patch Managers

### DIFF
--- a/jobs/build/cincinnati-prs/Jenkinsfile
+++ b/jobs/build/cincinnati-prs/Jenkinsfile
@@ -67,7 +67,10 @@ node {
     currentBuild.displayName = params.RELEASE_NAME
     currentBuild.description = ""
     dir(workdir) {
-        release.openCincinnatiPRs(params.RELEASE_NAME.trim(), params.ADVISORY_NUM.trim(), params.CANDIDATE_CHANNEL_ONLY, params.GITHUB_ORG.trim(), params.SKIP_OTA_SLACK_NOTIFICATION)
+        def releaseName = params.RELEASE_NAME.trim()
+        def ghorg = params.GITHUB_ORG.trim()
+        def noSlackOutput = params.SKIP_OTA_SLACK_NOTIFICATION
+        release.openCincinnatiPRs(releaseName, params.ADVISORY_NUM.trim(), params.CANDIDATE_CHANNEL_ONLY, ghorg, noSlackOutput)
     }
     buildlib.cleanWorkdir(workdir)
     buildlib.cleanWorkspace()

--- a/jobs/build/cincinnati-prs/Jenkinsfile
+++ b/jobs/build/cincinnati-prs/Jenkinsfile
@@ -70,7 +70,7 @@ node {
         def releaseName = params.RELEASE_NAME.trim()
         def ghorg = params.GITHUB_ORG.trim()
         def noSlackOutput = params.SKIP_OTA_SLACK_NOTIFICATION
-        def prs = release.openCincinnatiPRs(releaseName, params.ADVISORY_NUM.trim(), params.CANDIDATE_CHANNEL_ONLY, ghorg, noSlackOutput)
+        def prs = release.openCincinnatiPRs(releaseName, params.ADVISORY_NUM.trim(), params.CANDIDATE_CHANNEL_ONLY, ghorg)
         if ( prs ) {  // did we open any?
             release.sendCincinnatiPRsSlackNotification(releaseName, prs, ghorg, noSlackOutput)
         }

--- a/jobs/build/cincinnati-prs/Jenkinsfile
+++ b/jobs/build/cincinnati-prs/Jenkinsfile
@@ -70,7 +70,11 @@ node {
         def releaseName = params.RELEASE_NAME.trim()
         def ghorg = params.GITHUB_ORG.trim()
         def noSlackOutput = params.SKIP_OTA_SLACK_NOTIFICATION
-        release.openCincinnatiPRs(releaseName, params.ADVISORY_NUM.trim(), params.CANDIDATE_CHANNEL_ONLY, ghorg, noSlackOutput)
+        def prs = release.openCincinnatiPRs(releaseName, params.ADVISORY_NUM.trim(), params.CANDIDATE_CHANNEL_ONLY, ghorg, noSlackOutput)
+        if ( prs ) {  // did we open any?
+            release.sendCincinnatiPRsSlackNotification(releaseName, prs, ghorg, noSlackOutput)
+        }
+
     }
     buildlib.cleanWorkdir(workdir)
     buildlib.cleanWorkspace()

--- a/jobs/build/cincinnati-prs/Jenkinsfile
+++ b/jobs/build/cincinnati-prs/Jenkinsfile
@@ -26,6 +26,12 @@ node {
                 $class: 'ParametersDefinitionProperty',
                 parameterDefinitions: [
                     string(
+                        name: 'FROM_RELEASE_TAG',
+                        description: 'Nightly from which the release was derived (only used for Slack notification)',
+                        defaultValue: "",
+                        trim: true,
+                    ),
+                    string(
                         name: 'RELEASE_NAME',
                         description: 'The name of the release to add to Cincinnati via PRs',
                         defaultValue: "",

--- a/jobs/build/cincinnati-prs/Jenkinsfile
+++ b/jobs/build/cincinnati-prs/Jenkinsfile
@@ -78,7 +78,7 @@ node {
         def noSlackOutput = params.SKIP_OTA_SLACK_NOTIFICATION
         def prs = release.openCincinnatiPRs(releaseName, params.ADVISORY_NUM.trim(), params.CANDIDATE_CHANNEL_ONLY, ghorg)
         if ( prs ) {  // did we open any?
-            release.sendCincinnatiPRsSlackNotification(releaseName, prs, ghorg, noSlackOutput)
+            release.sendCincinnatiPRsSlackNotification(releaseName, params.FROM_RELEASE_TAG.trim(), prs, ghorg, noSlackOutput)
         }
 
     }

--- a/jobs/build/cincinnati-prs/README.md
+++ b/jobs/build/cincinnati-prs/README.md
@@ -25,6 +25,10 @@ A human would only need to run it if the job failed somehow before running it.
 
 See [Standard Parameters](/jobs/README.md#standard-parameters).
 
+### FROM\_RELEASE\_TAG
+
+Nightly from which the release was derived. Only used for informational purposes on the Slack notification message.
+
 ### RELEASE\_NAME
 
 The name of the release to add to Cincinnati via PRs, for example "4.5.6" or "4.6.0-fc.0"

--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -744,6 +744,7 @@ node {
                         build(
                                 job: '/aos-cd-builds/build%2Fcincinnati-prs',  propagate: true,
                                 parameters: [
+                                    buildlib.param('String', 'FROM_RELEASE_TAG', params.FROM_RELEASE_TAG),
                                     buildlib.param('String', 'RELEASE_NAME', release_name),
                                     buildlib.param('String', 'ADVISORY_NUM', "${advisory}"),
                                     booleanParam(name: 'CANDIDATE_CHANNEL_ONLY', value: true),

--- a/jobs/build/release/Jenkinsfile
+++ b/jobs/build/release/Jenkinsfile
@@ -493,6 +493,7 @@ node {
                         build(
                                 job: 'build%2Fcincinnati-prs',  propagate: true,
                                 parameters: [
+                                    buildlib.param('String', 'FROM_RELEASE_TAG', params.FROM_RELEASE_TAG),
                                     buildlib.param('String', 'RELEASE_NAME', release_name),
                                     buildlib.param('String', 'ADVISORY_NUM', "${advisory}"),
                                     booleanParam(name: 'CANDIDATE_CHANNEL_ONLY', value: candidate_pr_only),

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -908,7 +908,9 @@ def sendCincinnatiPRsSlackNotification(releaseName, fromReleaseTag, prs, ghorg='
     def (major, minor) = commonlib.extractMajorMinorVersionNumbers(releaseName)
 
     def slack_msg = "ART has opened Cincinnati PRs for ${releaseName}:\n\n"
-    slack_msg += "This release was promoted using nightly registry.ci.openshift.org/ocp/release:${fromReleaseTag}\n"
+    if ( fromReleaseTag ) {
+        slack_msg += "This release was promoted using nightly registry.ci.openshift.org/ocp/release:${fromReleaseTag}\n"
+    }
     slack_msg += "${prs}\n"
     slack_msg += "@patch-manager Please continue merging PRs for the next release.\n"
 

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -902,17 +902,23 @@ def openCincinnatiPRs(releaseName, advisory, candidate_only=false, ghorg='opensh
 
             def prs = readFile(prs_file).trim()
             if ( prs ) {  // did we open any?
-                def slack_msg = "ART has opened Cincinnati PRs for ${releaseName}:\n${prs}"
-                slack_msg += "\n@patch-manager ${major}.${minor}.z merge window is open for next week."
-                if ( ghorg == 'openshift' && !noSlackOutput) {
-                    slacklib.to('#forum-release').say(slack_msg)
-                } else {
-                    echo "Would have sent the following slack notification to #forum-release"
-                    echo slack_msg
-                }
+                sendCincinnatiPRsSlackNotification(releaseName, prs, ghorg, noSlackOutput)
             }
 
         }
+    }
+}
+
+def sendCincinnatiPRsSlackNotification(releaseName, prs, ghorg='openshift', noSlackOutput=false) {
+    def (major, minor) = commonlib.extractMajorMinorVersionNumbers(releaseName)
+
+    def slack_msg = "ART has opened Cincinnati PRs for ${releaseName}:\n${prs}"
+    slack_msg += "\n@patch-manager ${major}.${minor}.z merge window is open for next week."
+    if ( ghorg == 'openshift' && !noSlackOutput) {
+        slacklib.to('#forum-release').say(slack_msg)
+    } else {
+        echo "Would have sent the following slack notification to #forum-release"
+        echo slack_msg
     }
 }
 

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -904,7 +904,7 @@ def openCincinnatiPRs(releaseName, advisory, candidate_only=false, ghorg='opensh
     }
 }
 
-def sendCincinnatiPRsSlackNotification(releaseName, prs, ghorg='openshift', noSlackOutput=false) {
+def sendCincinnatiPRsSlackNotification(releaseName, fromReleaseTag, prs, ghorg='openshift', noSlackOutput=false) {
     def (major, minor) = commonlib.extractMajorMinorVersionNumbers(releaseName)
 
     def slack_msg = "ART has opened Cincinnati PRs for ${releaseName}:\n${prs}"

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -691,9 +691,8 @@ def isSupportEUS(String ocpVersion) {
  * @param candidate_only Only open PR for candidate; there is no advisory
  * @param ghorg For testing purposes, you can call this method specifying a personal github org/account. The
  *        openshift-bot must be a contributor in your fork of cincinnati-graph-data.
- * @param noSlackOutput If true, ota-monitor will not be notified
  */
-def openCincinnatiPRs(releaseName, advisory, candidate_only=false, ghorg='openshift', noSlackOutput=false) {
+def openCincinnatiPRs(releaseName, advisory, candidate_only=false, ghorg='openshift') {
     def (major, minor) = commonlib.extractMajorMinorVersionNumbers(releaseName)
     if ( major != 4 ) {
         error("Unable to open PRs for unknown major minor: ${major}.${minor}")

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -907,8 +907,11 @@ def openCincinnatiPRs(releaseName, advisory, candidate_only=false, ghorg='opensh
 def sendCincinnatiPRsSlackNotification(releaseName, fromReleaseTag, prs, ghorg='openshift', noSlackOutput=false) {
     def (major, minor) = commonlib.extractMajorMinorVersionNumbers(releaseName)
 
-    def slack_msg = "ART has opened Cincinnati PRs for ${releaseName}:\n${prs}"
-    slack_msg += "\n@patch-manager ${major}.${minor}.z merge window is open for next week."
+    def slack_msg = "ART has opened Cincinnati PRs for ${releaseName}:\n\n"
+    slack_msg += "This release was promoted using nightly registry.ci.openshift.org/ocp/release:${fromReleaseTag}\n"
+    slack_msg += "${prs}\n"
+    slack_msg += "@patch-manager Please continue merging PRs for the next release.\n"
+
     if ( ghorg == 'openshift' && !noSlackOutput) {
         slacklib.to('#forum-release').say(slack_msg)
     } else {

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -900,11 +900,7 @@ def openCincinnatiPRs(releaseName, advisory, candidate_only=false, ghorg='opensh
                 }
             }
 
-            def prs = readFile(prs_file).trim()
-            if ( prs ) {  // did we open any?
-                sendCincinnatiPRsSlackNotification(releaseName, prs, ghorg, noSlackOutput)
-            }
-
+            return readFile(prs_file).trim()
         }
     }
 }


### PR DESCRIPTION
New message expects nightly information (from which nightly the release was created). so I had to move some stuff around in order to accommodate this requirement without increasing even more the amount of arguments passed to `release.openCincinnatiPRs`.

All steps I took are described as individual commits, useful for PR review, but feel free to squash them on merge. if you choose to preserve the individual commits, it would be nice to have an explicit merge (`--no-ff`) for easier revert, should it happen.