### PR TITLE
HOTFIX build/helm_sync: wrap calls in `script` block

### DIFF
--- a/jobs/build/helm_sync/Jenkinsfile
+++ b/jobs/build/helm_sync/Jenkinsfile
@@ -58,8 +58,10 @@ pipeline {
         stage("Sync to mirror") {
             steps {
                 sh "tree ${params.VERSION}"
-                commonlib.syncDirToS3Mirror("${params.VERSION}/", "/pub/openshift-v4/x86_64/clients/helm/${params.VERSION}/")
-                commonlib.syncDirToS3Mirror("${params.VERSION}/", "/pub/openshift-v4/x86_64/clients/helm/latest/")
+                script {
+                    commonlib.syncDirToS3Mirror("${params.VERSION}/", "/pub/openshift-v4/x86_64/clients/helm/${params.VERSION}/")
+                    commonlib.syncDirToS3Mirror("${params.VERSION}/", "/pub/openshift-v4/x86_64/clients/helm/latest/")
+                }
 
                 sshagent(['aos-cd-test']) {
                     sh "scp -r ${params.VERSION} use-mirror-upload.ops.rhcloud.com:/srv/pub/openshift-v4/x86_64/clients/helm/"


### PR DESCRIPTION
```
startup failed:
WorkflowScript: 61: Method calls on objects not allowed outside "script" blocks. @ line 61, column 17.
                   commonlib.syncDirToS3Mirror("${params.VERSION}/", "/pub/openshift-v4/x86_64/clients/helm/${params.VERSION}/")
                   ^

WorkflowScript: 62: Method calls on objects not allowed outside "script" blocks. @ line 62, column 17.
                   commonlib.syncDirToS3Mirror("${params.VERSION}/", "/pub/openshift-v4/x86_64/clients/helm/latest/")
                   ^

WorkflowScript: 61: Arguments to "error" must be explicitly named. @ line 61, column 17.
                   commonlib.syncDirToS3Mirror("${params.VERSION}/", "/pub/openshift-v4/x86_64/clients/helm/${params.VERSION}/")
                   ^

WorkflowScript: 62: Arguments to "error" must be explicitly named. @ line 62, column 17.
                   commonlib.syncDirToS3Mirror("${params.VERSION}/", "/pub/openshift-v4/x86_64/clients/helm/latest/")
                   ^

4 errors
```