### PR TITLE
Run ocp4 release scans in parallel

### DIFF
--- a/jobs/build/ocp4_scan/Jenkinsfile
+++ b/jobs/build/ocp4_scan/Jenkinsfile
@@ -38,11 +38,6 @@ node('covscan') {
                         defaultValue: commonlib.ocp4Versions.join(','),
                         trim: true,
                     ),
-                    booleanParam(
-                        name: 'CLEAN_CLONE',
-                        defaultValue: false,
-                        description: 'Force all git repos to be re-pulled',
-                    ),
                     commonlib.suppressEmailParam(),
                     string(
                         name: 'MAIL_LIST_SUCCESS',

--- a/scheduled-jobs/build/ocp4_scan/Jenkinsfile
+++ b/scheduled-jobs/build/ocp4_scan/Jenkinsfile
@@ -5,7 +5,11 @@ properties( [
     disableResume(),
 ] )
 
-b = build job: '../aos-cd-builds/build%2Focp4_scan', propagate: false
+def versionJobs = [:]
+for ( version in commonlib.ocp4Versions ) {
+    versionJobs["scan-v${version}"] = {
+        build job: '../aos-cd-builds/build%2Focp4_scan', parameters: [string(name: 'VERSION', value: version)], propagate: false
+    }
+}
 
-currentBuild.description = "${b.displayName} - ${b.result}\n"
-currentBuild.result = b.result
+parallel versionJobs


### PR DESCRIPTION
The original implementation of scan-sources required upstream source
for each image to be cloned. This intensive (in terms of CPU and
disk space) operations was serialized to prevent exhausting resources.

scan-sources is now relatively quick (5 minutes) and does not clone
upstream source. Even with these improvements, with five releases
being scanned, a change in 4.x can wait to be detected for ~20 minutes
because of the serial scans of releases.

This change allows all scans to happen in parallel - meaning a 4.x
scan is primarily waiting for 4.x builds.