### PR TITLE
Rebuild job with custom ocp-build-data

### DIFF
--- a/jobs/build/rebuild/Jenkinsfile
+++ b/jobs/build/rebuild/Jenkinsfile
@@ -43,6 +43,12 @@ node {
                             defaultValue: "",
                             trim: true
                         ),
+                        string(
+                            name: 'DOOZER_DATA_PATH',
+                            description: 'ocp-build-data fork to use (e.g. assembly definition in your own fork)',
+                            defaultValue: "https://github.com/openshift/ocp-build-data",
+                            trim: true,
+                        ),
                         booleanParam(
                             name: 'IGNORE_LOCKS',
                             description: 'Do not wait for other builds in this version to complete (use only if you know they will not conflict)',
@@ -91,6 +97,7 @@ node {
             }
             cmd += [
                 "rebuild",
+                "--data-path", params.DOOZER_DATA_PATH,
                 "-g", "openshift-$params.BUILD_VERSION",
                 "--assembly", params.ASSEMBLY,
                 "--type", params.TYPE

--- a/jobs/build/rebuild/Jenkinsfile
+++ b/jobs/build/rebuild/Jenkinsfile
@@ -44,7 +44,7 @@ node {
                             trim: true
                         ),
                         string(
-                            name: 'DOOZER_DATA_PATH',
+                            name: 'OCP_BUILD_DATA_URL',
                             description: 'ocp-build-data fork to use (e.g. assembly definition in your own fork)',
                             defaultValue: "https://github.com/openshift/ocp-build-data",
                             trim: true,
@@ -97,7 +97,7 @@ node {
             }
             cmd += [
                 "rebuild",
-                "--data-path", params.DOOZER_DATA_PATH,
+                "--ocp-build-data-url", params.OCP_BUILD_DATA_URL,
                 "-g", "openshift-$params.BUILD_VERSION",
                 "--assembly", params.ASSEMBLY,
                 "--type", params.TYPE

--- a/pyartcd/pyartcd/pipelines/rebuild.py
+++ b/pyartcd/pyartcd/pipelines/rebuild.py
@@ -29,7 +29,7 @@ class RebuildPipeline:
     """ Rebuilds a component for an assembly """
 
     def __init__(self, runtime: Runtime, group: str, assembly: str,
-                 type: RebuildType, dg_key: str, data_path: str, logger: Optional[logging.Logger] = None):
+                 type: RebuildType, dg_key: str, ocp_build_data_url: str, logger: Optional[logging.Logger] = None):
         if assembly == "stream":
             raise ValueError("You may not rebuild a component for 'stream' assembly.")
         if type in [RebuildType.RPM, RebuildType.IMAGE] and not dg_key:
@@ -502,7 +502,7 @@ class RebuildPipeline:
 
 
 @cli.command("rebuild")
-@click.option("--data-path", metavar='PATH', default=None,
+@click.option("--ocp-build-data-url", metavar='BUILD_DATA', default=None,
               help="Git repo or directory containing groups metadata e.g. https://github.com/openshift/ocp-build-data")
 @click.option("-g", "--group", metavar='NAME', required=True,
               help="The group of components on which to operate. e.g. openshift-4.9")
@@ -515,10 +515,10 @@ class RebuildPipeline:
               help="The name of a component to rebase & build for. e.g. openshift-enterprise-cli")
 @pass_runtime
 @click_coroutine
-async def rebuild(runtime: Runtime, data_path: str, group: str, assembly: str, type: str, component: Optional[str]):
+async def rebuild(runtime: Runtime, ocp_build_data_url: str, group: str, assembly: str, type: str, component: Optional[str]):
     if type != "rhcos" and not component:
         raise click.BadParameter(f"'--component' is required for type {type}")
     elif type == "rhcos" and component:
         raise click.BadParameter("Option '--component' cannot be used when --type == 'rhcos'")
-    pipeline = RebuildPipeline(runtime, group=group, assembly=assembly, type=RebuildType[type.upper()], dg_key=component, data_path=data_path)
+    pipeline = RebuildPipeline(runtime, group=group, assembly=assembly, type=RebuildType[type.upper()], dg_key=component, ocp_build_data_url=ocp_build_data_url)
     await pipeline.run()

--- a/pyartcd/pyartcd/pipelines/rebuild.py
+++ b/pyartcd/pyartcd/pipelines/rebuild.py
@@ -29,7 +29,7 @@ class RebuildPipeline:
     """ Rebuilds a component for an assembly """
 
     def __init__(self, runtime: Runtime, group: str, assembly: str,
-                 type: RebuildType, dg_key: str, logger: Optional[logging.Logger] = None):
+                 type: RebuildType, dg_key: str, data_path: str, logger: Optional[logging.Logger] = None):
         if assembly == "stream":
             raise ValueError("You may not rebuild a component for 'stream' assembly.")
         if type in [RebuildType.RPM, RebuildType.IMAGE] and not dg_key:
@@ -53,7 +53,9 @@ class RebuildPipeline:
         # sets environment variables for Doozer
         self._doozer_env_vars = os.environ.copy()
         self._doozer_env_vars["DOOZER_WORKING_DIR"] = str(self.runtime.working_dir / "doozer-working")
-        ocp_build_data_url = self.runtime.config.get("build_config", {}).get("ocp_build_data_url")
+
+        if not ocp_build_data_url:
+            ocp_build_data_url = self.runtime.config.get("build_config", {}).get("ocp_build_data_url")
         if ocp_build_data_url:
             self._doozer_env_vars["DOOZER_DATA_PATH"] = ocp_build_data_url
 
@@ -500,6 +502,8 @@ class RebuildPipeline:
 
 
 @cli.command("rebuild")
+@click.option("--data-path", metavar='PATH', default=None,
+              help="Git repo or directory containing groups metadata e.g. https://github.com/openshift/ocp-build-data")
 @click.option("-g", "--group", metavar='NAME', required=True,
               help="The group of components on which to operate. e.g. openshift-4.9")
 @click.option("--assembly", metavar="ASSEMBLY_NAME", required=True,
@@ -511,10 +515,10 @@ class RebuildPipeline:
               help="The name of a component to rebase & build for. e.g. openshift-enterprise-cli")
 @pass_runtime
 @click_coroutine
-async def rebuild(runtime: Runtime, group: str, assembly: str, type: str, component: Optional[str]):
+async def rebuild(runtime: Runtime, data_path: str, group: str, assembly: str, type: str, component: Optional[str]):
     if type != "rhcos" and not component:
         raise click.BadParameter(f"'--component' is required for type {type}")
     elif type == "rhcos" and component:
         raise click.BadParameter("Option '--component' cannot be used when --type == 'rhcos'")
-    pipeline = RebuildPipeline(runtime, group=group, assembly=assembly, type=RebuildType[type.upper()], dg_key=component)
+    pipeline = RebuildPipeline(runtime, group=group, assembly=assembly, type=RebuildType[type.upper()], dg_key=component, data_path=data_path)
     await pipeline.run()


### PR DESCRIPTION
This will allow us to use rebuild job with an ocp-build-data fork
useful with the process we follow - when an assembly definition
 is in a PR and is not merged and we need to rebuild a component
and put the nvr back into the assembly definition.

hack job: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Frebuild/5/console