### PR TITLE
ocp4_scan+rhcos: rebuild when inconsistent

### DIFF
--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -166,7 +166,7 @@ node {
                     // RHEL which may have triggered our rebuild. If there are no changes to the RPMs, the build
                     // should exit quickly. If there are changes, the hope is that by the time our images are done
                     // building, RHCOS will be ready and build-sync will find consistent RPMs.
-                    build wait: false, propagate: false, job: '/aos-cd-builds/build%2Frhcos', parameters: [string(name: 'BUILD_VERSION', value: params.BUILD_VERSION)]
+                    build wait: false, propagate: false, job: 'build%2Frhcos', parameters: [string(name: 'BUILD_VERSION', value: params.BUILD_VERSION)]
                 }
 
                 stage("update dist-git") { joblib.stageUpdateDistgit() }

--- a/jobs/build/rhcos/Jenkinsfile
+++ b/jobs/build/rhcos/Jenkinsfile
@@ -52,6 +52,7 @@ node {
         // Disabling compose lock for now. Ideally we achieve a stable repo for RHCOS builds in the future,
         // but for now, being this strict is slowing down the delivery of nightlies.
         //lock("compose-lock-${params.BUILD_VERSION}") {
+        lock("rhcos-lock-${params.BUILD_VERSION}") {  // wait for all to succeed or fail for this version before starting more
         timestamps {
             def archJobs = [:]
             for (arch in arches) {
@@ -62,7 +63,7 @@ node {
                 }
                 archJobs["trigger-${jobArch}"] = {
                     try {
-                        lock(resource: "rhcos-build-capacity-${jobArch}", quantity: 2) {
+                        lock(resource: "rhcos-build-capacity-${jobArch}", quantity: 2) { // cluster capacity limited per arch
                             withCredentials([file(credentialsId: kubeconfigs[jobArch], variable: 'KUBECONFIG')]) {
                                 // the squid proxy inhibits communication to the p8 RHCOS cluster, so ensure it is in no_proxy
                                 sh  'export no_proxy=p8.psi.redhat.com,$no_proxy\n' +  
@@ -97,7 +98,7 @@ node {
             }
             parallel archJobs
         }
-        //}
+        }
     } finally {
     }
 }


### PR DESCRIPTION
right now, if an rhcos build does not succeed for all arches, it is not
retried and remains inconsistent until the next time ocp4 kicks off an
rhcos build when something else changes. rather than just blindly retry
failed arches (which could delay picking up other changes), we would
like ocp4_scan to kick off a build for all when it sees they are
inconsistent and there's no other reason to run ocp4.

this would not retry if _all_ rhcos builds attempted failed (no
inconsistency), but that seems unlikely to occur enough to be a problem.