### PR TITLE
promote-assembly: improvements, docs, and more tests

### DIFF
--- a/jobs/build/promote-assembly/README.md
+++ b/jobs/build/promote-assembly/README.md
@@ -160,6 +160,28 @@ After signing the release, the
 is used to create PRs to have the release (and upgrade edges) included in OCP 4
 [release channels](https://github.com/openshift/cincinnati-graph-data/tree/master/channels).
 
+## Permit certain validation failures
+This job runs a lot of validations against the release content, advisories, and bugs before actually promoting the release.
+In case of a validation error, a slack message will be sent to corresponding release channel.
+The release artist can rerun the job to retry (it is reentrant), or define a `promotion_permits` entry in assembly definition to permit that failure. A justification should be also given in the `why` field. Note the justification message will be public, so don't include any confidential or customer related information.
+
+Example:
+
+```yaml
+releases:
+  4.10.99:
+    assembly:
+      type: standard
+      promotion_permits:
+      - code: ATTACHED_BUGS
+        why: Luke told me this can be ignored
+```
+
+List of codes:
+- *BLOCKER_BUGS* Blocker bugs found for release.
+- *ATTACHED_BUGS* Error verifying attached bugs
+- *CVE_FLAWS* Error attaching CVE flaw bugs
+
 ## Known issues
 
 ### General flakiness

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -72,9 +72,14 @@ async def load_releases_config(build_data_path: os.PathLike) -> Dict:
     return yaml.safe_load(content)
 
 
-def get_assembly_type(assembly_name: str, releases_config: Dict):
+def get_assembly_type(releases_config: Dict, assembly_name: str):
     return assembly.assembly_type(model.Model(releases_config), assembly_name)
 
+def get_assmebly_basis(releases_config: Dict, assembly_name: str):
+    return assembly.assembly_basis(model.Model(releases_config), assembly_name)
+
+def get_assembly_promotion_permits(releases_config: Dict, assembly_name: str):
+    return assembly._assembly_config_struct(model.Model(releases_config), assembly_name, 'promotion_permits', {})
 
 def get_release_name(assembly_type: str, group_name: str, assembly_name: str, release_offset: Optional[int]):
     major, minor = isolate_major_minor_in_group(group_name)

--- a/pyartcd/tests/pipelines/test_promote.py
+++ b/pyartcd/tests/pipelines/test_promote.py
@@ -12,7 +12,7 @@ class TestPromotePipeline(TestCase):
     @patch("pyartcd.pipelines.promote.util.load_group_config", return_value={})
     def test_run_without_explicit_assembly_definition(self, load_group_config: AsyncMock, load_releases_config: AsyncMock):
         runtime = MagicMock(config={"build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"}}, working_dir=Path("/path/to/working"), dry_run=False)
-        pipeline = PromotePipeline(runtime, "openshift-4.10", "4.10.99", None, ["x86_64", "s390x"], False, False)
+        pipeline = PromotePipeline(runtime, group="openshift-4.10", assembly="4.10.99", release_offset=None, arches=["x86_64", "s390x"])
         with self.assertRaisesRegex(ValueError, "must be explictly defined"):
             asyncio.get_event_loop().run_until_complete(pipeline.run())
         load_group_config.assert_awaited_once_with("openshift-4.10", "4.10.99", env=ANY)
@@ -24,7 +24,7 @@ class TestPromotePipeline(TestCase):
     @patch("pyartcd.pipelines.promote.util.load_group_config", return_value={})
     def test_run_with_stream_assembly(self, load_group_config: AsyncMock, load_releases_config: AsyncMock):
         runtime = MagicMock(config={"build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"}}, working_dir=Path("/path/to/working"), dry_run=False)
-        pipeline = PromotePipeline(runtime, "openshift-4.10", "stream", None, ["x86_64", "s390x"], False, False)
+        pipeline = PromotePipeline(runtime, group="openshift-4.10", assembly="stream", release_offset=None, arches=["x86_64", "s390x"])
         with self.assertRaisesRegex(ValueError, "not supported"):
             asyncio.get_event_loop().run_until_complete(pipeline.run())
         load_group_config.assert_awaited_once_with("openshift-4.10", "stream", env=ANY)
@@ -36,7 +36,7 @@ class TestPromotePipeline(TestCase):
     @patch("pyartcd.pipelines.promote.util.load_group_config", return_value={})
     def test_run_with_custom_assembly_and_missing_release_offset(self, load_group_config: AsyncMock, load_releases_config: AsyncMock):
         runtime = MagicMock(config={"build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"}}, working_dir=Path("/path/to/working"), dry_run=False)
-        pipeline = PromotePipeline(runtime, "openshift-4.10", "art0001", None, ["x86_64", "s390x"], False, False)
+        pipeline = PromotePipeline(runtime, group="openshift-4.10", assembly="art0001", release_offset=None, arches=["x86_64", "s390x"])
         with self.assertRaisesRegex(ValueError, "release_offset is required"):
             asyncio.get_event_loop().run_until_complete(pipeline.run())
         load_group_config.assert_awaited_once_with("openshift-4.10", "art0001", env=ANY)
@@ -64,7 +64,7 @@ class TestPromotePipeline(TestCase):
     def test_run_with_custom_assembly(self, load_group_config: AsyncMock, load_releases_config: AsyncMock, get_release_image_info: AsyncMock,
                                       build_release_image: AsyncMock):
         runtime = MagicMock(config={"build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"}}, working_dir=Path("/path/to/working"), dry_run=False)
-        pipeline = PromotePipeline(runtime, "openshift-4.10", "art0001", "99", ["x86_64", "s390x"], False, False)
+        pipeline = PromotePipeline(runtime, group="openshift-4.10", assembly="art0001", release_offset=99, arches=["x86_64", "s390x"])
         pipeline._slack_client = AsyncMock()
         asyncio.get_event_loop().run_until_complete(pipeline.run())
         load_group_config.assert_awaited_once_with("openshift-4.10", "art0001", env=ANY)
@@ -81,7 +81,7 @@ class TestPromotePipeline(TestCase):
     @patch("pyartcd.pipelines.promote.util.load_group_config", return_value={})
     def test_run_with_standard_assembly_without_upgrade_edges(self, load_group_config: AsyncMock, load_releases_config: AsyncMock):
         runtime = MagicMock(config={"build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"}}, working_dir=Path("/path/to/working"), dry_run=False)
-        pipeline = PromotePipeline(runtime, "openshift-4.10", "4.10.99", None, ["x86_64", "s390x"], False, False)
+        pipeline = PromotePipeline(runtime, group="openshift-4.10", assembly="4.10.99", release_offset=None, arches=["x86_64", "s390x"])
         pipeline._slack_client = AsyncMock()
         with self.assertRaisesRegex(ValueError, "missing the required `upgrades` field"):
             asyncio.get_event_loop().run_until_complete(pipeline.run())
@@ -104,7 +104,12 @@ class TestPromotePipeline(TestCase):
         }
     } if raise_if_not_found else None)
     @patch("pyartcd.pipelines.promote.util.load_releases_config", return_value={
-        "releases": {"4.10.99": {"assembly": {"type": "standard"}}}
+        "releases": {"4.10.99": {"assembly": {"type": "standard", "basis": {"reference_releases": {
+            "x86_64": "nightly-x86_64",
+            "s390x": "nightly-s390x",
+            "ppc64le": "nightly-ppc64le",
+            "aarch64": "nightly-aarch64",
+        }}}}}
     })
     @patch("pyartcd.pipelines.promote.util.load_group_config", return_value={
         "upgrades": "4.10.98,4.9.99",
@@ -115,7 +120,7 @@ class TestPromotePipeline(TestCase):
                                         get_release_image_info: AsyncMock, build_release_image: AsyncMock):
         runtime = MagicMock(config={"build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"}},
                             working_dir=Path("/path/to/working"), dry_run=False)
-        pipeline = PromotePipeline(runtime, "openshift-4.10", "4.10.99", None, ["x86_64", "s390x", "ppc64le", "aarch64"], False, False)
+        pipeline = PromotePipeline(runtime, group="openshift-4.10", assembly="4.10.99", release_offset=None, arches=["x86_64", "s390x", "ppc64le", "aarch64"])
         pipeline._slack_client = AsyncMock()
         pipeline.check_blocker_bugs = AsyncMock()
         pipeline.attach_cve_flaws = AsyncMock()
@@ -140,10 +145,10 @@ class TestPromotePipeline(TestCase):
         pipeline.verify_attached_bugs.assert_awaited_once_with([1, 2, 3, 4])
         get_release_image_info.assert_any_await("quay.io/openshift-release-dev/ocp-release:4.10.99-x86_64", raise_if_not_found=ANY)
         get_release_image_info.assert_any_await("quay.io/openshift-release-dev/ocp-release:4.10.99-s390x", raise_if_not_found=ANY)
-        build_release_image.assert_any_await("4.10.99", "x86_64", ["4.10.98", "4.9.99"], {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}, "quay.io/openshift-release-dev/ocp-release:4.10.99-x86_64", None)
-        build_release_image.assert_any_await("4.10.99", "s390x", ["4.10.98", "4.9.99"], {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}, "quay.io/openshift-release-dev/ocp-release:4.10.99-s390x", None)
-        build_release_image.assert_any_await("4.10.99", "ppc64le", ["4.10.98", "4.9.99"], {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}, "quay.io/openshift-release-dev/ocp-release:4.10.99-ppc64le", None)
-        build_release_image.assert_any_await("4.10.99", "aarch64", ["4.10.98", "4.9.99"], {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}, "quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64", None)
+        build_release_image.assert_any_await("4.10.99", "x86_64", ["4.10.98", "4.9.99"], {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}, "quay.io/openshift-release-dev/ocp-release:4.10.99-x86_64", "nightly-x86_64")
+        build_release_image.assert_any_await("4.10.99", "s390x", ["4.10.98", "4.9.99"], {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}, "quay.io/openshift-release-dev/ocp-release:4.10.99-s390x", "nightly-s390x")
+        build_release_image.assert_any_await("4.10.99", "ppc64le", ["4.10.98", "4.9.99"], {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}, "quay.io/openshift-release-dev/ocp-release:4.10.99-ppc64le", "nightly-ppc64le")
+        build_release_image.assert_any_await("4.10.99", "aarch64", ["4.10.98", "4.9.99"], {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}, "quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64", "nightly-aarch64")
         pipeline._slack_client.bind_channel.assert_called_once_with("4.10.99")
         pipeline.get_image_stream_tag.assert_any_await("ocp", "release:4.10.99")
         pipeline.tag_release.assert_any_await("quay.io/openshift-release-dev/ocp-release:4.10.99-x86_64", "ocp/release:4.10.99")
@@ -155,3 +160,113 @@ class TestPromotePipeline(TestCase):
         pipeline.wait_for_stable.assert_any_await("4.10.99", "ppc64le", "4-stable-ppc64le")
         pipeline.wait_for_stable.assert_any_await("4.10.99", "aarch64", "4-stable-arm64")
         pipeline.send_image_list_email.assert_awaited_once_with("4.10.99", 2, ANY)
+
+    @patch("pyartcd.pipelines.promote.PromotePipeline.tag_release", return_value=None)
+    @patch("pyartcd.pipelines.promote.PromotePipeline.get_image_stream_tag", return_value=None)
+    @patch("pyartcd.pipelines.promote.PromotePipeline.build_release_image", return_value=None)
+    @patch("pyartcd.pipelines.promote.PromotePipeline.get_release_image_info", side_effect=lambda pullspec, raise_if_not_found=False: {
+        "image": pullspec,
+        "digest": f"fake:deadbeef",
+        "references": {
+            "spec": {
+                "tags": [
+                    {
+                        "name": "machine-os-content",
+                        "annotations": {"io.openshift.build.versions": "machine-os=00.00.212301010000-0"}
+                    }
+                ]
+            }
+        }
+    } if raise_if_not_found else None)
+    def test_promote_arch(self, get_release_image_info: AsyncMock, build_release_image: AsyncMock, get_image_stream_tag: AsyncMock, tag_release: AsyncMock):
+        runtime = MagicMock(config={"build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"}},
+                            working_dir=Path("/path/to/working"), dry_run=False)
+        pipeline = PromotePipeline(runtime, group="openshift-4.10", assembly="4.10.99", release_offset=None, arches=["x86_64", "s390x", "ppc64le", "aarch64"])
+        previous_list = ["4.10.98", "4.10.97", "4.9.99"]
+        metadata = {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}
+
+        # test x86_64
+        reference_release = "whatever-x86_64"
+        actual = asyncio.get_event_loop().run_until_complete(pipeline.promote_arch(release_name="4.10.99", arch="x86_64", previous_list=previous_list, metadata=metadata, reference_release=reference_release, tag_stable=True))
+        get_release_image_info.assert_any_await("quay.io/openshift-release-dev/ocp-release:4.10.99-x86_64")
+        build_release_image.assert_awaited_once_with("4.10.99", "x86_64", previous_list, metadata, "quay.io/openshift-release-dev/ocp-release:4.10.99-x86_64", reference_release)
+        get_image_stream_tag.assert_awaited_once_with("ocp", "release:4.10.99")
+        tag_release.assert_awaited_once_with("quay.io/openshift-release-dev/ocp-release:4.10.99-x86_64", "ocp/release:4.10.99")
+        self.assertEqual(actual["image"], "quay.io/openshift-release-dev/ocp-release:4.10.99-x86_64")
+
+        # test aarch64
+        reference_release = "whatever-aarch64"
+        get_release_image_info.reset_mock()
+        build_release_image.reset_mock()
+        get_image_stream_tag.reset_mock()
+        tag_release.reset_mock()
+        actual = asyncio.get_event_loop().run_until_complete(pipeline.promote_arch(release_name="4.10.99", arch="aarch64", previous_list=previous_list, metadata=metadata, reference_release=reference_release, tag_stable=True))
+        get_release_image_info.assert_any_await("quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64")
+        build_release_image.assert_awaited_once_with("4.10.99", "aarch64", previous_list, metadata, "quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64", reference_release)
+        get_image_stream_tag.assert_awaited_once_with("ocp-arm64", "release-arm64:4.10.99")
+        tag_release.assert_awaited_once_with("quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64", "ocp-arm64/release-arm64:4.10.99")
+        self.assertEqual(actual["image"], "quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64")
+
+        # test release tag already exists but doesn't match the to-be-promoted release image
+        get_image_stream_tag.return_value = {
+            "image": {
+                "dockerImageReference": "quay.io/openshift-release-dev/ocp-release@fake:foobar",
+            }
+        }
+        reference_release = "whatever-aarch64"
+        get_release_image_info.reset_mock()
+        build_release_image.reset_mock()
+        get_image_stream_tag.reset_mock()
+        tag_release.reset_mock()
+        with self.assertRaisesRegex(ValueError, "already exists, but it has a different digest"):
+            asyncio.get_event_loop().run_until_complete(pipeline.promote_arch(release_name="4.10.99", arch="aarch64", previous_list=previous_list, metadata=metadata, reference_release=reference_release, tag_stable=True))
+        get_release_image_info.assert_any_await("quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64")
+        build_release_image.assert_awaited_once_with("4.10.99", "aarch64", previous_list, metadata, "quay.io/openshift-release-dev/ocp-release:4.10.99-aarch64", reference_release)
+        get_image_stream_tag.assert_awaited_once_with("ocp-arm64", "release-arm64:4.10.99")
+        tag_release.assert_not_awaited()
+
+    @patch("pyartcd.pipelines.promote.exectools.cmd_assert_async", return_value=0)
+    def test_build_release_image_from_reference_release(self, cmd_assert_async: AsyncMock):
+        runtime = MagicMock(config={"build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"}},
+                            working_dir=Path("/path/to/working"), dry_run=False)
+        pipeline = PromotePipeline(runtime, group="openshift-4.10", assembly="4.10.99", release_offset=None, arches=["x86_64", "s390x", "ppc64le", "aarch64"])
+        previous_list = ["4.10.98", "4.10.97", "4.9.99"]
+        metadata = {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}
+
+        # test x86_64
+        reference_release = "whatever-x86_64"
+        dest_pullspec = "example.com/foo/release:4.10.99-x86_64"
+        asyncio.get_event_loop().run_until_complete(pipeline.build_release_image("4.10.99", "x86_64", previous_list, metadata, dest_pullspec, reference_release))
+        expected_cmd = ["oc", "adm", "release", "new", "-n", "ocp", "--name=4.10.99", "--to-image=example.com/foo/release:4.10.99-x86_64", "--from-release=registry.ci.openshift.org/ocp/release:whatever-x86_64", "--previous=4.10.98,4.10.97,4.9.99", "--metadata", "{\"description\": \"whatever\", \"url\": \"https://access.redhat.com/errata/RHBA-2099:2222\"}"]
+        cmd_assert_async.assert_awaited_once_with(expected_cmd, env=ANY, stdout=ANY)
+
+        # test aarch64
+        reference_release = "whatever-aarch64"
+        dest_pullspec = "example.com/foo/release:4.10.99-aarch64"
+        cmd_assert_async.reset_mock()
+        asyncio.get_event_loop().run_until_complete(pipeline.build_release_image("4.10.99", "aarch64", previous_list, metadata, dest_pullspec, reference_release))
+        expected_cmd = ["oc", "adm", "release", "new", "-n", "ocp-arm64", "--name=4.10.99", "--to-image=example.com/foo/release:4.10.99-aarch64", "--from-release=registry.ci.openshift.org/ocp-arm64/release-arm64:whatever-aarch64", "--previous=4.10.98,4.10.97,4.9.99", "--metadata", "{\"description\": \"whatever\", \"url\": \"https://access.redhat.com/errata/RHBA-2099:2222\"}"]
+        cmd_assert_async.assert_awaited_once_with(expected_cmd, env=ANY, stdout=ANY)
+
+    @patch("pyartcd.pipelines.promote.exectools.cmd_assert_async", return_value=0)
+    def test_build_release_image_from_image_stream(self, cmd_assert_async: AsyncMock):
+        runtime = MagicMock(config={"build_config": {"ocp_build_data_url": "https://example.com/ocp-build-data.git"}},
+                            working_dir=Path("/path/to/working"), dry_run=False)
+        pipeline = PromotePipeline(runtime, group="openshift-4.10", assembly="4.10.99", release_offset=None, arches=["x86_64", "s390x", "ppc64le", "aarch64"])
+        previous_list = ["4.10.98", "4.10.97", "4.9.99"]
+        metadata = {"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}
+
+        # test x86_64
+        reference_release = None
+        dest_pullspec = "example.com/foo/release:4.10.99-x86_64"
+        asyncio.get_event_loop().run_until_complete(pipeline.build_release_image("4.10.99", "x86_64", previous_list, metadata, dest_pullspec, reference_release))
+        expected_cmd = ['oc', 'adm', 'release', 'new', '-n', 'ocp', '--name=4.10.99', '--to-image=example.com/foo/release:4.10.99-x86_64', '--reference-mode=source', '--from-image-stream=4.10-art-assembly-4.10.99', '--previous=4.10.98,4.10.97,4.9.99', '--metadata', '{"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}']
+        cmd_assert_async.assert_awaited_once_with(expected_cmd, env=ANY, stdout=ANY)
+
+        # test aarch64
+        reference_release = None
+        dest_pullspec = "example.com/foo/release:4.10.99-aarch64"
+        cmd_assert_async.reset_mock()
+        asyncio.get_event_loop().run_until_complete(pipeline.build_release_image("4.10.99", "aarch64", previous_list, metadata, dest_pullspec, reference_release))
+        expected_cmd = ['oc', 'adm', 'release', 'new', '-n', 'ocp-arm64', '--name=4.10.99', '--to-image=example.com/foo/release:4.10.99-aarch64', '--reference-mode=source', '--from-image-stream=4.10-art-assembly-4.10.99-arm64', '--previous=4.10.98,4.10.97,4.9.99', '--metadata', '{"description": "whatever", "url": "https://access.redhat.com/errata/RHBA-2099:2222"}']
+        cmd_assert_async.assert_awaited_once_with(expected_cmd, env=ANY, stdout=ANY)


### PR DESCRIPTION
- Use doozerlib to parse assembly definitions. This allows promote job
  to handle assembly inheritance.
- Rename `waives` to `promotion_permits`.
- Add more unit tests.