### PR TITLE
Use custom cacert file

### DIFF
--- a/jobs/build/set_client_latest/S3-set-v4-client-latest.sh
+++ b/jobs/build/set_client_latest/S3-set-v4-client-latest.sh
@@ -53,7 +53,7 @@ for arch in ${ARCHES}; do
             x86_64) qarch="amd64" ;;
             aarch64) qarch="arm64" ;;
         esac
-        CHANNEL_RELEASES=$(curl -sH 'Accept:application/json' "https://api.openshift.com/api/upgrades_info/v1/graph?channel=${USE_CHANNEL}&arch=${qarch}" | jq '.nodes[].version' -r)
+        CHANNEL_RELEASES=$(curl -sH 'Accept:application/json' --cacert ~/cacert.pem "https://api.openshift.com/api/upgrades_info/v1/graph?channel=${USE_CHANNEL}&arch=${qarch}" | jq '.nodes[].version' -r)
         if [[ -z "$CHANNEL_RELEASES" ]]; then
             echo "No versions currently detected in ${USE_CHANNEL} for arch ${qarch} ; No ${LINK_NAME} will be set"
             if [[ "${MODE}" == "all" ]]; then


### PR DESCRIPTION
use-mirror-upload does not know the new CA yet for api.openshift.com.
This will have it use the newest ca file from mozilla as made available
from https://curl.se/docs/caextract.html.