### PR TITLE
Pause slack alerts to forum-release

### DIFF
--- a/jobs/build/build-sync/Jenkinsfile
+++ b/jobs/build/build-sync/Jenkinsfile
@@ -146,7 +146,7 @@ node {
             msg = "@release-artists - pipeline has failed to assemble release payload for ${BUILD_VERSION} (assembly ${ASSEMBLY}) ${failCount} times."
             slacklib.to(params.BUILD_VERSION).failure(msg)
             if (assembly == "stream" && (failCount == 2 || failCount == 5 || failCount == 15)) { // don't spam forum-release
-                slacklib.to("#forum-release").failure(msg)
+                slacklib.to(params.BUILD_VERSION).failure(msg)
             }
         }
 


### PR DESCRIPTION
Our alerting seems to be buggy at the moment, with fail count resetting and not being updated accurately
Till it's fixed, diverting alerts to our internal channels