### PR TITLE
Fix docker credentials so they use a paid account

### DIFF
--- a/sjb/actions/clonerefs.py
+++ b/sjb/actions/clonerefs.py
@@ -74,6 +74,12 @@ class ClonerefsAction(Action):
     done
 
     for (( i = 0; i < 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i < 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/ami_validate_origin_int_rhel_base.xml
+++ b/sjb/generated/ami_validate_origin_int_rhel_base.xml
@@ -143,6 +143,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/azure_build_base_image_centos.xml
+++ b/sjb/generated/azure_build_base_image_centos.xml
@@ -147,6 +147,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/azure_build_base_image_rhel.xml
+++ b/sjb/generated/azure_build_base_image_rhel.xml
@@ -147,6 +147,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/azure_build_node_image_centos.xml
+++ b/sjb/generated/azure_build_node_image_centos.xml
@@ -147,6 +147,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/azure_build_node_image_centos_310.xml
+++ b/sjb/generated/azure_build_node_image_centos_310.xml
@@ -152,6 +152,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/azure_build_node_image_rhel.xml
+++ b/sjb/generated/azure_build_node_image_rhel.xml
@@ -152,6 +152,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/azure_build_node_image_rhel_310.xml
+++ b/sjb/generated/azure_build_node_image_rhel_310.xml
@@ -152,6 +152,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/ci-kubernetes-aws-actuator.xml
+++ b/sjb/generated/ci-kubernetes-aws-actuator.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/ci-kubernetes-conformance-node-e2e-containerized-rhel.xml
+++ b/sjb/generated/ci-kubernetes-conformance-node-e2e-containerized-rhel.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/ci-kubernetes-conformance-node-e2e-rhel.xml
+++ b/sjb/generated/ci-kubernetes-conformance-node-e2e-rhel.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/ci-kubernetes-descheduler-e2e-gce.xml
+++ b/sjb/generated/ci-kubernetes-descheduler-e2e-gce.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/ci-kubernetes-machine-api-operator.xml
+++ b/sjb/generated/ci-kubernetes-machine-api-operator.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/pull-ci-openshift-cluster-api-actuator-pkg-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-cluster-api-actuator-pkg-master-e2e.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/pull-ci-openshift-cluster-api-provider-kubemark-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-cluster-api-provider-kubemark-master-e2e.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/pull-ci-openshift-cluster-api-provider-libvirt-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-cluster-api-provider-libvirt-master-e2e.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/pull-ci-openshift-cluster-autoscaler-operator-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-cluster-autoscaler-operator-master-e2e.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/pull-ci-openshift-kubernetes-autoscaler-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-kubernetes-autoscaler-master-e2e.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/pull-ci-openshift-machine-api-operator-master-e2e.xml
+++ b/sjb/generated/pull-ci-openshift-machine-api-operator-master-e2e.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/push_cluster_operator_images.xml
+++ b/sjb/generated/push_cluster_operator_images.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/push_jenkins_images.xml
+++ b/sjb/generated/push_jenkins_images.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/push_origin_aggregated_logging_release.xml
+++ b/sjb/generated/push_origin_aggregated_logging_release.xml
@@ -137,6 +137,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/push_origin_metrics_release.xml
+++ b/sjb/generated/push_origin_metrics_release.xml
@@ -137,6 +137,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/push_origin_metrics_release_310.xml
+++ b/sjb/generated/push_origin_metrics_release_310.xml
@@ -137,6 +137,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/push_origin_release.xml
+++ b/sjb/generated/push_origin_release.xml
@@ -147,6 +147,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/push_origin_release_310.xml
+++ b/sjb/generated/push_origin_release_310.xml
@@ -147,6 +147,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/push_origin_release_36.xml
+++ b/sjb/generated/push_origin_release_36.xml
@@ -147,6 +147,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/push_origin_release_37.xml
+++ b/sjb/generated/push_origin_release_37.xml
@@ -147,6 +147,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/push_origin_release_38.xml
+++ b/sjb/generated/push_origin_release_38.xml
@@ -147,6 +147,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/push_origin_release_39.xml
+++ b/sjb/generated/push_origin_release_39.xml
@@ -147,6 +147,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/push_wildfly_images.xml
+++ b/sjb/generated/push_wildfly_images.xml
@@ -143,6 +143,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_cluster_operator_e2e.xml
+++ b/sjb/generated/test_branch_cluster_operator_e2e.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_cluster_operator_unit.xml
+++ b/sjb/generated/test_branch_cluster_operator_unit.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_image_registry_integration.xml
+++ b/sjb/generated/test_branch_image_registry_integration.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_image_registry_unit.xml
+++ b/sjb/generated/test_branch_image_registry_unit.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_jenkins_client_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_client_plugin.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_jenkins_images.xml
+++ b/sjb/generated/test_branch_jenkins_images.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_openshift_login_plugin.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_jenkins_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_plugin.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_jenkins_sync_plugin.xml
+++ b/sjb/generated/test_branch_jenkins_sync_plugin.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_kubernetes_metrics_server_unit.xml
+++ b/sjb/generated/test_branch_kubernetes_metrics_server_unit.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_online_console_extensions.xml
+++ b/sjb/generated/test_branch_online_console_extensions.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_online_hibernation_unit.xml
+++ b/sjb/generated/test_branch_online_hibernation_unit.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_azure.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_azure.xml
@@ -180,6 +180,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_azure_310.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_azure_310.xml
@@ -180,6 +180,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce.xml
@@ -185,6 +185,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_310.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_310.xml
@@ -190,6 +190,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_37.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_37.xml
@@ -185,6 +185,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_39.xml
+++ b/sjb/generated/test_branch_openshift_ansible_extended_conformance_gce_39.xml
@@ -185,6 +185,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_openshift_ansible_logging.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_openshift_ansible_logging_310.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_openshift_ansible_logging_311.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_311.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file_310.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_openshift_ansible_logging_json_file_311.xml
+++ b/sjb/generated/test_branch_openshift_ansible_logging_json_file_311.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_aggregated_logging_json_file.xml
+++ b/sjb/generated/test_branch_origin_aggregated_logging_json_file.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_aggregated_logging_json_file_310.xml
+++ b/sjb/generated/test_branch_origin_aggregated_logging_json_file_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_aggregated_logging_json_file_311.xml
+++ b/sjb/generated/test_branch_origin_aggregated_logging_json_file_311.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_check.xml
+++ b/sjb/generated/test_branch_origin_check.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_check_310.xml
+++ b/sjb/generated/test_branch_origin_check_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_cmd.xml
+++ b/sjb/generated/test_branch_origin_cmd.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_cmd_310.xml
+++ b/sjb/generated/test_branch_origin_cmd_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_cross.xml
+++ b/sjb/generated/test_branch_origin_cross.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_cross_310.xml
+++ b/sjb/generated/test_branch_origin_cross_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_end_to_end.xml
+++ b/sjb/generated/test_branch_origin_end_to_end.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_end_to_end_310.xml
+++ b/sjb/generated/test_branch_origin_end_to_end_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_end_to_end_311.xml
+++ b/sjb/generated/test_branch_origin_end_to_end_311.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_builds_310.xml
+++ b/sjb/generated/test_branch_origin_extended_builds_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_builds_311.xml
+++ b/sjb/generated/test_branch_origin_extended_builds_311.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_clusterup.xml
+++ b/sjb/generated/test_branch_origin_extended_clusterup.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_clusterup_310.xml
+++ b/sjb/generated/test_branch_origin_extended_clusterup_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_azure.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_azure.xml
@@ -180,6 +180,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_azure_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_azure_310.xml
@@ -180,6 +180,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_crio.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_crio_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_crio_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce.xml
@@ -181,6 +181,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_gce_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce_310.xml
@@ -186,6 +186,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_gce_37.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce_37.xml
@@ -181,6 +181,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_gce_38.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce_38.xml
@@ -181,6 +181,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_gce_39.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_gce_39.xml
@@ -181,6 +181,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install-release-3.11.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install-release-3.11.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install_311.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_311.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install_36.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_36.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install_37.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_37.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install_38.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_38.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install_39.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_39.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install_containerized.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_containerized.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install_containerized_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_containerized_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install_in_tree.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_in_tree.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install_in_tree_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_in_tree_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_system_containers.xml
@@ -147,6 +147,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install_system_containers_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_system_containers_310.xml
@@ -147,6 +147,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_containerized_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_install_update_system_containers_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_k8s.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_k8s.xml
@@ -186,6 +186,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_k8s_310.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_k8s_310.xml
@@ -191,6 +191,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_conformance_k8s_39.xml
+++ b/sjb/generated/test_branch_origin_extended_conformance_k8s_39.xml
@@ -186,6 +186,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_gssapi.xml
+++ b/sjb/generated/test_branch_origin_extended_gssapi.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_gssapi_310.xml
+++ b/sjb/generated/test_branch_origin_extended_gssapi_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_image_ecosystem_310.xml
+++ b/sjb/generated/test_branch_origin_extended_image_ecosystem_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_image_ecosystem_311.xml
+++ b/sjb/generated/test_branch_origin_extended_image_ecosystem_311.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_image_registry_310.xml
+++ b/sjb/generated/test_branch_origin_extended_image_registry_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_ldap_groups.xml
+++ b/sjb/generated/test_branch_origin_extended_ldap_groups.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_ldap_groups_310.xml
+++ b/sjb/generated/test_branch_origin_extended_ldap_groups_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_networking.xml
+++ b/sjb/generated/test_branch_origin_extended_networking.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_extended_networking_310.xml
+++ b/sjb/generated/test_branch_origin_extended_networking_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_integration.xml
+++ b/sjb/generated/test_branch_origin_integration.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_integration_310.xml
+++ b/sjb/generated/test_branch_origin_integration_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_service_catalog.xml
+++ b/sjb/generated/test_branch_origin_service_catalog.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_service_catalog_310.xml
+++ b/sjb/generated/test_branch_origin_service_catalog_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_unit.xml
+++ b/sjb/generated/test_branch_origin_unit.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_unit_310.xml
+++ b/sjb/generated/test_branch_origin_unit_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_verify.xml
+++ b/sjb/generated/test_branch_origin_verify.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_verify_310.xml
+++ b/sjb/generated/test_branch_origin_verify_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_web_console.xml
+++ b/sjb/generated/test_branch_origin_web_console.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_web_console_310.xml
+++ b/sjb/generated/test_branch_origin_web_console_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_web_console_311.xml
+++ b/sjb/generated/test_branch_origin_web_console_311.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_web_console_39.xml
+++ b/sjb/generated/test_branch_origin_web_console_39.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_web_console_server_check.xml
+++ b/sjb/generated/test_branch_origin_web_console_server_check.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_origin_web_console_server_e2e.xml
+++ b/sjb/generated/test_branch_origin_web_console_server_e2e.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_branch_wildfly_images.xml
+++ b/sjb/generated/test_branch_wildfly_images.xml
@@ -144,6 +144,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_origin_device_manager_plugin_gpu.xml
+++ b/sjb/generated/test_origin_device_manager_plugin_gpu.xml
@@ -144,6 +144,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_cluster_operator_e2e.xml
+++ b/sjb/generated/test_pull_request_cluster_operator_e2e.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_cluster_operator_unit.xml
+++ b/sjb/generated/test_pull_request_cluster_operator_unit.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_descheduler_gce_39.xml
+++ b/sjb/generated/test_pull_request_descheduler_gce_39.xml
@@ -176,6 +176,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_image_registry_integration.xml
+++ b/sjb/generated/test_pull_request_image_registry_integration.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_image_registry_unit.xml
+++ b/sjb/generated/test_pull_request_image_registry_unit.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_jenkins_client_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_client_plugin.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_jenkins_images.xml
+++ b/sjb/generated/test_pull_request_jenkins_images.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_jenkins_openshift_login_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_openshift_login_plugin.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_jenkins_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_plugin.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_jenkins_sync_plugin.xml
+++ b/sjb/generated/test_pull_request_jenkins_sync_plugin.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_kubernetes_metrics_server_unit.xml
+++ b/sjb/generated/test_pull_request_kubernetes_metrics_server_unit.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_online_console_extensions.xml
+++ b/sjb/generated/test_pull_request_online_console_extensions.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_online_hibernation_unit.xml
+++ b/sjb/generated/test_pull_request_online_hibernation_unit.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_azure.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_azure.xml
@@ -180,6 +180,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_azure_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_azure_310.xml
@@ -180,6 +180,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce.xml
@@ -180,6 +180,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_310.xml
@@ -185,6 +185,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_37.xml
@@ -180,6 +180,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_39.xml
@@ -180,6 +180,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha.xml
@@ -180,6 +180,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha_310.xml
@@ -185,6 +185,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_gce_ha_39.xml
@@ -180,6 +180,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install-release-3.11.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install-release-3.11.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_containerized_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_crio_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_in_tree.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_in_tree.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_in_tree_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_in_tree_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_36.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_37.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_release_39.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers.xml
@@ -147,6 +147,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_310.xml
@@ -147,6 +147,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_36.xml
@@ -147,6 +147,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_37.xml
@@ -147,6 +147,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_system_containers_39.xml
@@ -147,6 +147,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_containerized_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_update_system_containers_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_extended_conformance_install_with_status_check_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_install_upgrade_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_install_upgrade_gce.xml
@@ -185,6 +185,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_install_upgrade_gce_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_install_upgrade_gce_310.xml
@@ -185,6 +185,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_launch_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_launch_gce.xml
@@ -176,6 +176,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_launch_gce_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_launch_gce_310.xml
@@ -181,6 +181,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_logging-release-3.11.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging-release-3.11.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_logging.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_311.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_311.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_36.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_36.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_37.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_37.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_logging_39.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_logging_39.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_tox.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_tox.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_ansible_tox_310.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_tox_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_service_catalog.xml
+++ b/sjb/generated/test_pull_request_openshift_service_catalog.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_service_catalog_310.xml
+++ b/sjb/generated/test_pull_request_openshift_service_catalog_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_openshift_service_catalog_311.xml
+++ b/sjb/generated/test_pull_request_openshift_service_catalog_311.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald-release-3.11.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald-release-3.11.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_310.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_36.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_36.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_37.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_37.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_journald_39.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_journald_39.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file-release-3.11.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file-release-3.11.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_310.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_36.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_36.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_37.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_37.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_39.xml
+++ b/sjb/generated/test_pull_request_origin_aggregated_logging_json_file_39.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_cmd.xml
+++ b/sjb/generated/test_pull_request_origin_cmd.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_cmd_310.xml
+++ b/sjb/generated/test_pull_request_origin_cmd_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_cross.xml
+++ b/sjb/generated/test_pull_request_origin_cross.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_cross_310.xml
+++ b/sjb/generated/test_pull_request_origin_cross_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_end_to_end.xml
+++ b/sjb/generated/test_pull_request_origin_end_to_end.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_end_to_end_310.xml
+++ b/sjb/generated/test_pull_request_origin_end_to_end_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_end_to_end_311.xml
+++ b/sjb/generated/test_pull_request_origin_end_to_end_311.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_builds_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_builds_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_builds_311.xml
+++ b/sjb/generated/test_pull_request_origin_extended_builds_311.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_clusterup-release-3.11.xml
+++ b/sjb/generated/test_pull_request_origin_extended_clusterup-release-3.11.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_clusterup.xml
+++ b/sjb/generated/test_pull_request_origin_extended_clusterup.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_clusterup_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_clusterup_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_conformance_azure.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_azure.xml
@@ -180,6 +180,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_conformance_azure_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_azure_310.xml
@@ -180,6 +180,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_crio.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_conformance_crio_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_crio_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce.xml
@@ -180,6 +180,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce_310.xml
@@ -185,6 +185,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce_37.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce_37.xml
@@ -180,6 +180,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_conformance_gce_39.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_gce_39.xml
@@ -180,6 +180,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install-release-3.11.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install-release-3.11.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_36.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_36.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_37.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_37.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_38.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_38.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_39.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_39.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_update.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_conformance_install_update_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_install_update_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_conformance_k8s.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_k8s.xml
@@ -181,6 +181,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_conformance_k8s_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_conformance_k8s_310.xml
@@ -186,6 +186,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_gssapi.xml
+++ b/sjb/generated/test_pull_request_origin_extended_gssapi.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_gssapi_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_gssapi_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_image_ecosystem_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_ecosystem_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_image_ecosystem_311.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_ecosystem_311.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_image_registry-release-3.11.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_registry-release-3.11.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_image_registry_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_image_registry_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_ldap_groups.xml
+++ b/sjb/generated/test_pull_request_origin_extended_ldap_groups.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_ldap_groups_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_ldap_groups_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_networking.xml
+++ b/sjb/generated/test_pull_request_origin_extended_networking.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_extended_networking_310.xml
+++ b/sjb/generated/test_pull_request_origin_extended_networking_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_integration.xml
+++ b/sjb/generated/test_pull_request_origin_integration.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_integration_310.xml
+++ b/sjb/generated/test_pull_request_origin_integration_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_launch_gce.xml
+++ b/sjb/generated/test_pull_request_origin_launch_gce.xml
@@ -176,6 +176,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_launch_gce_310.xml
+++ b/sjb/generated/test_pull_request_origin_launch_gce_310.xml
@@ -181,6 +181,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_service_catalog.xml
+++ b/sjb/generated/test_pull_request_origin_service_catalog.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_service_catalog_310.xml
+++ b/sjb/generated/test_pull_request_origin_service_catalog_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_unit.xml
+++ b/sjb/generated/test_pull_request_origin_unit.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_unit_310.xml
+++ b/sjb/generated/test_pull_request_origin_unit_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_verify.xml
+++ b/sjb/generated/test_pull_request_origin_verify.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_verify_310.xml
+++ b/sjb/generated/test_pull_request_origin_verify_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_web_console.xml
+++ b/sjb/generated/test_pull_request_origin_web_console.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_web_console_310.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_310.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_web_console_311.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_311.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_web_console_39.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_39.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_web_console_server_check.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_server_check.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_origin_web_console_server_e2e.xml
+++ b/sjb/generated/test_pull_request_origin_web_console_server_e2e.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_s2i_master.xml
+++ b/sjb/generated/test_pull_request_s2i_master.xml
@@ -142,6 +142,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi

--- a/sjb/generated/test_pull_request_wildfly_images.xml
+++ b/sjb/generated/test_pull_request_wildfly_images.xml
@@ -144,6 +144,12 @@ for (( i = 0; i &lt; 10; i++ )); do
     done
 
     for (( i = 0; i &lt; 10; i++ )); do
+            if scp -r -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/.docker openshiftdevel:; then
+                break
+            fi
+    done
+
+    for (( i = 0; i &lt; 10; i++ )); do
             if scp -F ${WORKSPACE}/.config/origin-ci-tool/inventory/.ssh_config /var/lib/jenkins/tweaks/*.rpm openshiftdevel:/data/; then
                 break
             fi


### PR DESCRIPTION
We were getting rate limit problems in these two tests in https://github.com/openshift/origin/pull/26989:

* test_pull_request_origin_cmd
* test_pull_request_origin_extended_clusterup-release-3.11

It turns out the tests were not using the credentials for our paid account; this PR gets those credentials onto the test VM.

I rolled out the changes for this PR for just those two tests and now the tests are  passing:

* https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/26989/test_pull_request_origin_cmd/25552
* https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/26989/test_pull_request_origin_cmd/25553
* https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/26989/test_pull_request_origin_extended_clusterup-release-3.11/2677
* https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/26989/test_pull_request_origin_extended_clusterup-release-3.11/2678

I ran the tests twice to show it's not a fluke.