### PR TITLE
Use repo files with proper authentication; install two missing packages

### DIFF
--- a/sjb/actions/clonerefs.py
+++ b/sjb/actions/clonerefs.py
@@ -66,12 +66,24 @@ class ClonerefsAction(Action):
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i < 10; i++ )); do
+    done
+    for (( i = 0; i < 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done""",
+    done
+
+    for (( i = 0; i < 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i < 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done""",
                     output_format=self.output_format
                 )
             ]

--- a/sjb/config/common/test_cases/origin_built_installed_release_311.yml
+++ b/sjb/config/common/test_cases/origin_built_installed_release_311.yml
@@ -36,6 +36,12 @@ extensions:
         fi
         sudo yum install -y "openshift-ansible${last_tag/openshift-ansible/}.git.0.${last_commit}.el7_9"
         rpm -q "openshift-ansible${last_tag/openshift-ansible/}.git.0.${last_commit}.el7_9"
+
+        # Not sure if this ever got installed (so I installed them here)
+        # TODO: We can comment this out and try later.
+        sudo rpm -ivh /data/iptables-services-1.4.21-35.el7.x86_64.rpm
+        sudo rpm -ivh /data/dnsmasq-2.76-16.el7.x86_64.rpm
+
     - type: "script"
       title: "install Ansible plugins"
       timeout: 600

--- a/sjb/config/common/test_cases/origin_minimal.yml
+++ b/sjb/config/common/test_cases/origin_minimal.yml
@@ -72,6 +72,23 @@ actions:
             ;;
         esac
       fi
+      pushd .
+      echo "Fixing up /etc/yum.repos.d and adding in credentials"
+      cd /etc/yum.repos.d
+      sudo tar xzvf /data/good_repos_rhui.tgz
+      set +x
+      source /data/mirror-os-cred.sh
+      set -x
+      for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+        set +x
+        sudo chmod a+rw ${i}.repo
+        sudo echo "username=$MIRROR_OS_USER" >> ${i}.repo
+        sudo echo "password=$MIRROR_OS_PASS" >> ${i}.repo
+        sudo chown root:root ${i}.repo
+        set -x
+      done
+      ls -l
+      popd
   - type: "script"
     title: "enable docker tested repo"
     timeout: 300

--- a/sjb/generated/ami_validate_origin_int_rhel_base.xml
+++ b/sjb/generated/ami_validate_origin_int_rhel_base.xml
@@ -135,12 +135,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/azure_build_base_image_centos.xml
+++ b/sjb/generated/azure_build_base_image_centos.xml
@@ -139,12 +139,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/azure_build_base_image_rhel.xml
+++ b/sjb/generated/azure_build_base_image_rhel.xml
@@ -139,12 +139,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/azure_build_node_image_centos.xml
+++ b/sjb/generated/azure_build_node_image_centos.xml
@@ -139,12 +139,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/azure_build_node_image_centos_310.xml
+++ b/sjb/generated/azure_build_node_image_centos_310.xml
@@ -144,12 +144,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/azure_build_node_image_rhel.xml
+++ b/sjb/generated/azure_build_node_image_rhel.xml
@@ -144,12 +144,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/azure_build_node_image_rhel_310.xml
+++ b/sjb/generated/azure_build_node_image_rhel_310.xml
@@ -144,12 +144,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/ci-kubernetes-aws-actuator.xml
+++ b/sjb/generated/ci-kubernetes-aws-actuator.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/ci-kubernetes-conformance-node-e2e-containerized-rhel.xml
+++ b/sjb/generated/ci-kubernetes-conformance-node-e2e-containerized-rhel.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/ci-kubernetes-conformance-node-e2e-rhel.xml
+++ b/sjb/generated/ci-kubernetes-conformance-node-e2e-rhel.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/ci-kubernetes-descheduler-e2e-gce.xml
+++ b/sjb/generated/ci-kubernetes-descheduler-e2e-gce.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/ci-kubernetes-machine-api-operator.xml
+++ b/sjb/generated/ci-kubernetes-machine-api-operator.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/pull-ci-openshift-cluster-api-actuator-pkg-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-cluster-api-actuator-pkg-master-e2e.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/pull-ci-openshift-cluster-api-provider-kubemark-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-cluster-api-provider-kubemark-master-e2e.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/pull-ci-openshift-cluster-api-provider-libvirt-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-cluster-api-provider-libvirt-master-e2e.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/pull-ci-openshift-cluster-autoscaler-operator-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-cluster-autoscaler-operator-master-e2e.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/pull-ci-openshift-kubernetes-autoscaler-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-kubernetes-autoscaler-master-e2e.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/pull-ci-openshift-machine-api-operator-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-machine-api-operator-master-e2e.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/push_cluster_operator_images.xml
+++ b/sjb/generated/push_cluster_operator_images.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/push_jenkins_images.xml
+++ b/sjb/generated/push_jenkins_images.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/push_origin_aggregated_logging_release.xml
+++ b/sjb/generated/push_origin_aggregated_logging_release.xml
@@ -129,12 +129,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/push_origin_metrics_release.xml
+++ b/sjb/generated/push_origin_metrics_release.xml
@@ -129,12 +129,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/push_origin_metrics_release_310.xml
+++ b/sjb/generated/push_origin_metrics_release_310.xml
@@ -129,12 +129,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/push_origin_release.xml
+++ b/sjb/generated/push_origin_release.xml
@@ -139,12 +139,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -255,6 +267,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/push_origin_release_310.xml
+++ b/sjb/generated/push_origin_release_310.xml
@@ -139,12 +139,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -255,6 +267,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/push_origin_release_36.xml
+++ b/sjb/generated/push_origin_release_36.xml
@@ -139,12 +139,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -255,6 +267,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/push_origin_release_37.xml
+++ b/sjb/generated/push_origin_release_37.xml
@@ -139,12 +139,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -255,6 +267,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/push_origin_release_38.xml
+++ b/sjb/generated/push_origin_release_38.xml
@@ -139,12 +139,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -255,6 +267,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/push_origin_release_39.xml
+++ b/sjb/generated/push_origin_release_39.xml
@@ -139,12 +139,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -255,6 +267,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/push_wildfly_images.xml
+++ b/sjb/generated/push_wildfly_images.xml
@@ -135,12 +135,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_cluster_operator_e2e.xml
+++ b/sjb/generated/test_branch_cluster_operator_e2e.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_cluster_operator_unit.xml
+++ b/sjb/generated/test_branch_cluster_operator_unit.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_image_registry_integration.xml
+++ b/sjb/generated/test_branch_image_registry_integration.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_image_registry_unit.xml
+++ b/sjb/generated/test_branch_image_registry_unit.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_jenkins_client_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_client_plugin.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -443,6 +472,11 @@ if [[ &#34;\${PULL_BASE_REF}&#34; == &#34;release-3.7&#34; || &#34;\${PULL_BASE_
 fi
 sudo yum install -y &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
 rpm -q &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
+
+# Not sure if this ever got installed (so I installed them here)
+# TODO: We can comment this out and try later.
+sudo rpm -ivh /data/iptables-services-1.4.21-35.el7.x86_64.rpm
+sudo rpm -ivh /data/dnsmasq-2.76-16.el7.x86_64.rpm
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_jenkins_images.xml
+++ b/sjb/generated/test_branch_jenkins_images.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_branch_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_openshift_login_plugin.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -443,6 +472,11 @@ if [[ &#34;\${PULL_BASE_REF}&#34; == &#34;release-3.7&#34; || &#34;\${PULL_BASE_
 fi
 sudo yum install -y &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
 rpm -q &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
+
+# Not sure if this ever got installed (so I installed them here)
+# TODO: We can comment this out and try later.
+sudo rpm -ivh /data/iptables-services-1.4.21-35.el7.x86_64.rpm
+sudo rpm -ivh /data/dnsmasq-2.76-16.el7.x86_64.rpm
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_jenkins_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_plugin.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -443,6 +472,11 @@ if [[ &#34;\${PULL_BASE_REF}&#34; == &#34;release-3.7&#34; || &#34;\${PULL_BASE_
 fi
 sudo yum install -y &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
 rpm -q &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
+
+# Not sure if this ever got installed (so I installed them here)
+# TODO: We can comment this out and try later.
+sudo rpm -ivh /data/iptables-services-1.4.21-35.el7.x86_64.rpm
+sudo rpm -ivh /data/dnsmasq-2.76-16.el7.x86_64.rpm
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_jenkins_sync_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_sync_plugin.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -443,6 +472,11 @@ if [[ &#34;\${PULL_BASE_REF}&#34; == &#34;release-3.7&#34; || &#34;\${PULL_BASE_
 fi
 sudo yum install -y &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
 rpm -q &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
+
+# Not sure if this ever got installed (so I installed them here)
+# TODO: We can comment this out and try later.
+sudo rpm -ivh /data/iptables-services-1.4.21-35.el7.x86_64.rpm
+sudo rpm -ivh /data/dnsmasq-2.76-16.el7.x86_64.rpm
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_kubernetes_metrics_server_unit.xml
+++ b/sjb/generated/test_branch_kubernetes_metrics_server_unit.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_online_console_extensions.xml
+++ b/sjb/generated/test_branch_online_console_extensions.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_online_hibernation_unit.xml
+++ b/sjb/generated/test_branch_online_hibernation_unit.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_azure.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_azure.xml
@@ -172,12 +172,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -288,6 +300,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_azure_310.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_azure_310.xml
@@ -172,12 +172,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -288,6 +300,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce.xml
@@ -177,12 +177,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -293,6 +305,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_310.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_310.xml
@@ -182,12 +182,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -298,6 +310,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_37.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_37.xml
@@ -177,12 +177,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -293,6 +305,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_39.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_39.xml
@@ -177,12 +177,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -293,6 +305,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_logging.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_logging_310.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_logging_311.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_311.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -458,6 +487,11 @@ if [[ &#34;\${PULL_BASE_REF}&#34; == &#34;release-3.7&#34; || &#34;\${PULL_BASE_
 fi
 sudo yum install -y &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
 rpm -q &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
+
+# Not sure if this ever got installed (so I installed them here)
+# TODO: We can comment this out and try later.
+sudo rpm -ivh /data/iptables-services-1.4.21-35.el7.x86_64.rpm
+sudo rpm -ivh /data/dnsmasq-2.76-16.el7.x86_64.rpm
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file_310.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file_311.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file_311.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -458,6 +487,11 @@ if [[ &#34;\${PULL_BASE_REF}&#34; == &#34;release-3.7&#34; || &#34;\${PULL_BASE_
 fi
 sudo yum install -y &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
 rpm -q &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
+
+# Not sure if this ever got installed (so I installed them here)
+# TODO: We can comment this out and try later.
+sudo rpm -ivh /data/iptables-services-1.4.21-35.el7.x86_64.rpm
+sudo rpm -ivh /data/dnsmasq-2.76-16.el7.x86_64.rpm
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_aggregated_logging_json_file.xml
+++ b/sjb/generated/test_branch_origin_aggregated_logging_json_file.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_aggregated_logging_json_file_310.xml
+++ b/sjb/generated/test_branch_origin_aggregated_logging_json_file_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_aggregated_logging_json_file_311.xml
+++ b/sjb/generated/test_branch_origin_aggregated_logging_json_file_311.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -458,6 +487,11 @@ if [[ &#34;\${PULL_BASE_REF}&#34; == &#34;release-3.7&#34; || &#34;\${PULL_BASE_
 fi
 sudo yum install -y &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
 rpm -q &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
+
+# Not sure if this ever got installed (so I installed them here)
+# TODO: We can comment this out and try later.
+sudo rpm -ivh /data/iptables-services-1.4.21-35.el7.x86_64.rpm
+sudo rpm -ivh /data/dnsmasq-2.76-16.el7.x86_64.rpm
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_check.xml
+++ b/sjb/generated/test_branch_origin_check.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_check_310.xml
+++ b/sjb/generated/test_branch_origin_check_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_cmd.xml
+++ b/sjb/generated/test_branch_origin_cmd.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_cmd_310.xml
+++ b/sjb/generated/test_branch_origin_cmd_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_cross.xml
+++ b/sjb/generated/test_branch_origin_cross.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_cross_310.xml
+++ b/sjb/generated/test_branch_origin_cross_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_end_to_end.xml
+++ b/sjb/generated/test_branch_origin_end_to_end.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_end_to_end_310.xml
+++ b/sjb/generated/test_branch_origin_end_to_end_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_end_to_end_311.xml
+++ b/sjb/generated/test_branch_origin_end_to_end_311.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_builds_310.xml
+++ b/sjb/generated/test_branch_origin_extended_builds_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_builds_311.xml
+++ b/sjb/generated/test_branch_origin_extended_builds_311.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_clusterup.xml
+++ b/sjb/generated/test_branch_origin_extended_clusterup.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_clusterup_310.xml
+++ b/sjb/generated/test_branch_origin_extended_clusterup_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_azure.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_azure.xml
@@ -172,12 +172,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -288,6 +300,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_azure_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_azure_310.xml
@@ -172,12 +172,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -288,6 +300,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_crio.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_crio_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_crio_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce.xml
@@ -173,12 +173,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -289,6 +301,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_gce_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce_310.xml
@@ -178,12 +178,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -294,6 +306,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_gce_37.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce_37.xml
@@ -173,12 +173,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -289,6 +301,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_gce_38.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce_38.xml
@@ -173,12 +173,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -289,6 +301,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_gce_39.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce_39.xml
@@ -173,12 +173,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -289,6 +301,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install-release-3.11.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install-release-3.11.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -443,6 +472,11 @@ if [[ &#34;\${PULL_BASE_REF}&#34; == &#34;release-3.7&#34; || &#34;\${PULL_BASE_
 fi
 sudo yum install -y &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
 rpm -q &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
+
+# Not sure if this ever got installed (so I installed them here)
+# TODO: We can comment this out and try later.
+sudo rpm -ivh /data/iptables-services-1.4.21-35.el7.x86_64.rpm
+sudo rpm -ivh /data/dnsmasq-2.76-16.el7.x86_64.rpm
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_311.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_311.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -443,6 +472,11 @@ if [[ &#34;\${PULL_BASE_REF}&#34; == &#34;release-3.7&#34; || &#34;\${PULL_BASE_
 fi
 sudo yum install -y &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
 rpm -q &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
+
+# Not sure if this ever got installed (so I installed them here)
+# TODO: We can comment this out and try later.
+sudo rpm -ivh /data/iptables-services-1.4.21-35.el7.x86_64.rpm
+sudo rpm -ivh /data/dnsmasq-2.76-16.el7.x86_64.rpm
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_36.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_36.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_37.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_37.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_38.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_38.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_39.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_39.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_containerized.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_containerized.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_containerized_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_containerized_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_in_tree.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_in_tree.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_in_tree_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_in_tree_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
@@ -139,12 +139,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -270,6 +282,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_system_containers_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_system_containers_310.xml
@@ -139,12 +139,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -270,6 +282,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_k8s.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_k8s.xml
@@ -178,12 +178,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -294,6 +306,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_k8s_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_k8s_310.xml
@@ -183,12 +183,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -299,6 +311,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_conformance_k8s_39.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_k8s_39.xml
@@ -178,12 +178,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -294,6 +306,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_gssapi.xml
+++ b/sjb/generated/test_branch_origin_extended_gssapi.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_gssapi_310.xml
+++ b/sjb/generated/test_branch_origin_extended_gssapi_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_image_ecosystem_310.xml
+++ b/sjb/generated/test_branch_origin_extended_image_ecosystem_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_image_ecosystem_311.xml
+++ b/sjb/generated/test_branch_origin_extended_image_ecosystem_311.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -443,6 +472,11 @@ if [[ &#34;\${PULL_BASE_REF}&#34; == &#34;release-3.7&#34; || &#34;\${PULL_BASE_
 fi
 sudo yum install -y &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
 rpm -q &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
+
+# Not sure if this ever got installed (so I installed them here)
+# TODO: We can comment this out and try later.
+sudo rpm -ivh /data/iptables-services-1.4.21-35.el7.x86_64.rpm
+sudo rpm -ivh /data/dnsmasq-2.76-16.el7.x86_64.rpm
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_image_registry_310.xml
+++ b/sjb/generated/test_branch_origin_extended_image_registry_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_ldap_groups.xml
+++ b/sjb/generated/test_branch_origin_extended_ldap_groups.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_ldap_groups_310.xml
+++ b/sjb/generated/test_branch_origin_extended_ldap_groups_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_networking.xml
+++ b/sjb/generated/test_branch_origin_extended_networking.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_extended_networking_310.xml
+++ b/sjb/generated/test_branch_origin_extended_networking_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_integration.xml
+++ b/sjb/generated/test_branch_origin_integration.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_integration_310.xml
+++ b/sjb/generated/test_branch_origin_integration_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_service_catalog.xml
+++ b/sjb/generated/test_branch_origin_service_catalog.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_service_catalog_310.xml
+++ b/sjb/generated/test_branch_origin_service_catalog_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_unit.xml
+++ b/sjb/generated/test_branch_origin_unit.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_unit_310.xml
+++ b/sjb/generated/test_branch_origin_unit_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_verify.xml
+++ b/sjb/generated/test_branch_origin_verify.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_verify_310.xml
+++ b/sjb/generated/test_branch_origin_verify_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_web_console.xml
+++ b/sjb/generated/test_branch_origin_web_console.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_web_console_310.xml
+++ b/sjb/generated/test_branch_origin_web_console_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_web_console_311.xml
+++ b/sjb/generated/test_branch_origin_web_console_311.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_web_console_39.xml
+++ b/sjb/generated/test_branch_origin_web_console_39.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_web_console_server_check.xml
+++ b/sjb/generated/test_branch_origin_web_console_server_check.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_origin_web_console_server_e2e.xml
+++ b/sjb/generated/test_branch_origin_web_console_server_e2e.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_branch_wildfly_images.xml
+++ b/sjb/generated/test_branch_wildfly_images.xml
@@ -136,12 +136,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_origin_device_manager_plugin_gpu.xml
+++ b/sjb/generated/test_origin_device_manager_plugin_gpu.xml
@@ -136,12 +136,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -252,6 +264,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_cluster_operator_e2e.xml
+++ b/sjb/generated/test_pull_request_cluster_operator_e2e.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_cluster_operator_unit.xml
+++ b/sjb/generated/test_pull_request_cluster_operator_unit.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_descheduler_gce_39.xml
+++ b/sjb/generated/test_pull_request_descheduler_gce_39.xml
@@ -168,12 +168,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -284,6 +296,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_image_registry_integration.xml
+++ b/sjb/generated/test_pull_request_image_registry_integration.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_image_registry_unit.xml
+++ b/sjb/generated/test_pull_request_image_registry_unit.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_jenkins_client_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_client_plugin.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -443,6 +472,11 @@ if [[ &#34;\${PULL_BASE_REF}&#34; == &#34;release-3.7&#34; || &#34;\${PULL_BASE_
 fi
 sudo yum install -y &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
 rpm -q &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
+
+# Not sure if this ever got installed (so I installed them here)
+# TODO: We can comment this out and try later.
+sudo rpm -ivh /data/iptables-services-1.4.21-35.el7.x86_64.rpm
+sudo rpm -ivh /data/dnsmasq-2.76-16.el7.x86_64.rpm
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_jenkins_images.xml
+++ b/sjb/generated/test_pull_request_jenkins_images.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_openshift_login_plugin.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -443,6 +472,11 @@ if [[ &#34;\${PULL_BASE_REF}&#34; == &#34;release-3.7&#34; || &#34;\${PULL_BASE_
 fi
 sudo yum install -y &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
 rpm -q &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
+
+# Not sure if this ever got installed (so I installed them here)
+# TODO: We can comment this out and try later.
+sudo rpm -ivh /data/iptables-services-1.4.21-35.el7.x86_64.rpm
+sudo rpm -ivh /data/dnsmasq-2.76-16.el7.x86_64.rpm
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_jenkins_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_plugin.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -443,6 +472,11 @@ if [[ &#34;\${PULL_BASE_REF}&#34; == &#34;release-3.7&#34; || &#34;\${PULL_BASE_
 fi
 sudo yum install -y &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
 rpm -q &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
+
+# Not sure if this ever got installed (so I installed them here)
+# TODO: We can comment this out and try later.
+sudo rpm -ivh /data/iptables-services-1.4.21-35.el7.x86_64.rpm
+sudo rpm -ivh /data/dnsmasq-2.76-16.el7.x86_64.rpm
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_jenkins_sync_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_sync_plugin.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -443,6 +472,11 @@ if [[ &#34;\${PULL_BASE_REF}&#34; == &#34;release-3.7&#34; || &#34;\${PULL_BASE_
 fi
 sudo yum install -y &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
 rpm -q &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
+
+# Not sure if this ever got installed (so I installed them here)
+# TODO: We can comment this out and try later.
+sudo rpm -ivh /data/iptables-services-1.4.21-35.el7.x86_64.rpm
+sudo rpm -ivh /data/dnsmasq-2.76-16.el7.x86_64.rpm
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_kubernetes_metrics_server_unit.xml
+++ b/sjb/generated/test_pull_request_kubernetes_metrics_server_unit.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_online_console_extensions.xml
+++ b/sjb/generated/test_pull_request_online_console_extensions.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_online_hibernation_unit.xml
+++ b/sjb/generated/test_pull_request_online_hibernation_unit.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_azure.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_azure.xml
@@ -172,12 +172,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -288,6 +300,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_azure_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_azure_310.xml
@@ -172,12 +172,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -288,6 +300,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce.xml
@@ -172,12 +172,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -288,6 +300,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_310.xml
@@ -177,12 +177,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -293,6 +305,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_37.xml
@@ -172,12 +172,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -288,6 +300,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_39.xml
@@ -172,12 +172,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -288,6 +300,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha.xml
@@ -172,12 +172,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -288,6 +300,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha_310.xml
@@ -177,12 +177,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -293,6 +305,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha_39.xml
@@ -172,12 +172,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -288,6 +300,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install-release-3.11.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install-release-3.11.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -443,6 +472,11 @@ if [[ &#34;\${PULL_BASE_REF}&#34; == &#34;release-3.7&#34; || &#34;\${PULL_BASE_
 fi
 sudo yum install -y &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
 rpm -q &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
+
+# Not sure if this ever got installed (so I installed them here)
+# TODO: We can comment this out and try later.
+sudo rpm -ivh /data/iptables-services-1.4.21-35.el7.x86_64.rpm
+sudo rpm -ivh /data/dnsmasq-2.76-16.el7.x86_64.rpm
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_in_tree.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_in_tree.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_in_tree_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_in_tree_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_36.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_37.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_39.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
@@ -139,12 +139,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -270,6 +282,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_310.xml
@@ -139,12 +139,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -270,6 +282,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_36.xml
@@ -139,12 +139,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -270,6 +282,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_37.xml
@@ -139,12 +139,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -270,6 +282,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_39.xml
@@ -139,12 +139,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -270,6 +282,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_install_upgrade_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_install_upgrade_gce.xml
@@ -177,12 +177,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -293,6 +305,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_install_upgrade_gce_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_install_upgrade_gce_310.xml
@@ -177,12 +177,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -293,6 +305,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_launch_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_launch_gce.xml
@@ -168,12 +168,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -284,6 +296,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_launch_gce_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_launch_gce_310.xml
@@ -173,12 +173,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -289,6 +301,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_logging-release-3.11.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging-release-3.11.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -458,6 +487,11 @@ if [[ &#34;\${PULL_BASE_REF}&#34; == &#34;release-3.7&#34; || &#34;\${PULL_BASE_
 fi
 sudo yum install -y &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
 rpm -q &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
+
+# Not sure if this ever got installed (so I installed them here)
+# TODO: We can comment this out and try later.
+sudo rpm -ivh /data/iptables-services-1.4.21-35.el7.x86_64.rpm
+sudo rpm -ivh /data/dnsmasq-2.76-16.el7.x86_64.rpm
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_logging.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_311.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_311.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -458,6 +487,11 @@ if [[ &#34;\${PULL_BASE_REF}&#34; == &#34;release-3.7&#34; || &#34;\${PULL_BASE_
 fi
 sudo yum install -y &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
 rpm -q &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
+
+# Not sure if this ever got installed (so I installed them here)
+# TODO: We can comment this out and try later.
+sudo rpm -ivh /data/iptables-services-1.4.21-35.el7.x86_64.rpm
+sudo rpm -ivh /data/dnsmasq-2.76-16.el7.x86_64.rpm
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_36.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_37.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_39.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_tox.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_tox.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_ansible_tox_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_tox_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_service_catalog.xml
+++ b/sjb/generated/test_pull_request_openshift_service_catalog.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_service_catalog_310.xml
+++ b/sjb/generated/test_pull_request_openshift_service_catalog_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_openshift_service_catalog_311.xml
+++ b/sjb/generated/test_pull_request_openshift_service_catalog_311.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald-release-3.11.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald-release-3.11.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -458,6 +487,11 @@ if [[ &#34;\${PULL_BASE_REF}&#34; == &#34;release-3.7&#34; || &#34;\${PULL_BASE_
 fi
 sudo yum install -y &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
 rpm -q &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
+
+# Not sure if this ever got installed (so I installed them here)
+# TODO: We can comment this out and try later.
+sudo rpm -ivh /data/iptables-services-1.4.21-35.el7.x86_64.rpm
+sudo rpm -ivh /data/dnsmasq-2.76-16.el7.x86_64.rpm
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_310.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_36.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_36.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_37.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_37.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_39.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_39.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file-release-3.11.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file-release-3.11.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -458,6 +487,11 @@ if [[ &#34;\${PULL_BASE_REF}&#34; == &#34;release-3.7&#34; || &#34;\${PULL_BASE_
 fi
 sudo yum install -y &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
 rpm -q &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
+
+# Not sure if this ever got installed (so I installed them here)
+# TODO: We can comment this out and try later.
+sudo rpm -ivh /data/iptables-services-1.4.21-35.el7.x86_64.rpm
+sudo rpm -ivh /data/dnsmasq-2.76-16.el7.x86_64.rpm
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_310.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_36.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_36.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_37.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_37.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_39.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_39.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -265,6 +277,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_cmd.xml
+++ b/sjb/generated/test_pull_request_origin_cmd.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_cmd_310.xml
+++ b/sjb/generated/test_pull_request_origin_cmd_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_cross.xml
+++ b/sjb/generated/test_pull_request_origin_cross.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_cross_310.xml
+++ b/sjb/generated/test_pull_request_origin_cross_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_end_to_end.xml
+++ b/sjb/generated/test_pull_request_origin_end_to_end.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_end_to_end_310.xml
+++ b/sjb/generated/test_pull_request_origin_end_to_end_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_end_to_end_311.xml
+++ b/sjb/generated/test_pull_request_origin_end_to_end_311.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_builds_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_builds_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_builds_311.xml
+++ b/sjb/generated/test_pull_request_origin_extended_builds_311.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -443,6 +472,11 @@ if [[ &#34;\${PULL_BASE_REF}&#34; == &#34;release-3.7&#34; || &#34;\${PULL_BASE_
 fi
 sudo yum install -y &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
 rpm -q &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
+
+# Not sure if this ever got installed (so I installed them here)
+# TODO: We can comment this out and try later.
+sudo rpm -ivh /data/iptables-services-1.4.21-35.el7.x86_64.rpm
+sudo rpm -ivh /data/dnsmasq-2.76-16.el7.x86_64.rpm
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_clusterup-release-3.11.xml
+++ b/sjb/generated/test_pull_request_origin_extended_clusterup-release-3.11.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_clusterup.xml
+++ b/sjb/generated/test_pull_request_origin_extended_clusterup.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_clusterup_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_clusterup_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_azure.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_azure.xml
@@ -172,12 +172,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -288,6 +300,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_azure_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_azure_310.xml
@@ -172,12 +172,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -288,6 +300,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_crio_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_crio_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
@@ -172,12 +172,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -288,6 +300,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce_310.xml
@@ -177,12 +177,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -293,6 +305,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce_37.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce_37.xml
@@ -172,12 +172,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -288,6 +300,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce_39.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce_39.xml
@@ -172,12 +172,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -288,6 +300,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install-release-3.11.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install-release-3.11.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -443,6 +472,11 @@ if [[ &#34;\${PULL_BASE_REF}&#34; == &#34;release-3.7&#34; || &#34;\${PULL_BASE_
 fi
 sudo yum install -y &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
 rpm -q &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
+
+# Not sure if this ever got installed (so I installed them here)
+# TODO: We can comment this out and try later.
+sudo rpm -ivh /data/iptables-services-1.4.21-35.el7.x86_64.rpm
+sudo rpm -ivh /data/dnsmasq-2.76-16.el7.x86_64.rpm
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_36.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_36.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_37.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_37.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_38.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_38.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_39.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_39.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_update_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_update_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_k8s.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_k8s.xml
@@ -173,12 +173,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -289,6 +301,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_conformance_k8s_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_k8s_310.xml
@@ -178,12 +178,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -294,6 +306,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_gssapi.xml
+++ b/sjb/generated/test_pull_request_origin_extended_gssapi.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_gssapi_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_gssapi_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_image_ecosystem_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_ecosystem_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_image_ecosystem_311.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_ecosystem_311.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -443,6 +472,11 @@ if [[ &#34;\${PULL_BASE_REF}&#34; == &#34;release-3.7&#34; || &#34;\${PULL_BASE_
 fi
 sudo yum install -y &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
 rpm -q &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
+
+# Not sure if this ever got installed (so I installed them here)
+# TODO: We can comment this out and try later.
+sudo rpm -ivh /data/iptables-services-1.4.21-35.el7.x86_64.rpm
+sudo rpm -ivh /data/dnsmasq-2.76-16.el7.x86_64.rpm
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_image_registry-release-3.11.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_registry-release-3.11.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;
@@ -443,6 +472,11 @@ if [[ &#34;\${PULL_BASE_REF}&#34; == &#34;release-3.7&#34; || &#34;\${PULL_BASE_
 fi
 sudo yum install -y &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
 rpm -q &#34;openshift-ansible\${last_tag/openshift-ansible/}.git.0.\${last_commit}.el7_9&#34;
+
+# Not sure if this ever got installed (so I installed them here)
+# TODO: We can comment this out and try later.
+sudo rpm -ivh /data/iptables-services-1.4.21-35.el7.x86_64.rpm
+sudo rpm -ivh /data/dnsmasq-2.76-16.el7.x86_64.rpm
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_image_registry_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_registry_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_ldap_groups.xml
+++ b/sjb/generated/test_pull_request_origin_extended_ldap_groups.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_ldap_groups_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_ldap_groups_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_networking.xml
+++ b/sjb/generated/test_pull_request_origin_extended_networking.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_extended_networking_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_networking_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_integration.xml
+++ b/sjb/generated/test_pull_request_origin_integration.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_integration_310.xml
+++ b/sjb/generated/test_pull_request_origin_integration_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_launch_gce.xml
+++ b/sjb/generated/test_pull_request_origin_launch_gce.xml
@@ -168,12 +168,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -284,6 +296,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_launch_gce_310.xml
+++ b/sjb/generated/test_pull_request_origin_launch_gce_310.xml
@@ -173,12 +173,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -289,6 +301,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_service_catalog.xml
+++ b/sjb/generated/test_pull_request_origin_service_catalog.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_service_catalog_310.xml
+++ b/sjb/generated/test_pull_request_origin_service_catalog_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_unit.xml
+++ b/sjb/generated/test_pull_request_origin_unit.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_unit_310.xml
+++ b/sjb/generated/test_pull_request_origin_unit_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_verify.xml
+++ b/sjb/generated/test_pull_request_origin_verify.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_verify_310.xml
+++ b/sjb/generated/test_pull_request_origin_verify_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_web_console.xml
+++ b/sjb/generated/test_pull_request_origin_web_console.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_web_console_310.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_310.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_web_console_311.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_311.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_web_console_39.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_39.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_web_console_server_check.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_server_check.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_origin_web_console_server_e2e.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_server_e2e.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash
@@ -250,6 +262,23 @@ if [[ &#34;\${JOB_NAME}&#34; == *update* ]]; then
       ;;
   esac
 fi
+pushd .
+echo &#34;Fixing up /etc/yum.repos.d and adding in credentials&#34;
+cd /etc/yum.repos.d
+sudo tar xzvf /data/good_repos_rhui.tgz
+set +x
+source /data/mirror-os-cred.sh
+set -x
+for i in charlie oso-rhui-rhel-server-extras oso-rhui-rhel-server-releases-optional oso-rhui-rhel-server-releases oso-rhui-rhel-server-rhscl rhel-7-server-ansible-2.4-rpms rhel-7-server-ansible-2.6-rpms; do
+  set +x
+  sudo chmod a+rw \${i}.repo
+  sudo echo &#34;username=\$MIRROR_OS_USER&#34; &gt;&gt; \${i}.repo
+  sudo echo &#34;password=\$MIRROR_OS_PASS&#34; &gt;&gt; \${i}.repo
+  sudo chown root:root \${i}.repo
+  set -x
+done
+ls -l
+popd
 SCRIPT
 chmod +x &#34;${script}&#34;
 scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config &#34;${script}&#34; openshiftdevel:&#34;${script}&#34;

--- a/sjb/generated/test_pull_request_s2i_master.xml
+++ b/sjb/generated/test_pull_request_s2i_master.xml
@@ -134,12 +134,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash

--- a/sjb/generated/test_pull_request_wildfly_images.xml
+++ b/sjb/generated/test_pull_request_wildfly_images.xml
@@ -136,12 +136,24 @@ for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.config/gcloud/gcs-publisher-credentials.json openshiftdevel:/data/credentials.json; then
                 break
             fi
-        done
-            for (( i = 0; i &lt; 10; i++ )); do
+    done
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/mirror-os-cred.sh openshiftdevel:/data/mirror-os-cred.sh; then
                 break
             fi
-        done</command>
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
+            if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/good_repos_rhui.tgz openshiftdevel:/data/; then
+                break
+            fi
+    done</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Shell>
           <command>#!/bin/bash


### PR DESCRIPTION
This directory (on jenkins) has files that can "patch" the aws e2c instance where things are run:

```
# ls -l /var/lib/jenkins/tweaks/
total 340
-rw-r--r--. 1 root root 285848 Feb  3 07:33 dnsmasq-2.76-16.el7.x86_64.rpm
-rw-r--r--. 1 root root   3179 Feb  3 07:33 good_repos_rhui.tgz  <-- does not contain creds
-rw-r--r--. 1 root root  53704 Feb  3 07:33 iptables-services-1.4.21-35.el7.x86_64.rpm
```

We can work on this more later (including generating the `/etc/yum.repod.d` files instead of just un'taring them there and adding the two .rpms to mirror.openshift.com). But for now, the ansible playbooks finish and get farther than they have in a while.

The `good_repos_rui.tgz` was created by taking the existing repos on the VM, updating  baseurl, removing credentials, and tar'ing up the files in place.

Test method:

* Make a PR [like this](https://github.com/openshift/origin-aggregated-logging/pull/2239)
* Make these modifications and push them to Jenkins for the two tests mentioned in the PR in the first step
```
$ ./sjb/generate.sh
$ ./sjb/push-update.sh sjb/generated/test_pull_request_origin_aggregated_logging_json_file-release-3.11.xml
$ ./sjb/push-update.sh sjb/generated/test_pull_request_origin_aggregated_logging_journald-release-3.11.xml
```
* Run the tests, check the logs

Here are logs:
  * https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_origin-aggregated-logging/2239/test_pull_request_origin_aggregated_logging_journald-release-3.11/849/build-log.txt
  * https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_origin-aggregated-logging/2239/test_pull_request_origin_aggregated_logging_json_file-release-3.11/647/build-log.txt