### PR TITLE
Do not emit passwords when we disable repos w/ password auth

### DIFF
--- a/sjb/config/common/test_cases/origin_minimal.yml
+++ b/sjb/config/common/test_cases/origin_minimal.yml
@@ -48,7 +48,7 @@ actions:
     script: |-
       sudo yum-config-manager --disable centos-paas-sig-openshift-origin\*-rpms
       sudo yum-config-manager --disable origin-deps-rhel7\* || true
-      sudo yum-config-manager --disable rhel-7-server-ose\* || true
+      sudo yum-config-manager --disable rhel-7-server-ose\* |grep -v "password" |grep -v "username" || true
 
       if [[ "${JOB_NAME}" == *update* ]]; then
         branch="${PULL_BASE_REF:-"master"}"

--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_crio_rpm.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_crio_rpm.yml
@@ -44,7 +44,7 @@ extensions:
       script: |-
         sudo yum-config-manager --disable centos-paas-sig-openshift-origin\*-rpms
         sudo yum-config-manager --disable origin-deps-rhel7\* || true
-        sudo yum-config-manager --disable rhel-7-server-ose\* || true
+        sudo yum-config-manager --disable rhel-7-server-ose\* |grep -v "password" |grep -v "username" || true
 
         branch="${PULL_BASE_REF:-"master"}"
         case "${branch}" in

--- a/sjb/config/test_cases/test_branch_origin_extended_conformance_crio_rpm_310.yml
+++ b/sjb/config/test_cases/test_branch_origin_extended_conformance_crio_rpm_310.yml
@@ -44,7 +44,7 @@ extensions:
       script: |-
         sudo yum-config-manager --disable centos-paas-sig-openshift-origin\*-rpms
         sudo yum-config-manager --disable origin-deps-rhel7\* || true
-        sudo yum-config-manager --disable rhel-7-server-ose\* || true
+        sudo yum-config-manager --disable rhel-7-server-ose\* |grep -v "password" |grep -v "username" || true
 
         branch="${PULL_BASE_REF:-"master"}"
         case "${branch}" in


### PR DESCRIPTION
If we are to use mirror.openshift.com for `rhel-7-server-ose*` repos, disabling them actually prints out the full info (including password).  We'd like to avoid seeing the password in the log.