### PR TITLE
ocp4: Build any necessary bundles

### DIFF
--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -448,21 +448,11 @@ def stageSyncImages() {
         return
     }
 
-    def record_log = buildlib.parse_record_log(doozerWorking)
-    def records = record_log.get('build', [])
-    def operator_nvrs = []
-    for (record in records) {
-        if (record["has_olm_bundle"] != '1' || record['status'] != '0' || !record["nvrs"]) {
-            continue
-        }
-        operator_nvrs << record["nvrs"].split(",")[0]
-    }
     buildlib.sync_images(
         version.major,
         version.minor,
         "aos-team-art@redhat.com",
         params.ASSEMBLY,
-        operator_nvrs,
         params.DOOZER_DATA_PATH
     )
 }

--- a/jobs/build/olm_bundle/olm_bundles.groovy
+++ b/jobs/build/olm_bundle/olm_bundles.groovy
@@ -66,8 +66,8 @@ def build_bundles(String[] only, String[] exclude, String[] operator_nvrs, Strin
         cmd += " --force"
     if (params.DRY_RUN)
         cmd += " --dry-run"
-    cmd += " -- "
-    cmd += operator_nvrs.join(' ')
+    if (operator_nvrs)
+        cmd += " -- ${operator_nvrs.join(' ')}"
     buildlib.doozer("${doozer_opts} ${cmd}")
     def record_log = buildlib.parse_record_log(doozer_working)
     def records = record_log.get('build_olm_bundle', [])


### PR DESCRIPTION
In case an ocp4 build gets interrupted after the operator was built, but
before the bundle build completed, the build of the bundle will not be
retried.

This commit changes that behavior, it calls olm_bundle indiscriminately
from the ocp4 job, picking up if a previous bundle was not attempted.
This mimics the approach in pyartcd prepare-release, where the doozer
bundle command gets called for all bundles (and in the general case has
othing to do).

The custom job also calls olm_bundle. The behavior of being selective
has not been changed, as a targeted approach is generally desired
behavior there.