### PR TITLE
add quiet period for health job

### DIFF
--- a/jobs/scanning/images-health/Jenkinsfile
+++ b/jobs/scanning/images-health/Jenkinsfile
@@ -8,6 +8,7 @@ node() {
     properties(
         [
             disableConcurrentBuilds(),
+            quietPeriod(540),
             [
                 $class : 'ParametersDefinitionProperty',
                 parameterDefinitions: [

--- a/jobs/scanning/images-health/Jenkinsfile
+++ b/jobs/scanning/images-health/Jenkinsfile
@@ -8,7 +8,7 @@ node() {
     properties(
         [
             disableConcurrentBuilds(),
-            quietPeriod(540),
+            quietPeriod(5400),
             [
                 $class : 'ParametersDefinitionProperty',
                 parameterDefinitions: [


### PR DESCRIPTION
Every Monday, our healthjob always gets stuck or fails when querying pr. Although I increased the waiting time in the doozer function, it doesn't seem to have the expected effect. I want to try to increase the interval between each job