### PR TITLE
Forward doozer data path to build-sync and olm_bundle jobs

### DIFF
--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -260,6 +260,7 @@ node {
                         "aos-team-art@redhat.com", // "reply to"
                         params.ASSEMBLY,
                         operator_nvrs,
+                        doozer_data_path
                     )
                 }
             }

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -463,6 +463,7 @@ def stageSyncImages() {
         "aos-team-art@redhat.com",
         params.ASSEMBLY,
         operator_nvrs,
+        params.DOOZER_DATA_PATH
     )
 }
 

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -671,7 +671,7 @@ def sweep(String buildVersion, Boolean sweepBuilds = false, Boolean attachBugs =
     }
 }
 
-def sync_images(major, minor, mail_list, assembly, operator_nvrs = null) {
+def sync_images(major, minor, mail_list, assembly, operator_nvrs = null, doozer_data_path) {
     // Run an image sync after a build. This will mirror content from
     // internal registries to quay. After a successful sync an image
     // stream is updated with the new tags and pullspecs.
@@ -689,6 +689,7 @@ def sync_images(major, minor, mail_list, assembly, operator_nvrs = null) {
         results.add build(job: 'build%2Fbuild-sync', propagate: false, parameters: [
             param('String', 'BUILD_VERSION', fullVersion),  // https://stackoverflow.com/a/53735041
             param('String', 'ASSEMBLY', assembly),
+            param('String', 'DOOZER_DATA_PATH', doozer_data_path),
             param('Boolean', 'DRY_RUN', params.DRY_RUN),
         ])
     }, "olm-bundle": {
@@ -696,6 +697,7 @@ def sync_images(major, minor, mail_list, assembly, operator_nvrs = null) {
             results.add build(job: 'build%2Folm_bundle', propagate: false, parameters: [
                 param('String', 'BUILD_VERSION', fullVersion),  // https://stackoverflow.com/a/53735041
                 param('String', 'ASSEMBLY', assembly),
+                param('String', 'DOOZER_DATA_PATH', doozer_data_path),
                 param('String', 'OPERATOR_NVRS', operator_nvrs != null ? operator_nvrs.join(",") : ""),
                 param('Boolean', 'DRY_RUN', params.DRY_RUN),
             ])


### PR DESCRIPTION
Follows #3058

Now that `olm_bundle` has a `DOOZER_DATA_PATH` param, we can forward from `ocp4` and `custom` jobs that trigger it.
Note that the function `buildlib.sync_images` is called only by these 2 jobs.