### PR TITLE
custom: do not offer to sweep bugs / builds

### DIFF
--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -83,28 +83,13 @@ node {
                     ),
                     choice(
                         name: 'IMAGE_MODE',
-                        description: 'How to update image dist-gits: with a source rebase, or not at all (no version/release update)',
+                        description: 'How to update image dist-gits: with a source rebase, or not at all (re-run as-is)',
                         choices: ['rebase', 'nothing'].join('\n'),
                     ),
                     booleanParam(
                         name: 'SCRATCH',
                         description: 'Run scratch builds (only unrelated images, no children)',
                         defaultValue: false,
-                    ),
-                    booleanParam(
-                        name: 'SWEEP_BUGS',
-                        description: 'Sweep and attach bugs to advisories',
-                        defaultValue: false,
-                    ),
-                    string(
-                        name: 'IMAGE_ADVISORY_ID',
-                        description: 'Advisory id for attaching new images if desired. Enter "default" to use current advisory from ocp-build-data',
-                        trim: true
-                    ),
-                    string(
-                        name: 'RPM_ADVISORY_ID',
-                        description: 'Advisory id for attaching new rpms if desired. Enter "default" to use current advisory from ocp-build-data',
-                        trim: true,
                     ),
                     commonlib.suppressEmailParam(),
                     string(
@@ -272,36 +257,6 @@ node {
                         params.ASSEMBLY,
                         operator_nvrs,
                     )
-                }
-            }
-
-            stage ('Attach Images') {
-                if (params.IMAGE_ADVISORY_ID != "") {
-                    def attach = params.IMAGE_ADVISORY_ID == "default" ? "--use-default-advisory image" : "--attach ${params.IMAGE_ADVISORY_ID}"
-                    buildlib.elliott """
-                    --data-path ${doozer_data_path}
-                    --group 'openshift-${majorVersion}.${minorVersion}'
-                    find-builds
-                    --kind image
-                    ${attach}
-                    """
-                }
-
-                if (params.RPM_ADVISORY_ID != "") {
-                    def attach = params.RPM_ADVISORY_ID == "default" ? "--use-default-advisory rpm" : "--attach ${params.RPM_ADVISORY_ID}"
-                    buildlib.elliott """
-                    --data-path ${doozer_data_path}
-                    --group 'openshift-${majorVersion}.${minorVersion}'
-                    find-builds
-                    --kind rpm
-                    ${attach}
-                    """
-                }
-            }
-
-            stage('sweep') {
-                if (params.SWEEP_BUGS) {
-                    buildlib.sweep(params.BUILD_VERSION)
                 }
             }
 

--- a/jobs/build/custom/README.md
+++ b/jobs/build/custom/README.md
@@ -133,22 +133,11 @@ should change to using the same parameters at some point, just for consistency.
 This specifies the mode to use with doozer to update image dist-gits:
 * `rebase`: this default is almost always what you should use. It rebases the
   code in the dist-git with the current source code.
-* `update-dockerfile`: just update the Dockerfile with new metadata, not new
-  source. This is useful for rebuilding 3.11 images with signed RPMs without
-  changing source contents at all, but in 4.y should almost never be used
-  (see below).
 * `nothing`: change nothing, just build with current dist-git contents. This will
   not work as desired if the contents have already built successfully. This is
   only useful to retry a build that failed for some reason - bugs, system
   failures, buildroot changes, and such. There is not usually much need for this
   option.
-
-> :warning: In 4.y, when rebuilding an OLM operator or operand, a rebase is
-> required in order for the operator CSV references to work correctly
-> (otherwise they are likely to point at images that are not published). Other
-> images can be built with `update-dockerfile` safely in the case where you
-> don't want to pull in newer changes; but this is a rare use case, and you
-> don't want to get sloppy and include an operator/operand by accident.
 
 ### SCRATCH
 
@@ -162,47 +151,6 @@ build will fail. This can only be used for targeted builds, not a mass rebuild.
 :warning:
 
 After a scratch build, images will not be synced.
-
-### SWEEP\_BUGS
-
-When true, run the `sweep` job to sweep and attach `MODIFIED` bugs into the
-default advisories for the build version (_NOT_ those specified by parameters
-below).
-
-> :warning: Note that this sweeps _all_ bugs, regardless of whether any builds
-> include related changes. Usually this is not desired, but may be useful if
-> you know all bugs will be ready to be swept at the end of the build.
-
-### IMAGE\_ADVISORY\_ID
-
-(Optional) If specified, attach _all_ latest container images to this advisory
-when the job completes. Specify `default` to use the default value from
-`ocp-build-data`.
-
-In 3.11 this can be useful when doing the signed build for a release, to sweep
-all the containers images when built.
-
-In 4.y builds there is little use for this. It is not scoped to just the images
-that were built in this run - it will attempt to attach _all_ latest images to
-a single advisory (not split by payload/extras). This is basically only useful
-for looking at CHI grades before continuing.
-
-> :warning: This attempts to attach all builds to the same advisory, but if
-> builds are already attached elsewhere, they will not be re-attached.
-
-### RPM\_ADVISORY\_ID
-
-(Optional) If specified, attach _all_ latest RPM package builds to this
-advisory when the job completes. Specify `default` to use the default value
-from `ocp-build-data`.
-
-There is little use for this.
-* In 3.11 you will usually want to sweep RPMs with the `signed-compose` job.
-* In 4.y RPM builds have usually already been swept, but you may want to use this
-  if the job built new ones.
-
-> :warning: This attempts to attach all builds to the same advisory, but if
-> builds are already attached elsewhere, they will not be re-attached.
 
 ### MAIL\_LIST\_SUCCESS
 


### PR DESCRIPTION
sweeps in this context are more likely to be confusing than helpful.
so just remove the option and the user can decide how to address those
separately instead of accidentally sweeping way more than intended.