### PR TITLE
Use "pip list" instead of "pip freeze" to get art-tools dependencies

### DIFF
--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -129,7 +129,7 @@ def setup_venv() {
     commonlib.shell(script: "pip install -e pyartcd/")
 
     out = sh(
-        script: 'pip freeze | grep "doozer\\|elliott"',
+        script: 'pip list | grep "doozer\\|elliott"',
         returnStdout: true
     )
     echo "Installed pyartcd:"


### PR DESCRIPTION
`pip freeze` prints: `-e git+https://github.com/openshift/doozer@405d562ca4590bf8a2d7904034c8307772f0dd8a#egg=rh_doozer&subdirectory=../../../art-tools/doozer`

 `pip list` prints instead: `rh-elliott         2.0.14.dev2+g2fe537d <install path>`