### PR TITLE
prepare-release: Check blocker bugs against the stream assembly.

### DIFF
--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -271,11 +271,12 @@ class PrepareReleasePipeline:
         return arch_nightlies
 
     def check_blockers(self):
+        # Note: --assembly option should always be "stream". We are checking blocker bugs for this release branch regardless of the sweep cutoff timestamp.
         cmd = [
             "elliott",
             f"--working-dir={self.elliott_working_dir}",
             f"--group={self.group_name}",
-            "--assembly", self.assembly,
+            "--assembly=stream",
             "find-bugs",
             "--mode=blocker",
             "--exclude-status=ON_QA",


### PR DESCRIPTION
`--assembly` option should always be "stream". We need to check blocker bugs for this release branch regardless of the sweep cutoff timestamp.