### PR TITLE
Add Doozer data path param to build olm bundles

### DIFF
--- a/jobs/build/olm_bundle/Jenkinsfile
+++ b/jobs/build/olm_bundle/Jenkinsfile
@@ -42,6 +42,12 @@ pipeline {
             trim: true,
         )
         string(
+            name: 'DOOZER_DATA_PATH',
+            description: 'ocp-build-data fork to use (e.g. test customizations on your own fork)',
+            defaultValue: "https://github.com/openshift/ocp-build-data",
+            trim: true,
+        )
+        string(
             name: 'OPERATOR_NVRS',
             description: '(Optional) List **only** the operator NVRs you want to build bundles for, everything else gets ignored. The operators should not be mode:disabled/wip in ocp-build-data',
             defaultValue: "",
@@ -147,7 +153,7 @@ pipeline {
             steps {
                 script {
                     lock("olm_bundle-${params.BUILD_VERSION}") {
-                        bundle_nvrs = olm_bundles.build_bundles(only, exclude, operator_nvrs)
+                        bundle_nvrs = olm_bundles.build_bundles(only, exclude, operator_nvrs, params.DOOZER_DATA_PATH)
                     }
                     echo "Successfully built:\n${bundle_nvrs.join('\n')}"
                 }

--- a/jobs/build/olm_bundle/olm_bundles.groovy
+++ b/jobs/build/olm_bundle/olm_bundles.groovy
@@ -54,8 +54,9 @@ def get_builds_from_advisory(advisory) {
  * :param operator_nvrs: only build bundles for given <operator_nvrs>
  * Return a list of built <bundle_nvrs>
  */
-def build_bundles(String[] only, String[] exclude, String[] operator_nvrs) {
+def build_bundles(String[] only, String[] exclude, String[] operator_nvrs, String data_path) {
     def cmd = ""
+    cmd += "--data-path=${data_path}"
     if (only)
         cmd += " --images=${only.join(',')}"
     if (exclude)


### PR DESCRIPTION
Both OCP4 and custom jobs allow us to specify DOOZER_DATA_PATH to test customization on our forks. This is not currently handled by the `olm_bundle` job that gets triggered afterwards, resulting in possible inconsistencies. As an example, [this build](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Folm_bundle/7534/console) failed because it picked `openshift/ocp-build-data` where the operator was disabled for 4.11.

[This one](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/dpaolell/job/olm_bundle/5/console) instead succeeded as it was pointed to the right fork