### PR TITLE
[ART-3705] Validate upgrade edges from prev releases.yml

### DIFF
--- a/jobs/build/promote-assembly/README.md
+++ b/jobs/build/promote-assembly/README.md
@@ -177,10 +177,13 @@ releases:
         why: Luke told me this can be ignored
 ```
 
-List of codes:
-- *BLOCKER_BUGS* Blocker bugs found for release.
-- *ATTACHED_BUGS* Error verifying attached bugs
-- *CVE_FLAWS* Error attaching CVE flaw bugs
+Promotion Permit codes:
+- *UPGRADE_EDGES* Permit failing Upgrade-Edges (`upgrades`) validation for a release.
+- *BLOCKER_BUGS* Permit failing Blocker-Bugs check for a release.
+- *ATTACHED_BUGS* Permit failing Verify-attached-bugs validation for release advisories.
+- *CVE_FLAWS* Permit failing Attach-CVE-flaws (bugs) to release advisories.
+- *NO_ERRATA* Permit standard assembly to not have an Image advisory.
+- *INVALID_ERRATA_STATUS* Permit standard assembly release advisories to not have LiveID or be in undesired Errata status.
 
 ## Known issues
 

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -278,7 +278,7 @@ Please open a chat with @cluster-bot and issue each of these lines individually:
         previous_list = list(map(lambda s: s.strip(), upgrades_str.split(","))) if upgrades_str else []
         # Ensure all versions in previous list are valid semvers.
         if any(map(lambda version: not VersionInfo.isvalid(version), previous_list)):
-            raise ValueError("Previous list (`upgrades` field in group config) has an invalid semver.")
+            raise VerificationError("Previous list (`upgrades` field in group config) has an invalid semver.")
 
         major, minor = util.isolate_major_minor_in_group(self.group)
         if minor < 1:
@@ -310,7 +310,7 @@ Please open a chat with @cluster-bot and issue each of these lines individually:
         latest_prev = in_previous_list[0]
         greater_than_latest_prev = [x for x in not_in_previous_list if semver.compare(x, latest_prev) == 1]  # if x > latest_prev
         if greater_than_latest_prev:
-            raise ValueError(f"`upgrades` does not contain {greater_than_latest_prev} edge(s) defined in {show_spec}. These versions were found to be greater than the latest previous upgrade edge {latest_prev}")
+            raise VerificationError(f"`upgrades` does not contain {greater_than_latest_prev} edge(s) defined in {show_spec}. These versions were found to be greater than the latest previous upgrade edge {latest_prev}")
         return previous_list
 
     async def check_blocker_bugs(self):

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -294,19 +294,20 @@ Please open a chat with @cluster-bot and issue each of these lines individually:
         releases_config = yaml.safe_load(proc.stdout)
 
         def looks_standard_upgrade_edge(config, x):
-            rel_type = config['releases'][x]['assembly'].get('type','')
+            rel_type = config['releases'][x]['assembly'].get('type', '')
             is_not_custom = rel_type != 'custom'
-            is_candidate = (rel_type == 'candidate') or (re.match("rc\.\d+", x) or re.match("fc\.\d+", x))
-            looks_standard = re.match(f"{major}\.{minor-1}.\d+", x)
+            is_candidate = (rel_type == 'candidate') or (re.match(r'rc\.\d+', x) or re.match(r'fc\.\d+', x))
+            looks_standard = re.match(rf'{major}\.{minor-1}.\d+', x)
             return is_not_custom and (is_candidate or looks_standard)
 
         assembly_names = [x for x in releases_config['releases'].keys() if looks_standard_upgrade_edge(releases_config, x)]
+
         def sort_semver(versions):
             return sorted(versions, key=functools.cmp_to_key(semver.compare), reverse=True)
         in_previous_list = sort_semver([x for x in assembly_names if x in previous_list])
         not_in_previous_list = [x for x in assembly_names if x not in previous_list]
         latest_prev = in_previous_list[0]
-        greater_than_latest_prev = [x for x in not_in_previous_list if semver.compare(x, latest_prev) == 1] # if x > latest_prev
+        greater_than_latest_prev = [x for x in not_in_previous_list if semver.compare(x, latest_prev) == 1]  # if x > latest_prev
         if greater_than_latest_prev:
             raise ValueError(f"`upgrades` does not contain {greater_than_latest_prev} edge(s) defined in {show_spec}. These versions were found to be greater than the latest previous upgrade edge {latest_prev}")
         return previous_list
@@ -635,7 +636,7 @@ Please open a chat with @cluster-bot and issue each of these lines individually:
     async def send_image_list_email(self, release_name: str, advisory: int, archive_dir: Path):
         content = await self.get_advisory_image_list(advisory)
         subject = f"OCP {release_name} Image List"
-        return await exectools.to_thread(self._mail.send_mail, self.runtime.config["email"][f"promote_image_list_recipients"], subject, content, archive_dir=archive_dir, dry_run=self.runtime.dry_run)
+        return await exectools.to_thread(self._mail.send_mail, self.runtime.config["email"]["promote_image_list_recipients"], subject, content, archive_dir=archive_dir, dry_run=self.runtime.dry_run)
 
 
 @cli.command("promote")

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -10,7 +10,7 @@ from collections import OrderedDict
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Tuple
 from urllib.parse import quote
-import yaml
+from ruamel.yaml import YAML
 
 import aiohttp
 import click
@@ -25,6 +25,8 @@ from semver import VersionInfo
 from tenacity import (RetryError, before_sleep_log, retry,
                       retry_if_exception_type, retry_if_result,
                       stop_after_attempt, wait_fixed)
+
+yaml = YAML(typ="safe")
 
 
 class PromotePipeline:
@@ -296,7 +298,7 @@ Please open a chat with @cluster-bot and issue each of these lines individually:
             show_spec,
         ]
         _, stdout, _ = await exectools.cmd_gather_async(cmd, cwd=Path(build_data_path), stderr=None)
-        releases_config = yaml.safe_load(stdout)
+        releases_config = yaml.load(stdout)
 
         assembly_names = [name for name in releases_config['releases'].keys() if util.looks_standard_upgrade_edge(releases_config, name, major, minor - 1)]
         assembly_semvers = [util.get_valid_semver(name, major, minor - 1) for name in assembly_names]

--- a/pyartcd/pyartcd/slack.py
+++ b/pyartcd/pyartcd/slack.py
@@ -6,10 +6,13 @@ from slack_sdk.web.async_client import AsyncWebClient
 
 _LOGGER = logging.getLogger(__name__)
 
+
 class SlackClient:
     """ A SlackClient allows pipelines to send Slack messages.
     """
+
     DEFAULT_CHANNEL = "#art-release"
+
     def __init__(self, token: str, job_name: Optional[str], job_run_name: Optional[str], job_run_url: Optional[str], dry_run: bool = False) -> None:
         self.token = token
         self.channel = self.DEFAULT_CHANNEL

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -75,11 +75,14 @@ async def load_releases_config(build_data_path: os.PathLike) -> Dict:
 def get_assembly_type(releases_config: Dict, assembly_name: str):
     return assembly.assembly_type(model.Model(releases_config), assembly_name)
 
+
 def get_assmebly_basis(releases_config: Dict, assembly_name: str):
     return assembly.assembly_basis(model.Model(releases_config), assembly_name)
 
+
 def get_assembly_promotion_permits(releases_config: Dict, assembly_name: str):
     return assembly._assembly_config_struct(model.Model(releases_config), assembly_name, 'promotion_permits', [])
+
 
 def get_release_name(assembly_type: str, group_name: str, assembly_name: str, release_offset: Optional[int]):
     major, minor = isolate_major_minor_in_group(group_name)

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -103,3 +103,21 @@ def get_release_name(assembly_type: str, group_name: str, assembly_name: str, re
     else:
         raise ValueError(f"Assembly type {assembly_type} is not supported.")
     return release_name
+
+
+def is_assembly_name_candidate(assembly_name):
+    return re.match(r'rc\.\d+', assembly_name) or re.match(r'fc\.\d+', assembly_name)
+
+
+def looks_standard_upgrade_edge(config, assembly_name, major, minor):
+    rel_type = config['releases'][assembly_name]['assembly'].get('type', '')
+    is_not_custom = rel_type != assembly.AssemblyTypes.CUSTOM.value
+    is_candidate = (rel_type == assembly.AssemblyTypes.CANDIDATE.value) or is_assembly_name_candidate(assembly_name)
+    looks_standard = re.match(rf'{major}\.{minor}.\d+', assembly_name)
+    return is_not_custom and (is_candidate or looks_standard)
+
+
+def get_valid_semver(assembly_name, major, minor):
+    if is_assembly_name_candidate(assembly_name):
+        return f'{major}.{minor}.0-{assembly_name}'
+    return assembly_name

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -1,14 +1,18 @@
 import os
 import re
+import functools
+import semver
 from pathlib import Path
 from typing import Dict, Optional, Tuple
 
 import aiofiles
-import yaml
+from ruamel.yaml import YAML
 from doozerlib import assembly, model
 from doozerlib.util import brew_arch_for_go_arch, brew_suffix_for_arch, go_arch_for_brew_arch, go_suffix_for_arch
 
 from pyartcd import exectools
+
+yaml = YAML(typ="safe")
 
 
 def isolate_el_version_in_release(release: str) -> Optional[int]:
@@ -60,7 +64,7 @@ async def load_group_config(group: str, assembly: str, env=None) -> Dict:
     if env is None:
         env = os.environ.copy()
     _, stdout, _ = await exectools.cmd_gather_async(cmd, stderr=None, env=env)
-    group_config = yaml.safe_load(stdout)
+    group_config = yaml.load(stdout)
     if not isinstance(group_config, dict):
         raise ValueError("ocp-build-data contains invalid group config.")
     return group_config
@@ -69,7 +73,7 @@ async def load_group_config(group: str, assembly: str, env=None) -> Dict:
 async def load_releases_config(build_data_path: os.PathLike) -> Dict:
     async with aiofiles.open(Path(build_data_path) / "releases.yml", "r") as f:
         content = await f.read()
-    return yaml.safe_load(content)
+    return yaml.load(content)
 
 
 def get_assembly_type(releases_config: Dict, assembly_name: str):
@@ -121,3 +125,21 @@ def get_valid_semver(assembly_name, major, minor):
     if is_assembly_name_candidate(assembly_name):
         return f'{major}.{minor}.0-{assembly_name}'
     return assembly_name
+
+
+def sorted_semver(versions):
+    return sorted(versions, key=functools.cmp_to_key(semver.compare), reverse=True)
+
+
+async def get_all_assembly_semvers_for_release(major, minor, build_data_path):
+    show_spec = f"origin/openshift-{major}.{minor}:releases.yml"
+    cmd = [
+        "git",
+        "show",
+        show_spec,
+    ]
+    _, stdout, _ = await exectools.cmd_gather_async(cmd, cwd=Path(build_data_path), stderr=None)
+    releases_config = yaml.load(stdout)
+
+    assembly_names = [name for name in releases_config['releases'].keys() if looks_standard_upgrade_edge(releases_config, name, major, minor)]
+    return [get_valid_semver(name, major, minor) for name in assembly_names]

--- a/pyartcd/tests/pipelines/test_promote.py
+++ b/pyartcd/tests/pipelines/test_promote.py
@@ -166,7 +166,7 @@ class TestPromotePipeline(TestCase):
     @patch("pyartcd.pipelines.promote.PromotePipeline.build_release_image", return_value=None)
     @patch("pyartcd.pipelines.promote.PromotePipeline.get_release_image_info", side_effect=lambda pullspec, raise_if_not_found=False: {
         "image": pullspec,
-        "digest": f"fake:deadbeef",
+        "digest": "fake:deadbeef",
         "references": {
             "spec": {
                 "tags": [


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-3705

Test:
- [Fail] SLACK_BOT_TOKEN='4' ./artcd --config=../config/artcd.toml -C . -vv --dry-run promote -g openshift-4.9 --assembly 4.9.20 --skip-attached-bug-check --arch=x86_64
```
ValueError: `upgrades` does not contain ['4.8.31', '4.8.30'] edge(s) defined in origin/openshift-4.8:releases.yml. These versions were found to be greater than the latest previous upgrade edge 4.8.29
```
- [Success] SLACK_BOT_TOKEN='4' ./artcd --config=../config/artcd.toml -C . -vv --dry-run promote -g openshift-4.9 --assembly 4.9.21 --skip-attached-bug-check --arch=x86_64