### PR TITLE
Convert to using user/password authentication for mirror.openshift.com yum repo

### DIFF
--- a/sjb/actions/oct_install.py
+++ b/sjb/actions/oct_install.py
@@ -14,6 +14,12 @@ EOF
 source "${WORKSPACE}/activate"
 mkdir -p "${OCT_CONFIG_HOME}"
 rm -rf "${OCT_CONFIG_HOME}/origin-ci-tool"
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo "ERROR: missing file: mirror-os-cred.sh"
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client 'keypair_name' 'openshift-dev'
 oct configure aws-client 'private_key_path' '/var/lib/jenkins/.ssh/openshift-dev.pem'"""

--- a/sjb/config/common/test_cases/origin.yml
+++ b/sjb/config/common/test_cases/origin.yml
@@ -160,11 +160,12 @@ actions:
       name=dockertested
       baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
       enabled=1
-      sslclientcert=/var/lib/yum/client-cert.pem
-      sslclientkey=/var/lib/yum/client-key.pem
       sslverify=0
       REPO
       fi
+      set +x
+      echo "username=$MIRROR_OS_USER" >> /etc/yum.repos.d/dockertested.repo
+      echo "password=$MIRROR_OS_PASS" >> /etc/yum.repos.d/dockertested.repo
 post_actions:
   - type: "host_script"
     title: "assemble GCS output"

--- a/sjb/config/common/test_cases/origin_built_installed_release.yml
+++ b/sjb/config/common/test_cases/origin_built_installed_release.yml
@@ -15,10 +15,11 @@ extensions:
         name=rhel-7-server-ansible-2.6-rpms
         baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
         enabled=1
-        sslclientcert=/var/lib/yum/client-cert.pem
-        sslclientkey=/var/lib/yum/client-key.pem
         sslverify=0
         REPO
+        set +x
+        echo "username=$MIRROR_OS_USER" >> /etc/yum.repos.d/dockertested.repo
+        echo "password=$MIRROR_OS_PASS" >> /etc/yum.repos.d/dockertested.repo
 
         sudo yum repolist
     - type: "script"

--- a/sjb/config/common/test_cases/origin_built_installed_release_311.yml
+++ b/sjb/config/common/test_cases/origin_built_installed_release_311.yml
@@ -15,10 +15,11 @@ extensions:
         name=rhel-7-server-ansible-2.6-rpms
         baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
         enabled=1
-        sslclientcert=/var/lib/yum/client-cert.pem
-        sslclientkey=/var/lib/yum/client-key.pem
         sslverify=0
         REPO
+        set +x
+        echo "username=$MIRROR_OS_USER" >> /etc/yum.repos.d/dockertested.repo
+        echo "password=$MIRROR_OS_PASS" >> /etc/yum.repos.d/dockertested.repo
 
         sudo yum repolist
     - type: "script"

--- a/sjb/config/common/test_cases/origin_minimal.yml
+++ b/sjb/config/common/test_cases/origin_minimal.yml
@@ -84,10 +84,11 @@ actions:
       name=dockertested
       baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
       enabled=1
-      sslclientcert=/var/lib/yum/client-cert.pem
-      sslclientkey=/var/lib/yum/client-key.pem
       sslverify=0
       REPO
+      set +x
+      echo "username=$MIRROR_OS_USER" >> /etc/yum.repos.d/dockertested.repo
+      echo "password=$MIRROR_OS_PASS" >> /etc/yum.repos.d/dockertested.repo
       fi
 post_actions:
   - type: "host_script"

--- a/sjb/generated/ami_build_origin_int_fedora_crio.xml
+++ b/sjb/generated/ami_build_origin_int_fedora_crio.xml
@@ -102,6 +102,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/ami_build_origin_int_rhel_base.xml
+++ b/sjb/generated/ami_build_origin_int_rhel_base.xml
@@ -61,6 +61,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/ami_build_origin_int_rhel_build.xml
+++ b/sjb/generated/ami_build_origin_int_rhel_build.xml
@@ -57,6 +57,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/ami_build_origin_int_rhel_crio.xml
+++ b/sjb/generated/ami_build_origin_int_rhel_crio.xml
@@ -102,6 +102,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/ami_build_origin_int_rhel_fork.xml
+++ b/sjb/generated/ami_build_origin_int_rhel_fork.xml
@@ -82,6 +82,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/ami_validate_origin_int_rhel_base.xml
+++ b/sjb/generated/ami_validate_origin_int_rhel_base.xml
@@ -111,6 +111,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/azure_build_base_image_centos.xml
+++ b/sjb/generated/azure_build_base_image_centos.xml
@@ -117,6 +117,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/azure_build_base_image_rhel.xml
+++ b/sjb/generated/azure_build_base_image_rhel.xml
@@ -117,6 +117,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/azure_build_node_image_centos.xml
+++ b/sjb/generated/azure_build_node_image_centos.xml
@@ -117,6 +117,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/azure_build_node_image_centos_310.xml
+++ b/sjb/generated/azure_build_node_image_centos_310.xml
@@ -122,6 +122,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/azure_build_node_image_rhel.xml
+++ b/sjb/generated/azure_build_node_image_rhel.xml
@@ -122,6 +122,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/azure_build_node_image_rhel_310.xml
+++ b/sjb/generated/azure_build_node_image_rhel_310.xml
@@ -122,6 +122,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/ci-kubernetes-aws-actuator.xml
+++ b/sjb/generated/ci-kubernetes-aws-actuator.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/ci-kubernetes-conformance-node-e2e-containerized-rhel.xml
+++ b/sjb/generated/ci-kubernetes-conformance-node-e2e-containerized-rhel.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/ci-kubernetes-conformance-node-e2e-rhel.xml
+++ b/sjb/generated/ci-kubernetes-conformance-node-e2e-rhel.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/ci-kubernetes-descheduler-e2e-gce.xml
+++ b/sjb/generated/ci-kubernetes-descheduler-e2e-gce.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/ci-kubernetes-machine-api-operator.xml
+++ b/sjb/generated/ci-kubernetes-machine-api-operator.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/pull-ci-openshift-cluster-api-actuator-pkg-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-cluster-api-actuator-pkg-master-e2e.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/pull-ci-openshift-cluster-api-provider-kubemark-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-cluster-api-provider-kubemark-master-e2e.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/pull-ci-openshift-cluster-api-provider-libvirt-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-cluster-api-provider-libvirt-master-e2e.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/pull-ci-openshift-cluster-autoscaler-operator-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-cluster-autoscaler-operator-master-e2e.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/pull-ci-openshift-kubernetes-autoscaler-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-kubernetes-autoscaler-master-e2e.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/pull-ci-openshift-machine-api-operator-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-machine-api-operator-master-e2e.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/push_cluster_operator_images.xml
+++ b/sjb/generated/push_cluster_operator_images.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/push_image_inspector_images.xml
+++ b/sjb/generated/push_image_inspector_images.xml
@@ -87,6 +87,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/push_jenkins_images.xml
+++ b/sjb/generated/push_jenkins_images.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/push_origin_aggregated_logging_release.xml
+++ b/sjb/generated/push_origin_aggregated_logging_release.xml
@@ -107,6 +107,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/push_origin_metrics_release.xml
+++ b/sjb/generated/push_origin_metrics_release.xml
@@ -107,6 +107,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/push_origin_metrics_release_310.xml
+++ b/sjb/generated/push_origin_metrics_release_310.xml
@@ -107,6 +107,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/push_origin_release.xml
+++ b/sjb/generated/push_origin_release.xml
@@ -117,6 +117,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -265,10 +271,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/push_origin_release_310.xml
+++ b/sjb/generated/push_origin_release_310.xml
@@ -117,6 +117,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -265,10 +271,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/push_origin_release_36.xml
+++ b/sjb/generated/push_origin_release_36.xml
@@ -117,6 +117,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -265,10 +271,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/push_origin_release_37.xml
+++ b/sjb/generated/push_origin_release_37.xml
@@ -117,6 +117,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -265,10 +271,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/push_origin_release_38.xml
+++ b/sjb/generated/push_origin_release_38.xml
@@ -117,6 +117,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -265,10 +271,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/push_origin_release_39.xml
+++ b/sjb/generated/push_origin_release_39.xml
@@ -117,6 +117,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -265,10 +271,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/push_wildfly_images.xml
+++ b/sjb/generated/push_wildfly_images.xml
@@ -113,6 +113,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_branch_cluster_operator_e2e.xml
+++ b/sjb/generated/test_branch_cluster_operator_e2e.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_cluster_operator_unit.xml
+++ b/sjb/generated/test_branch_cluster_operator_unit.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_crio_e2e_features_fedora.xml
+++ b/sjb/generated/test_branch_crio_e2e_features_fedora.xml
@@ -102,6 +102,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_branch_crio_e2e_features_rhel.xml
+++ b/sjb/generated/test_branch_crio_e2e_features_rhel.xml
@@ -102,6 +102,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_branch_crio_e2e_fedora.xml
+++ b/sjb/generated/test_branch_crio_e2e_fedora.xml
@@ -102,6 +102,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_branch_crio_e2e_rhel.xml
+++ b/sjb/generated/test_branch_crio_e2e_rhel.xml
@@ -102,6 +102,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_branch_image_inspector_images.xml
+++ b/sjb/generated/test_branch_image_inspector_images.xml
@@ -87,6 +87,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_branch_image_registry_integration.xml
+++ b/sjb/generated/test_branch_image_registry_integration.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_image_registry_unit.xml
+++ b/sjb/generated/test_branch_image_registry_unit.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_jenkins_client_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_client_plugin.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -402,10 +409,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_branch_jenkins_images.xml
+++ b/sjb/generated/test_branch_jenkins_images.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_branch_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_openshift_login_plugin.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -402,10 +409,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_branch_jenkins_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_plugin.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -402,10 +409,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_branch_jenkins_sync_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_sync_plugin.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -402,10 +409,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_branch_kubernetes_metrics_server_unit.xml
+++ b/sjb/generated/test_branch_kubernetes_metrics_server_unit.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_online_console_extensions.xml
+++ b/sjb/generated/test_branch_online_console_extensions.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_online_hibernation_unit.xml
+++ b/sjb/generated/test_branch_online_hibernation_unit.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_azure.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_azure.xml
@@ -150,6 +150,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -298,10 +304,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_azure_310.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_azure_310.xml
@@ -150,6 +150,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -298,10 +304,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce.xml
@@ -155,6 +155,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -303,10 +309,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_310.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_310.xml
@@ -160,6 +160,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -308,10 +314,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_37.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_37.xml
@@ -155,6 +155,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -303,10 +309,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_39.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_39.xml
@@ -155,6 +155,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -303,10 +309,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_logging.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -417,10 +424,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_branch_openshift_ansible_logging_310.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_logging_311.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_311.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -417,10 +424,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -417,10 +424,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file_310.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file_311.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file_311.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -417,10 +424,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_branch_origin_aggregated_logging_json_file.xml
+++ b/sjb/generated/test_branch_origin_aggregated_logging_json_file.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -417,10 +424,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_branch_origin_aggregated_logging_json_file_310.xml
+++ b/sjb/generated/test_branch_origin_aggregated_logging_json_file_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_aggregated_logging_json_file_311.xml
+++ b/sjb/generated/test_branch_origin_aggregated_logging_json_file_311.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -417,10 +424,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_branch_origin_check.xml
+++ b/sjb/generated/test_branch_origin_check.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_check_310.xml
+++ b/sjb/generated/test_branch_origin_check_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_cmd.xml
+++ b/sjb/generated/test_branch_origin_cmd.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_cmd_310.xml
+++ b/sjb/generated/test_branch_origin_cmd_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_cross.xml
+++ b/sjb/generated/test_branch_origin_cross.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_cross_310.xml
+++ b/sjb/generated/test_branch_origin_cross_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_end_to_end.xml
+++ b/sjb/generated/test_branch_origin_end_to_end.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_end_to_end_310.xml
+++ b/sjb/generated/test_branch_origin_end_to_end_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_end_to_end_311.xml
+++ b/sjb/generated/test_branch_origin_end_to_end_311.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_builds_310.xml
+++ b/sjb/generated/test_branch_origin_extended_builds_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_builds_311.xml
+++ b/sjb/generated/test_branch_origin_extended_builds_311.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -402,10 +409,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_branch_origin_extended_clusterup.xml
+++ b/sjb/generated/test_branch_origin_extended_clusterup.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_clusterup_310.xml
+++ b/sjb/generated/test_branch_origin_extended_clusterup_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_azure.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_azure.xml
@@ -150,6 +150,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -298,10 +304,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_azure_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_azure_310.xml
@@ -150,6 +150,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -298,10 +304,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_crio.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_crio_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_crio_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_crio_rpm.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_crio_rpm.xml
@@ -131,6 +131,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -346,11 +352,12 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
 fi
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_crio_rpm_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_crio_rpm_310.xml
@@ -131,6 +131,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -346,11 +352,12 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
 fi
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce.xml
@@ -151,6 +151,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -299,10 +305,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_gce_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce_310.xml
@@ -156,6 +156,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -304,10 +310,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_gce_37.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce_37.xml
@@ -151,6 +151,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -299,10 +305,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_gce_38.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce_38.xml
@@ -151,6 +151,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -299,10 +305,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_gce_39.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce_39.xml
@@ -151,6 +151,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -299,10 +305,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install-release-3.11.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install-release-3.11.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -402,10 +409,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_branch_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -402,10 +409,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_branch_origin_extended_conformance_install_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_311.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_311.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -402,10 +409,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_branch_origin_extended_conformance_install_36.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_36.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_37.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_37.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_38.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_38.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_39.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_39.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_containerized.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_containerized.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_containerized_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_containerized_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_in_tree.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_in_tree.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_in_tree_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_in_tree_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
@@ -117,6 +117,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -280,10 +286,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -422,10 +429,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_branch_origin_extended_conformance_install_system_containers_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_system_containers_310.xml
@@ -117,6 +117,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -280,10 +286,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_k8s.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_k8s.xml
@@ -156,6 +156,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -304,10 +310,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_k8s_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_k8s_310.xml
@@ -161,6 +161,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -309,10 +315,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_k8s_39.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_k8s_39.xml
@@ -156,6 +156,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -304,10 +310,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_gssapi.xml
+++ b/sjb/generated/test_branch_origin_extended_gssapi.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_gssapi_310.xml
+++ b/sjb/generated/test_branch_origin_extended_gssapi_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_image_ecosystem_310.xml
+++ b/sjb/generated/test_branch_origin_extended_image_ecosystem_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_image_ecosystem_311.xml
+++ b/sjb/generated/test_branch_origin_extended_image_ecosystem_311.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -402,10 +409,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_branch_origin_extended_image_registry_310.xml
+++ b/sjb/generated/test_branch_origin_extended_image_registry_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_ldap_groups.xml
+++ b/sjb/generated/test_branch_origin_extended_ldap_groups.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_ldap_groups_310.xml
+++ b/sjb/generated/test_branch_origin_extended_ldap_groups_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_networking.xml
+++ b/sjb/generated/test_branch_origin_extended_networking.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_networking_310.xml
+++ b/sjb/generated/test_branch_origin_extended_networking_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_integration.xml
+++ b/sjb/generated/test_branch_origin_integration.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_integration_310.xml
+++ b/sjb/generated/test_branch_origin_integration_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_service_catalog.xml
+++ b/sjb/generated/test_branch_origin_service_catalog.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_service_catalog_310.xml
+++ b/sjb/generated/test_branch_origin_service_catalog_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_unit.xml
+++ b/sjb/generated/test_branch_origin_unit.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_unit_310.xml
+++ b/sjb/generated/test_branch_origin_unit_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_verify.xml
+++ b/sjb/generated/test_branch_origin_verify.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_verify_310.xml
+++ b/sjb/generated/test_branch_origin_verify_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_web_console.xml
+++ b/sjb/generated/test_branch_origin_web_console.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_web_console_310.xml
+++ b/sjb/generated/test_branch_origin_web_console_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_web_console_311.xml
+++ b/sjb/generated/test_branch_origin_web_console_311.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_web_console_39.xml
+++ b/sjb/generated/test_branch_origin_web_console_39.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_web_console_server_check.xml
+++ b/sjb/generated/test_branch_origin_web_console_server_check.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_web_console_server_e2e.xml
+++ b/sjb/generated/test_branch_origin_web_console_server_e2e.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_branch_ovn_kubernetes_unit.xml
+++ b/sjb/generated/test_branch_ovn_kubernetes_unit.xml
@@ -102,6 +102,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_branch_wildfly_images.xml
+++ b/sjb/generated/test_branch_wildfly_images.xml
@@ -114,6 +114,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_origin_device_manager_plugin_gpu.xml
+++ b/sjb/generated/test_origin_device_manager_plugin_gpu.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -262,10 +268,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -404,10 +411,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_cluster_operator_e2e.xml
+++ b/sjb/generated/test_pull_request_cluster_operator_e2e.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_cluster_operator_unit.xml
+++ b/sjb/generated/test_pull_request_cluster_operator_unit.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_crio_ami_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_ami_fedora.xml
@@ -102,6 +102,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_pull_request_crio_ami_rhel.xml
+++ b/sjb/generated/test_pull_request_crio_ami_rhel.xml
@@ -102,6 +102,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_pull_request_crio_critest_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_critest_fedora.xml
@@ -102,6 +102,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_pull_request_crio_critest_rhel.xml
+++ b/sjb/generated/test_pull_request_crio_critest_rhel.xml
@@ -102,6 +102,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_pull_request_crio_e2e_crun_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_e2e_crun_fedora.xml
@@ -102,6 +102,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_pull_request_crio_e2e_crun_fedora_cgroupv2.xml
+++ b/sjb/generated/test_pull_request_crio_e2e_crun_fedora_cgroupv2.xml
@@ -102,6 +102,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_pull_request_crio_e2e_features_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_e2e_features_fedora.xml
@@ -102,6 +102,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_pull_request_crio_e2e_features_rhel.xml
+++ b/sjb/generated/test_pull_request_crio_e2e_features_rhel.xml
@@ -102,6 +102,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_pull_request_crio_e2e_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_e2e_fedora.xml
@@ -102,6 +102,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_pull_request_crio_e2e_rhel.xml
+++ b/sjb/generated/test_pull_request_crio_e2e_rhel.xml
@@ -102,6 +102,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_pull_request_crio_integration_crun_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_integration_crun_fedora.xml
@@ -102,6 +102,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_pull_request_crio_integration_crun_fedora_cgroupv2.xml
+++ b/sjb/generated/test_pull_request_crio_integration_crun_fedora_cgroupv2.xml
@@ -102,6 +102,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_pull_request_crio_integration_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_integration_fedora.xml
@@ -102,6 +102,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_pull_request_crio_integration_kata_fedora.xml
+++ b/sjb/generated/test_pull_request_crio_integration_kata_fedora.xml
@@ -102,6 +102,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_pull_request_crio_integration_rhel.xml
+++ b/sjb/generated/test_pull_request_crio_integration_rhel.xml
@@ -102,6 +102,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_pull_request_descheduler_gce_39.xml
+++ b/sjb/generated/test_pull_request_descheduler_gce_39.xml
@@ -146,6 +146,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -294,10 +300,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_image_registry_integration.xml
+++ b/sjb/generated/test_pull_request_image_registry_integration.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_image_registry_unit.xml
+++ b/sjb/generated/test_pull_request_image_registry_unit.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_jenkins_client_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_client_plugin.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -402,10 +409,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_jenkins_images.xml
+++ b/sjb/generated/test_pull_request_jenkins_images.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_pull_request_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_openshift_login_plugin.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -402,10 +409,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_jenkins_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_plugin.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -402,10 +409,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_jenkins_sync_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_sync_plugin.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -402,10 +409,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_kubernetes_metrics_server_unit.xml
+++ b/sjb/generated/test_pull_request_kubernetes_metrics_server_unit.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_online_console_extensions.xml
+++ b/sjb/generated/test_pull_request_online_console_extensions.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_online_hibernation_unit.xml
+++ b/sjb/generated/test_pull_request_online_hibernation_unit.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_azure.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_azure.xml
@@ -150,6 +150,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -298,10 +304,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_azure_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_azure_310.xml
@@ -150,6 +150,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -298,10 +304,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce.xml
@@ -150,6 +150,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -298,10 +304,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_310.xml
@@ -155,6 +155,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -303,10 +309,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_37.xml
@@ -150,6 +150,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -298,10 +304,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_39.xml
@@ -150,6 +150,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -298,10 +304,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha.xml
@@ -150,6 +150,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -298,10 +304,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha_310.xml
@@ -155,6 +155,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -303,10 +309,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha_39.xml
@@ -150,6 +150,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -298,10 +304,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install-release-3.11.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install-release-3.11.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -402,10 +409,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -402,10 +409,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio_rpm.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio_rpm.xml
@@ -141,6 +141,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -399,11 +405,12 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
 fi
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio_rpm_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio_rpm_310.xml
@@ -141,6 +141,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -399,11 +405,12 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
 fi
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_in_tree.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_in_tree.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_in_tree_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_in_tree_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_36.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -402,10 +409,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_37.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -402,10 +409,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_39.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -402,10 +409,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
@@ -117,6 +117,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -280,10 +286,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -422,10 +429,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_310.xml
@@ -117,6 +117,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -280,10 +286,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_36.xml
@@ -117,6 +117,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -280,10 +286,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -422,10 +429,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_37.xml
@@ -117,6 +117,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -280,10 +286,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -422,10 +429,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_39.xml
@@ -117,6 +117,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -280,10 +286,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -422,10 +429,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -402,10 +409,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_install_upgrade_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_install_upgrade_gce.xml
@@ -155,6 +155,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -303,10 +309,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_install_upgrade_gce_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_install_upgrade_gce_310.xml
@@ -155,6 +155,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -303,10 +309,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_launch_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_launch_gce.xml
@@ -146,6 +146,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -294,10 +300,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_launch_gce_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_launch_gce_310.xml
@@ -151,6 +151,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -299,10 +305,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_logging-release-3.11.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging-release-3.11.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -417,10 +424,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_logging.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -417,10 +424,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_311.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_311.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -417,10 +424,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_36.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -417,10 +424,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_37.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -417,10 +424,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_39.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -417,10 +424,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_openshift_ansible_tox.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_tox.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_tox_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_tox_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_service_catalog.xml
+++ b/sjb/generated/test_pull_request_openshift_service_catalog.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_service_catalog_310.xml
+++ b/sjb/generated/test_pull_request_openshift_service_catalog_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_service_catalog_311.xml
+++ b/sjb/generated/test_pull_request_openshift_service_catalog_311.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald-release-3.11.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald-release-3.11.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -417,10 +424,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -417,10 +424,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_310.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_36.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_36.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -417,10 +424,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_37.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_37.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -417,10 +424,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_39.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_39.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -417,10 +424,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file-release-3.11.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file-release-3.11.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -417,10 +424,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -417,10 +424,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_310.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_36.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_36.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -417,10 +424,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_37.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_37.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -417,10 +424,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_39.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_39.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -275,10 +281,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -417,10 +424,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_cmd.xml
+++ b/sjb/generated/test_pull_request_origin_cmd.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_cmd_310.xml
+++ b/sjb/generated/test_pull_request_origin_cmd_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_cross.xml
+++ b/sjb/generated/test_pull_request_origin_cross.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_cross_310.xml
+++ b/sjb/generated/test_pull_request_origin_cross_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_end_to_end.xml
+++ b/sjb/generated/test_pull_request_origin_end_to_end.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_end_to_end_310.xml
+++ b/sjb/generated/test_pull_request_origin_end_to_end_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_end_to_end_311.xml
+++ b/sjb/generated/test_pull_request_origin_end_to_end_311.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_builds_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_builds_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_builds_311.xml
+++ b/sjb/generated/test_pull_request_origin_extended_builds_311.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -402,10 +409,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_extended_clusterup-release-3.11.xml
+++ b/sjb/generated/test_pull_request_origin_extended_clusterup-release-3.11.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_clusterup.xml
+++ b/sjb/generated/test_pull_request_origin_extended_clusterup.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_clusterup_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_clusterup_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_azure.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_azure.xml
@@ -150,6 +150,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -298,10 +304,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_azure_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_azure_310.xml
@@ -150,6 +150,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -298,10 +304,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_crio_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_crio_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_crio_rpm.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_crio_rpm.xml
@@ -131,6 +131,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -346,11 +352,12 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
 fi
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_crio_rpm_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_crio_rpm_310.xml
@@ -131,6 +131,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -346,11 +352,12 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
 fi
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
@@ -150,6 +150,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -298,10 +304,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce_310.xml
@@ -155,6 +155,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -303,10 +309,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce_37.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce_37.xml
@@ -150,6 +150,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -298,10 +304,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce_39.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce_39.xml
@@ -150,6 +150,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -298,10 +304,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install-release-3.11.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install-release-3.11.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -402,10 +409,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -402,10 +409,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_36.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_36.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_37.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_37.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_38.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_38.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_39.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_39.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -402,10 +409,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_update_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_update_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_k8s.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_k8s.xml
@@ -151,6 +151,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -299,10 +305,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_k8s_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_k8s_310.xml
@@ -156,6 +156,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -304,10 +310,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_gssapi.xml
+++ b/sjb/generated/test_pull_request_origin_extended_gssapi.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_gssapi_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_gssapi_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_image_ecosystem_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_ecosystem_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_image_ecosystem_311.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_ecosystem_311.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -402,10 +409,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_extended_image_registry-release-3.11.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_registry-release-3.11.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;
@@ -402,10 +409,11 @@ cat &lt;&lt;REPO &gt;/etc/yum.repos.d/rhel-7-server-ansible-2.6-rpms.repo
 name=rhel-7-server-ansible-2.6-rpms
 baseurl=https://mirror.openshift.com/enterprise/rhel/rhel-7-server-ansible-2.6-rpms/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 
 sudo yum repolist
 SCRIPT

--- a/sjb/generated/test_pull_request_origin_extended_image_registry_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_registry_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_ldap_groups.xml
+++ b/sjb/generated/test_pull_request_origin_extended_ldap_groups.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_ldap_groups_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_ldap_groups_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_networking.xml
+++ b/sjb/generated/test_pull_request_origin_extended_networking.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_networking_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_networking_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_integration.xml
+++ b/sjb/generated/test_pull_request_origin_integration.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_integration_310.xml
+++ b/sjb/generated/test_pull_request_origin_integration_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_launch_gce.xml
+++ b/sjb/generated/test_pull_request_origin_launch_gce.xml
@@ -146,6 +146,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -294,10 +300,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_launch_gce_310.xml
+++ b/sjb/generated/test_pull_request_origin_launch_gce_310.xml
@@ -151,6 +151,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -299,10 +305,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_service_catalog.xml
+++ b/sjb/generated/test_pull_request_origin_service_catalog.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_service_catalog_310.xml
+++ b/sjb/generated/test_pull_request_origin_service_catalog_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_service_catalog_39.xml
+++ b/sjb/generated/test_pull_request_origin_service_catalog_39.xml
@@ -122,6 +122,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -330,11 +336,12 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
 fi
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_unit.xml
+++ b/sjb/generated/test_pull_request_origin_unit.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_unit_310.xml
+++ b/sjb/generated/test_pull_request_origin_unit_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_verify.xml
+++ b/sjb/generated/test_pull_request_origin_verify.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_verify_310.xml
+++ b/sjb/generated/test_pull_request_origin_verify_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_web_console.xml
+++ b/sjb/generated/test_pull_request_origin_web_console.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_web_console_310.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_310.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_web_console_311.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_311.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_web_console_39.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_39.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_web_console_server_check.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_server_check.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_web_console_server_e2e.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_server_e2e.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>
@@ -260,10 +266,11 @@ if [[ &#34;\${PULL_BASE_REF:-master}&#34; == &#34;master&#34; || &#34;\${PULL_BA
 name=dockertested
 baseurl=https://mirror.openshift.com/enterprise/rhel/dockertested/x86_64/os/
 enabled=1
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
 sslverify=0
 REPO
+set +x
+echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
+echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; /etc/yum.repos.d/dockertested.repo
 fi
 SCRIPT
 chmod +x &#34;${script}&#34;

--- a/sjb/generated/test_pull_request_ovn_kubernetes_rhel.xml
+++ b/sjb/generated/test_pull_request_ovn_kubernetes_rhel.xml
@@ -102,6 +102,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_pull_request_s2i_master.xml
+++ b/sjb/generated/test_pull_request_s2i_master.xml
@@ -112,6 +112,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>

--- a/sjb/generated/test_pull_request_wildfly_images.xml
+++ b/sjb/generated/test_pull_request_wildfly_images.xml
@@ -114,6 +114,12 @@ EOF
 source &#34;${WORKSPACE}/activate&#34;
 mkdir -p &#34;${OCT_CONFIG_HOME}&#34;
 rm -rf &#34;${OCT_CONFIG_HOME}/origin-ci-tool&#34;
+if [[ -f /var/lib/jenkins/mirror-os-cred.sh ]; then
+  source /var/lib/jenkins/mirror-os-cred.sh
+else
+  echo &#34;ERROR: missing file: mirror-os-cred.sh&#34;
+  exit 1
+fi
 oct configure ansible-client verbosity 2
 oct configure aws-client &#39;keypair_name&#39; &#39;openshift-dev&#39;
 oct configure aws-client &#39;private_key_path&#39; &#39;/var/lib/jenkins/.ssh/openshift-dev.pem&#39;</command>


### PR DESCRIPTION
These enviroment variables:
* MIRROR_OS_USER
* MIRROR_OS_PASS

are expected to be defined before these scripts run (by sourcing a file that resides on the jenkins server which runs ansible).

I believe we still need to generate the files (in the generate directory) and push them for this all to take effect (but don't know how yet...).

update: the files were generated using:

```
pip install -r sjb/requirements.txt
sjb/generate.sh
```

and then added to this PR.