### PR TITLE
Update Go version to 1.18 for source-to-image

### DIFF
--- a/sjb/config/test_cases/test_pull_request_s2i_master.yml
+++ b/sjb/config/test_cases/test_pull_request_s2i_master.yml
@@ -7,7 +7,7 @@ extensions:
     timeout: 300
     repository: "source-to-image"
     script: |-
-      export BUILD_GO_VERSION=go1.12.5 
+      export BUILD_GO_VERSION=go1.18 
       wget -q https://dl.google.com/go/${BUILD_GO_VERSION}.linux-amd64.tar.gz && sudo tar -C /usr/local -xzf ${BUILD_GO_VERSION}.linux-amd64.tar.gz && sudo rm /bin/go* && sudo ln -s /usr/local/go/bin/go /usr/local/go/bin/godoc /usr/local/go/bin/gofmt /bin
       make build
       sudo cp /data/src/github.com/openshift/source-to-image/_output/local/bin/linux/amd64/s2i /usr/bin

--- a/sjb/generated/test_pull_request_s2i_master.xml
+++ b/sjb/generated/test_pull_request_s2i_master.xml
@@ -221,7 +221,7 @@ cat &lt;&lt;SCRIPT &gt;&#34;${script}&#34;
 #!/bin/bash
 set -o errexit -o nounset -o pipefail -o xtrace
 cd &#34;\${GOPATH}/src/github.com/openshift/source-to-image&#34;
-export BUILD_GO_VERSION=go1.12.5 
+export BUILD_GO_VERSION=go1.18 
 wget -q https://dl.google.com/go/\${BUILD_GO_VERSION}.linux-amd64.tar.gz &amp;&amp; sudo tar -C /usr/local -xzf \${BUILD_GO_VERSION}.linux-amd64.tar.gz &amp;&amp; sudo rm /bin/go* &amp;&amp; sudo ln -s /usr/local/go/bin/go /usr/local/go/bin/godoc /usr/local/go/bin/gofmt /bin
 make build
 sudo cp /data/src/github.com/openshift/source-to-image/_output/local/bin/linux/amd64/s2i /usr/bin


### PR DESCRIPTION
Update the S2I job to use Go 1.18