### PR TITLE
prepare-release: Fix ImportError

### DIFF
--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -14,6 +14,7 @@ import click
 import jinja2
 import semver
 from doozerlib.assembly import AssemblyTypes
+from doozerlib.util import go_suffix_for_arch
 from elliottlib.assembly import assembly_group_config
 from elliottlib.errata import get_bug_ids
 from elliottlib.model import Model
@@ -25,7 +26,7 @@ from pyartcd.mail import MailService
 from pyartcd.record import parse_record_log
 from pyartcd.runtime import Runtime
 from pyartcd.util import (get_assembly_basis, get_assembly_type,
-                          get_release_name, go_suffix_for_arch)
+                          get_release_name)
 from ruamel.yaml import YAML
 from tenacity import retry, stop_after_attempt, wait_fixed
 


### PR DESCRIPTION
Fixes the following error:
```python
  File "/mnt/workspace/jenkins/working/_cd-builds_build_prepare-release/pyartcd/pyartcd/__main__.py", line 4, in <module>
    from pyartcd.pipelines import (prepare_release, promote, rebuild,
  File "/mnt/workspace/jenkins/working/_cd-builds_build_prepare-release/pyartcd/pyartcd/pipelines/prepare_release.py", line 27, in <module>
    from pyartcd.util import (get_assembly_basis, get_assembly_type,
ImportError: cannot import name 'go_suffix_for_arch'
```

It turns out go_suffix_for_arch was removed from pyartcd.util by this commit: https://github.com/openshift/aos-cd-jobs/commit/1a2e45c4641212cd98f965e7e7ff422a6b0d4622#diff-6a68c2ae2c26daa692da9c2b42a8e7a6d88d9e73f7b505e4afddbb8c0dfc673eR8-R10
When I worked on this PR https://github.com/openshift/aos-cd-jobs/pull/3028, I didn’t have that above commit pulled.

This PR fixes the issue by importing `go_suffix_for_arch` directly from
`doozerlib.util`.