### PR TITLE
[ART-3383] Add check-bugs job + scheduled job

### DIFF
--- a/jobs/build/check-bugs/Jenkinsfile
+++ b/jobs/build/check-bugs/Jenkinsfile
@@ -49,6 +49,9 @@ pipeline {
         stage("check-regressions") {
             steps {
                 script {
+                    if (next_is_prerelease(params.BUILD_VERSION)) {
+                        return
+                    }
                     bugs = commonlib.shell(
                         returnStdout: true,
                         script: """
@@ -91,4 +94,10 @@ pipeline {
             }
         }
     }
+}
+
+def next_is_prerelease(version) {
+    def (major, minor) = commonlib.extractMajorMinorVersionNumbers(version)
+    def next_version = major.toString() + '.' + (minor + 1).toString()
+    commonlib.ocpReleaseState[next_version]['release'].isEmpty()
 }

--- a/jobs/build/check-bugs/Jenkinsfile
+++ b/jobs/build/check-bugs/Jenkinsfile
@@ -1,0 +1,94 @@
+#!/usr/bin/env groovy
+node {
+    checkout scm
+    buildlib = load("pipeline-scripts/buildlib.groovy")
+    commonlib = buildlib.commonlib
+    commonlib.describeJob("check-bugs", """
+        ----------
+        Check Bugs
+        ----------
+        Looks for blocker bugs and potential regressions, report findings on Slack.
+
+        Timing: Daily run, scheduled.
+    """)
+}
+
+pipeline {
+    agent any
+
+    options {
+        disableResume()
+        skipDefaultCheckout()
+    }
+
+    parameters {
+        choice(
+            name: "BUILD_VERSION",
+            description: "OSE Version",
+            choices: commonlib.ocpMajorVersions['all'],
+        )
+    }
+
+    stages {
+        stage("check-blockers") {
+            steps {
+                script {
+                    blocker_bugs = commonlib.shell(
+                        returnStdout: true,
+                        script: """
+                            ${buildlib.ELLIOTT_BIN}
+                            --group openshift-${params.BUILD_VERSION}
+                            find-bugs
+                            --mode blocker
+                            --report
+                        """.stripIndent().tr("\n", " ").trim()
+                    ).trim()
+                }
+            }
+        }
+        stage("check-regressions") {
+            steps {
+                script {
+                    bugs = commonlib.shell(
+                        returnStdout: true,
+                        script: """
+                            ${buildlib.ELLIOTT_BIN}
+                            --group openshift-${params.BUILD_VERSION}
+                            find-bugs
+                            --mode sweep
+                            | tail -n1
+                            | cut -d':' -f2
+                            | tr -d ,
+                        """.stripIndent().tr("\n", " ").trim()
+                    ).trim()
+
+                    potential_regressions = commonlib.shell(
+                        returnStdout: true,
+                        script: """
+                            ${buildlib.ELLIOTT_BIN}
+                            --group openshift-${params.BUILD_VERSION}
+                            verify-bugs ${bugs}
+                        """.stripIndent().tr("\n", " ").trim()
+                    ).trim()
+                }
+            }
+        }
+        stage("slack-notification") {
+            steps {
+                script {
+                    commonlib.slacklib.to(params.BUILD_VERSION).say("""
+                    *blocker bugs*
+                    ```
+                    ${blocker_bugs}
+                    ```
+
+                    *potential regressions*
+                    ```
+                    ${potential_regressions}
+                    ```
+                    """)
+                }
+            }
+        }
+    }
+}

--- a/jobs/build/check-bugs/Jenkinsfile
+++ b/jobs/build/check-bugs/Jenkinsfile
@@ -99,5 +99,10 @@ pipeline {
 def next_is_prerelease(version) {
     def (major, minor) = commonlib.extractMajorMinorVersionNumbers(version)
     def next_version = major.toString() + '.' + (minor + 1).toString()
-    commonlib.ocpReleaseState[next_version]['release'].isEmpty()
+    try {
+        return commonlib.ocpReleaseState[next_version]['release'].isEmpty()
+    } catch (Exception e) {
+        // there is no "next_version" release defined in ocpReleaseState
+        return true
+    }
 }

--- a/jobs/build/check-bugs/README.md
+++ b/jobs/build/check-bugs/README.md
@@ -1,0 +1,18 @@
+# Check bugs
+
+## Purpose
+
+Check for potential blocker bugs and regressions for a given OCP release, and
+alert ARTists on Slack, in order to raise awareness of such issues at any time,
+ideally before release preparation on Wednesday.
+
+## Timing
+
+It can be run by humans at any time, but it will also be invoked by a daily
+scheduled job.
+
+## Parameters
+
+### BUILD\_VERSION
+
+Target OCP version.

--- a/scheduled-jobs/build/check-bugs/Jenkinsfile
+++ b/scheduled-jobs/build/check-bugs/Jenkinsfile
@@ -1,0 +1,14 @@
+properties( [
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '100', daysToKeepStr: '', numToKeepStr: '100')),
+    disableConcurrentBuilds(),
+    disableResume(),
+] )
+
+def commonlib = load("pipeline-scripts/commonlib.groovy")
+commonlib.ocpVersions.each { it ->
+    b = build(
+        job: '../aos-cd-builds/build%2Fcheck-bugs',
+        propagate: false,
+        parameters: [string(name: 'BUILD_VERSION', it)],
+    )
+}


### PR DESCRIPTION
Look for potential blocker bugs and regressions of a given OCP version and communicate findings to ARTists on Slack.

Depends on https://github.com/openshift/elliott/pull/244 for `check-regressions` stage.

_*NOTE:* requires real tests on buildvm. Since these jobs don't affect our release flow, I'd suggest we merge it rather sooner, and follow up on any issues that show up_ 