### PR TITLE
prepare_release.py: create advisory live ids directly

### DIFF
--- a/config/artcd.toml
+++ b/config/artcd.toml
@@ -12,7 +12,6 @@ smtp_server = "smtp.corp.redhat.com"
 from = "aos-art-automation@redhat.com"
 reply_to = "aos-team-art@redhat.com"
 cc = ["aos-team-art@redhat.com"]
-live_id_request_recipients = ["openshift-ccs@redhat.com"]
 prepare_release_notification_recipients_ocp4=["multi-arch-zstream-testing@redhat.com", "aos-qe@redhat.com"]
 prepare_release_notification_recipients_ocp3=["aos-qe@redhat.com"]
 

--- a/pyartcd/config.example.toml
+++ b/pyartcd/config.example.toml
@@ -12,7 +12,6 @@ smtp_server="smtp.corp.redhat.com"
 from="aos-art-automation@redhat.com"
 reply_to="aos-team-art@redhat.com"
 cc=["aos-team-art@redhat.com"]
-live_id_request_recipients=["openshift-ccs@redhat.com"]
 prepare_release_notification_recipients_ocp4=["multi-arch-zstream-testing@redhat.com", "aos-qe@redhat.com"]
 prepare_release_notification_recipients_ocp3=["aos-qe@redhat.com"]
 

--- a/scheduled-jobs/build/sync-for-ci/Jenkinsfile
+++ b/scheduled-jobs/build/sync-for-ci/Jenkinsfile
@@ -36,14 +36,6 @@ node() {
         group = "openshift-${version}"
         def arches = buildlib.branch_arches(group)
 
-        if ( version == '4.8' ) {
-            // We are enabling aarch for reposync ahead of actual support in group.yml
-            // This logic can be removed when 4.8 is building with aarch.
-            if ( !arches.contains('aarch64') ) {
-                arches.add('aarch64')
-            }
-        }
-
         for ( String arch : arches ) {
             runFor(group, version, arch)
         }

--- a/tekton-pipelines/config/artcd-config.yaml
+++ b/tekton-pipelines/config/artcd-config.yaml
@@ -17,7 +17,6 @@ data:
     from="aos-art-automation@redhat.com"
     reply_to="aos-team-art@redhat.com"
     cc=["aos-team-art@redhat.com"]
-    live_id_request_recipients=["openshift-ccs@redhat.com"]
     prepare_release_notification_recipients=["multi-arch-zstream-testing@redhat.com", "aos-qe@redhat.com"]
 
     [jira]


### PR DESCRIPTION
we now have the ability to create our own live ids, so let's do that instead of asking docs.
UPDATE: now relies on [elliott creating live id](https://github.com/openshift/elliott/commit/9e4a6b3efb7eda5c9c4734d610d5644ca64cd298).