### PR TITLE
git clone: use https protocol

### DIFF
--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -122,7 +122,7 @@ def setup_venv() {
     commonlib.shell(script: "pip install --upgrade pip")
     if (params.DOOZER_COMMIT) {
         where = DOOZER_COMMIT.split('@')
-        commonlib.shell(script: "rm -rf art-tools/doozer ; cd art-tools; git clone git://github.com/${where[0]}/doozer.git; cd doozer; git checkout ${where[1]}")
+        commonlib.shell(script: "rm -rf art-tools/doozer ; cd art-tools; git clone https://github.com/${where[0]}/doozer.git; cd doozer; git checkout ${where[1]}")
     }
     commonlib.shell(script: "pip install -q -e art-tools/doozer/")
     commonlib.shell(script: "pip install -q -e art-tools/elliott/")


### PR DESCRIPTION
Got an error with custom Doozer fork:

```
rm -rf art-tools/doozer ; cd art-tools; git clone git://github.com/vfreex/doozer.git; cd doozer; git checkout master

[Pipeline] sh
Cloning into 'doozer'...
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```