### PR TITLE
[ART-3634] Numerically sort OCP versions for setting symlinks

### DIFF
--- a/scheduled-jobs/maintenance/set_cincinnati_links/Jenkinsfile
+++ b/scheduled-jobs/maintenance/set_cincinnati_links/Jenkinsfile
@@ -25,7 +25,10 @@ def runFor(version, channelPrefix, linkName) {
 
 @NonCPS
 def sortedVersions() {
-  return commonlib.ocp4Versions.sort(false)
+  return commonlib.ocp4Versions.sort {
+    def _, minor = it.tokenize('.')
+    minor
+  }
 }
 
 node() {


### PR DESCRIPTION
set_client_latest must run in order (from lower releases to higher) ... and that stopped happening since 4.10, because it is not sorting the versions properly.

```
def ocp4Versions = ["4.10", "4.9", "4.8", "4.7", "4.6"]

ocp4Versions.sort(false)
=> [4.10, 4.6, 4.7, 4.8, 4.9]

ocp4Versions.sort {
  def _, minor = it.tokenize(".")
  minor
}
=> [4.6, 4.7, 4.8, 4.9, 4.10]
```