### PR TITLE
Update test_pull_request_s2i_master to use Go 1.18

### DIFF
--- a/sjb/config/test_cases/test_pull_request_s2i_master.yml
+++ b/sjb/config/test_cases/test_pull_request_s2i_master.yml
@@ -7,8 +7,8 @@ extensions:
     timeout: 300
     repository: "source-to-image"
     script: |-
-      export BUILD_GO_VERSION=go1.12.5 
-      wget -q https://dl.google.com/go/${BUILD_GO_VERSION}.linux-amd64.tar.gz && sudo tar -C /usr/local -xzf ${BUILD_GO_VERSION}.linux-amd64.tar.gz && sudo rm /bin/go* && sudo ln -s /usr/local/go/bin/go /usr/local/go/bin/godoc /usr/local/go/bin/gofmt /bin
+      export BUILD_GO_VERSION=go1.18.3
+      wget -q https://go.dev/dl/${BUILD_GO_VERSION}.linux-amd64.tar.gz && sudo tar -C /usr/local -xzf ${BUILD_GO_VERSION}.linux-amd64.tar.gz && sudo rm /bin/go* && sudo ln -s /usr/local/go/bin/go /usr/local/go/bin/godoc /usr/local/go/bin/gofmt /bin
       make build
       sudo cp /data/src/github.com/openshift/source-to-image/_output/local/bin/linux/amd64/s2i /usr/bin
       echo "Printing s2i version"


### PR DESCRIPTION
Update the configuration for the test_pull_request_s2i_master job from using Go 1.13 to using Go 1.18.