### PR TITLE
custom job should push built images to additional registries

### DIFF
--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -235,7 +235,7 @@ node {
             stage("build images") {
                 if (!any_images_to_build) { return }
                 base_command = "${doozerOpts} ${include_exclude} --profile ${repo_type}"
-                command = "${base_command} images:build ${params.SCRATCH ? '--scratch' : ''}"
+                command = "${base_command} images:build --push-to-defaults ${params.SCRATCH ? '--scratch' : ''}"
                 try {
                     buildlib.doozer command
                 } catch (err) {


### PR DESCRIPTION
Commit a143ea095b657ff858303aba9c37f074ee5df2e1 deleted `images:push` call from `custom` job.
We found we still need to push to additional registries (reg-aws) because QE is using it.