### PR TITLE
ART-3377 Rhcos sync from release tag

### DIFF
--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -742,11 +742,11 @@ ${reason}"""
                 rhcos_mirror_prefix = is_prerelease ? "pre-release" : "$major.$minor"
 
                 sync_params = [
-                    buildlib.param('String','BUILD_VERSION', "$major.$minor"),
-                    buildlib.param('String','NAME', release_name),
+                    buildlib.param('String','OCP_VERSION', "$major.$minor"),
+                    buildlib.param('String','OVERRIDE_NAME', release_name),
                     buildlib.param('String','ARCH', arch),
-                    buildlib.param('String','RHCOS_MIRROR_PREFIX', rhcos_mirror_prefix),
-                    buildlib.param('String','RHCOS_BUILD', rhcos_build),
+                    buildlib.param('String','MIRROR_PREFIX', rhcos_mirror_prefix),
+                    buildlib.param('String','OVERRIDE_BUILD', rhcos_build),
                     booleanParam(name: 'DRY_RUN', value: params.DRY_RUN),
                     booleanParam(name: 'MOCK', value: params.MOCK)
                 ]

--- a/jobs/build/rhcos_sync/Jenkinsfile
+++ b/jobs/build/rhcos_sync/Jenkinsfile
@@ -38,7 +38,7 @@ node {
                 parameterDefinitions: [
                     string(
                         name: 'FROM_RELEASE_TAG',
-                        description: 'Release Image to get RHCOS buildID from ex - 4.8.2 or 4.8.0-0.nightly-2021-07-21-150743',
+                        description: 'Release Image to get RHCOS buildID from ex - 4.8.2-x86_64 or 4.8.0-0.nightly-2021-07-21-150743',
                         defaultValue: "",
                         trim: true,
                     ),

--- a/jobs/build/rhcos_sync/Jenkinsfile
+++ b/jobs/build/rhcos_sync/Jenkinsfile
@@ -95,9 +95,7 @@ node {
     )
 
     commonlib.checkMock()
-    
-    
-    
+
     if (params.OVERRIDE_RHCOS_BUILD != "") {
         if (params.OVERRIDE_ARCH == "" || params.OVERRIDE_NAME == "") {
             error("Need OVERRIDE_ARCH, OVERRIDE_NAME values")
@@ -112,13 +110,13 @@ node {
         if (!params.FROM_RELEASE_TAG) {
             error("Need FROM_RELEASE_TAG")
         }
-        
+
         tag = params.FROM_RELEASE_TAG
         (major, minor) = commonlib.extractMajorMinorVersionNumbers(tag)
-        
+
         (arch, priv) = release.getReleaseTagArchPriv(tag)
         suffix = release.getArchPrivSuffix(arch, priv)
-        
+
         cmd = "oc image info -o json \$(oc adm release info --image-for machine-os-content registry.ci.openshift.org/ocp$suffix/release$suffix:$tag) | jq -r .config.config.Labels.version"
         rhcos_build =  commonlib.shell(
             returnStdout: true,
@@ -131,7 +129,7 @@ node {
         // todo: if 4.X.Y exact release name then major.minor else pre-release
         rhcos_mirror_prefix = is_prerelease ? "pre-release" : "$major.$minor"
     }
-    
+
     echo("Initializing RHCOS-${params.RHCOS_MIRROR_PREFIX} sync: #${currentBuild.number}")
     build.initialize()
 
@@ -141,8 +139,8 @@ node {
         } else {
             stage("Get/Generate sync list") { build.rhcosSyncManualInput() }
         }
-        stage("Mirror artifacts") { 
-            build.rhcosSyncMirrorArtifacts(rhcos_mirror_prefix, arch, rhcos_build, name) 
+        stage("Mirror artifacts") {
+            build.rhcosSyncMirrorArtifacts(rhcos_mirror_prefix, arch, rhcos_build, name)
         }
         // stage("Gen AMI docs") { build.rhcosSyncGenDocs() }
         stage("Slack notification to release channel") {

--- a/jobs/build/rhcos_sync/Jenkinsfile
+++ b/jobs/build/rhcos_sync/Jenkinsfile
@@ -2,8 +2,8 @@
 
 node {
     checkout scm
-    def release = load("pipeline-scripts/release.groovy")
     def build = load("build.groovy")
+    def releaselib = build.releaselib
     def buildlib = build.buildlib
     def commonlib = build.commonlib
     def slacklib = commonlib.slacklib
@@ -36,13 +36,13 @@ node {
             [
                 $class : 'ParametersDefinitionProperty',
                 parameterDefinitions: [
-                    commonlib.ocpVersionParam('BUILD_VERSION', '4'),
                     string(
                         name: 'FROM_RELEASE_TAG',
                         description: 'Release Image to get RHCOS buildID from ex - 4.8.2 or 4.8.0-0.nightly-2021-07-21-150743',
                         defaultValue: "",
                         trim: true,
                     ),
+                    commonlib.ocpVersionParam('OCP_VERSION', '4', ['auto']),
                     string(
                         name: 'OVERRIDE_BUILD',
                         description: 'ID of the RHCOS build to sync. e.g.: 42.80.20190828.2. This overrides FROM_RELEASE_TAG.',
@@ -50,13 +50,13 @@ node {
                         trim: true,
                     ),
                     choice(
-                        name: 'OVERRIDE_ARCH',
-                        description: 'Which architecture of RHCOS build to look for. This overrides FROM_RELEASE_TAG. Required with OVERRIDE_BUILD',
-                        choices: ([""] + commonlib.brewArches),
+                        name: 'ARCH',
+                        description: 'Which architecture of RHCOS build to look for. Required with OVERRIDE_BUILD',
+                        choices: (["auto"] + commonlib.brewArches),
                     ),
                     string(
                         name: 'OVERRIDE_NAME',
-                        description: 'The release name, like 4.2.0, or 4.2.0-0.nightly-2019-08-28-152644. This overrides FROM_RELEASE_TAG. Required with OVERRIDE_BUILD',
+                        description: 'The release name, like 4.2.0, or 4.2.0-0.nightly-2019-08-28-152644. Required with OVERRIDE_BUILD',
                         defaultValue: "",
                         trim: true,
                     ),
@@ -97,13 +97,20 @@ node {
     commonlib.checkMock()
 
     if (params.OVERRIDE_BUILD != "") {
-        if (params.OVERRIDE_ARCH == "" || params.OVERRIDE_NAME == "") {
-            error("Need OVERRIDE_ARCH, OVERRIDE_NAME values")
+        if (params.OVERRIDE_NAME == "") {
+            error("Need a valid OVERRIDE_NAME value")
+        }
+        if (params.ARCH == "auto") {
+            error("ARCH cannot be auto, need to be explicit")
         }
         if (params.MIRROR_PREFIX == "auto") {
             error("MIRROR_PREFIX cannot be auto, need to be explicit")
         }
-        rhcos_build = params.OVERRIDE_BUILD
+        if (params.OCP_VERSION == "auto") {
+            error("OCP_VERSION cannot be auto, need to be explicit")
+        }
+        ocpVersion = params.OCP_VERSION
+        rhcosBuild = params.OVERRIDE_BUILD
         arch = params.OVERRIDE_ARCH
         name = params.OVERRIDE_NAME
     } else {
@@ -112,27 +119,37 @@ node {
         }
 
         tag = params.FROM_RELEASE_TAG
-        (major, minor) = commonlib.extractMajorMinorVersionNumbers(tag)
+        if (params.OVERRIDE_NAME != "") {
+            name = params.OVERRIDE_NAME
+        } else {
+            name = tag
+        }
 
-        (arch, priv) = release.getReleaseTagArchPriv(tag)
-        suffix = release.getArchPrivSuffix(arch, priv)
+        (major, minor) = commonlib.extractMajorMinorVersionNumbers(tag)
+        ocpVersion = "$major.$minor"
+
+        (arch, priv) = releaselib.getReleaseTagArchPriv(tag)
+        suffix = releaselib.getArchPrivSuffix(arch, priv)
 
         cmd = "oc image info -o json \$(oc adm release info --image-for machine-os-content registry.ci.openshift.org/ocp$suffix/release$suffix:$tag) | jq -r .config.config.Labels.version"
-        rhcos_build =  commonlib.shell(
+        rhcosBuild =  commonlib.shell(
             returnStdout: true,
             script: cmd
         ).trim()
-        print("RHCOS build: $rhcos_build")
     }
 
     if (params.MIRROR_PREFIX == 'auto') {
         pattern = /$major\.$minor\.(\d+)-$arch/
-        is_stable = a ==~ pattern
-        rhcos_mirror_prefix = is_stable ? "$major.$minor" : "pre-release"
+        is_stable = tag ==~ pattern
+        mirrorPrefix = is_stable ? ocpVersion : "pre-release"
+    } else {
+        mirrorPrefix = params.MIRROR_PREFIX
     }
 
+    print("RHCOS build: $rhcosBuild, arch: $arch, mirror prefix: $mirrorPrefix")
+
     echo("Initializing RHCOS-${params.MIRROR_PREFIX} sync: #${currentBuild.number}")
-    build.initialize()
+    build.initialize(ocpVersion, rhcosBuild, arch, name, mirrorPrefix)
 
     try {
         if ( params.SYNC_LIST == "" ) {
@@ -141,13 +158,13 @@ node {
             stage("Get/Generate sync list") { build.rhcosSyncManualInput() }
         }
         stage("Mirror artifacts") {
-            build.rhcosSyncMirrorArtifacts(rhcos_mirror_prefix, arch, rhcos_build, name)
+            build.rhcosSyncMirrorArtifacts(mirrorPrefix, arch, rhcosBuild, name)
         }
-        // stage("Gen AMI docs") { build.rhcosSyncGenDocs() }
+        // stage("Gen AMI docs") { build.rhcosSyncGenDocs(rhcosBuild) }
         stage("Slack notification to release channel") {
-            slacklib.to(params.BUILD_VERSION).say("""
-            *:heavy_check_mark: rhcos_sync (${params.RHCOS_MIRROR_PREFIX}) successful*
-            https://mirror.openshift.com/pub/openshift-v4/${params.ARCH}/dependencies/rhcos/${params.RHCOS_MIRROR_PREFIX}/${params.NAME}/
+            slacklib.to(ocpVersion).say("""
+            *:heavy_check_mark: rhcos_sync (${mirrorPrefix}) successful*
+            https://mirror.openshift.com/pub/openshift-v4/${arch}/dependencies/rhcos/${mirrorPrefix}/${name}/
 
             buildvm job: ${commonlib.buildURL('console')}
             """)
@@ -155,9 +172,9 @@ node {
 
         // only run for x86_64 since no AMIs for other arches
         // only sync AMI to ROSA Marketplace account when no custom sync list is defined
-        if ( params.SYNC_LIST == "" && params.ARCH == "x86_64") {
+        if ( params.SYNC_LIST == "" && arch == "x86_64") {
             stage("Mirror ROSA AMIs") {
-                if ( params.ARCH != 'x86_64' ) {
+                if ( arch != 'x86_64' ) {
                     echo "Skipping ROSA sync for non-x86 arch"
                     return
                 }
@@ -169,23 +186,23 @@ node {
                 }
             }
             stage("Slack notification to release channel") {
-                slacklib.to(params.BUILD_VERSION).say("""
-                *:heavy_check_mark: rosa_sync (${params.NAME}) successful*
+                slacklib.to(ocpVersion).say("""
+                *:heavy_check_mark: rosa_sync (${name}) successful*
                 """)
             }
         }
     } catch ( err ) {
-        slacklib.to(params.BUILD_VERSION).say("""
-        *:heavy_exclamation_mark: rhcos_sync ${params.RHCOS_MIRROR_PREFIX} failed*
+        slacklib.to(ocpVersion).say("""
+        *:heavy_exclamation_mark: rhcos_sync ${mirrorPrefix} failed*
         buildvm job: ${commonlib.buildURL('console')}
         """)
         commonlib.email(
             to: "aos-art-automation+failed-rhcos-sync@redhat.com",
             from: "aos-art-automation@redhat.com",
             replyTo: "aos-team-art@redhat.com",
-            subject: "Error during OCP ${params.RHCOS_MIRROR_PREFIX} build sync",
+            subject: "Error during OCP ${mirrorPrefix} build sync",
             body: """
-There was an issue running build-sync for OCP ${params.RHCOS_MIRROR_PREFIX}:
+There was an issue running build-sync for OCP ${mirrorPrefix}:
 
     ${err}
 """)

--- a/jobs/build/rhcos_sync/Jenkinsfile
+++ b/jobs/build/rhcos_sync/Jenkinsfile
@@ -111,7 +111,7 @@ node {
         }
         ocpVersion = params.OCP_VERSION
         rhcosBuild = params.OVERRIDE_BUILD
-        arch = params.OVERRIDE_ARCH
+        arch = params.ARCH
         name = params.OVERRIDE_NAME
     } else {
         if (!params.FROM_RELEASE_TAG) {

--- a/jobs/build/rhcos_sync/Jenkinsfile
+++ b/jobs/build/rhcos_sync/Jenkinsfile
@@ -45,24 +45,24 @@ node {
                     ),
                     string(
                         name: 'OVERRIDE_BUILD',
-                        description: 'ID of the RHCOS build to sync. e.g.: 42.80.20190828.2. This overrides PAYLOAD_IMAGE.',
+                        description: 'ID of the RHCOS build to sync. e.g.: 42.80.20190828.2. This overrides FROM_RELEASE_TAG.',
                         defaultValue: "",
                         trim: true,
                     ),
                     choice(
                         name: 'OVERRIDE_ARCH',
-                        description: 'Which architecture of RHCOS build to look for. This overrides PAYLOAD_IMAGE. Required with OVERRIDE_RHCOS_BUILD',
+                        description: 'Which architecture of RHCOS build to look for. This overrides FROM_RELEASE_TAG. Required with OVERRIDE_BUILD',
                         choices: ([""] + commonlib.brewArches),
                     ),
                     string(
                         name: 'OVERRIDE_NAME',
-                        description: 'The release name, like 4.2.0, or 4.2.0-0.nightly-2019-08-28-152644. This overrides PAYLOAD_IMAGE. Required with OVERRIDE_RHCOS_BUILD',
+                        description: 'The release name, like 4.2.0, or 4.2.0-0.nightly-2019-08-28-152644. This overrides FROM_RELEASE_TAG. Required with OVERRIDE_BUILD',
                         defaultValue: "",
                         trim: true,
                     ),
                     choice(
-                        name: 'OVERRIDE_MIRROR_PREFIX',
-                        description: 'Where to place this release under https://mirror.openshift.com/pub/openshift-v4/ARCH/dependencies/rhcos/. Auto sets to image version for stable releases, pre-release for all other.',
+                        name: 'MIRROR_PREFIX',
+                        description: 'Where to place this release under https://mirror.openshift.com/pub/openshift-v4/ARCH/dependencies/rhcos/. Auto sets to image version for stable releases (example if FROM_RELEASE_TAG is 4.8.4-x86_64 then directory is 4.8), pre-release for all other FROM_RELEASE_TAG values. "auto" cannot be used with OVERRIDE_BUILD',
                         choices: (['auto' ,'pre-release', 'test'] + commonlib.ocp4Versions),
                     ),
                     string(
@@ -96,14 +96,14 @@ node {
 
     commonlib.checkMock()
 
-    if (params.OVERRIDE_RHCOS_BUILD != "") {
+    if (params.OVERRIDE_BUILD != "") {
         if (params.OVERRIDE_ARCH == "" || params.OVERRIDE_NAME == "") {
             error("Need OVERRIDE_ARCH, OVERRIDE_NAME values")
         }
-        if (params.RHCOS_MIRROR_PREFIX == "auto") {
-            error("RHCOS_MIRROR_PREFIX cannot be auto, need to be explicit")
+        if (params.MIRROR_PREFIX == "auto") {
+            error("MIRROR_PREFIX cannot be auto, need to be explicit")
         }
-        rhcos_build = params.OVERRIDE_RHCOS_BUILD
+        rhcos_build = params.OVERRIDE_BUILD
         arch = params.OVERRIDE_ARCH
         name = params.OVERRIDE_NAME
     } else {
@@ -125,12 +125,13 @@ node {
         print("RHCOS build: $rhcos_build")
     }
 
-    if (params.RHCOS_MIRROR_PREFIX == 'auto') {
-        // todo: if 4.X.Y exact release name then major.minor else pre-release
-        rhcos_mirror_prefix = is_prerelease ? "pre-release" : "$major.$minor"
+    if (params.MIRROR_PREFIX == 'auto') {
+        pattern = /$major\.$minor\.(\d+)-$arch/
+        is_stable = a ==~ pattern
+        rhcos_mirror_prefix = is_stable ? "$major.$minor" : "pre-release"
     }
 
-    echo("Initializing RHCOS-${params.RHCOS_MIRROR_PREFIX} sync: #${currentBuild.number}")
+    echo("Initializing RHCOS-${params.MIRROR_PREFIX} sync: #${currentBuild.number}")
     build.initialize()
 
     try {

--- a/jobs/build/rhcos_sync/Jenkinsfile
+++ b/jobs/build/rhcos_sync/Jenkinsfile
@@ -2,6 +2,7 @@
 
 node {
     checkout scm
+    def release = load("pipeline-scripts/release.groovy")
     def build = load("build.groovy")
     def buildlib = build.buildlib
     def commonlib = build.commonlib
@@ -37,26 +38,32 @@ node {
                 parameterDefinitions: [
                     commonlib.ocpVersionParam('BUILD_VERSION', '4'),
                     string(
-                        name: 'NAME',
-                        description: 'The release name, like 4.2.0, or 4.2.0-0.nightly-2019-08-28-152644',
+                        name: 'FROM_RELEASE_TAG',
+                        description: 'Release Image to get RHCOS buildID from ex - 4.8.2 or 4.8.0-0.nightly-2021-07-21-150743',
                         defaultValue: "",
                         trim: true,
-                    ),
-                    choice(
-                        name: 'ARCH',
-                        description: 'Which architecture of RHCOS build to look for',
-                        choices: commonlib.brewArches,
-                    ),
-                    choice(
-                        name: 'RHCOS_MIRROR_PREFIX',
-                        description: 'Where to place this release under https://mirror.openshift.com/pub/openshift-v4/ARCH/dependencies/rhcos/',
-                        choices: (['pre-release', 'test'] + commonlib.ocp4Versions),
                     ),
                     string(
-                        name: 'RHCOS_BUILD',
-                        description: 'ID of the RHCOS build to sync. e.g.: 42.80.20190828.2',
+                        name: 'OVERRIDE_BUILD',
+                        description: 'ID of the RHCOS build to sync. e.g.: 42.80.20190828.2. This overrides PAYLOAD_IMAGE.',
                         defaultValue: "",
                         trim: true,
+                    ),
+                    choice(
+                        name: 'OVERRIDE_ARCH',
+                        description: 'Which architecture of RHCOS build to look for. This overrides PAYLOAD_IMAGE. Required with OVERRIDE_RHCOS_BUILD',
+                        choices: ([""] + commonlib.brewArches),
+                    ),
+                    string(
+                        name: 'OVERRIDE_NAME',
+                        description: 'The release name, like 4.2.0, or 4.2.0-0.nightly-2019-08-28-152644. This overrides PAYLOAD_IMAGE. Required with OVERRIDE_RHCOS_BUILD',
+                        defaultValue: "",
+                        trim: true,
+                    ),
+                    choice(
+                        name: 'OVERRIDE_MIRROR_PREFIX',
+                        description: 'Where to place this release under https://mirror.openshift.com/pub/openshift-v4/ARCH/dependencies/rhcos/. Auto sets to image version for stable releases, pre-release for all other.',
+                        choices: (['auto' ,'pre-release', 'test'] + commonlib.ocp4Versions),
                     ),
                     string(
                         name: 'SYNC_LIST',
@@ -88,6 +95,43 @@ node {
     )
 
     commonlib.checkMock()
+    
+    
+    
+    if (params.OVERRIDE_RHCOS_BUILD != "") {
+        if (params.OVERRIDE_ARCH == "" || params.OVERRIDE_NAME == "") {
+            error("Need OVERRIDE_ARCH, OVERRIDE_NAME values")
+        }
+        if (params.RHCOS_MIRROR_PREFIX == "auto") {
+            error("RHCOS_MIRROR_PREFIX cannot be auto, need to be explicit")
+        }
+        rhcos_build = params.OVERRIDE_RHCOS_BUILD
+        arch = params.OVERRIDE_ARCH
+        name = params.OVERRIDE_NAME
+    } else {
+        if (!params.FROM_RELEASE_TAG) {
+            error("Need FROM_RELEASE_TAG")
+        }
+        
+        tag = params.FROM_RELEASE_TAG
+        (major, minor) = commonlib.extractMajorMinorVersionNumbers(tag)
+        
+        (arch, priv) = release.getReleaseTagArchPriv(tag)
+        suffix = release.getArchPrivSuffix(arch, priv)
+        
+        cmd = "oc image info -o json \$(oc adm release info --image-for machine-os-content registry.ci.openshift.org/ocp$suffix/release$suffix:$tag) | jq -r .config.config.Labels.version"
+        rhcos_build =  commonlib.shell(
+            returnStdout: true,
+            script: cmd
+        ).trim()
+        print("RHCOS build: $rhcos_build")
+    }
+
+    if (params.RHCOS_MIRROR_PREFIX == 'auto') {
+        // todo: if 4.X.Y exact release name then major.minor else pre-release
+        rhcos_mirror_prefix = is_prerelease ? "pre-release" : "$major.$minor"
+    }
+    
     echo("Initializing RHCOS-${params.RHCOS_MIRROR_PREFIX} sync: #${currentBuild.number}")
     build.initialize()
 
@@ -97,7 +141,9 @@ node {
         } else {
             stage("Get/Generate sync list") { build.rhcosSyncManualInput() }
         }
-        stage("Mirror artifacts") { build.rhcosSyncMirrorArtifacts() }
+        stage("Mirror artifacts") { 
+            build.rhcosSyncMirrorArtifacts(rhcos_mirror_prefix, arch, rhcos_build, name) 
+        }
         // stage("Gen AMI docs") { build.rhcosSyncGenDocs() }
         stage("Slack notification to release channel") {
             slacklib.to(params.BUILD_VERSION).say("""

--- a/jobs/build/rhcos_sync/build.groovy
+++ b/jobs/build/rhcos_sync/build.groovy
@@ -113,7 +113,7 @@ def rhcosSyncGenDocs(rhcosBuild) {
         // TODO
         // sh("sh ../gen-docs.sh < meta.json > rhcos-${rhcosBuild}.adoc")
     }
-    artifacts.add("${rhcosWorking}/rhcos-${params.rhcosBuild}.adoc")
+    artifacts.add("${rhcosWorking}/rhcos-${rhcosBuild}.adoc")
 }
 
 

--- a/jobs/build/rhcos_sync/build.groovy
+++ b/jobs/build/rhcos_sync/build.groovy
@@ -1,5 +1,6 @@
-buildlib = load("pipeline-scripts/buildlib.groovy")
-commonlib = buildlib.commonlib
+releaselib = load("pipeline-scripts/release.groovy")
+buildlib = releaselib.buildlib
+commonlib = releaselib.commonlib
 rhcosWorking = "rhcos_working"
 logLevel = ""
 dryRun = ""
@@ -14,7 +15,7 @@ syncList = "rhcos-synclist-${currentBuild.number}.txt"
 enforce_allowlist = false
 rhcos_allowlist = [ "gcp", "initramfs", "iso", "kernel", "metal", "openstack", "qemu", "vmware", "dasd" ]
 
-def initialize() {
+def initialize(ocpVersion, rhcosBuild, arch, name, mirrorPrefix) {
     buildlib.cleanWorkdir(rhcosWorking)
 
     // Example URL paths (visit https://releases-rhcos-art.cloud.privileged.psi.redhat.com/ to view yourself):
@@ -30,9 +31,6 @@ def initialize() {
     // 4.3 with non-x86 arch:   releases/rhcos-4.3-s390x/43.81.202001300441.0/s390x/meta.json
 
     // Sub in some vars according to params
-    def ocpVersion = params.BUILD_VERSION
-    def rhcosBuild = params.RHCOS_BUILD
-    def arch = params.ARCH
     def archSuffix = commonlib.brewSuffixForArch(arch)
     def archDir = ocpVersion == "4.2" ? "" : "/${arch}"
     baseUrl = "https://art-rhcos-ci.s3.amazonaws.com/releases/rhcos-${ocpVersion}${archSuffix}/${rhcosBuild}${archDir}"
@@ -41,9 +39,7 @@ def initialize() {
     // Actual meta.json
     metaUrl = baseUrl + "/meta.json"
 
-    name = params.NAME
-
-    currentBuild.displayName = "${params.NAME} - ${params.RHCOS_BUILD}:${params.ARCH} - ${params.RHCOS_MIRROR_PREFIX}"
+    currentBuild.displayName = "${name} - ${rhcosBuild}:${arch} - ${mirrorPrefix}"
     currentBuild.description = "Meta JSON: ${metaUrl}"
 
     if ( params.DRY_RUN ) {
@@ -80,11 +76,11 @@ def rhcosSyncPrintArtifacts() {
     writeFile file: syncList, text: "${imageUrls.join('\n')}"
 }
 
-def rhcosSyncMirrorArtifacts(rhcos_mirror_prefix, arch, rhcos_build, name) {
+def rhcosSyncMirrorArtifacts(rhcosMirrorPrefix, arch, rhcosBuild, name) {
     sh("scp ${syncList} use-mirror-upload.ops.rhcloud.com:/tmp/")
-    def invokeOpts = " --prefix ${rhcos_mirror_prefix}" +
+    def invokeOpts = " --prefix ${rhcosMirrorPrefix}" +
         " --arch ${arch}" +
-        " --buildid ${rhcos_build}" +
+        " --buildid ${rhcosBuild}" +
         " --version ${name}" 
 
     if ( params.FORCE ) {
@@ -112,12 +108,12 @@ def rhcosSyncROSA() {
     commonlib.shell("${env.WORKSPACE}/build-scripts/rosa-sync/rosa_sync.sh ${rhcosWorking}/meta.json ${params.DRY_RUN}")
 }
 
-def rhcosSyncGenDocs() {
+def rhcosSyncGenDocs(rhcosBuild) {
     dir( rhcosWorking ) {
         // TODO
-        // sh("sh ../gen-docs.sh < meta.json > rhcos-${params.RHCOS_BUILD}.adoc")
+        // sh("sh ../gen-docs.sh < meta.json > rhcos-${rhcosBuild}.adoc")
     }
-    artifacts.add("${rhcosWorking}/rhcos-${params.RHCOS_BUILD}.adoc")
+    artifacts.add("${rhcosWorking}/rhcos-${params.rhcosBuild}.adoc")
 }
 
 

--- a/jobs/build/rhcos_sync/build.groovy
+++ b/jobs/build/rhcos_sync/build.groovy
@@ -80,12 +80,12 @@ def rhcosSyncPrintArtifacts() {
     writeFile file: syncList, text: "${imageUrls.join('\n')}"
 }
 
-def rhcosSyncMirrorArtifacts() {
+def rhcosSyncMirrorArtifacts(rhcos_mirror_prefix, arch, rhcos_build, name) {
     sh("scp ${syncList} use-mirror-upload.ops.rhcloud.com:/tmp/")
-    def invokeOpts = " --prefix ${params.RHCOS_MIRROR_PREFIX}" +
-        " --arch ${params.ARCH}" +
-        " --buildid ${params.RHCOS_BUILD}" +
-        " --version ${params.NAME}" 
+    def invokeOpts = " --prefix ${rhcos_mirror_prefix}" +
+        " --arch ${arch}" +
+        " --buildid ${rhcos_build}" +
+        " --version ${name}" 
 
     if ( params.FORCE ) {
             invokeOpts += " --force"

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -226,12 +226,12 @@ def dryrunParam(description = 'Run job without side effects') {
     ]
 }
 
-def ocpVersionParam(name='MINOR_VERSION', majorVersion='all') {
+def ocpVersionParam(name='MINOR_VERSION', majorVersion='all', extraOpts=[]) {
     return [
         name: name,
         description: 'OSE Version',
         $class: 'hudson.model.ChoiceParameterDefinition',
-        choices: ocpMajorVersions[majorVersion].join('\n'),
+        choices: (extraOpts + ocpMajorVersions[majorVersion]).join('\n'),
     ]
 }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-3377

Test run: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Frhcos_sync/33/

Test Promote run: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Fpromote/58/console - which triggered [#36](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Frhcos_sync/36/) (fail), pushed fix and retriggered to [#37](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Frhcos_sync/37/) (success)

Note: This job is called by promote job. needs to change promote job as well otherwise promote job will break.
