### PR TITLE
Sign RCs with Release key

### DIFF
--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -256,7 +256,9 @@ node {
         case "candidate":
             is_prerelease = true
             release_name = "${major}.${minor}.0-${params.ASSEMBLY}"
-            CLIENT_TYPE = 'ocp-dev-preview'  // Trigger beta2 key
+            if (params.ASSEMBLY.startsWith('fc') {
+                CLIENT_TYPE = 'ocp-dev-preview'  // Trigger beta2 key
+            }
             break
         default:
             error("Unsupported release type $release_type")


### PR DESCRIPTION
According to https://docs.google.com/document/d/16eGVikCYARd6nUUtAIHFRKXa7R_rU5Exc9jUPcQoG8A/edit#heading=h.olawonjgfrhf

RCs need to get signed with the Release key, whereas FCs need to get
signed with the beta-2 key.