### PR TITLE
Bump for multi apply

### DIFF
--- a/jobs/build/build-sync/build.groovy
+++ b/jobs/build/build-sync/build.groovy
@@ -39,67 +39,32 @@ def initialize() {
 
 
 // ######################################################################
-// This will create a list of SOURCE=DEST strings in the output
-// file(s). Will take a few minutes because we must query brew and the
-// registry for each image.
+// Determine the content to update in the ART latest imagestreams
+// and apply those changes on the CI cluster. The verb will also mirroring
+// out images to the quay monorepos.
 def buildSyncGenInputs() {
     echo("Generating SRC=DEST and ImageStreams for arches")
     def images = imageList ? "--images '${imageList}'" : ''
     def excludeArchesParam = ""
     for(arch in excludeArches)
         excludeArchesParam += " --exclude-arch ${arch}"
-    def skipGCTaggingParam = params.DRY_RUN ? '--skip-gc-tagging' : ''
-    buildlib.doozer """
+    def dryRunParams = params.DRY_RUN ? '--skip-gc-tagging --moist-run' : ''
+    withEnv(["KUBECONFIG=${buildlib.ciKubeconfig}"]) {
+        buildlib.doozer """
 ${images}
 --working-dir "${mirrorWorking}"
 --data-path "${params.DOOZER_DATA_PATH}"
 --group 'openshift-${params.BUILD_VERSION}'
 release:gen-payload
+--output-dir "${mirrorWorking}/gen-payload-artifacts"
+--apply
 ${params.EMERGENCY_IGNORE_ISSUES?'--emergency-ignore-issues':''}
 ${excludeArchesParam}
-${skipGCTaggingParam}
+${dryRunParams}
 """
-    echo("Generated files:")
-    echo("######################################################################")
-    def mirroringFiles = findFiles(glob: 'src_dest.*').collect{ it.path }
-    for (f in mirroringFiles) {
-        echo("######################################################################")
-        echo(f)
-        echo(readFile(file: f))
     }
-    mirroringKeys = mirroringFiles.collect{(it.split("\\.") as List).last()} // src_dest.x86_64 -> x86_64
-    echo("Moving generated files into working directory for archival purposes")
-    sh("mv src_dest* ${mirrorWorking}/")
-    sh("mv image_stream*.yaml ${mirrorWorking}/")
-    artifacts.addAll(["MIRROR_working/src_dest*", "MIRROR_working/image_stream*"])
-    try {
-        artifacts.addAll(["MIRROR_working/state.yaml"])
-        state = readYaml(file: "MIRROR_working/state.yaml")
-        if (state.required_fail > 0 || state.optional_fail > 0) {
-            echo "Not all images are updated. See Doozer logs and state.yaml"
-            currentBuild.result = "UNSTABLE"
-        }
-    } catch (ex) {
-        echo "Unable to read MIRROR_working/state.yaml"
-        currentBuild.result = "UNSTABLE"
-    }
-}
+    artifacts.addAll(["${mirrorWorking}/gen-payload-artifacts/*"])
 
-// ######################################################################
-// Now run the actual mirroring commands. We wrap this in a retry()
-// loop because it is known to fail occassionally depending on the
-// health of the source/destination endpoints.
-def buildSyncMirrorImages() {
-    for ( String key: mirroringKeys ) {
-        retry ( 3 ) {
-            echo("Attempting to mirror: ${key}")
-            // Always login again. It may expire between loops
-            // depending on amount of time elapsed
-            buildlib.registry_quay_dev_login()
-            def dryRun = "--dry-run=${params.DRY_RUN ? 'true' : 'false'}"
-            buildlib.oc "${logLevel} image mirror ${dryRun} --filename=${mirrorWorking}/src_dest.${key}"
-        }
-    }
 }
 
 def backupAllImageStreams() {
@@ -113,82 +78,6 @@ def backupAllImageStreams() {
     }
     commonlib.shell("tar zcvf app.ci-backup.tgz *.backup.yaml && rm *.backup.yaml")
     commonlib.safeArchiveArtifacts(["app.ci-backup.tgz"])
-}
-
-
-def buildSyncApplyImageStreams() {
-    echo("Updating ImageStream's")
-    def failures = []
-    def isFiles = findFiles(glob: "MIRROR_working/image_stream.*.yaml").collect{ it.path }
-    for ( String isFile: isFiles ) {
-        def imageStream = readYaml file: isFile
-        def theStream = imageStream.metadata.name
-        def namespace = imageStream.metadata.namespace
-
-        // Get the current IS and save it to disk. We may need this for debugging.
-        def currentIS = getImageStream(theStream, namespace)
-        writeJSON(file: "pre-apply-${namespace}-${theStream}.json", json: currentIS)
-        artifacts.addAll(["pre-apply-${namespace}-${theStream}.json"])
-
-        // We check for updates by comparing the object's 'resourceVersion'
-        def currentResourceVersion = currentIS.metadata?.resourceVersion ?: 0
-        echo("Current resourceVersion for ${theStream}: ${currentResourceVersion}")
-
-        // Ok, try the update. Jack that debug output up high, just in case
-        echo("Going to apply this ImageStream:")
-        echo(readFile(file: isFile))
-        def dryRun = "--dry-run=${params.DRY_RUN ? 'client' : 'none'}"
-        buildlib.oc("${logLevel} apply ${dryRun} --filename=${isFile} --kubeconfig ${buildlib.ciKubeconfig}")
-
-        // Now we verify that the change went through and save the bits as we go
-        def newIS = getImageStream(theStream, namespace)
-        writeJSON(file: "post-apply-${namespace}-${theStream}.json", json: newIS)
-        artifacts.addAll(["post-apply-${namespace}-${theStream}.json"])
-        def newResourceVersion = newIS.metadata.resourceVersion
-        if ( newResourceVersion == currentResourceVersion ) {
-            if ( params.DRY_RUN ) {
-                echo("IS `.metadata.resourceVersion` has not updated, which is expected in a dry run.")
-            } else {
-                echo("IS `.metadata.resourceVersion` has not updated, it should have updated. Please use the debug info above to report this issue")
-                currentBuild.description += "<br>ImageStream update failed for ${isFile}"
-                failures << isFile
-            }
-        }
-        if ( params.PUBLISH ) {
-            def reponame = namespace.replace("ocp", "release")
-            def image = "registry.ci.openshift.org/${namespace}/${reponame}:${theStream}"
-            def name = "${params.BUILD_VERSION}.0-${params.ASSEMBLY}"  // must be semver
-            def cmd = """
-                adm release new -n ${namespace} --name ${name} --to-image=${image}
-                --reference-mode=source --from-image-stream ${theStream}
-            """
-
-            if ( params.DRY_RUN ) {
-                echo("Would have created the release image as follows: ${cmd}")
-                continue
-            }
-            buildlib.oc("${logLevel} --kubeconfig ${buildlib.ciKubeconfig} registry login")
-            retry(3) {  // many times the IS is in a weird state for a while
-                sleep(5)
-                buildlib.oc("${logLevel} --kubeconfig ${buildlib.ciKubeconfig} ${cmd}")
-            }
-            currentBuild.description += "<br>Published ${image}"
-        }
-    }
-    if (failures) {
-        msg = "Image Stream did not update for ${failures}"
-        slackChannel = slacklib.to(params.BUILD_VERSION)
-        slackChannel.say(msg)
-        throw new Exception(msg)
-    }
-}
-
-// Get a JSON object of the named image stream in the ocp
-// namespace. The image stream is also saved locally for debugging
-// purposes.
-def getImageStream(is, ns) {
-    def isJson = readJSON(text: buildlib.oc(" get is ${is} -n ${ns} --ignore-not-found -o json --kubeconfig ${buildlib.ciKubeconfig}", [capture: true]).trim() ?: "{}")
-    return isJson
 }
 
 return this


### PR DESCRIPTION
Allow doozer to perform the imagestream updates to inform the release controller. Logic to mirror and update imagestreams is being removed from groovy.