### PR TITLE
[ART-3656] build-sync: Don't fail in case of no change

### DIFF
--- a/jobs/build/build-sync/build.groovy
+++ b/jobs/build/build-sync/build.groovy
@@ -129,7 +129,7 @@ def buildSyncApplyImageStreams() {
         def currentIS = getImageStream(theStream, namespace)
         def currentISfilename = "pre-apply-${namespace}-${theStream}.json"
         writeJSON(file: currentISfilename, json: currentIS)
-        artifacts.addAll(["pre-apply-${namespace}-${theStream}.json"])
+        artifacts.addAll([currentISfilename])
 
         // Make sure there's still an update to IS
         def diffStatus = buildlib.oc("--kubeconfig ${buildlib.ciKubeconfig} diff --filename=${isFile}", [returnStatus: true])
@@ -152,7 +152,7 @@ def buildSyncApplyImageStreams() {
         def newIS = getImageStream(theStream, namespace)
         newISfilename = "post-apply-${namespace}-${theStream}.json"
         writeJSON(file: newISfilename, json: newIS)
-        artifacts.addAll(["post-apply-${namespace}-${theStream}.json"])
+        artifacts.addAll([newISfilename])
 
         def newResourceVersion = newIS.metadata.resourceVersion
         if ( newResourceVersion == currentResourceVersion ) {

--- a/jobs/build/build-sync/build.groovy
+++ b/jobs/build/build-sync/build.groovy
@@ -132,7 +132,7 @@ def buildSyncApplyImageStreams() {
         artifacts.addAll([currentISfilename])
 
         // Make sure there's still an update to IS
-        def diffStatus = buildlib.oc("--kubeconfig ${buildlib.ciKubeconfig} diff --filename=${isFile}", [returnStatus: true])
+        def diffStatus = buildlib.oc("--kubeconfig ${buildlib.ciKubeconfig} diff --filename=${isFile}", [capture: true, returnStatus: true])
         if ( diffStatus == 0 ) {
             echo("No difference found in generated and current IS. Skipping")
             continue

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -154,6 +154,7 @@ def elliott(cmd, opts=[:]){
 def oc(cmd, opts=[:]){
     return commonlib.shell(
         returnStdout: opts.capture ?: false,
+        returnStatus: opts.returnStatus ?: false,
         script: "GOTRACEBACK=all /usr/bin/oc ${cleanWhitespace(cmd)}"
     )
 }


### PR DESCRIPTION
Right now multiple build-syncs can be running in parallel / close to each other. 
This causes one of them to fail since a previous one updated the imagestreams
 and there's nothing to do. In that case one of our verification fails - 
with error "Image Stream did not update"
since it thinks we failed to perform an update. This change fixes that by skipping if 
there isn't an update to apply

Test run: 
- no update - https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Fbuild-sync/4/console
- update - https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Fbuild-sync/5/console