### PR TITLE
Unverbose to reduce logspam

### DIFF
--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -467,7 +467,7 @@ function extract_opm() {
         PATH_ARGS+=(--path "/usr/bin/registry/$binary:$OUTDIR")
     done
 
-    GOTRACEBACK=all oc -v5 image extract --confirm --only-files "${PATH_ARGS[@]}" -- "$OPERATOR_REGISTRY"
+    GOTRACEBACK=all oc -v4 image extract --confirm --only-files "${PATH_ARGS[@]}" -- "$OPERATOR_REGISTRY"
 
     # Compress binaries into tar.gz files and calculate sha256 digests
     pushd "$OUTDIR"


### PR DESCRIPTION
There are some lines like the following in the build logs:
```
I1006 16:09:21.513077   32524 extract.go:667] Exclude etc/security/pam_env.conf due to missing prefix usr/bin/registry/
```

These are not very actionable, other than by the scroll wheel or the
PageDown button. To get a sense of the amount of lines:

```
curl -sSL https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fpromote/676/consoleText | grep -c extract.go:667
30963
```

Reducing verbosity with one level makes it disappear.