### PR TITLE
remove trim() to avoid java.lang.NullPointerException

### DIFF
--- a/jobs/build/check-bugs/Jenkinsfile
+++ b/jobs/build/check-bugs/Jenkinsfile
@@ -136,7 +136,7 @@ node {
                     verify-bugs ${bugs}
                     > .log
                 """.stripIndent().tr("\n", " ").trim()
-            ).trim()
+            )
             echo "No potential regressions found"
         } catch (err) {
             // If regressions are found, notify Slack


### PR DESCRIPTION
This PR should fix annoying messages like this: https://coreos.slack.com/archives/C01UQM3PM3L/p1646017487642089