### PR TITLE
[ART-3861] notify #art-team when buildvm is running out of space

### DIFF
--- a/jobs/maintenance/check-disk-usage-on-buildvm/Jenkinsfile
+++ b/jobs/maintenance/check-disk-usage-on-buildvm/Jenkinsfile
@@ -1,0 +1,72 @@
+#!/usr/bin/env groovy
+node {
+    checkout scm
+    def commonlib = load("pipeline-scripts/commonlib.groovy")
+
+    commonlib.describeJob("check-disk-usage-on-buildvm", """
+----------
+Check disk usage on buildvm
+----------
+Check if disk usage on buildvm exceeds a treshold;
+notify ART team if it does.
+    """)
+
+
+    properties(
+        [
+            disableResume(),
+            [
+                $class: 'ParametersDefinitionProperty',
+                parameterDefinitions: [
+                    commonlib.mockParam(),
+                    string(
+                        name: "THRESHOLD",
+                        description: 'Max disk usage, expressed as percentage; example: 90',
+                        defaultValue: '90',
+                        trim: true,
+                    ),
+                    string(
+                        name: "SLACK_CHANNEL",
+                        description: 'Slack channel to notify. ' +
+                                     'Example: #team-art-debug',
+                        defaultValue: '#team-art',
+                        trim: true,
+                    )
+                ]
+            ]
+        ]
+    )
+
+    // Check for mock build
+    commonlib.checkMock()
+
+    partitions_to_check = [
+        "/dev/mapper/rhel_buildvm-root",
+        "/dev/mapper/workspace-workspace"
+    ]
+
+    warnings = []
+
+    for (String partition : partitions_to_check) {
+        disk_usage = sh(
+            script: "df -h | grep ${partition} | tr -s ' ' | cut -d ' ' -f5 | tr -d %",
+            returnStdout: true
+        ).trim().toInteger()
+        echo "Disk usage on `${partition}`: ${disk_usage}%"
+
+        if (disk_usage > params.THRESHOLD.toInteger()) {
+            warnings.add("Disk usage on \u0060${partition}\u0060: ${disk_usage}%")
+        }
+    }
+
+    if (warnings) {
+        message = "*:warning: @release-artists buildvm disk usage alert*"
+        for (String warning : warnings) {
+            message = message + "\n" + warning
+        }
+        echo message
+        commonlib.slacklib.to(params.SLACK_CHANNEL).say(message)
+    } else {
+        echo "No disk space warnings"
+    }
+}

--- a/jobs/maintenance/check-disk-usage-on-buildvm/README.md
+++ b/jobs/maintenance/check-disk-usage-on-buildvm/README.md
@@ -1,0 +1,10 @@
+# Check disk usasge on buildvm
+
+## Purpose
+
+Check if disk usage on buildvm exceeds a treshold; notify ART team if it does.
+
+## Timing
+
+It can be run by humans at any time, but it will also be invoked by a daily
+scheduled job.

--- a/scheduled-jobs/maintenance/check-disk-usage-on-buildvm/Jenkinsfile
+++ b/scheduled-jobs/maintenance/check-disk-usage-on-buildvm/Jenkinsfile
@@ -1,0 +1,15 @@
+properties( [
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '100', daysToKeepStr: '', numToKeepStr: '100')),
+    disableConcurrentBuilds(),
+    disableResume(),
+] )
+
+node() {
+    checkout scm
+
+    build(
+        job: '../aos-cd-builds/maintenance%2Fcheck-disk-usage-on-buildvm',
+        parameters: [string(name: 'THRESHOLD', value: '90'), string(name: 'SLACK_CHANNEL', value: '#art-team')],
+        propagate: false,
+    )
+}

--- a/scheduled-jobs/maintenance/check-disk-usage-on-buildvm/README.md
+++ b/scheduled-jobs/maintenance/check-disk-usage-on-buildvm/README.md
@@ -1,0 +1,8 @@
+# Check disk usage on buildvm
+
+## Purpose
+
+Check if disk usage on buildvm exceeds a treshold; notify ART team if it does.
+
+## Timing
+Every day, at 10pm EST


### PR DESCRIPTION
The idea here is to have the scheduled job running once a day. If the partitions of interest are used for more than 90% (this can be easily tuned in the scheduled job), a notification will be sent to our private Slack channel. 

Currently, I considered these two partitions as relevant:
`
    partitions_to_check = [
        "/dev/mapper/rhel_buildvm-root",
        "/dev/mapper/workspace-workspace"
    ]
`
If more should be added, please add in the comments.