### PR TITLE
Add new_minor scripts

### DIFF
--- a/hacks/new_minor/README.md
+++ b/hacks/new_minor/README.md
@@ -1,0 +1,34 @@
+# New Minor: Scripts for verifying distgit and tag setup
+
+This is a set of scripts that can be used to verify what needs to be done to get
+distgit branches and brew tags set up to initiate a new minor release.
+
+Main entry point is `branch-new-release`, which should be invoked as:
+
+```sh\
+./branch-new-release 4.11
+```
+
+This script will export the variables `new_version` and `old_version`, and run
+the `./verify-*` scripts.
+
+What do the `verify-*` scripts check?
+
+## verify-brew-tags
+- checks if tags from the old version have a relating tag in the new version
+- checks if the tags have the same arches set up
+- checks if it has the same children (tag inheritence)
+
+## verify-candidate-contents
+Compares builds from both candidate tags, and filters out builds created by
+known automation. And shows differences.
+
+## verify-override-tag-contents
+Same as `verify-candidate-contents`, but for `-override`.
+
+## verify-distgit-branch
+Checks if distgit branches are available. Warning, it queries cgit, so there
+might be cache issues.
+
+## verify-pkg-whitelist
+Checks if allowed packages in `rhaos-$version-rhel-$rhel` is the same.

--- a/hacks/new_minor/branch-new-release
+++ b/hacks/new_minor/branch-new-release
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+new_version="$1"
+
+IFS=. read -r major minor <<<"4.11"
+
+valid_input=1
+[[ "$major" =~ ^[0-9]+$ ]] || valid_input=0
+[[ "$minor" =~ ^[0-9]+$ ]] || valid_input=0
+
+(( valid_input )) || {
+  echo "Need single arg specifying new version, e.g. '4.11'" >/dev/stderr
+  exit 1
+}
+
+old_version="$major.$((minor - 1))"
+
+export new_version
+export old_version
+
+for f in ./verify-*; do
+  echo "Running $f"
+  $f
+done

--- a/hacks/new_minor/verify-brew-tags
+++ b/hacks/new_minor/verify-brew-tags
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+old="rhaos-$old_version"
+new="rhaos-$new_version"
+
+export LC_ALL=C
+
+echo "Tag existance needing inspection:"
+comm -3 <(brew list-tags "${new}-rhel-*"| sort) <(brew list-tags "${old}-rhel-*" | sed "s/^${old}/$new/" | sort)
+
+echo "Tag inheritance needing inspection:"
+
+tag_arches() {
+  local tag
+  tag="$1"
+  brew call --json-output getTag "$tag" | jq -r '.arches | gsub(" +"; "\n")' | sort
+}
+
+tag_children() {
+  local tag
+  tag="$1"
+  brew call --json-output getInheritanceData "$tag" |
+    jq -r '.[].name' |
+    sort
+}
+
+for tag in $(brew list-tags "${new}*"); do
+  old_tag="$(sed "s/^$new/$old/" <<<"$tag")"
+  result=wrong
+  if diff -q <(tag_children "$tag") <(tag_children "$old_tag" | sed "s/^$old/$new/") >/dev/null 2>&1; then
+    result=good
+  fi
+  [[ "$result" == wrong ]] && echo "$result:tag_inheritance:$tag"
+done
+
+echo "Tag arches needing inspection:"
+for tag in $(brew list-tags "${new}*"); do
+  old_tag="$(sed "s/^$new/$old/" <<<"$tag")"
+  result=wrong
+  if diff -q <(tag_arches "$tag") <(tag_arches "$old_tag" | sed "s/^$old/$new/") >/dev/null 2>&1; then
+    result=good
+  fi
+  [[ "$result" == wrong ]] && echo "$result:tag_arches:$tag"
+done

--- a/hacks/new_minor/verify-candidate-contents
+++ b/hacks/new_minor/verify-candidate-contents
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+builds() {
+  tag="$1"
+  brew -q list-tagged --latest "$tag" |
+    awk '
+      $3 != "ocp-build/buildvm.openshift.eng.bos.redhat.com" && \
+        $3 != "osp-build/osp-trunk.hosted.upshift.rdu2.redhat.com" && \
+        $3 != "contra/pipeline" && \
+        $3 != "openvswitch-ci/openvswitch-ci.ntdv.lab.eng.bos.redhat.com" \
+        { print $1 }
+      ' |
+    sort
+}
+
+old="$old_version"
+new="$new_version"
+
+for rhel in 7 8; do
+  echo "==== Checking $rhel ===="
+  echo "only in $old"
+  echo "        only in $new"
+  comm -3 <(builds rhaos-$old-rhel-$rhel-candidate) <(builds rhaos-$new-rhel-$rhel-candidate)
+done

--- a/hacks/new_minor/verify-distgit-branch
+++ b/hacks/new_minor/verify-distgit-branch
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script verifies if distgits for images managed by ocp-build-data exist for a branch.
+# This is to replace the `doozer images:clone` verification step, as that consumes a lot of time.
+# This completes in a few seconds.
+
+new="$new_version"
+
+check_branch() {
+  local repo branch result url
+  repo="$1"
+  branch="$2"
+  url="http://pkgs.devel.redhat.com/cgit/${repo}/tree/?h=${branch}"
+  result=bad
+  if curl --fail -XHEAD -sSL "$url" >/dev/null 2>&1; then
+    result=good
+  fi
+  echo "$result:$repo:$branch"
+}
+export -f check_branch
+
+image_list() {
+  doozer -g openshift-$new images:list 2>/dev/null |
+    awk '
+      !f && /---/ { f=1; next }
+      /----/ { f=0; next }
+      f
+    '
+}
+
+rpm_list() {
+  cat <<EORPM
+rpms/afterburn
+rpms/bootupd
+rpms/conmon
+rpms/console-login-helper-messages
+rpms/containernetworking-plugins
+rpms/coreos-installer
+rpms/cri-o
+rpms/cri-tools
+rpms/ignition
+rpms/jq
+rpms/oniguruma
+rpms/openshift
+rpms/openshift-ansible
+rpms/openshift-clients
+rpms/openshift-enterprise-service-idler
+rpms/openshift-kuryr
+rpms/redhat-release-coreos
+rpms/runc
+rpms/toolbox
+EORPM
+}
+
+rm -f log
+
+{
+  image_list |
+    xargs --max-args=1 --max-procs=16 -I {} bash -c "check_branch {} rhaos-$new-rhel-8" |
+  rpm_list |
+    xargs --max-args=1 --max-procs=16 -I {} bash -c "check_branch {} rhaos-$new-rhel-7" |
+  rpm_list |
+    xargs --max-args=1 --max-procs=16 -I {} bash -c "check_branch {} rhaos-$new-rhel-8" |
+} |
+  awk '
+    /^good:/{g++}
+    /^bad:/{b++}
+    END {printf("good: %s, bad: %s, %s %%\n", g, b, int(100 * g /(g+b)))}
+  '

--- a/hacks/new_minor/verify-override-tag-contents
+++ b/hacks/new_minor/verify-override-tag-contents
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+old="$old_version"
+new="$new_version"
+
+latest_tagged() {
+  tag="$1"
+  brew -q list-tagged --latest "$tag" |
+    awk '{print $1}' |
+    sort
+}
+
+for rhel in 7 8; do
+  echo "=== rhel-$rhel"
+  echo "only in $old"
+  echo "        only in $new"
+  comm -3 <(latest_tagged "rhaos-$old-rhel-$rhel-override") <(latest_tagged "rhaos-$new-rhel-$rhel-override")
+done

--- a/hacks/new_minor/verify-pkg-whitelist
+++ b/hacks/new_minor/verify-pkg-whitelist
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+pkg_whitelist() {
+  tag="$1"
+  brew --quiet list-pkgs --tag "$tag" | awk '{print $1}' | sort
+}
+
+new="$new_version"
+old="$old_version"
+
+for rhel in 7 8; do
+  echo "====== rhel-$rhel ======"
+  echo "only in $old"
+  echo "               only in $new"
+  comm -3 <(pkg_whitelist "rhaos-$old-rhel-$rhel") <(pkg_whitelist "rhaos-$new-rhel-$rhel")
+done


### PR DESCRIPTION
# New Minor: Scripts for verifying distgit and tag setup

This is a set of scripts that can be used to verify what needs to be done to get
distgit branches and brew tags set up to initiate a new minor release.

Main entry point is `branch-new-release`, which should be invoked as:

```sh
./branch-new-release 4.11
```

This script will export the variables `new_version` and `old_version`, and run
the `./verify-*` scripts.

What do the `verify-*` scripts check?

## verify-brew-tags
- checks if tags from the old version have a relating tag in the new version
- checks if the tags have the same arches set up
- checks if it has the same children (tag inheritence)

## verify-candidate-contents
Compares builds from both candidate tags, and filters out builds created by
known automation. And shows differences.

## verify-override-tag-contents
Same as `verify-candidate-contents`, but for `-override`.

## verify-distgit-branch
Checks if distgit branches are available. Warning, it queries cgit, so there
might be cache issues.

## verify-pkg-whitelist
Checks if allowed packages in `rhaos-$version-rhel-$rhel` is the same.