### PR TITLE
Remove patch manager from slack notification when opening PRs

### DIFF
--- a/jobs/build/cincinnati-prs/Jenkinsfile
+++ b/jobs/build/cincinnati-prs/Jenkinsfile
@@ -8,7 +8,7 @@ node {
         <hr />
         <h2>Create the PRs for Cincinnati to publish a release</h2>
         <hr />
-        <p><b>Timing</b>: The "release" job runs this once the release is accepted.</p>
+        <p><b>Timing</b>: The promote job runs this once the release is accepted.</p>
         This creates PRs to enter the new release in all the relevant Cincinnati channels <a href="https://github.com/openshift/cincinnati-graph-data/tree/master/channels" target="_blank">here</a>
         <a href="https://github.com/openshift/aos-cd-jobs/blob/master/jobs/build/cincinnati-prs/README.md">For more details see the README.</a>
     """)
@@ -67,7 +67,6 @@ node {
             disableConcurrentBuilds()
         ]
     )   // Please update README.md if modifying parameter names or semantics
-
     commonlib.checkMock()
     workdir = "${env.WORKSPACE}/workdir"
     buildlib.cleanWorkdir(workdir, true)

--- a/jobs/build/cincinnati-prs/Jenkinsfile
+++ b/jobs/build/cincinnati-prs/Jenkinsfile
@@ -8,7 +8,7 @@ node {
         <hr />
         <h2>Create the PRs for Cincinnati to publish a release</h2>
         <hr />
-        <p><b>Timing</b>: The promote job runs this once the release is accepted.</p>
+        <p><b>Timing</b>: The promote-assembly job runs this once the release is accepted.</p>
         This creates PRs to enter the new release in all the relevant Cincinnati channels <a href="https://github.com/openshift/cincinnati-graph-data/tree/master/channels" target="_blank">here</a>
         <a href="https://github.com/openshift/aos-cd-jobs/blob/master/jobs/build/cincinnati-prs/README.md">For more details see the README.</a>
     """)

--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -863,7 +863,6 @@ def sendCincinnatiPRsSlackNotification(releaseName, fromReleaseTag, prs, ghorg='
     if (additional_text) {
         slack_msg += "${additional_text}\n"
     }
-    slack_msg += "@patch-manager Please continue merging PRs for the next release.\n"
 
     if ( ghorg == 'openshift' && !noSlackOutput) {
         slacklib.to('#forum-release').say(slack_msg)


### PR DESCRIPTION
Now that we have gotten rid of merge window we can remove this ping for resuming merging