### PR TITLE
[ART-4164][ART-3476] digest and client-type not required for message-digest

### DIFF
--- a/jobs/build/coreos-installer_sync/Jenkinsfile
+++ b/jobs/build/coreos-installer_sync/Jenkinsfile
@@ -86,7 +86,7 @@ node {
 
     stage("calculate shasum") {
         commonlib.shell(
-            script: "cd ${workdir} && find . -type f -exec sha256sum {} + > sha256sum.txt",
+            script: "cd ${workdir}/${params.VERSION} && sha256sum * > sha256sum.txt",
         )
     }
 
@@ -99,7 +99,7 @@ node {
                 ].join('\n')
             )
         } else {
-            sh "tree ${workdir} && cat ${workdir}/sha256sum.txt"
+            sh "tree ${workdir}/${params.VERSION} && cat ${workdir}/${params.VERSION}/sha256sum.txt"
             commonlib.syncDirToS3Mirror("${workdir}/${params.VERSION}/", "/pub/openshift-v4/x86_64/clients/coreos-installer/${params.VERSION}/")
             commonlib.syncDirToS3Mirror("${workdir}/${params.VERSION}/", "/pub/openshift-v4/x86_64/clients/coreos-installer/latest/")
         }

--- a/jobs/signing/sign-artifacts/Jenkinsfile
+++ b/jobs/signing/sign-artifacts/Jenkinsfile
@@ -119,7 +119,7 @@ node {
 
         def digest = commonlib.sanitizeInvisible(params.DIGEST).trim()
         def digestParam = digest ? "--digest ${digest}" : ""
-        if ( !(digest ==~ /sha256:[0-9a-f]{64}/) ) {
+        if ( digest && !(digest ==~ /sha256:[0-9a-f]{64}/) ) {
             currentBuild.description = "bad digest"
             error("The digest does not look like 'sha256:hex64'")
         }

--- a/jobs/signing/sign-artifacts/umb_producer.py
+++ b/jobs/signing/sign-artifacts/umb_producer.py
@@ -98,7 +98,7 @@ release_name_opt = click.option("--release-name", required=True, metavar="SEMVER
 arch_opt = click.option("--arch", required=True, metavar="ARCHITECTURE",
                    type=click.Choice(['x86_64', 'ppc64le', 's390x', 'aarch64', 'multi']),
                    help="Which architecture this release was built for")
-client_type = click.option("--client-type", required=True, metavar="VAL",
+client_type = click.option("--client-type", metavar="VAL", default='ocp',
                    type=click.Choice(['ocp', 'ocp-dev-preview']),
                    help="What type of client needs to be signed")
 client_cert = click.option("--client-cert", required=True, metavar="CERT-PATH",


### PR DESCRIPTION
when signing coreos-installer it will use message-digest methord, there is no digest and client-type
test job:
coreos-installer-sync https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/ximhan/job/build%252Fcoreos-installer_sync/5/console
sign-artifacts: https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/signing-jobs/job/signing%252Fsign-artifacts/17180/console
on mirror: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/coreos-installer/v0.15.0-2/