### PR TITLE
Fix venv setup

### DIFF
--- a/jobs/build/check-bugs/Jenkinsfile
+++ b/jobs/build/check-bugs/Jenkinsfile
@@ -36,9 +36,6 @@ node {
     // Check for mock build
     commonlib.checkMock()
 
-    // Install pyartcd
-    commonlib.shell(script: "pip install --no-cache-dir --upgrade -e ./pyartcd")
-
     // Check bugs
     stage('check-bugs') {
         sh "rm -rf ./artcd_working && mkdir -p ./artcd_working"

--- a/jobs/build/prepare-release/Jenkinsfile
+++ b/jobs/build/prepare-release/Jenkinsfile
@@ -87,8 +87,6 @@ node {
                 }
                 currentBuild.displayName += " - $params.VERSION - $params.ASSEMBLY"
             }
-
-            commonlib.shell(script: "pip install -e ./pyartcd")
         }
         stage ("Notify release channel") {
             if (params.DRY_RUN) {

--- a/jobs/build/rebuild/Jenkinsfile
+++ b/jobs/build/rebuild/Jenkinsfile
@@ -73,7 +73,6 @@ node {
                 currentBuild.displayName += " - [DRY RUN]"
             }
             currentBuild.displayName += " - $params.ASSEMBLY - $params.TYPE - ${params.DISTGIT_KEY?: '(N/A)'}"
-            commonlib.shell(script: "pip install -e ./pyartcd")
         }
         stage ("Notify release channel") {
             if (params.DRY_RUN) {

--- a/jobs/build/sweep/Jenkinsfile
+++ b/jobs/build/sweep/Jenkinsfile
@@ -63,9 +63,6 @@ node {
     // Check for mock build
     commonlib.checkMock()
 
-    // Install pyartcd
-    commonlib.shell(script: "pip install --upgrade -e ./pyartcd")
-
     // Init
     echo "Initializing bug sweep for ${params.BUILD_VERSION}. Sync: #${currentBuild.number}"
     currentBuild.displayName = "${params.BUILD_VERSION}"

--- a/jobs/build/tarball-sources/Jenkinsfile
+++ b/jobs/build/tarball-sources/Jenkinsfile
@@ -64,7 +64,6 @@ node {
 
     commonlib.checkMock()
     buildlib.initialize()
-    commonlib.shell(script: "pip install -e ./pyartcd")
 
     try {
         sshagent(['openshift-bot']) {

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -127,6 +127,7 @@ def setup_venv() {
         }
         commonlib.shell(script: "pip install -q -e art-tools/doozer/")
         commonlib.shell(script: "pip install -q -e art-tools/elliott/")
+        commonlib.shell(script: "pip install -e pyartcd/")
     } catch (Exception ex) {
         print(ex)
     }

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -125,8 +125,8 @@ def setup_venv() {
             where = DOOZER_COMMIT.split('@')
             commonlib.shell(script: "rm -rf art-tools/doozer ; cd art-tools; git clone git://github.com/${where[0]}/doozer.git; cd doozer; git checkout ${where[1]}")
         }
-        commonlib.shell(script: "pip install -q -r art-tools/doozer/requirements.txt")
-        commonlib.shell(script: "pip install -q -r art-tools/elliott/requirements.txt")
+        commonlib.shell(script: "pip install -q -e art-tools/doozer/")
+        commonlib.shell(script: "pip install -q -e art-tools/elliott/")
     } catch (Exception ex) {
         print(ex)
     }

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -127,6 +127,13 @@ def setup_venv() {
     commonlib.shell(script: "pip install -q -e art-tools/doozer/")
     commonlib.shell(script: "pip install -q -e art-tools/elliott/")
     commonlib.shell(script: "pip install -e pyartcd/")
+
+    out = sh(
+        script: 'pip freeze | grep "doozer\\|elliott"',
+        returnStdout: true
+    )
+    echo "Installed pyartcd:"
+    echo "${out}"
 }
 
 def doozer(cmd, opts=[:]){

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -119,19 +119,14 @@ def setup_venv() {
     env.VIRTUAL_ENV = "${VIRTUAL_ENV}"
     env.PATH = "${VIRTUAL_ENV}/bin:${env.WORKSPACE}/art-tools/elliott:${env.WORKSPACE}/art-tools/doozer:${env.PATH}"
 
-    try {
-        commonlib.shell(script: "pip install --upgrade pip")
-        if (params.DOOZER_COMMIT) {
-            where = DOOZER_COMMIT.split('@')
-            commonlib.shell(script: "rm -rf art-tools/doozer ; cd art-tools; git clone git://github.com/${where[0]}/doozer.git; cd doozer; git checkout ${where[1]}")
-        }
-        commonlib.shell(script: "pip install -q -e art-tools/doozer/")
-        commonlib.shell(script: "pip install -q -e art-tools/elliott/")
-        commonlib.shell(script: "pip install -e pyartcd/")
-    } catch (Exception ex) {
-        print(ex)
+    commonlib.shell(script: "pip install --upgrade pip")
+    if (params.DOOZER_COMMIT) {
+        where = DOOZER_COMMIT.split('@')
+        commonlib.shell(script: "rm -rf art-tools/doozer ; cd art-tools; git clone git://github.com/${where[0]}/doozer.git; cd doozer; git checkout ${where[1]}")
     }
-
+    commonlib.shell(script: "pip install -q -e art-tools/doozer/")
+    commonlib.shell(script: "pip install -q -e art-tools/elliott/")
+    commonlib.shell(script: "pip install -e pyartcd/")
 }
 
 def doozer(cmd, opts=[:]){


### PR DESCRIPTION
Calling ```pip install -r <art-tool>/requirements.txt``` is dangerous, as it does not necessarily install latest submodule code. It can either pull from PyPI, or use a cached version of the tool if the virtual env folder wasn't wiped out. Using ```pip install -e``` makes sure latest ```setup.py``` is called for each tool.

Pyartcd can also be installed within the same folder, instead of delegating to each pipeline that's using it. This ensures consistency and avoids code duplication.

By removing the ```try-catch``` block that surrounds the virtualenv setup, we make sure that if errors are raised the job will stop, instead of running with outdated versions of our tooling (buildvm has old versions of doozer and elliott installed at system level, that will serve as unwanted fallback if the virtualenv is not created successfully)