### PR TITLE
Remove spamming notifications about failed nightlies

### DIFF
--- a/jobs/build/build-sync/Jenkinsfile
+++ b/jobs/build/build-sync/Jenkinsfile
@@ -143,16 +143,6 @@ node {
         }
         writeFile file: failCountFile, text: "${failCount}"
 
-        if (failCount > 1) {
-            msg = "@release-artists - pipeline has failed to assemble release payload for ${BUILD_VERSION} (assembly ${ASSEMBLY}) ${failCount} times."
-            if (failCount % 2 == 0) {  // spam ourselves a little more often than forum-release
-                slacklib.to(params.BUILD_VERSION).failure(msg)
-            }
-            if (assembly == "stream" && (failCount % 5 == 0) && (failCount < 50)) {  // let forum-release know why no new builds
-                slacklib.to("#forum-release").failure(msg)
-            }
-        }
-
         currentBuild.displayName += " [FAILURE]"
         commonlib.email(
                 to: "aos-art-automation+failed-build-sync@redhat.com",

--- a/scheduled-jobs/build/poll-for-failed-nightlies/Jenkinsfile
+++ b/scheduled-jobs/build/poll-for-failed-nightlies/Jenkinsfile
@@ -104,26 +104,6 @@ node() {
                     // The N latest nightlies have been rejected.
                     echo "The last ${THRESHOLD} nightlies for ${stream_name} have been rejected: ${stream_results}"
                     currentBuild.result = "UNSTABLE"
-                    notificationFile = "${stream_name}.last_notification"
-                    lastNotification = 0
-                    if (fileExists(notificationFile)) {
-                        numStr = readFile(file: notificationFile).trim()
-                        if (numStr?.isLong()) {
-                            lastNotification = numStr.toLong()
-                        }
-                    }
-                    HOURS = 4
-                    if ( System.currentTimeMillis() - lastNotification > 1000 * 60 * 60 * HOURS ) {
-                        // has it been longer than X hours since the last notification?
-                        echo "Notification will occur!"
-                        writeFile(file: notificationFile, text: "${System.currentTimeMillis()}" )
-                        currentBuild.description += "\nNotifying for ${stream_name}"
-                        commonlib.slacklib.to(stream_name).failure("@release-artists - Detected latest ${rejects} nightlies have been rejected in ${stream_name}")
-                        commonlib.slacklib.to('#forum-release').say("@patch-manager - ART automation has detected that the latest ${rejects} nightlies have been rejected in ${stream_name}")
-                        commonlib.slacklib.to('#forum-release-oversight').say("ART automation has detected that the latest ${rejects} nightlies have been rejected in ${stream_name}")
-                    } else {
-                        echo "Skipping notification since it has not been more than ${HOURS} hours since the last notification: ${System.currentTimeMillis()} - ${lastNotification}"
-                    }
                 } else {
                     echo "The last ${THRESHOLD} nightlies didn't all fail for ${stream_name} have been rejected: ${stream_results}"
                 }


### PR DESCRIPTION
Recently, repeated failures in nightlies have triggered tons of notifications on various slack channels. See [here](https://coreos.slack.com/archives/CJARLA942/p1648851792500539) for examples.
This is frustrating our attempts to have useful, easy to find warnings to be used by release artists, patch managers, and the like.

This PR removes these messages, and is meant to be the starting point of a discussion that will eventually entail a more efficient way to schedule and handle these checks.