### PR TITLE
Have two cri-o in plashet

### DIFF
--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -1459,6 +1459,7 @@ def buildBuildingPlashet(version, release, el_major, include_embargoed, auto_sig
                     "--include-previous-for python3-openvswitch", // this is a package prefix
                     "--include-previous-for ovn", // this is a package prefix
                     "--include-previous-for haproxy", // avoid chicken and egg issues with base image & haproxy bumps
+                    "--include-previous-for cri-o", // Fix regression in 4.10 CI
                     "--poll-for 15",   // wait up to 15 minutes for auto-signing to work its magic.
             ].join(' '))
         }


### PR DESCRIPTION
See https://coreos.slack.com/archives/C01CQA76KMX/p1639060078470200

A regression is suspected in cri-o, and rhcos probably wants to pin
previous version.