### PR TITLE
Custom data path in build-sync

### DIFF
--- a/jobs/build/build-sync/Jenkinsfile
+++ b/jobs/build/build-sync/Jenkinsfile
@@ -41,6 +41,12 @@ node {
                                         defaultValue: "stream",
                                         trim: true,
                                     ),
+                                    string(
+                                        name: 'DOOZER_DATA_PATH',
+                                        description: 'ocp-build-data fork to use (e.g. assembly definition in your own fork)',
+                                        defaultValue: "https://github.com/openshift/ocp-build-data",
+                                        trim: true,
+                                    ),
                                     booleanParam(
                                             name        : 'DEBUG',
                                             description : 'Run "oc" commands with greater logging',

--- a/jobs/build/build-sync/build.groovy
+++ b/jobs/build/build-sync/build.groovy
@@ -48,12 +48,16 @@ def buildSyncGenInputs() {
     def excludeArchesParam = ""
     for(arch in excludeArches)
         excludeArchesParam += " --exclude-arch ${arch}"
+    def skipGCTaggingParam = params.DRY_RUN ? '--skip-gc-tagging' : ''
     buildlib.doozer """
 ${images}
---working-dir "${mirrorWorking}" --group 'openshift-${params.BUILD_VERSION}'
+--working-dir "${mirrorWorking}"
+--data-path "${doozer_data_path}"
+--group 'openshift-${params.BUILD_VERSION}'
 release:gen-payload
 ${params.EMERGENCY_IGNORE_ISSUES?'--emergency-ignore-issues':''}
 ${excludeArchesParam}
+${skipGCTaggingParam}
 """
     echo("Generated files:")
     echo("######################################################################")


### PR DESCRIPTION
I wanted to use a custom data path for testing out not-yet-ready assembly definitions.
Was thinking we could force dry_run when a custom data path is used, to be extra safe. 
Plus use --skip-gc-tagging flag, when running in dry_run mode.