### PR TITLE
Migrate promote job to Python

### DIFF
--- a/config/artcd.toml
+++ b/config/artcd.toml
@@ -14,6 +14,7 @@ reply_to = "aos-team-art@redhat.com"
 cc = ["aos-team-art@redhat.com"]
 prepare_release_notification_recipients_ocp4=["multi-arch-zstream-testing@redhat.com", "aos-qe@redhat.com"]
 prepare_release_notification_recipients_ocp3=["wzheng@redhat.com", "gpei@redhat.com", "aos-qe@redhat.com", "mp-entitlement-qe@redhat.com", "openshift-lp-test@redhat.com", "pprakash@redhat.com"]
+promote_image_list_recipients = ["openshift-ccs@redhat.com"]
 
 [jira]
 url = "https://issues.redhat.com"

--- a/jobs/build/promote-assembly/Jenkinsfile
+++ b/jobs/build/promote-assembly/Jenkinsfile
@@ -1,0 +1,354 @@
+#!/usr/bin/env groovy
+
+node {
+    checkout scm
+    def release = load("pipeline-scripts/release.groovy")
+    def buildlib = release.buildlib
+    def commonlib = buildlib.commonlib
+    def slacklib = commonlib.slacklib
+    commonlib.describeJob("promote-assembly", """
+        <h2>Publish official OCP 4 release artifacts</h2>
+        <b>Timing</b>: <a href="https://github.com/openshift/art-docs/blob/master/4.y.z-stream.md#create-the-release-image" target="_blank">4.y z-stream doc</a>
+
+        Be aware that by default the job stops for user input very early on. It
+        sends slack alerts in our release channels when this occurs.
+
+        For more details see the <a href="https://github.com/openshift/aos-cd-jobs/blob/master/jobs/build/promote/README.md" target="_blank">README</a>
+    """)
+
+
+    // Expose properties for a parameterized build
+    properties(
+        [
+            disableResume(),
+            buildDiscarder(
+                logRotator(
+                    artifactDaysToKeepStr: '',
+                    artifactNumToKeepStr: '',
+                    daysToKeepStr: '',
+                    numToKeepStr: '')),
+            [
+                $class: 'ParametersDefinitionProperty',
+                parameterDefinitions: [
+                    commonlib.ocpVersionParam('VERSION', '4'),  // not used by "stream" assembly
+                    string(
+                        name: 'ASSEMBLY',
+                        description: 'The name of an assembly to promote.',
+                        defaultValue: "stream",
+                        trim: true,
+                    ),
+                    string(
+                        name: 'ARCHES',
+                        description: '(Optional) A comma separated list of architectures for the release. Leave empty to promote all arches.',
+                        trim: true,
+                    ),
+                    string(
+                        name: 'RELEASE_OFFSET',
+                        description: 'Integer. Required for a custom release. Do not specify for a standard or candidate release. If offset is X for 4.9, the release name will be 4.9.X-assembly.ASSEMBLY_NAME',
+                        trim: true,
+                    ),
+                    booleanParam(
+                        name: 'PERMIT_PAYLOAD_OVERWRITE',
+                        description: 'DO NOT USE without team lead approval. Allows the pipeline to overwrite an existing payload in quay.',
+                        defaultValue: false,
+                    ),
+                    booleanParam(
+                        name: 'SKIP_CINCINNATI_PR_CREATION',
+                        description: 'DO NOT USE without team lead approval. This is an unusual option.',
+                        defaultValue: false,
+                    ),
+                    booleanParam(
+                        name: 'SKIP_OTA_SLACK_NOTIFICATION',
+                        description: 'Do not notify OTA team in slack for new PRs',
+                        defaultValue: false,
+                    ),
+                    booleanParam(
+                        name: 'SKIP_IMAGE_LIST',
+                        description: '(Standard Release) Do not gather an advisory image list for docs.',
+                        defaultValue: false,
+                    ),
+                    booleanParam(
+                        name: 'SKIP_SIGNING',
+                        description: 'Do not sign the release.',
+                        defaultValue: false,
+                    ),
+                    booleanParam(
+                        name: 'FORCE_RHCOS_SYNC',
+                        description: '(Standard Release) Always sync RHCOS images to mirrors.',
+                        defaultValue: false,
+                    ),
+                    string(
+                        name: 'MAIL_LIST_SUCCESS',
+                        description: 'Success Mailing List',
+                        defaultValue: [
+                            'aos-cicd@redhat.com',
+                            'aos-qe@redhat.com',
+                            'aos-art-automation+new-release@redhat.com',
+                        ].join(','),
+                        trim: true,
+                    ),
+                    commonlib.dryrunParam('Take no actions. Note: still notifies and runs signing job (which fails)'),
+                    commonlib.mockParam(),
+                ]
+            ],
+        ]
+    )
+
+    commonlib.checkMock()
+    def (major, minor) = commonlib.extractMajorMinorVersionNumbers(params.VERSION)
+    // TODO: Move commonlib.ocpReleaseState to ocp-build-data or somewhere.
+    def arches = params.ARCHES? commonlib.parseList(params.ARCHES) : commonlib.ocpReleaseState["${major}.${minor}"]?.release
+    if (!arches) {
+        error("Could determine which architectures to release. Make sure they are specified in `commonlib.ocpReleaseState`.")
+    }
+    def release_offset = params.RELEASE_OFFSET? Integer.parseInt(params.RELEASE_OFFSET) : null
+    def skipAttachedBugCheck = false
+    def next_minor = "${major}.${minor + 1}"
+    if (!(commonlib.ocpReleaseState[next_minor] && commonlib.ocpReleaseState[next_minor]["release"])) {
+        // If next_minor is not released yet, don't check attatched bugs.
+        // TODO: CVE flaw check should be exempted after https://github.com/openshift/elliott/pull/239 is merged.
+        skipAttachedBugCheck = true
+    }
+    if (params.DRY_RUN) {
+        currentBuild.displayName += " (dry-run)"
+        currentBuild.description += " [DRY RUN]"
+    }
+    currentBuild.displayName += " ${params.VERSION} - ${params.ASSEMBLY}"
+
+    stage("Initialize") {
+        // Install pyartcd
+        commonlib.shell(script: "pip install -e ./pyartcd")
+        // must be able to access remote registry for verification
+        buildlib.registry_quay_dev_login()
+    }
+
+    def release_info = {}
+
+    stage("promote release") {
+        sh "rm -rf ./artcd_working && mkdir -p ./artcd_working"
+        def cmd = [
+            "artcd",
+            "-v",
+            "--working-dir=./artcd_working",
+            "--config=./config/artcd.toml",
+        ]
+        if (params.DRY_RUN) {
+            cmd << "--dry-run"
+        }
+        cmd += [
+            "promote",
+            "--group=openshift-${params.VERSION}",
+            "--assembly=${params.ASSEMBLY}",
+        ]
+        if (release_offset != null) {
+            cmd << "--release-offset=${release_offset}"
+        }
+        if (skipAttachedBugCheck) {
+            cmd << "--skip-attached-bug-check"
+        }
+        if (params.SKIP_IMAGE_LIST) {
+            cmd << "--skip-image-list"
+        }
+        if (params.PERMIT_PAYLOAD_OVERWRITE) {
+            cmd << "--permit-overwrite"
+        }
+        for (arch in arches) {
+            cmd << "--arch=${arch}"
+        }
+        echo "Will run ${cmd}"
+        env.https_proxy="http://proxy.squi-001.prod.iad2.dc.redhat.com:3128"
+        env.http_proxy="http://proxy.squi-001.prod.iad2.dc.redhat.com:3128"
+        env.no_proxy="localhost,127.0.0.1,openshiftapps.com,engineering.redhat.com,devel.redhat.com,bos.redhat.com,github.com"
+        withEnv(["KUBECONFIG=${buildlib.ciKubeconfig}"]) {
+            withCredentials([string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN')]) {
+                def out = sh(script: cmd.join(' '), returnStdout: true).trim()
+                echo "artcd returns:\n$out"
+                release_info = readJSON(text: out)
+            }
+        }
+    }
+
+    buildlib.registry_quay_dev_login()  // chances are, earlier auth has expired
+
+    def justifications =release_info.justifications ?: []
+    def quay_url = "quay.io/openshift-release-dev/ocp-release"
+    def client_type = 'ocp'
+    if ((release_info.type == "candidate" && !release_info.assembly.startsWith('rc.')) || release_info.type == "custom") {
+        // Feature candidates and custom releases use client_type ocp-dev-preview and beta2 signing key.
+        client_type = 'ocp-dev-preview'
+    }
+    stage("mirror binaries") {
+        if (params.SKIP_MIRROR_BINARIES) {
+            echo "Skip mirroring binaries."
+            return
+        }
+        for (arch in arches) {
+            arch = commonlib.brewArchForGoArch(arch)
+            def dest_release_tag = release.destReleaseTag(release_info.name, arch)
+            retry(3) {
+                echo "Mirroring client binaries for $arch"
+                if (!params.DRY_RUN) {
+                    sshagent(['aos-cd-test']) {
+                        release.stagePublishClient(quay_url, dest_release_tag, release_info.name, arch, client_type)
+                    }
+                } else {
+                    echo "[DRY RUN] Would have sync'd client binaries for ${quay_url}:${dest_release_tag} to mirror ${arch}/clients/${client_type}/${release_info.name}."
+                }
+            }
+        }
+    }
+
+    stage("sync RHCOS") {
+        def is_prerelease = release_info.type == "candidate"
+        if (release_info.type == "custom") {
+            echo "Skipping RHCOS sync for a custom release."
+            return
+        }
+        if (!is_prerelease && !params.FORCE_RHCOS_SYNC) {
+            echo "Skipping RHCOS sync for a ${release_info.type} release."
+            return
+        }
+        def rhcos_mirror_prefix = is_prerelease ? "pre-release" : "$major.$minor"
+        for (arch in arches) {
+            arch = commonlib.brewArchForGoArch(arch)
+            def rhcos_build = release_info.content[arch].rhcos_version
+            if (!rhcos_build) {
+                echo "Skip mirroring RHCOS for $arch"
+                continue
+            }
+            print("RHCOS build for $arch: $rhcos_build")
+            def sync_params = [
+                buildlib.param('String','OCP_VERSION', "$major.$minor"),
+                buildlib.param('String','OVERRIDE_NAME', release_info.name),
+                buildlib.param('String','ARCH', arch),
+                buildlib.param('String','MIRROR_PREFIX', rhcos_mirror_prefix),
+                buildlib.param('String','OVERRIDE_BUILD', rhcos_build),
+                booleanParam(name: 'DRY_RUN', value: params.DRY_RUN),
+                booleanParam(name: 'MOCK', value: params.MOCK)
+            ]
+            build(
+                job: '/aos-cd-builds/build%252Frhcos_sync',
+                propagate: false,
+                parameters: sync_params
+            )
+        }
+    }
+
+    stage("sign artifacts") {
+        if (params.SKIP_SIGNING) {
+            echo "Signing artifacts is skipped."
+            return
+        }
+        for (arch in arches) {
+            arch = commonlib.brewArchForGoArch(arch)
+            def payloadDigest = release_info.content[arch].digest
+            echo "Signing $arch"
+            release.signArtifacts(
+                name: release_info.name,
+                signature_name: "signature-1",
+                dry_run: params.DRY_RUN,
+                env: "prod",
+                key_name: client_type=='ocp'?"redhatrelease2":"beta2",
+                arch: arch,
+                digest: payloadDigest,
+                client_type: client_type,
+            )
+        }
+    }
+
+    stage("send release message") {
+        if (release_info.type == "custom") {
+            echo "Don't send release messages for a custom release."
+            return
+        }
+        if (params.SKIP_SIGNING) {
+            echo "Don't send release messages because SKIP_SIGNING is set."
+            return
+        }
+        if (params.DRY_RUN) {
+            echo "DRY_RUN: Would have sent release messages."
+            return
+        }
+        for (arch in arches) {
+            arch = commonlib.brewArchForGoArch(arch)
+            release.sendReleaseCompleteMessage(["name": release_info.name], release_info.advisory, release_info.live_url, arch)
+        }
+    }
+
+    stage("channel prs") {
+        if (release_info.type == "custom") {
+            echo "Skipping PR creation for custom (hotfix) release."
+            return
+        }
+        if (params.SKIP_CINCINNATI_PR_CREATION) {
+            echo "Don't create Cincinnati PRs because SKIP_CINCINNATI_PR_CREATION is set"
+            return
+        }
+        if (params.DRY_RUN) {
+            echo "[DRY RUN] Would have created Cincinnati PRs."
+            return
+        }
+        def candidate_pr_note = ""
+        if (justifications) {
+            candidate_pr_note += ""
+            for (String justification: justifications) {
+                candidate_pr_note += "${justification}\n"
+            }
+        }
+        def from_releases = release_info.content.findAll{ k, v -> v.from_release }.collect {k, v -> v.from_release.split(":")[-1] }
+        build(
+            job: '/aos-cd-builds/build%2Fcincinnati-prs',  propagate: true,
+            parameters: [
+                buildlib.param('String', 'FROM_RELEASE_TAG', from_releases.join(",")),
+                buildlib.param('String', 'RELEASE_NAME', release_info.name),
+                buildlib.param('String', 'ADVISORY_NUM', "${release_info.advisory?: 0}"),
+                buildlib.param('String', 'GITHUB_ORG', 'openshift'),
+                buildlib.param('String', 'CANDIDATE_PR_NOTE', candidate_pr_note),
+                booleanParam(name: 'SKIP_OTA_SLACK_NOTIFICATION', value: params.SKIP_OTA_SLACK_NOTIFICATION)
+            ]
+        )
+    }
+
+    stage("validate RHSAs") {
+        if (params.DRY_RUN) {
+            return
+        }
+        def advisory_map = release.getAdvisories("openshift-${params.VERSION}")?: [:]
+        advisory_map.each { k, v ->
+            if (v <= 0) {
+                return
+            }
+            advisory_id = "$v"
+            res = commonlib.shell(
+                script: "${buildlib.ELLIOTT_BIN} validate-rhsa ${advisory_id}",
+                returnAll: true,
+            )
+            if (res.returnStatus != 0) {
+                msg = """
+                    Review of CVE situation required for advisory <https://errata.devel.redhat.com/advisory/${advisory_id}|${advisory_id}>.
+                    Report:
+                    ```
+                    ${res.stdout}
+                    ```
+                    Note: For GA image advisories this is expected to fail.
+                """.stripIndent()
+                slacklib.to(params.VERSION).say(msg)
+            }
+        }
+    }
+    stage("Send mail") {
+        dry_subject = ""
+        if (params.DRY_RUN) { dry_subject = "[DRY RUN] "}
+        def pullspecs = release_info.content.findAll{ k, v -> v.pullspec }.collect {k, v -> v.pullspec }
+        commonlib.email(
+            to: "${params.MAIL_LIST_SUCCESS}",
+            replyTo: "aos-team-art@redhat.com",
+            from: "aos-art-automation@redhat.com",
+            subject: "${dry_subject}Success building release payload: ${release_name}",
+            body: """
+Jenkins Job: ${env.BUILD_URL}
+PullSpecs: ${pullspecs.join(",")}
+        """);
+        buildlib.cleanWorkspace()
+    }
+}

--- a/jobs/build/promote-assembly/README.md
+++ b/jobs/build/promote-assembly/README.md
@@ -1,0 +1,177 @@
+# Promote OCP 4 release images
+
+## Purpose
+
+This job creates release images as described in the
+[4.y z-stream doc](https://github.com/openshift/art-docs/blob/master/4.y.z-stream.md#create-the-release-image)
+and publishes them to be available for customers.
+
+The "release image" (also known as the "payload") represents the core OpenShift
+artifacts. It is a container image built on the `cluster-version-operator`
+member, adding references to all of the container images that are considered
+part of core OpenShift. These references are pullspecs to where those images
+can be found (by sha256sum) under the monorepo
+quay.io/openshift-release-dev/ocp-v4.0-art-dev
+
+Extras images (OLM operators/operands/bundles, miscellaneous tools) are not
+part of the release image (though they are part of a release), and must be
+published and pulled from registry.redhat.io instead of quay.io. Payload
+and extras images are sorted into separate advisories for a release.
+
+During development, architecture-specific release-controllers create "nightly"
+(the name has stuck although they're created much more often) release images
+for each architecture with all of the latest builds. When ART is preparing for
+a release, we select a set of nightly images (one per arch) for QE to verify.
+The purpose of this job is to re-build and publish a release image for customer
+use after QE verification.
+
+For the default use case, this job:
+ * performs basic validation of the release contents
+ * publishes a nightly as an [officially named release image](https://amd64.ocp.releases.ci.openshift.org/#4-stable) with with a list of releases allowed to upgrade to it
+ * waits up to three hours for the release to pass acceptance tests (currently, just upgrade tests)
+ * opens pull requests to [cinci-graph-data](https://github.com/openshift/cincinnati-graph-data/tree/master/channels)
+ * copies the clients to the [mirror](http://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/)
+ * signs the clients and release image
+ * ...and handles other odds and ends for a release
+
+There are minor differences when this job runs for FCs, RCs, or hotfixes.
+
+The job may fail if verification fails. It sends
+slack alerts in a relevant release channel (like `art-release-4-7`) when this occurs.
+You may rerun this job after the related issues are resolved.
+
+## Timing
+
+This job is run manually per the release schedule.
+
+Promotion should wait for QE to have a chance to review, and should not occur
+if there are blockers outstanding for a release. It may be delayed or omitted
+as needed. In general, it is best if it occurs early in the day as the
+acceptance tests are more likely to pass then.
+
+## Parameters
+
+### Standard parameters DRY\_RUN, MOCK
+
+See [Standard Parameters](/jobs/README.md#standard-parameters).
+
+### VERSION
+This specifies the OCP minor version (e.g. 4.10)
+
+### ASSEMBLY
+
+This specifies the name of the assembly. The assembly must be explicitly defined in releases.yml.
+
+### ARCHES
+
+Leave this to empty to promote all supported architectures.
+Otherwise, specify a list of architectures (separated by comma) to promote (e.g. x86_64,aarch64).
+
+### RELEASE\_OFFSET
+
+This parameter is required to promote a custom release. If offset is X for 4.9, the release name will be 4.9.X-assembly.ASSEMBLY_NAME.
+
+
+### PERMIT\_PAYLOAD\_OVERWRITE
+
+**DO NOT USE** without discussing with your team or pillar lead for approval.
+
+This allows the pipeline to overwrite an existing payload in quay. We have
+done this a few times in the past and it has caused weirdness. Really, if a
+release has been created and we can't use it, we should just create another.
+Probably we should just get rid of this option.
+
+### SKIP\_VERIFY\_BUGS
+
+For a standard release, skip verifying advisory bugs.
+
+You may want to use this to save time on releases with thousands of bugs that
+have already been verified (say while releasing another arch).
+
+### SKIP\_CINCINNATI\_PR\_CREATION
+
+**DO NOT USE** without discussing with your team or pillar lead for approval.
+
+This *prevents* creating PRs to enter the new release in Cincinnati (to make it
+visible to customers for install/upgrade).
+
+### SKIP\_OTA\_SLACK\_NOTIFICATION
+
+Do not notify the OTA team in slack about new PRs created for Cincinnati.
+Probably only useful for testing the job.
+
+### SKIP\_IMAGE\_LIST
+
+For a Standard `x86_64` release, this job normally gathers a list of images
+from the image advisory and sends it to docs for inclusion in the release notes.
+
+This option prevents that. There is probably not much reason to do this.
+
+### MAIL\_LIST\_SUCCESS
+
+Address(es) to mail when the job succeeds.
+
+## Related Group config fields
+
+The following fields can be defined in `group.yml` or `releases.yml` `assembly.group` section:
+
+```yaml
+advisories:
+  image: 86637
+  rpm: 86633
+  extras: 86638
+  metadata: 86639
+upgrades: 4.6.24,4.6.25,4.6.26
+description: "some text"
+```
+
+### upgrades
+
+This is used to specify which releases to allow to upgrade to this release. This field is optional for custom releases.
+If no upgrade edges are expected, please explicitly set the `upgrade` field to empty string.
+
+### description
+
+Should not be defined unless you know otherwise. This adds text in the release image
+metadata that we have never actually had a use for. It has been available since
+the beginning of OCP 4 and remains available in case we ever find a use for it.
+
+## Dependencies
+
+Aside from all the jobs that had to run before this one in order to prepare release artifacts in the first place,
+this job also relies on other jobs as part of its function.
+
+### oc\_sync
+
+Actually this job is _not_ invoked; but the code for syncing the oc client out
+to mirror.openshift.com is shared between the jobs, which is useful when
+something prevents completing the sync step during the promotion.
+
+### signing-jobs/sign-artifacts
+
+Once the release image is created (and if necessary has passed tests), the
+[signing job](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/signing-jobs/job/signing%252Fsign-artifacts/)
+is used to sign the release image and oc client with Red Hat's key.
+
+### cincinnati-prs
+
+After signing the release, the
+[cincinnati-prs job](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fcincinnati-prs/)
+is used to create PRs to have the release (and upgrade edges) included in OCP 4
+[release channels](https://github.com/openshift/cincinnati-graph-data/tree/master/channels).
+
+## Known issues
+
+### General flakiness
+
+Considering the importance of this job, it is ironically difficult to change
+and test safely. This is mainly because the job relies on making actual changes
+(creating a release in `4-stable`, syncing clients) and then following up on
+the results, and it's impossible to test all the logic even with a dry run.
+And we only run it a few times a week.
+
+So changes frequently break the job right when we need it and leave a release incomplete.
+
+Most of what should have happened later in the job can be replicated by manually
+running other jobs, which is useful when it breaks for some reason. See:
+[Release job failures](https://github.com/openshift/art-docs/blob/master/4.y.z-stream.md#release-job-failures)

--- a/pyartcd/config.example.toml
+++ b/pyartcd/config.example.toml
@@ -1,23 +1,23 @@
 [advisory]
-assigned_to="openshift-qe-errata@redhat.com"
-manager="vlaad@redhat.com"
-package_owner="lmeyer@redhat.com"
+assigned_to = "openshift-qe-errata@redhat.com"
+manager = "vlaad@redhat.com"
+package_owner = "lmeyer@redhat.com"
 
 [build_config]
 ocp_build_data_url = "https://github.com/openshift/ocp-build-data.git"
-ocp_build_data_repo_push_url="git@github.com:openshift/ocp-build-data.git"
+ocp_build_data_repo_push_url = "git@github.com:openshift/ocp-build-data.git"
 
 [email]
-smtp_server="smtp.corp.redhat.com"
-from="aos-art-automation@redhat.com"
-reply_to="aos-team-art@redhat.com"
-cc=["aos-team-art@redhat.com"]
+smtp_server = "smtp.corp.redhat.com"
+from = "aos-art-automation@redhat.com"
+reply_to = "aos-team-art@redhat.com"
+cc = ["aos-team-art@redhat.com"]
 prepare_release_notification_recipients_ocp4=["multi-arch-zstream-testing@redhat.com", "aos-qe@redhat.com"]
-prepare_release_notification_recipients_ocp3=["aos-qe@redhat.com"]
+prepare_release_notification_recipients_ocp3=["wzheng@redhat.com", "gpei@redhat.com", "aos-qe@redhat.com", "mp-entitlement-qe@redhat.com", "openshift-lp-test@redhat.com", "pprakash@redhat.com"]
+promote_image_list_recipients = ["openshift-ccs@redhat.com"]
 
 [jira]
-url="https://issues.redhat.com"
-
+url = "https://issues.redhat.com"
 [jira.templates]
-ocp4="OCPPLAN-4756"
-ocp3="OCPPLAN-1373"
+ocp4 = "OCPPLAN-4756"
+ocp3 = "OCPPLAN-1373"

--- a/pyartcd/pyartcd/__main__.py
+++ b/pyartcd/pyartcd/__main__.py
@@ -1,7 +1,8 @@
 from typing import Optional, Sequence
 
 from pyartcd.cli import cli
-from pyartcd.pipelines import prepare_release, rebuild, tarball_sources
+from pyartcd.pipelines import (prepare_release, promote, rebuild,
+                               tarball_sources)
 
 
 def main(args: Optional[Sequence[str]] = None):

--- a/pyartcd/pyartcd/constants.py
+++ b/pyartcd/pyartcd/constants.py
@@ -4,3 +4,5 @@ PLASHET_REMOTE_BASE_DIR = "/mnt/rcm-guest/puddles/RHAOS/plashets"
 
 TARBALL_SOURCES_REMOTE_HOST = "ocp-build@rcm-guest.app.eng.bos.redhat.com"
 TARBALL_SOURCES_REMOTE_BASE_DIR = "/mnt/rcm-guest/ocp-client-handoff"
+
+RELEASE_IMAGE_REPO = "quay.io/openshift-release-dev/ocp-release"

--- a/pyartcd/pyartcd/exceptions.py
+++ b/pyartcd/pyartcd/exceptions.py
@@ -1,0 +1,2 @@
+class VerificationError(ValueError):
+    pass

--- a/pyartcd/pyartcd/exectools.py
+++ b/pyartcd/pyartcd/exectools.py
@@ -68,7 +68,7 @@ async def cmd_gather_async(cmd: Union[List[str], str], check: bool = True, **kwa
     stdout = stdout.decode() if stdout else ""
     stderr = stderr.decode() if stderr else ""
     if proc.returncode != 0:
-        msg = f"Process {cmd_list!r} exited with {proc.returncode}\nstdout>>{stdout}<<\nstderr>>{stderr}<<\n"
+        msg = f"Process {cmd_list!r} exited with code {proc.returncode}.\nstdout>>{stdout}<<\nstderr>>{stderr}<<\n"
         if check:
             raise ChildProcessError(msg)
         else:
@@ -91,7 +91,7 @@ async def cmd_assert_async(cmd: Union[List[str], str], check: bool = True, **kwa
     proc = await asyncio.subprocess.create_subprocess_exec(cmd_list[0], *cmd_list[1:], **kwargs)
     returncode = await proc.wait()
     if returncode != 0:
-        msg = f"Process {cmd_list!r} exited with {returncode}"
+        msg = f"Process {cmd_list!r} exited with code {returncode}."
         if check:
             raise ChildProcessError(msg)
         else:

--- a/pyartcd/pyartcd/mail.py
+++ b/pyartcd/pyartcd/mail.py
@@ -71,5 +71,5 @@ class MailService:
             _LOGGER.info("Sent email to %s: %s - %s",
                          msg["To"], subject, content)
         else:
-            _LOGGER.warn("Would have sent email: %s", msg)
+            _LOGGER.warn("[DRY RUN] Would have sent email: %s", msg)
         return msg

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -1,0 +1,628 @@
+import asyncio
+import functools
+import json
+import logging
+import os
+import re
+import sys
+import traceback
+from collections import OrderedDict
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+from urllib.parse import quote
+
+import aiohttp
+import click
+import semver
+from doozerlib import assembly
+from doozerlib.util import brew_arch_for_go_arch, brew_suffix_for_arch
+from pyartcd import constants, exectools, util
+from pyartcd.cli import cli, click_coroutine, pass_runtime
+from pyartcd.exceptions import VerificationError
+from pyartcd.runtime import Runtime
+from semver import VersionInfo
+from tenacity import (RetryError, before_sleep_log, retry,
+                      retry_if_exception_type, retry_if_result,
+                      stop_after_attempt, wait_fixed)
+
+
+class PromotePipeline:
+    DEST_RELEASE_IMAGE_REPO = constants.RELEASE_IMAGE_REPO
+
+    def __init__(self, runtime: Runtime, group: str, assembly: str, release_offset: Optional[int],
+                 arches: Iterable[str], skip_blocker_bug_check: bool = False, skip_attached_bug_check: bool = False,
+                 skip_image_list: bool = False, permit_overwrite: bool = False) -> None:
+        self.runtime = runtime
+        self.group = group
+        self.assembly = assembly
+        self.release_offset = release_offset
+        self.arches = list(arches)
+        self.skip_blocker_bug_check = skip_blocker_bug_check
+        self.skip_attached_bug_check = skip_attached_bug_check
+        self.skip_image_list = skip_image_list
+        self.permit_overwrite = permit_overwrite
+
+        self._logger = self.runtime.logger
+        self._slack_client = self.runtime.new_slack_client()
+        self._mail = self.runtime.new_mail_client()
+
+        self._working_dir = self.runtime.working_dir
+        self._doozer_working_dir = self._working_dir / "doozer-working"
+        self._doozer_env_vars = os.environ.copy()
+        self._doozer_env_vars["DOOZER_WORKING_DIR"] = str(self._doozer_working_dir)
+        self._doozer_lock = asyncio.Lock()
+        self._elliott_working_dir = self._working_dir / "elliott-working"
+        self._elliott_env_vars = os.environ.copy()
+        self._elliott_env_vars["ELLIOTT_WORKING_DIR"] = str(self._elliott_working_dir)
+        self._elliott_lock = asyncio.Lock()
+        self._ocp_build_data_url = self.runtime.config.get("build_config", {}).get("ocp_build_data_url")
+        if self._ocp_build_data_url:
+            self._elliott_env_vars["ELLIOTT_DATA_PATH"] = self._ocp_build_data_url
+            self._doozer_env_vars["DOOZER_DATA_PATH"] = self._ocp_build_data_url
+
+    async def run(self):
+        logger = self.runtime.logger
+
+        # Load group config and releases.yml
+        logger.info("Loading build data...")
+        group_config = await util.load_group_config(self.group, self.assembly, env=self._doozer_env_vars)
+        releases_config = await util.load_releases_config(self._doozer_working_dir / "ocp-build-data")
+        release_config: Optional[Dict] = releases_config.get("releases", {}).get(self.assembly)
+        if release_config is None:
+            raise ValueError(f"To promote this release, assembly {self.assembly} must be explictly defined in releases.yml.")
+
+        release_issue_waivers = release_config.get("assembly", {}).get("waives", [])
+
+        # Get release name
+        assembly_type = util.get_assembly_type(self.assembly, releases_config)
+        release_name = util.get_release_name(assembly_type, self.group, self.assembly, self.release_offset)
+        # Ensure release name is valid
+        if not VersionInfo.isvalid(release_name):
+            raise ValueError(f"Release name `{release_name}` is not a valid semver.")
+        logger.info("Release name: %s", release_name)
+
+        self._slack_client.bind_channel(release_name)
+        slack_response = await self._slack_client.say(f"Promoting release `{release_name}`")
+        slack_thread = slack_response["message"]["ts"]
+
+        justifications = []
+        try:
+            # Get arches
+            arches = self.arches or group_config.get("arches", [])
+            arches = list(set(map(brew_arch_for_go_arch, arches)))
+            if not arches:
+                raise ValueError("No arches specified.")
+            # Get previous list
+            upgrades_str: Optional[str] = group_config.get("upgrades")
+            if upgrades_str is None and assembly_type != assembly.AssemblyTypes.CUSTOM:
+                raise ValueError(f"Group config for assembly {self.assembly} is missing the required `upgrades` field. If no upgrade edges are expected, please explicitly set the `upgrade` field to empty string.")
+            previous_list = list(map(lambda s: s.strip(), upgrades_str.split(","))) if upgrades_str else []
+            # Ensure all versions in previous list are valid semvers.
+            if any(map(lambda version: not VersionInfo.isvalid(version), previous_list)):
+                raise ValueError("Previous list (`upgrades` field in group config) has an invalid semver.")
+
+            # Check for blocker bugs
+            if self.skip_blocker_bug_check or assembly_type in [assembly.AssemblyTypes.CANDIDATE, assembly.AssemblyTypes.CUSTOM]:
+                logger.info("Blocker Bug check is skipped.")
+            else:
+                logger.info("Checking for blocker bugs...")
+                # TODO: Needs an option in releases.yml to skip this check
+                try:
+                    await self.check_blocker_bugs()
+                except VerificationError as err:
+                    logger.warn("Blocker bugs found for release; do not proceed without resolving; see https://github.com/openshift-eng/art-docs/blob/master/release/4.y.z-stream.md#handling-blocker-bugs: %s", err)
+                    justification = self._reraise_if_not_waived(err, "BLOCKER_BUGS", release_issue_waivers)
+                    justifications.append(justification)
+                logger.info("No blocker bugs found.")
+
+            # If there are CVEs, convert RHBAs to RHSAs and attach CVE flaw bugs
+            impetus_advisories = group_config.get("advisories", {})
+            futures = []
+            for impetus, advisory in impetus_advisories.items():
+                if not advisory:
+                    continue
+                if advisory < 0:  # placeholder advisory id is still in group config?
+                    raise ValueError("Found invalid %s advisory %s", impetus, advisory)
+                logger.info("Attaching CVE flaws for %s advisory %s...", impetus, advisory)
+                futures.append(self.attach_cve_flaws(advisory))
+            try:
+                await asyncio.gather(*futures)
+            except ChildProcessError as err:
+                logger.warn("Error attaching CVE flaw bugs: %s", err)
+                justification = self._reraise_if_not_waived(err, "CVE_FLAWS", release_issue_waivers)
+                justifications.append(justification)
+
+            # Ensure the image advisory is in QE (or later) state.
+            # TODO: We may need an option to permit all advisories states
+            image_advisory = impetus_advisories.get("image", 0)
+            errata_url = ""
+
+            if assembly_type == assembly.AssemblyTypes.STANDARD:
+                if image_advisory <= 0:
+                    err = VerificationError(f"No associated image advisory for {self.assembly} is defined.")
+                    self._raise_if_not_waived(err, "NO_ERRATA", release_issue_waivers)
+                    logger.warning("%s", err)
+                else:
+                    logger.info("Verifying associated image advisory %s...", image_advisory)
+                    image_advisory_info = await self.get_advisory_info(image_advisory)
+                    try:
+                        self.verify_image_advisory(image_advisory_info)
+                        live_id = self.get_live_id(image_advisory_info)
+                        assert live_id
+                        errata_url = f"https://access.redhat.com/errata/{live_id}"  # don't quote
+                    except VerificationError as err:
+                        logger.warning("%s", err)
+                        justification = self._raise_if_not_waived(err, "INVALID_ERRATA_STATUS", release_issue_waivers)
+                        justifications.append(justification)
+
+            # Verify attached bugs
+            advisories = list(filter(lambda ad: ad > 0, impetus_advisories.values()))
+            if advisories:
+                if self.skip_attached_bug_check:
+                    logger.info("Skip checking attached bugs.")
+                else:
+                    logger.info("Verifying attached bugs...")
+                    try:
+                        await self.verify_attached_bugs(advisories)
+                    except ChildProcessError as err:
+                        logger.warn("Error verifying attached bugs: %s", err)
+                        justification = self._reraise_if_not_waived(err, "ATTACHED_BUGS", release_issue_waivers)
+                        justifications.append(justification)
+
+            # Promote release images
+            futures = []
+            metadata = {}
+            description = group_config.get("description")
+            if description:
+                logger.warning("The following description message will be included in the metadata of release image: %s", description)
+                metadata["description"] = str(description)
+            if errata_url:
+                metadata["url"] = errata_url
+            reference_releases = release_config.get("assembly", {}).get("basis", {}).get("reference_releases", {})
+            tag_stable = assembly_type in [assembly.AssemblyTypes.STANDARD, assembly.AssemblyTypes.CANDIDATE]
+            release_infos = await self.promote_all_arches(release_name, arches, previous_list, metadata, reference_releases, tag_stable)
+            self._logger.info("All release images for %s have been promoted.", release_name)
+
+            # Wait for release controllers
+            pullspecs = list(map(lambda r: r["image"], release_infos))
+            if not tag_stable:
+                self._logger.warning("This release will not appear on release controllers. Pullspecs: %s", release_name, ", ".join(pullspecs))
+                await self._slack_client.say(f"Hi @release-artists. Release {release_name} is ready. It will not appear on the release controllers. Please tell the user to manually pull the release images: {', '.join(pullspecs)}", slack_thread)
+            else:  # Wait for release images to be accepted by the release controllers
+                self._logger.info("All release images for %s have been successfully promoted. Pullspecs: %s", release_name, ", ".join(pullspecs))
+
+                self._logger.info("Determining upgrade tests...")
+                test_commands = self._get_upgrade_tests_commands(release_name, previous_list)
+                message = f"""Hi @release-artists . A new release `{release_name}` is ready and needs some upgrade tests to be triggered.
+Please open a chat with @cluster-bot and issue each of these lines individually:
+{os.linesep.join(test_commands)}
+"""
+                await self._slack_client.say(message, slack_thread)
+
+                self._logger.info("Waiting for release images for %s to be accepted by the release controller...", release_name)
+                futures = []
+                for arch in arches:
+                    go_arch_suffix = util.go_suffix_for_arch(arch)
+                    release_stream = f"4-stable{go_arch_suffix}"
+                    futures.append(self.wait_for_stable(release_name, arch, release_stream))
+                try:
+                    await asyncio.gather(*futures)
+                except RetryError as err:
+                    message = f"Timeout waiting for release to be accepted by the release controllers: {err}"
+                    self._logger.error(message)
+                    self._logger.exception(err)
+                    raise TimeoutError(message)
+
+                self._logger.info("All release images for %s have been accepted by the release controllers.", release_name)
+
+                message = f"Hi @release-artists . Release `{release_name}` has been accepted by the release controllers."
+                await self._slack_client.say(message, slack_thread)
+
+                # Send image list
+                if not image_advisory:
+                    self._logger.warning("No need to send an advisory image list because this release doesn't have an image advisory.")
+                elif assembly_type == assembly.AssemblyTypes.CANDIDATE:
+                    self._logger.warning("No need to send an advisory image list for a candidate release.")
+                elif self.skip_image_list:
+                    self._logger.warning("Skip sending advisory image list")
+                else:
+                    self._logger.info("Gathering and sending advisory image list...")
+                    mail_dir = self._working_dir / "email"
+                    await self.send_image_list_email(release_name, image_advisory, mail_dir)
+                    self._logger.info("Advisory image list sent.")
+
+        except Exception as err:
+            self._logger.exception(err)
+            error_message = f"Error promoting release {release_name}: {err}\n {traceback.format_exc()}"
+            message = f"Hi @release-artists . Promoting release {release_name} failed with: {error_message}"
+            await self._slack_client.say(message, slack_thread)
+            raise
+
+        # Print release infos to console
+        data = {
+            "group": self.group,
+            "assembly": self.assembly,
+            "type": assembly_type.value,
+            "name": release_name,
+            "content": {},
+            "justifications": justifications,
+        }
+        if errata_url:
+            data["advisory"] = image_advisory
+            data["live_url"] = errata_url
+        for arch, release_info in zip(arches, release_infos):
+            data["content"][arch] = {
+                "pullspec": release_info["image"],
+                "digest": release_info["digest"],
+            }
+            from_release = release_info.get("references", {}).get("metadata", {}).get("annotations", {}).get("release.openshift.io/from-release")
+            if from_release:
+                data["content"][arch]["from_release"] = from_release
+            rhcos = next((t for t in release_info.get("references", {}).get("spec", {}).get("tags", []) if t["name"] == "machine-os-content"), None)
+            if rhcos:
+                rhcos_version = rhcos["annotations"]["io.openshift.build.versions"].split("=")[1]  # machine-os=48.84.202112162302-0 => 48.84.202112162302-0
+                data["content"][arch]["rhcos_version"] = rhcos_version
+
+        json.dump(data, sys.stdout)
+
+    def _reraise_if_not_waived(self, err: VerificationError, code: str, waivers: Iterable[Dict]):
+        waiver = next(filter(lambda waiver: waiver["code"] == code, waivers), None)
+        if not waiver:
+            raise err
+        justification: Optional[str] = waiver.get("why")
+        if not justification:
+            raise ValueError("A justification is required to waive issue %s.", code)
+        self.logger.warn("Issue %s is waived with justification: %s", err, justification)
+        return justification
+
+    async def check_blocker_bugs(self):
+        # Note: --assembly option should always be "stream". We are checking blocker bugs for this release branch regardless of the sweep cutoff timestamp.
+        cmd = [
+            "elliott",
+            f"--group={self.group}",
+            "--assembly=stream",
+            "find-bugs",
+            "--mode=blocker",
+            "--report"
+        ]
+        async with self._elliott_lock:
+            _, stdout, _ = await exectools.cmd_gather_async(cmd, env=self._elliott_env_vars, stderr=None)
+        match = re.search(r"Found ([0-9]+) bugs", stdout)
+        if not match:
+            raise IOError(f"Could determine whether this release has blocker bugs. Elliott printed unexpected message: {stdout}")
+        if int(match[1]) != 0:
+            raise VerificationError(f"{int(match[1])} blocker Bug(s) found for release; do not proceed without resolving. See https://github.com/openshift-eng/art-docs/blob/master/release/4.y.z-stream.md#handling-blocker-bugs")
+
+    async def attach_cve_flaws(self, advisory: int):
+        # raise ChildProcessError("test")
+        cmd = [
+            "elliott",
+            f"--group={self.group}",
+            "attach-cve-flaws",
+            f"--advisory={advisory}",
+        ]
+        if self.runtime.dry_run:
+            cmd.append("--dry-run")
+        async with self._elliott_lock:
+            await exectools.cmd_assert_async(cmd, env=self._elliott_env_vars, stdout=sys.stderr)
+
+    async def get_advisory_info(self, advisory: int) -> Dict:
+        cmd = [
+            "elliott",
+            f"--group={self.group}",
+            "get",
+            "--json", "-",
+            "--", f"{advisory}"
+        ]
+        async with self._elliott_lock:
+            _, stdout, _ = await exectools.cmd_gather_async(cmd, env=self._elliott_env_vars, stderr=None)
+        advisory_info = json.loads(stdout)
+        if not isinstance(advisory_info, dict):
+            raise ValueError(f"Got invalid advisory info for advisory {advisory}: {advisory_info}.")
+        return advisory_info
+
+    @staticmethod
+    def get_live_id(advisory_info: Dict):
+        # Extract live ID from advisory info
+        # Examples:
+        # - advisory with a live ID
+        #     "errata_id": 2681,
+        #     "fulladvisory": "RHBA-2019:2681-02",
+        #     "id": 46049,
+        #     "old_advisory": "RHBA-2019:46049-02",
+        # - advisory without a live ID
+        #     "errata_id": 46143,
+        #     "fulladvisory": "RHBA-2019:46143-01",
+        #     "id": 46143,
+        #     "old_advisory": null,
+        if advisory_info["errata_id"] == advisory_info["id"]:
+            # advisory doesn't have a live ID
+            return None
+        live_id = advisory_info["fulladvisory"].rsplit("-", 1)[0]  # RHBA-2019:2681-02 => RHBA-2019:2681
+        return live_id
+
+    def verify_image_advisory(self, advisory_info: Dict):
+        issues = []
+        live_id = self.get_live_id(advisory_info)
+        if not live_id:
+            issues.append(f"Advisory {advisory_info['id']} doesn't have a live ID.")
+        if advisory_info["status"] not in {"QE", "REL_PREP", "PUSH_READY", "IN_PUSH", "SHIPPED_LIVE"}:
+            issues.append(f"Advisory {advisory_info['id']} cannot be in {advisory_info['status']} state.")
+        if issues:
+            raise VerificationError(f"Advisory {advisory_info['id']} has the following issues:\n" + '\n'.join(issues))
+
+    async def verify_attached_bugs(self, advisories: Iterable[int]):
+        advisories = list(advisories)
+        if not advisories:
+            self._logger.warning("No advisories to verify.")
+            return
+        cmd = [
+            "elliott",
+            f"--group={self.group}",
+            "verify-attached-bugs",
+            "--"
+        ]
+        for advisory in advisories:
+            cmd.append(f"{advisory}")
+        async with self._elliott_lock:
+            await exectools.cmd_assert_async(cmd, env=self._elliott_env_vars, stdout=sys.stderr)
+
+    async def promote_all_arches(self, release_name: str, arches: List[str], previous_list: List[str], metadata: Optional[Dict], reference_releases: Dict[str, str], tag_stable: bool):
+        futures = []
+        for arch in arches:
+            futures.append(self.promote_arch(release_name, arch, previous_list, metadata, reference_releases.get(arch), tag_stable))
+        try:
+            release_infos = await asyncio.gather(*futures)
+        except ChildProcessError as err:
+            self._logger.error("Error promoting release images: %s\n%s", str(err), traceback.format_exc())
+            raise
+        return release_infos
+
+    async def promote_arch(self, release_name: str, arch: str, previous_list: List[str], metadata: Optional[Dict], reference_release: Optional[str], tag_stable: bool):
+        brew_arch = util.brew_arch_for_go_arch(arch)  # ensure we are using Brew arches (e.g. aarch64) instead of golang arches (e.g. arm64).
+        dest_image_tag = f"{release_name}-{brew_arch}"
+        dest_image_pullspec = f"{self.DEST_RELEASE_IMAGE_REPO}:{dest_image_tag}"
+        self._logger.info("Checking if release image %s for %s (%s) already exists...", release_name, arch, dest_image_pullspec)
+        dest_image_info = await self.get_release_image_info(dest_image_pullspec)
+        if dest_image_info:  # this arch-specific release image is already promoted
+            self._logger.warning("Release image %s for %s (%s) already exists", release_name, arch, dest_image_info["image"])
+            # TODO: Check if the existing release image matches the assembly definition.
+
+        if not dest_image_info or self.permit_overwrite:
+            if dest_image_info:
+                self._logger.warning("The existing release image %s will be overwritten!", dest_image_pullspec)
+            self._logger.info("Building arch-specific release image %s for %s (%s)...", release_name, arch, dest_image_pullspec)
+            await self.build_release_image(release_name, brew_arch, previous_list, metadata, dest_image_pullspec, reference_release)
+            self._logger.info("Release image for %s %s has been built and pushed to %s", release_name, arch, dest_image_pullspec)
+            self._logger.info("Getting release image information for %s...", dest_image_pullspec)
+            if not self.runtime.dry_run:
+                dest_image_info = await self.get_release_image_info(dest_image_pullspec, raise_if_not_found=True)
+            else:
+                # populate fake data for dry run
+                dest_image_info = {
+                    "image": f"example.com/fake-release:{release_name}{brew_suffix_for_arch(arch)}",
+                    "digest": f"fake:deadbeef{brew_suffix_for_arch(arch)}",
+                    "references": {
+                        "spec": {
+                            "tags": [
+                                {
+                                    "name": "machine-os-content",
+                                    "annotations": {"io.openshift.build.versions": "machine-os=00.00.212301010000-0"}
+                                }
+                            ]
+                        }
+                    }
+                }
+                if reference_release:
+                    dest_image_info["references"]["metadata"] = {"annotations": {"release.openshift.io/from-release": reference_release}}
+                else:
+                    major, minor = util.isolate_major_minor_in_group(self.group)
+                    go_arch_suffix = util.go_suffix_for_arch(arch, is_private=False)
+                    dest_image_info["references"]["metadata"] = {"annotations": {"release.openshift.io/from-image-stream": f"fake{go_arch_suffix}/{major}.{minor}-art-assembly-{self.assembly}{go_arch_suffix}"}}
+
+        if not tag_stable:
+            self._logger.info("Release image %s will not appear on the release controller.", dest_image_pullspec)
+            return dest_image_info
+
+        go_arch_suffix = util.go_suffix_for_arch(arch)
+        namespace = f"ocp{go_arch_suffix}"
+        image_stream_tag = f"release{go_arch_suffix}:{release_name}"
+        namespace_image_stream_tag = f"{namespace}/{image_stream_tag}"
+        self._logger.info("Checking if ImageStreamTag %s exists...", namespace_image_stream_tag)
+        ist = await self.get_image_stream_tag(namespace, image_stream_tag)
+        if ist:
+            ist_digest = ist["image"]["dockerImageReference"].split("@")[-1]
+            if ist_digest == dest_image_info["digest"]:
+                self._logger.info("ImageStreamTag %s already exists with digest %s matching release image %s.", namespace_image_stream_tag, ist_digest, dest_image_pullspec)
+                return dest_image_info
+            message = f"ImageStreamTag {namespace_image_stream_tag} already exists, but it has a different digest ({ist_digest}) from the expected release image {dest_image_pullspec} ({dest_image_info['digest']})."
+            if not self.permit_overwrite:
+                raise ValueError(message)
+            self._logger.warning(message)
+        else:
+            self._logger.info("ImageStreamTag %s doesn't exist.", namespace_image_stream_tag)
+
+        self._logger.info("Tagging release image %s into %s...", dest_image_pullspec, namespace_image_stream_tag)
+        await self.tag_release(dest_image_pullspec, namespace_image_stream_tag)
+        self._logger.info("Release image %s has been tagged into %s.", dest_image_pullspec, namespace_image_stream_tag)
+        return dest_image_info
+
+    @staticmethod
+    async def get_release_image_info(pullspec: str, raise_if_not_found: bool = False):
+        cmd = ["oc", "adm", "release", "info", "-o", "json", "--", pullspec]
+        env = os.environ.copy()
+        env["GOTRACEBACK"] = "all"
+        rc, stdout, stderr = await exectools.cmd_gather_async(cmd, check=False, env=env)
+        if rc != 0:
+            if "not found: manifest unknown" in stderr:
+                # release image doesn't exist
+                if raise_if_not_found:
+                    raise IOError(f"Image {pullspec} is not found.")
+                return None
+            raise ChildProcessError(f"Error running {cmd}: exit_code={rc}, stdout={stdout}, stderr={stderr}")
+        info = json.loads(stdout)
+        if not isinstance(info, dict):
+            raise ValueError(f"Invalid release info: {info}")
+        return info
+
+    @staticmethod
+    def _get_upgrade_tests_commands(release_name: str, previous_list: List[str]):
+        previous_list = sorted(previous_list, key=functools.cmp_to_key(semver.compare), reverse=True)
+        versions_by_minor: OrderedDict = OrderedDict()
+        for version_str in previous_list:
+            version = VersionInfo.parse(version_str)
+            minor_version = f"{version.major}.{version.minor}"
+            versions_by_minor.setdefault(minor_version, []).append(str(version))
+
+        test_edges = []
+        for _, versions in versions_by_minor.items():
+            if len(versions) <= 15:
+                test_edges.extend(versions)
+                continue
+            test_edges.extend(versions[:5])  # add first 5
+            # 5 equally distributed between versions[5:-5]
+            step = (len(versions) - 10) // 5
+            test_edges.extend(versions[5:-5][step::step])
+            test_edges.extend(versions[-5:])  # add last 5
+
+        test_commands = []
+        platforms = ['aws', 'gcp', 'azure']
+        for edge in test_edges:
+            platform = platforms[len(test_commands) % len(platforms)]
+            test_commands.append(f"test upgrade {edge} {release_name} {platform}")
+        return test_commands
+
+    async def build_release_image(self, release_name: str, arch: str, previous_list: List[str], metadata: Optional[Dict], dest_image_pullspec: str, src_image_pullspec: Optional[str]):
+        go_arch_suffix = util.go_suffix_for_arch(arch, is_private=False)
+        cmd = [
+            "oc",
+            "adm",
+            "release",
+            "new",
+            "-n",
+            f"ocp{go_arch_suffix}",
+            f"--name={release_name}",
+            f"--to-image={dest_image_pullspec}",
+        ]
+        if self.runtime.dry_run:
+            cmd.append("--dry-run")
+        if src_image_pullspec:
+            cmd.append(f"--from-release=registry.ci.openshift.org/ocp{go_arch_suffix}/release{go_arch_suffix}:{src_image_pullspec}")
+        else:
+            major, minor = util.isolate_major_minor_in_group(self.group)
+            src_image_stream = f"{major}.{minor}-art-assembly-{self.assembly}{go_arch_suffix}"
+            cmd.extend(["--reference-mode=source", f"--from-image-stream={src_image_stream}"])
+
+        if previous_list:
+            cmd.append(f"--previous={','.join(previous_list)}")
+        if metadata:
+            cmd.append("--metadata")
+            cmd.append(json.dumps(metadata))
+        env = os.environ.copy()
+        env["GOTRACEBACK"] = "all"
+        await exectools.cmd_assert_async(cmd, env=env, stdout=sys.stderr)
+
+    async def get_image_stream_tag(self, namespace: str, image_stream_tag: str):
+        cmd = [
+            "oc",
+            "-n",
+            namespace,
+            "get",
+            "imagestreamtag",
+            "-o",
+            "json",
+            "--ignore-not-found",
+            "--",
+            image_stream_tag,
+        ]
+        env = os.environ.copy()
+        env["GOTRACEBACK"] = "all"
+        _, stdout, _ = await exectools.cmd_gather_async(cmd, env=env, stderr=None)
+        stdout = stdout.strip()
+        if not stdout:  # Not found
+            return None
+        return json.loads(stdout)
+
+    async def tag_release(self, image_pullspec: str, image_stream_tag: str):
+        cmd = [
+            "oc",
+            "tag",
+            "--",
+            image_pullspec,
+            image_stream_tag,
+        ]
+        if self.runtime.dry_run:
+            self._logger.warning("[DRY RUN] Would have run %s", cmd)
+            return
+        env = os.environ.copy()
+        env["GOTRACEBACK"] = "all"
+        await exectools.cmd_assert_async(cmd, env=env, stdout=sys.stderr)
+
+    async def wait_for_stable(self, release_name: str, arch: str, release_stream: str):
+        go_arch = util.go_arch_for_brew_arch(arch)
+        release_controller_url = f"https://{go_arch}.ocp.releases.ci.openshift.org"
+        if self.runtime.dry_run:
+            actual_phase = await self.get_release_phase(release_controller_url, release_stream, release_name)
+            self._logger.warning("[DRY RUN] Release %s for %s has phase %s. Assume accepted.", release_name, arch, actual_phase)
+            return
+        return await retry(
+            stop=(stop_after_attempt(36)),  # wait for 5m * 36 = 180m = 3 hours
+            wait=wait_fixed(300),  # wait for 5 minutes between retries
+            retry=(retry_if_result(lambda phase: phase != "Accepted") | retry_if_exception_type()),
+            before_sleep=before_sleep_log(self._logger, logging.WARNING),
+        )(self.get_release_phase)(release_controller_url, release_stream, release_name)
+
+    @staticmethod
+    async def get_release_phase(release_controller_url: str, release_stream: str, release_name: str):
+        api_path = f"/api/v1/releasestream/{quote(release_stream)}/release/{quote(release_name)}"
+        full_url = f"{release_controller_url}{api_path}"
+        async with aiohttp.ClientSession() as session:
+            async with session.get(full_url) as response:
+                if response.status == 404:
+                    return None
+                response.raise_for_status()
+                release_info = await response.json()
+                return release_info.get("phase")
+
+    async def get_advisory_image_list(self, image_advisory: int):
+        cmd = [
+            "elliott",
+            "advisory-images",
+            "-a",
+            f"{image_advisory}",
+        ]
+        async with self._elliott_lock:
+            _, stdout, _ = await exectools.cmd_gather_async(cmd, env=self._elliott_env_vars, stderr=None)
+        return stdout
+
+    async def send_image_list_email(self, release_name: str, advisory: int, archive_dir: Path):
+        content = await self.get_advisory_image_list(advisory)
+        subject = f"OCP {release_name} Image List"
+        return await exectools.to_thread(self._mail.send_mail, self.runtime.config["email"][f"promote_image_list_recipients"], subject, content, archive_dir=archive_dir, dry_run=self.runtime.dry_run)
+
+
+@cli.command("promote")
+@click.option("-g", "--group", metavar='NAME', required=True,
+              help="The group of components on which to operate. e.g. openshift-4.9")
+@click.option("--assembly", metavar="ASSEMBLY_NAME", required=True,
+              help="The name of an assembly. e.g. 4.9.1")
+@click.option("--release-offset", "-r", metavar="OFFSET", type=int,
+              help="Use this option if assembly type is custom. If offset is X for 4.9, release name will become 4.9.X-assembly.ASSEMBLY_NAME.")
+@click.option("--arch", "arches", metavar="ARCH", multiple=True,
+              help="[Multiple] Only promote given arch-specific release image. If not specified, this job will promote all architectures defined in group config.")
+@click.option("--skip-blocker-bug-check", is_flag=True,
+              help="Skip blocker bug check. Note block bugs are never checked for CUSTOM and CANDIDATE releases.")
+@click.option("--skip-attached-bug-check", is_flag=True,
+              help="Skip attached bug check. Note attached bugs are never checked for CUSTOM and CANDIDATE releases.")
+@click.option("--skip-image-list", is_flag=True,
+              help="Do not gather an advisory image list for docs.")
+@click.option("--permit-overwrite", is_flag=True,
+              help="DANGER! Allows the pipeline to overwrite an existing payload.")
+@pass_runtime
+@click_coroutine
+async def promote(runtime: Runtime, group: str, assembly: str, release_offset: Optional[int],
+                  arches: Tuple[str, ...], skip_blocker_bug_check: bool, skip_attached_bug_check: bool, skip_image_list: bool, permit_overwrite: bool):
+    pipeline = PromotePipeline(runtime, group, assembly, release_offset, arches,
+                               skip_blocker_bug_check, skip_attached_bug_check, skip_image_list,
+                               permit_overwrite)
+    await pipeline.run()

--- a/pyartcd/pyartcd/runtime.py
+++ b/pyartcd/pyartcd/runtime.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, Optional
 import toml
 
 from pyartcd.jira import JIRAClient
+from pyartcd.mail import MailService
+from pyartcd.slack import SlackClient
 
 
 class Runtime:
@@ -13,11 +15,11 @@ class Runtime:
         self.config = config
         self.working_dir = working_dir
         self.dry_run = dry_run
-        self.logger = logging.getLogger()
+        self.logger = logging.getLogger("pyartcd")
 
-        # ensures working_dir
+        # checks working_dir
         if not self.working_dir.is_dir():
-            raise IOError(f"Working directory {self.working_dir} doesn't exist.")
+            raise IOError(f"Working directory {self.working_dir.absolute()} doesn't exist.")
 
     @classmethod
     def from_config_file(cls, config_filename: Path, working_dir: Path, dry_run: bool):
@@ -31,3 +33,28 @@ class Runtime:
             if not jira_token:
                 raise ValueError("JIRA_TOKEN environment variable is not set")
         return JIRAClient.from_url(self.config["jira"]["url"], token_auth=jira_token)
+
+    def new_slack_client(self, token: Optional[str] = None):
+        if not token:
+            token = os.environ.get("SLACK_BOT_TOKEN")
+            if not token:
+                raise ValueError("SLACK_BOT_TOKEN environment variable is not set")
+        return SlackClient(token, dry_run=self.dry_run,
+                           job_name=self.get_job_name(),
+                           job_run_url=self.get_job_run_url(),
+                           job_run_name=self.get_job_run_name())
+
+    def new_mail_client(self):
+        return MailService.from_config(self.config)
+
+    def get_job_name(self):
+        return os.environ.get("JOB_NAME")
+
+    def get_job_run_name(self):
+        return os.environ.get("BUILD_ID")
+
+    def get_job_run_url(self):
+        url = os.environ.get("BUILD_URL")
+        if not url:
+            return None
+        return f"{url}console"

--- a/pyartcd/pyartcd/slack.py
+++ b/pyartcd/pyartcd/slack.py
@@ -1,0 +1,55 @@
+import logging
+import re
+from typing import Optional
+
+from slack_sdk.web.async_client import AsyncWebClient
+
+_LOGGER = logging.getLogger(__name__)
+
+class SlackClient:
+    """ A SlackClient allows pipelines to send Slack messages.
+    """
+    DEFAULT_CHANNEL = "#art-release"
+    def __init__(self, token: str, job_name: Optional[str], job_run_name: Optional[str], job_run_url: Optional[str], dry_run: bool = False) -> None:
+        self.token = token
+        self.channel = self.DEFAULT_CHANNEL
+        self.job_name = job_name
+        self.job_run_name = job_run_name
+        self.job_run_url = job_run_url
+        self.dry_run = dry_run
+        self.as_user = "art-release-bot"
+        self.icon_emoji = ":robot_face:"
+        self._client = AsyncWebClient(token=token)
+
+    def bind_channel(self, channel_or_release: Optional[str]):
+        """ Bind this SlackClient to a specified Slack channel. Future messages will be sent to that channel.
+        :param channel_or_release: An explicit channel name ('#art-team') or a string that contains a prefix of the
+        release the jobs is associated with (e.g. '4.5.2-something' => '4.5'). If a release is specified, the
+        slack channel will be #art-release-MAJOR-MINOR. If None or empty string is specified, the slack channel will be the default channel.
+        """
+        if not channel_or_release:
+            self.channel = self.DEFAULT_CHANNEL
+            return
+        if channel_or_release.startswith("#"):
+            self.channel = channel_or_release
+            return
+        match = re.compile(r"(\d+)\.(\d+)").match(channel_or_release)
+        if match:
+            self.channel = f"#art-release-{match[1]}-{match[2]}"
+        else:
+            raise ValueError(f"Invalid channel_or_release value: {channel_or_release}")
+
+    async def say(self, message: str, thread_ts: Optional[str] = None):
+        attachments = []
+        if self.job_run_url:
+            attachments.append({
+                "title": f"Job: {self.job_name} <{self.job_run_url}|{self.job_run_name}>",
+                "color": "#439FE0",
+            })
+        if self.dry_run:
+            _LOGGER.warning("[DRY RUN] Would have sent slack message to %s: %s %s", self.channel, message, attachments)
+            return {"message": {"ts": "fake"}}
+        response = await self._client.chat_postMessage(channel=self.channel, text=message, thread_ts=thread_ts,
+                                                       username=self.as_user, link_names=True, attachments=attachments,
+                                                       icon_emoji=self.icon_emoji, reply_broadcast=False)
+        return response.data

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -1,8 +1,12 @@
-import re
-from typing import Optional, Tuple
-
-import yaml
 import os
+import re
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+import aiofiles
+import yaml
+from doozerlib import assembly, model
+from doozerlib.util import brew_arch_for_go_arch, brew_suffix_for_arch, go_arch_for_brew_arch, go_suffix_for_arch
 
 from pyartcd import exectools
 
@@ -39,13 +43,13 @@ def isolate_major_minor_in_group(group_name: str) -> Tuple[int, int]:
     a OCP major.minor version. If it does, it returns the version value as (int, int).
     If it is not found, (None, None) is returned.
     """
-    match = re.fullmatch(r"openshift-(\d+).(\d)", group_name)
+    match = re.fullmatch(r"openshift-(\d+).(\d+)", group_name)
     if not match:
         return None, None
     return int(match[1]), int(match[2])
 
 
-async def load_group_config(group: str, assembly: str, env=None):
+async def load_group_config(group: str, assembly: str, env=None) -> Dict:
     cmd = [
         "doozer",
         "--group", group,
@@ -57,4 +61,37 @@ async def load_group_config(group: str, assembly: str, env=None):
         env = os.environ.copy()
     _, stdout, _ = await exectools.cmd_gather_async(cmd, stderr=None, env=env)
     group_config = yaml.safe_load(stdout)
+    if not isinstance(group_config, dict):
+        raise ValueError("ocp-build-data contains invalid group config.")
     return group_config
+
+
+async def load_releases_config(build_data_path: os.PathLike) -> Dict:
+    async with aiofiles.open(Path(build_data_path) / "releases.yml", "r") as f:
+        content = await f.read()
+    return yaml.safe_load(content)
+
+
+def get_assembly_type(assembly_name: str, releases_config: Dict):
+    return assembly.assembly_type(model.Model(releases_config), assembly_name)
+
+
+def get_release_name(assembly_type: str, group_name: str, assembly_name: str, release_offset: Optional[int]):
+    major, minor = isolate_major_minor_in_group(group_name)
+    if major is None or minor is None:
+        raise ValueError(f"Invalid group name: {group_name}")
+    if assembly_type == assembly.AssemblyTypes.CUSTOM:
+        if release_offset is None:
+            raise ValueError("release_offset is required for a CUSTOM release.")
+        release_name = f"{major}.{minor}.{release_offset}-assembly.{assembly_name}"
+    elif assembly_type == assembly.AssemblyTypes.CANDIDATE:
+        if release_offset is not None:
+            raise ValueError("release_offset can't be set for a CANDIDATE release.")
+        release_name = f"{major}.{minor}.0-{assembly_name}"
+    elif assembly_type == assembly.AssemblyTypes.STANDARD:
+        if release_offset is not None:
+            raise ValueError("release_offset can't be set for a STANDARD release.")
+        release_name = f"{assembly_name}"
+    else:
+        raise ValueError(f"Assembly type {assembly_type} is not supported.")
+    return release_name

--- a/pyartcd/requirements.txt
+++ b/pyartcd/requirements.txt
@@ -1,3 +1,4 @@
+aiohttp[speedups] >= 3.6
 aiofiles
 click
 contextvars
@@ -5,5 +6,8 @@ Jinja2
 jira ~= 3.1.1
 toml
 rh-elliott
+rh-doozer
 ruamel.yaml
+semver ~= 2.13.0
+slack_sdk ~= 3.13.0
 tenacity

--- a/pyartcd/tests/pipelines/test_promote.py
+++ b/pyartcd/tests/pipelines/test_promote.py
@@ -1,0 +1,157 @@
+import asyncio
+from pathlib import Path
+from unittest import TestCase
+
+from mock import AsyncMock, MagicMock, patch
+from mock.mock import ANY
+from pyartcd.pipelines.promote import PromotePipeline
+
+
+class TestPromotePipeline(TestCase):
+    @patch("pyartcd.pipelines.promote.util.load_releases_config", return_value={})
+    @patch("pyartcd.pipelines.promote.util.load_group_config", return_value={})
+    def test_run_without_explicit_assembly_definition(self, load_group_config: AsyncMock, load_releases_config: AsyncMock):
+        runtime = MagicMock(config={"build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"}}, working_dir=Path("/path/to/working"), dry_run=False)
+        pipeline = PromotePipeline(runtime, "openshift-4.10", "4.10.99", None, ["x86_64", "s390x"], False, False)
+        with self.assertRaisesRegex(ValueError, "must be explictly defined"):
+            asyncio.get_event_loop().run_until_complete(pipeline.run())
+        load_group_config.assert_awaited_once_with("openshift-4.10", "4.10.99", env=ANY)
+        load_releases_config.assert_awaited_once_with(Path("/path/to/working/doozer-working/ocp-build-data"))
+
+    @patch("pyartcd.pipelines.promote.util.load_releases_config", return_value={
+        "releases": {"stream": {"assembly": {"type": "stream"}}}
+    })
+    @patch("pyartcd.pipelines.promote.util.load_group_config", return_value={})
+    def test_run_with_stream_assembly(self, load_group_config: AsyncMock, load_releases_config: AsyncMock):
+        runtime = MagicMock(config={"build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"}}, working_dir=Path("/path/to/working"), dry_run=False)
+        pipeline = PromotePipeline(runtime, "openshift-4.10", "stream", None, ["x86_64", "s390x"], False, False)
+        with self.assertRaisesRegex(ValueError, "not supported"):
+            asyncio.get_event_loop().run_until_complete(pipeline.run())
+        load_group_config.assert_awaited_once_with("openshift-4.10", "stream", env=ANY)
+        load_releases_config.assert_awaited_once_with(Path("/path/to/working/doozer-working/ocp-build-data"))
+
+    @patch("pyartcd.pipelines.promote.util.load_releases_config", return_value={
+        "releases": {"art0001": {"assembly": {"type": "custom"}}}
+    })
+    @patch("pyartcd.pipelines.promote.util.load_group_config", return_value={})
+    def test_run_with_custom_assembly_and_missing_release_offset(self, load_group_config: AsyncMock, load_releases_config: AsyncMock):
+        runtime = MagicMock(config={"build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"}}, working_dir=Path("/path/to/working"), dry_run=False)
+        pipeline = PromotePipeline(runtime, "openshift-4.10", "art0001", None, ["x86_64", "s390x"], False, False)
+        with self.assertRaisesRegex(ValueError, "release_offset is required"):
+            asyncio.get_event_loop().run_until_complete(pipeline.run())
+        load_group_config.assert_awaited_once_with("openshift-4.10", "art0001", env=ANY)
+        load_releases_config.assert_awaited_once_with(Path("/path/to/working/doozer-working/ocp-build-data"))
+
+    @patch("pyartcd.pipelines.promote.PromotePipeline.build_release_image", return_value=None)
+    @patch("pyartcd.pipelines.promote.PromotePipeline.get_release_image_info", side_effect=lambda pullspec, raise_if_not_found=False: {
+        "image": pullspec,
+        "digest": f"fake:deadbeef-{pullspec}",
+        "references": {
+            "spec": {
+                "tags": [
+                    {
+                        "name": "machine-os-content",
+                        "annotations": {"io.openshift.build.versions": "machine-os=00.00.212301010000-0"}
+                    }
+                ]
+            }
+        }
+    } if raise_if_not_found else None)
+    @patch("pyartcd.pipelines.promote.util.load_releases_config", return_value={
+        "releases": {"art0001": {"assembly": {"type": "custom"}}}
+    })
+    @patch("pyartcd.pipelines.promote.util.load_group_config", return_value={})
+    def test_run_with_custom_assembly(self, load_group_config: AsyncMock, load_releases_config: AsyncMock, get_release_image_info: AsyncMock,
+                                      build_release_image: AsyncMock):
+        runtime = MagicMock(config={"build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"}}, working_dir=Path("/path/to/working"), dry_run=False)
+        pipeline = PromotePipeline(runtime, "openshift-4.10", "art0001", "99", ["x86_64", "s390x"], False, False)
+        pipeline._slack_client = AsyncMock()
+        asyncio.get_event_loop().run_until_complete(pipeline.run())
+        load_group_config.assert_awaited_once_with("openshift-4.10", "art0001", env=ANY)
+        load_releases_config.assert_awaited_once_with(Path("/path/to/working/doozer-working/ocp-build-data"))
+        get_release_image_info.assert_any_await("quay.io/openshift-release-dev/ocp-release:4.10.99-assembly.art0001-x86_64", raise_if_not_found=ANY)
+        get_release_image_info.assert_any_await("quay.io/openshift-release-dev/ocp-release:4.10.99-assembly.art0001-s390x", raise_if_not_found=ANY)
+        build_release_image.assert_any_await("4.10.99-assembly.art0001", "x86_64", [], {}, "quay.io/openshift-release-dev/ocp-release:4.10.99-assembly.art0001-x86_64", None)
+        build_release_image.assert_any_await("4.10.99-assembly.art0001", "s390x", [], {}, "quay.io/openshift-release-dev/ocp-release:4.10.99-assembly.art0001-s390x", None)
+        pipeline._slack_client.bind_channel.assert_called_once_with("4.10.99-assembly.art0001")
+
+    @patch("pyartcd.pipelines.promote.util.load_releases_config", return_value={
+        "releases": {"4.10.99": {"assembly": {"type": "standard"}}}
+    })
+    @patch("pyartcd.pipelines.promote.util.load_group_config", return_value={})
+    def test_run_with_standard_assembly_without_upgrade_edges(self, load_group_config: AsyncMock, load_releases_config: AsyncMock):
+        runtime = MagicMock(config={"build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"}}, working_dir=Path("/path/to/working"), dry_run=False)
+        pipeline = PromotePipeline(runtime, "openshift-4.10", "4.10.99", None, ["x86_64", "s390x"], False, False)
+        pipeline._slack_client = AsyncMock()
+        with self.assertRaisesRegex(ValueError, "missing the required `upgrades` field"):
+            asyncio.get_event_loop().run_until_complete(pipeline.run())
+        load_group_config.assert_awaited_once_with("openshift-4.10", "4.10.99", env=ANY)
+        load_releases_config.assert_awaited_once_with(Path("/path/to/working/doozer-working/ocp-build-data"))
+
+    @patch("pyartcd.pipelines.promote.PromotePipeline.build_release_image", return_value=None)
+    @patch("pyartcd.pipelines.promote.PromotePipeline.get_release_image_info", side_effect=lambda pullspec, raise_if_not_found=False: {
+        "image": pullspec,
+        "digest": f"fake:deadbeef-{pullspec}",
+        "references": {
+            "spec": {
+                "tags": [
+                    {
+                        "name": "machine-os-content",
+                        "annotations": {"io.openshift.build.versions": "machine-os=00.00.212301010000-0"}
+                    }
+                ]
+            }
+        }
+    } if raise_if_not_found else None)
+    @patch("pyartcd.pipelines.promote.util.load_releases_config", return_value={
+        "releases": {"4.10.99": {"assembly": {"type": "standard"}}}
+    })
+    @patch("pyartcd.pipelines.promote.util.load_group_config", return_value={
+        "upgrades": "4.10.98,4.9.99",
+        "advisories": {"rpm": 1, "image": 2, "extras": 3, "metadata": 4},
+        "description": "whatever",
+    })
+    def test_run_with_standard_assembly(self, load_group_config: AsyncMock, load_releases_config: AsyncMock,
+                                        get_release_image_info: AsyncMock, build_release_image: AsyncMock):
+        runtime = MagicMock(config={"build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"}},
+                            working_dir=Path("/path/to/working"), dry_run=False)
+        pipeline = PromotePipeline(runtime, "openshift-4.10", "4.10.99", None, ["x86_64", "s390x", "ppc64le", "aarch64"], False, False)
+        pipeline._slack_client = AsyncMock()
+        pipeline.check_blocker_bugs = AsyncMock()
+        pipeline.attach_cve_flaws = AsyncMock()
+        pipeline.get_advisory_info = AsyncMock(return_value={
+            "id": 2,
+            "errata_id": 2222,
+            "fulladvisory": "RHBA-2099:2222-02",
+            "status": "QE",
+        })
+        pipeline.verify_attached_bugs = AsyncMock(return_value=None)
+        pipeline.get_image_stream_tag = AsyncMock(return_value=None)
+        pipeline.tag_release = AsyncMock(return_value=None)
+        pipeline.wait_for_stable = AsyncMock(return_value=None)
+        pipeline.send_image_list_email = AsyncMock()
+        asyncio.get_event_loop().run_until_complete(pipeline.run())
+        load_group_config.assert_awaited_once_with("openshift-4.10", "4.10.99", env=ANY)
+        load_releases_config.assert_awaited_once_with(Path("/path/to/working/doozer-working/ocp-build-data"))
+        pipeline.check_blocker_bugs.assert_awaited_once_with()
+        for advisory in [1, 2, 3, 4]:
+            pipeline.attach_cve_flaws.assert_any_await(advisory)
+        pipeline.get_advisory_info.assert_awaited_once_with(2)
+        pipeline.verify_attached_bugs.assert_awaited_once_with([1, 2, 3, 4])
+        get_release_image_info.assert_any_await("quay.io/openshift-release-dev/ocp-release:4.10.99-x86_64", raise_if_not_found=ANY)
+        get_release_image_info.assert_any_await("quay.io/openshift-release-dev/ocp-release:4.10.99-s390x", raise_if_not_found=ANY)
+        build_release_image.assert_any_await("4.10.99", "x86_64", ["4.10.98", "4.9.99"], {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}, "quay.io/openshift-release-dev/ocp-release:4.10.99-x86_64", None)
+        build_release_image.assert_any_await("4.10.99", "s390x", ["4.10.98", "4.9.99"], {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}, "quay.io/openshift-release-dev/ocp-release:4.10.99-s390x", None)
+        build_release_image.assert_any_await("4.10.99", "ppc64le", ["4.10.98", "4.9.99"], {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}, "quay.io/openshift-release-dev/ocp-release:4.10.99-ppc64le", None)
+        build_release_image.assert_any_await("4.10.99", "aarch64", ["4.10.98", "4.9.99"], {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}, "quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64", None)
+        pipeline._slack_client.bind_channel.assert_called_once_with("4.10.99")
+        pipeline.get_image_stream_tag.assert_any_await("ocp", "release:4.10.99")
+        pipeline.tag_release.assert_any_await("quay.io/openshift-release-dev/ocp-release:4.10.99-x86_64", "ocp/release:4.10.99")
+        pipeline.tag_release.assert_any_await("quay.io/openshift-release-dev/ocp-release:4.10.99-s390x", "ocp-s390x/release-s390x:4.10.99")
+        pipeline.tag_release.assert_any_await("quay.io/openshift-release-dev/ocp-release:4.10.99-ppc64le", "ocp-ppc64le/release-ppc64le:4.10.99")
+        pipeline.tag_release.assert_any_await("quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64", "ocp-arm64/release-arm64:4.10.99")
+        pipeline.wait_for_stable.assert_any_await("4.10.99", "x86_64", "4-stable")
+        pipeline.wait_for_stable.assert_any_await("4.10.99", "s390x", "4-stable-s390x")
+        pipeline.wait_for_stable.assert_any_await("4.10.99", "ppc64le", "4-stable-ppc64le")
+        pipeline.wait_for_stable.assert_any_await("4.10.99", "aarch64", "4-stable-arm64")
+        pipeline.send_image_list_email.assert_awaited_once_with("4.10.99", 2, ANY)


### PR DESCRIPTION
Created `promote-assembly` job to replace the existing `promote` and
`multi_promote` jobs.
See `jobs/build/promote-assembly/README.md` for instructions.