### PR TITLE
Revert "ocp3.11: Get rid of publishing to rcm-guest"

### DIFF
--- a/jobs/build/ocp3/Jenkinsfile
+++ b/jobs/build/ocp3/Jenkinsfile
@@ -740,6 +740,11 @@ node {
                 commonlib.slacklib.to(params.BUILD_VERSION).failure("Failed ${params.BUILD_VERSION} publishing oc binary art-srv-enterprise S3")
             }
 
+
+            // Push the building puddle out to the correct directory on the mirrors (e.g. online-int, online-stg, or enterprise-X.Y)
+            buildlib.invoke_on_rcm_guest("push-to-mirrors.sh", SYMLINK_NAME, NEW_FULL_VERSION, BUILD_MODE)
+
+            // push-to-mirrors.sh sets up a different puddle name on rcm-guest and the mirrors
             PLASHET = "v${NEW_FULL_VERSION}_${PLASHET}"
             final mirror_url = "https://mirror.openshift.com/enterprise/enterprise-${params.BUILD_VERSION}"
 
@@ -761,6 +766,8 @@ node {
                         params.MAIL_LIST_FAILURE)
                 }
             }
+
+            buildlib.invoke_on_rcm_guest("publish-oc-binary.sh", params.BUILD_VERSION, NEW_FULL_VERSION)
 
             stage("sweep") {
                 buildlib.sweep(params.BUILD_VERSION)


### PR DESCRIPTION
Reverts openshift/aos-cd-jobs#2871