### PR TITLE
Fix build/coreos-installer_sync

### DIFF
--- a/jobs/build/coreos-installer_sync/Jenkinsfile
+++ b/jobs/build/coreos-installer_sync/Jenkinsfile
@@ -70,7 +70,7 @@ node {
                 rm --recursive --force ./*
                 brew --quiet download-build ${params.NVR}
                 shopt -s nullglob
-                rm --force *bootinfra* *.src.rpm
+                rm --force *bootinfra* *dracut* *.src.rpm
                 tree
             """
         )


### PR DESCRIPTION
Now there are more artifacts (dracut) inside the brew package, and the code in `extract.sh` wasn't expecting their presence.