### PR TITLE
Disable proxy for quay interactions

### DIFF
--- a/jobs/build/build-sync/build.groovy
+++ b/jobs/build/build-sync/build.groovy
@@ -67,7 +67,7 @@ def buildSyncGenInputs() {
 
     def dryRunParams = params.DRY_RUN ? '--skip-gc-tagging --moist-run' : ''
 
-    withEnv(["KUBECONFIG=${buildlib.ciKubeconfig}"]) {
+    withEnv(["KUBECONFIG=${buildlib.ciKubeconfig}", "https_proxy=", "http_proxy="]) {
         sh "rm -rf ${env.WORKSPACE}/${output_dir}"
         buildlib.doozer """
 ${images}


### PR DESCRIPTION
Invocations of `oc image info` were failing spuriously with
"Forbidden" back from quay.
Ultimately I found that turning off the proxy eliminated the
problem.