### PR TITLE
sweep&check_bugs: don't use `--upgrade` flag for pip install

### DIFF
--- a/jobs/build/check-bugs/Jenkinsfile
+++ b/jobs/build/check-bugs/Jenkinsfile
@@ -37,7 +37,7 @@ node {
     commonlib.checkMock()
 
     // Install pyartcd
-    commonlib.shell(script: "pip install --no-cache-dir --upgrade -e ./pyartcd")
+    commonlib.shell(script: "pip install -e ./pyartcd")
 
     // Check bugs
     stage('check-bugs') {

--- a/jobs/build/sweep/Jenkinsfile
+++ b/jobs/build/sweep/Jenkinsfile
@@ -64,7 +64,7 @@ node {
     commonlib.checkMock()
 
     // Install pyartcd
-    commonlib.shell(script: "pip install --upgrade -e ./pyartcd")
+    commonlib.shell(script: "pip install -e ./pyartcd")
 
     // Init
     echo "Initializing bug sweep for ${params.BUILD_VERSION}. Sync: #${currentBuild.number}"


### PR DESCRIPTION
`--upgrade` may overrides Elliott and Doozer with the versions on PyPI.