### PR TITLE
update conditions when to update ocp-dev-preview/pre-release

### DIFF
--- a/jobs/build/set_client_latest/S3-set-v4-client-latest.sh
+++ b/jobs/build/set_client_latest/S3-set-v4-client-latest.sh
@@ -121,8 +121,10 @@ for arch in ${ARCHES}; do
       # We should have a directory "stable" with the 4.9 content.
       transferClientIfNeeded "${target_dir}/${RELEASE}/" "${target_dir}/${LINK_NAME}/"
 
-      # On the old mirror, clients/ocp-dev-preview/pre-release linked to ../ocp/candidate. Replicate that by copying the artifacts over.
-      if [[ "$LINK_NAME" == "latest" ]]; then
+      # On the old mirror, clients/ocp-dev-preview/pre-release linked to ../ocp/candidate after start creating 4.x RC.
+      # and clients/ocp-dev-preview/pre-release should link to ../latest after 4.x GA
+      # Replicate that by copying the artifacts over.
+      if [[ "$LINK_NAME" == "latest" && "$CLIENT_TYPE" == "ocp-dev-preview" ]]; then
         # This is where console.openshift.com points to find dev-preview artifacts
         transferClientIfNeeded "${target_dir}/${RELEASE}/" "pub/openshift-v4/${arch}/clients/ocp-dev-preview/pre-release/"
       fi


### PR DESCRIPTION
[https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp-dev-preview/pre-release/] is intended to point at published dev-previews (accepted nightly images; latest-4.y) until we start having RCs; then it should point at the latest candidate. Then at GA it should switch to the next release’s dev-previews.