### PR TITLE
ocp4_scan: Build rhcos also when INCONSISTENT_RHCOS_RPMS is permitted

### DIFF
--- a/jobs/build/ocp4_scan/Jenkinsfile
+++ b/jobs/build/ocp4_scan/Jenkinsfile
@@ -171,6 +171,7 @@ timeout(activity: true, time: 30, unit: 'MINUTES') {
                                             --working-dir ${doozer_working}
                                             --group 'openshift-${version}'
                                             inspect:stream INCONSISTENT_RHCOS_RPMS
+                                            --strict
                                             """, [capture: true]
                                         )
                                         echo stdout


### PR DESCRIPTION
Deploying https://github.com/openshift/doozer/pull/584