### PR TITLE
Fix syntax error

### DIFF
--- a/scheduled-jobs/build/sync-for-ci/Jenkinsfile
+++ b/scheduled-jobs/build/sync-for-ci/Jenkinsfile
@@ -27,7 +27,13 @@ def sortedVersions() {
   // Return versions honoring semver, but exclude disabled
   def disabled = []
   def s = commonlib.ocp4Versions.sort(false) {
-    def (major, minor) = it.tokenize('.')
+    def major_minor = it.tokenize('.')
+
+    assert major_minor.size() == 2
+
+    def major = major_minor[0]
+    def minor = major_minor[1]
+
     major*100000 + minor
   }
   return s.findAll { !disabled.contains(it) }


### PR DESCRIPTION
Compare 1df8e51a18e1a3e4d60e5328d5fd9a5d8080f51a