### PR TITLE
[ART-3668] [wip] Fix prerelease status of fc's

### DIFF
--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -530,8 +530,10 @@ def extractMajorMinorVersionNumbers(String version) {
  * e.g. "4.1.0-rc.9" => true
  * https://semver.org/spec/v2.0.0.html#spec-item-9
  */
-String isPreRelease(String version) {
-    return (version =~ /^(\d+\.\d+\.\d+(-?))/)[0][1] == "-"
+Boolean isPreRelease(String version) {
+    def matcher = version =~  /^(?:\d+\.\d+\.\d+)(-(?:rc|fc))?/
+    if (matcher[0][-1]) { return true }
+    return false
 }
 
 /**


### PR DESCRIPTION
The cincinatti-prs job ran into an error while creating 4.10.0-fc.0, as
it believes that this version is not a prerelease. This should fix that.

Tested locally with

```groovy
versions = [
  "4.1.0-rc.9": true,
  "4.9.23": false,
  "4.8.23-assembly.art123": false,
  "4.10.0-fc.5": true
]

Boolean currentIsPreRelease(String version) {
    return (version =~ /^(\d+\.\d+\.\d+(-?))/)[0][1] == "-"
}

Boolean futureIsPreRelease(String version) {
    def matcher = version =~  /^(?:\d+\.\d+\.\d+)(-(?:rc|fc))?/
    if (matcher[0][-1]) { return true }
    return false
 }

versions.each { version, isPrerelease ->
    println "${version} ${isPrerelease} ${currentIsPreRelease(version)} ${futureIsPreRelease(version)} ${isPrerelease == futureIsPreRelease(version)}"
}
```

Result:
```
4.1.0-rc.9 true false true true
4.9.23 false false false true
4.8.23-assembly.art123 false false false true
4.10.0-fc.5 true false true true
```

(The last "column" should all be "true")