### PR TITLE
Try inheriting proxy settings

### DIFF
--- a/scheduled-jobs/build/sync-rhacs/Jenkinsfile
+++ b/scheduled-jobs/build/sync-rhacs/Jenkinsfile
@@ -12,7 +12,6 @@ node() {
     stage('sync bucket local') {
         withCredentials([file(credentialsId: 'rhacs-sync-gs-account', variable: 'FILE')]) {
             sh '''
-            unset https_proxy
             export PATH=$PATH:/mnt/nfs/home/jenkins/google-cloud-sdk/bin
             rm -rf .config
             mkdir .config


### PR DESCRIPTION
I think https://cloud.google.com/sdk/docs/proxy-settings says that the proxy can be configured through the environment variables. Want to see this fail before setting them with `gcloud set proxy/*` commands.