### PR TITLE
build/rhcos: vary cluster resource limits

### DIFF
--- a/jobs/build/rhcos/Jenkinsfile
+++ b/jobs/build/rhcos/Jenkinsfile
@@ -48,6 +48,12 @@ node {
             's390x': 'jenkins_serviceaccount_osbs-s390x-3.prod.engineering.redhat.com.kubeconfig',
             'aarch64': 'jenkins_serviceaccount_osbs-aarch64-1.engineering.redhat.com',
         ]
+        resourceLimits = [
+            'x86_64': 6,
+            'ppc64le': 2,
+            's390x': 4,
+            'aarch64': 4,
+        ]
 
         // Disabling compose lock for now. Ideally we achieve a stable repo for RHCOS builds in the future,
         // but for now, being this strict is slowing down the delivery of nightlies.
@@ -63,7 +69,7 @@ node {
                 }
                 archJobs["trigger-${jobArch}"] = {
                     try {
-                        lock(resource: "rhcos-build-capacity-${jobArch}", quantity: 2) { // cluster capacity limited per arch
+                        lock(resource: "rhcos-build-capacity-${jobArch}", quantity: resourceLimits[jobArch]) { // cluster capacity limited per arch
                             withCredentials([file(credentialsId: kubeconfigs[jobArch], variable: 'KUBECONFIG')]) {
                                 // the squid proxy inhibits communication to the p8 RHCOS cluster, so ensure it is in no_proxy
                                 sh  'export no_proxy=p8.psi.redhat.com,$no_proxy\n' +  


### PR DESCRIPTION
we had rhcos builds today that could have run but were waiting because two rhcos builds were already in progress.
the limit is really only 2 for ppc, the rest can handle more.