### PR TITLE
 [ART-3561] Fix late push image for 3.11

### DIFF
--- a/jobs/build/ocp3/Jenkinsfile
+++ b/jobs/build/ocp3/Jenkinsfile
@@ -684,6 +684,12 @@ node {
                             --filter-by-os amd64
                             --push-to-defaults ${ODCS_OPT}
                         """
+                        buildlib.doozer """
+                            ${doozerOpts}
+                            --images=openshift-enterprise
+                            images:push
+                            --to-defaults
+                        """
                     }
                     catch (err) {
                         record_log = buildlib.parse_record_log(DOOZER_WORKING)

--- a/jobs/build/ocp3/Jenkinsfile
+++ b/jobs/build/ocp3/Jenkinsfile
@@ -684,6 +684,9 @@ node {
                             --filter-by-os amd64
                             --push-to-defaults ${ODCS_OPT}
                         """
+                        // The late push of openshift-enterprise broke since assemblies are available, as
+                        // the search for trhe latest build gets pinned to the brew event. Rather than
+                        // actually fixing, just push this until OCP3.11 or reg-aws is EOL.
                         buildlib.doozer """
                             ${doozerOpts}
                             --images=openshift-enterprise


### PR DESCRIPTION
Ensure openshift-enterprise AKA openshift3/ose-control-plane gets pushed
to reg-aws.

Addresses https://issues.redhat.com/browse/ART-3561