### PR TITLE
ART 3395 Job to accept a release

### DIFF
--- a/hacks/release_controller/accept.py
+++ b/hacks/release_controller/accept.py
@@ -2,77 +2,86 @@
 import click
 import os
 import sys
-import openshift as oc
 import re
 import requests
 import subprocess
+import functools
+import semver
+
+
+def sort_semver(versions):
+    return sorted(versions, key=functools.cmp_to_key(semver.compare), reverse=True)
 
 
 @click.command()
 @click.option('-a', '--arch', default='amd64', help='Release architecture', type=click.Choice(['amd64',
-              'arm64','s390x','ppc64le']))
+              'arm64', 's390x', 'ppc64le']))
 @click.option('-r', '--release', required=True, help='Release name (e.g. 4.3.13)')
-@click.option('-u', '--upgrade-url', default=None, required=False, help='URL to successful upgrade job')
-@click.option('-m', '--upgrade-minor-url', default=None, required=False, help='URL to successful upgrade-minor job')
 @click.option("--reject", type=bool, is_flag=True, default=False, help='Reject instead of accept the release')
 @click.option("--confirm", type=bool, is_flag=True, default=False,
               help="Must be specified to apply changes to server")
 @click.option("--why", default=None, required=False, help='Reason to perform this action. required with --reject')
-@click.option("--allow-upgrade-to-change", type=bool, is_flag=True, default=False,
-              help='Allow when new upgrade-to version is different from old upgrade-to')
-def run(arch, release, upgrade_url, upgrade_minor_url, confirm, reject, why, allow_upgrade_to_change):
+def run(arch, release, confirm, reject, why):
 
     """
-    Sets annotations to force OpenShift release acceptance.
-    Requires https://github.com/openshift/openshift-client-python to be setup in your PYTHONPATH.
-
-    \b
-    Add github user to this group to enable them: https://github.com/openshift/release/pull/15827
-
-    \b
-    If openshift-client-python is in $HOME/projects/openshift-client-python:
-    $ export PYTHONPATH=$PYTHONPATH:$HOME/projects/openshift-client-python/packages
+    Verify that Passing upgrade tests exist force OpenShift release acceptance.
+    Requires KUBECONFIG env var to be available
 
     \b
     Example invocation:
-    $ ./accept.py -r 4.4.0-rc.3
-                  -u 'https://prow.ci.openshift.org/view/...origin-installer-e2e-gcp-upgrade/575'
-                  -m 'https://prow.ci.openshift.org/view/...origin-installer-e2e-gcp-upgrade/461'
-                  --confirm
+    $ ./accept.py -r 4.9.46 --confirm
     """
-
-    if not upgrade_minor_url and not upgrade_url:
-        raise click.BadParameter('One or both upgrade urls must be specified in order to accept the release')
-
     if reject and not why:
         raise click.BadParameter('--why (a reason) is required when rejecting a release')
 
     kubeconfig = os.getenv('KUBECONFIG')
-    if not kubeconfig:
-        raise ValueError('cannot find KUBECONFIG env')
-
-    release_phase_rejected = 'Rejected'
-    upgrade_state_failed = 'Failed'
+    if confirm and not kubeconfig:
+        raise ValueError('Cannot find KUBECONFIG env')
 
     rc_url = f'https://{arch}.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/release/{release}'
     release_info = requests.get(rc_url).json()
-    if release_info['phase'] != release_phase_rejected:
-        click.echo(f'release is not {release_phase_rejected}. aborting')
-        sys.exit(1)
-    
-    if upgrade_url:
-        old_test = release_info['blockingJobs']['upgrade']
-        if old_test['state'] != upgrade_state_failed:
-            click.echo(f'existing upgrade test is not {upgrade_state_failed}. aborting')
-            sys.exit(1)
-        assert_upgrade_test_state(release, arch, old_test['url'], upgrade_url, allow_upgrade_to_change)
+    release_phase_accepted = 'Accepted'
+    if release_info['phase'] == release_phase_accepted:
+        click.echo(f'Release is already {release_phase_accepted}. Nothing to do')
+        sys.exit(0)
 
-    if upgrade_minor_url:
-        old_test = release_info['blockingJobs']['upgrade-minor']
-        if old_test['state'] != upgrade_state_failed:
-            click.echo(f'existing upgrade test is not {upgrade_state_failed}. aborting')
-            sys.exit(1)
-        assert_upgrade_test_state(release, arch, old_test['url'], upgrade_minor_url, allow_upgrade_to_change)
+    upgrade_state_failed = 'Failed'
+    upgrade_state_succeeded = 'Succeeded'
+
+    major, minor = re.search(r'(\d+)\.(\d+).', release).groups()
+    major, minor = int(major), int(minor)
+    versions = [entry['From'] for entry in release_info['upgradesTo']]
+    upgrade_version = sort_semver([x for x in versions if x.startswith(f'{major}.{minor}')])[0]
+    upgrade_minor_version = sort_semver([x for x in versions if x.startswith(f'{major}.{minor-1}')])[0]
+
+    upgrade_info, upgrade_minor_info = None, None
+    for entry in release_info['upgradesTo']:
+        if entry['From'] == upgrade_version:
+            upgrade_info = entry
+        if entry['From'] == upgrade_minor_version:
+            upgrade_minor_info = entry
+
+    upgrade_test = release_info['results']['blockingJobs']['upgrade']['state']
+    if upgrade_test == upgrade_state_failed:
+        if upgrade_info['Success'] > 0:
+            for _, test in upgrade_info['History'].items():
+                if test['state'] == upgrade_state_succeeded:
+                    upgrade_url = test['url']
+                    click.echo(f'Found passing upgrade test from {upgrade_version}: {upgrade_url}')
+                    break
+        else:
+            raise ValueError(f'Could not find a successful upgrade test from {upgrade_version}')
+
+    upgrade_minor_test = release_info['results']['blockingJobs']['upgrade-minor']['state']
+    if upgrade_minor_test == upgrade_state_failed:
+        if upgrade_minor_info['Success'] > 0:
+            for _, test in upgrade_minor_info['History'].items():
+                if test['state'] == upgrade_state_succeeded:
+                    upgrade_minor_url = test['url']
+                    click.echo(f'Found passing upgrade test from {upgrade_minor_version}: {upgrade_minor_url}')
+                    break
+        else:
+            raise ValueError(f'Could not find a successful upgrade-minor test from {upgrade_minor_version}')
 
     accept_script_name = 'release-tool.py'
     accept_script_url = f'https://raw.githubusercontent.com/openshift/release-controller/master/hack/{accept_script_name}'
@@ -106,56 +115,17 @@ def run(arch, release, upgrade_url, upgrade_minor_url, confirm, reject, why, all
         release
     ])
 
-    print(f"Running command {cmd}")
+    if not confirm:
+        click.echo(f"Would have run {cmd}")
+        sys.exit(0)
+
+    click.echo(f"Running command {cmd}")
     result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False, universal_newlines=True)
     if result.returncode != 0:
         raise IOError(
             f"Command {cmd} returned {result.returncode}: stdout={result.stdout}, stderr={result.stderr}"
         )
-    print(result.stdout)
-
-
-def assert_upgrade_test_state(release_name, arch, old_prowjob_url, new_prowjob_url, allow_upgrade_to_change=False):
-    prowjob_success = 'success'
-    prowjob_fail = 'failure'
-    prow_host = 'https://prow.ci.openshift.org'
-    gcs_host = 'https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com'
-    subdir = 'origin-ci-test/logs'
-    prow_pattern = rf'{prow_host}/view/gs/{subdir}/(.*)/(\d+)'
-
-    def get_prowjob(prowjob_url):
-        z = re.match(prow_pattern, prowjob_url)
-        if not z or len(z.groups()) != 2:
-            raise ValueError(f"given url [{prowjob_url}] doesn't match pattern [{prow_pattern}]")
-        test_name, test_id = z.groups()
-        gcs_bucket_url = f'{gcs_host}/gcs/{subdir}/{test_name}/{test_id}/prowjob.json'
-        r = requests.get(gcs_bucket_url)
-        prowjob = oc.Model(r.json())
-        return prowjob
-
-    # make sure existing test has failed
-    old_prowjob = get_prowjob(old_prowjob_url)
-    old_upgrade_to = old_prowjob.metadata.annotations["release.openshift.io/from-tag"]
-    if old_prowjob.status.state != prowjob_fail:
-        raise ValueError(f'existing prowjob {old_prowjob_url} test has state={old_prowjob.status.state} and not {prowjob_fail}')
-
-    # make sure new test has passed
-    new_prowjob = get_prowjob(new_prowjob_url)
-    if new_prowjob.status.state != prowjob_success:
-        raise ValueError(f'new prowjob {new_prowjob_url} test has state={new_prowjob.status.state} and not {prowjob_success}')
-
-    # make sure new test release tag is same as the given release
-    new_release = new_prowjob.metadata.annotations["release.openshift.io/tag"]
-    if new_release != release_name:
-        raise ValueError(f'new prowjob {new_prowjob_url} test has release tag={new_release} and not {release_name}')
-
-    # make sure new test upgrade_to is same as old test upgrade_to
-    new_upgrade_to = new_prowjob.metadata.annotations["release.openshift.io/from-tag"]
-    if new_upgrade_to != old_upgrade_to:
-        if allow_upgrade_to_change:
-            print('new prowjob upgrade_to_version is different from old prowjob. --allow-upgrade-to-change is in effect so progressing..')
-        else:
-            raise ValueError(f'new prowjob {new_prowjob_url} has upgrade_to={new_upgrade_to} and not {old_upgrade_to}. To override pass --allow-upgrade-to-change')
+    click.echo(result.stdout)
 
 
 if __name__ == '__main__':

--- a/hacks/release_controller/accept.py
+++ b/hacks/release_controller/accept.py
@@ -1,23 +1,29 @@
 #!/usr/bin/python3
 import click
+import os
+import sys
 import openshift as oc
 import json
-import time
-import pprint
+import re
+import requests
+import subprocess
 
 WARNING = '\033[91m'
 ENDC = '\033[0m'
 
 
 @click.command()
-@click.option('-a', '--arch', default='amd64', help='Release architecture (amd64, s390x, ppc64le)')
+@click.option('-a', '--arch', default='amd64', help='Release architecture', type=click.Choice(['amd64',
+'arm64','s390x','ppc64le']))
 @click.option('-r', '--release', required=True, help='Release name (e.g. 4.3.13)')
 @click.option('-u', '--upgrade-url', default=None, required=False, help='URL to successful upgrade job')
 @click.option('-m', '--upgrade-minor-url', default=None, required=False, help='URL to successful upgrade-minor job')
 @click.option("--reject", type=bool, is_flag=True, default=False, help='Reject instead of accept the release')
 @click.option("--confirm", type=bool, is_flag=True, default=False,
               help="Must be specified to apply changes to server")
-def run(arch, release, upgrade_url, upgrade_minor_url, confirm, reject):
+@click.option("--why", default=None, required=False, help='Reason to perform this action. required with --reject')
+@click.option("--allow-upgrade-to-change", type=bool, is_flag=True, default=False, help='Allow when new upgrade-to version is different from old upgrade-to')
+def run(arch, release, upgrade_url, upgrade_minor_url, confirm, reject, why, allow_upgrade_to_change):
 
     """
     Sets annotations to force OpenShift release acceptance.
@@ -33,62 +39,129 @@ def run(arch, release, upgrade_url, upgrade_minor_url, confirm, reject):
     \b
     Example invocation:
     $ ./accept.py -r 4.4.0-rc.3
-                  -u 'https://prow.svc.ci.openshift.org/view/...origin-installer-e2e-gcp-upgrade/575'
-                  -m 'https://prow.svc.ci.openshift.org/view/...origin-installer-e2e-gcp-upgrade/461'
+                  -u 'https://prow.ci.openshift.org/view/...origin-installer-e2e-gcp-upgrade/575'
+                  -m 'https://prow.ci.openshift.org/view/...origin-installer-e2e-gcp-upgrade/461'
                   --confirm
     """
 
     if not upgrade_minor_url and not upgrade_url:
         click.echo('One or both upgrade urls must be specified in order to accept the release')
-        exit(1)
+        sys.exit(1)
 
-    arch_suffix = ''
-    if arch != 'amd64' and arch != 'x86_64':
-        arch_suffix = f'-{arch}'
+    if reject and not why:
+        click.echo('--why (a reason) is required when rejecting a release')
+        sys.exit(1)
 
-    with oc.api_server(api_url='https://api.ci.l2s4.p1.openshiftapps.com:6443'), \
-         oc.project(f'ocp{arch_suffix}'):
+    kubeconfig = os.getenv('KUBECONFIG')
+    if not kubeconfig:
+        click.echo('cannot find KUBECONFIG env')
+        sys.exit(1)
 
-        istag_qname = f'istag/release{arch_suffix}:{release}'
-        istag = oc.selector(istag_qname).object(ignore_not_found=True)
-        if not istag:
-            raise IOError(f'Could not find {istag_qname}')
+    release_phase_rejected = 'Rejected'
+    upgrade_state_failed = 'Failed'
 
-        ts = int(round(time.time() * 1000))
-        backup_filename = f'release{arch_suffix}_{release}.{ts}.json'
-        if confirm:
-            with open(backup_filename, mode='w+', encoding='utf-8') as backup:
-                print(f'Creating backup file: {backup_filename}')
-                backup.write(json.dumps(istag.model._primitive(), indent=4))
+    rc_url = f'https://{arch}.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/release/{release}'
+    release_info = requests.get(rc_url).json()
+    if release_info['phase'] != release_phase_rejected:
+        click.echo(f'release is not {release_phase_rejected}. aborting')
+        sys.exit(1)
+    
+    if upgrade_url:
+        old_test = release_info['blockingJobs']['upgrade']
+        if old_test['state'] != upgrade_state_failed:
+            click.echo(f'existing upgrade test is not {upgrade_state_failed}. aborting')
+            sys.exit(1)
+        assert_upgrade_test_state(release, arch, old_test['url'], upgrade_url, allow_upgrade_to_change)
 
-        def make_release_accepted(obj):
-            for annotations in (obj.model.image.metadata.annotations, obj.model.metadata.annotations, obj.model.tag.annotations):
-                annotations.pop('release.openshift.io/message', None)
-                annotations.pop('release.openshift.io/reason', None)
-                annotations['release.openshift.io/phase'] = 'Accepted' if not reject else 'Rejected'
+    if upgrade_minor_url:
+        old_test = release_info['blockingJobs']['upgrade-minor']
+        if old_test['state'] != upgrade_state_failed:
+            click.echo(f'existing upgrade test is not {upgrade_state_failed}. aborting')
+            sys.exit(1)
+        assert_upgrade_test_state(release, arch, old_test['url'], upgrade_minor_url, allow_upgrade_to_change)
 
-                verify_str = annotations['release.openshift.io/verify']
-                verify = oc.Model(json.loads(verify_str))
-                verify.upgrade.state = 'Succeeded' if not reject else 'Failed'
-                if upgrade_url:
-                    verify.upgrade.url = upgrade_url
-                verify['upgrade-minor'].state = 'Succeeded' if not reject else 'Failed'
-                if upgrade_minor_url:
-                    verify['upgrade-minor'].url = upgrade_minor_url
-                annotations['release.openshift.io/verify'] = json.dumps(verify._primitive(), indent=None)
+    accept_script_name = 'release-tool.py'
+    accept_script_url = f'https://raw.githubusercontent.com/openshift/release-controller/master/hack/{accept_script_name}'
 
-            print(json.dumps(obj.model._primitive(), indent=4))
-            if confirm:
-                print('Attempting to apply this object.')
-                return True
-            else:
-                print(WARNING + '--confirm was not specified. Run again to apply these changes.' + ENDC)
-                exit(0)
+    response = requests.get(accept_script_url)
+    with open(accept_script_name, 'w') as f:
+        f.write(response.text)
 
-        make_release_accepted(istag)
-        istag.replace()
-        print('Success!')
-        print(f'Backup written to: {backup_filename}')
+    action = 'reject' if reject else 'accept'
+    message = f'Manually {action}ed by ART'
+
+    if reject or why:
+        reason = why
+    else:
+        reason = 'Accepting a release on the basis a successful upgrade test'
+
+    cmd = [
+        'python3', accept_script_name,
+        '--arch', arch,
+        '--message', message,
+        '--reason', reason,
+        '--context', 'app.ci',
+        '--kubeconfig', kubeconfig,
+        '--imagestream', 'release'
+    ]
+    if confirm:
+        cmd += '--execute'
+    
+    cmd.extend([
+        action,
+        release
+    ])
+
+    print(f"Running command {cmd}")
+    result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False, universal_newlines=True)
+    if result.returncode != 0:
+        raise IOError(
+            f"Command {cmd} returned {result.returncode}: stdout={result.stdout}, stderr={result.stderr}"
+        )
+    print(result.stdout)
+
+
+def assert_upgrade_test_state(release_name, arch, old_prowjob_url, new_prowjob_url, allow_upgrade_to_change=False):
+    prowjob_success = 'success'
+    prowjob_fail = 'failure'
+    prow_host = 'https://prow.ci.openshift.org'
+    gcs_host = 'https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com'
+    subdir = 'origin-ci-test/logs'
+    prow_pattern = rf'{prow_host}/view/gs/{subdir}/(.*)/(\d+)'
+
+    def get_prowjob(prowjob_url):
+        z = re.match(prow_pattern, prowjob_url)
+        if not z or len(z.groups()) != 2:
+            raise ValueError(f"given url [{prowjob_url}] doesn't match pattern [{prow_pattern}]")
+        test_name, test_id = z.groups()
+        gcs_bucket_url = f'{gcs_host}/gcs/{subdir}/{test_name}/{test_id}/prowjob.json'
+        r = requests.get(gcs_bucket_url)
+        prowjob = oc.Model(r.json())
+        return prowjob
+
+    # make sure existing test has failed
+    old_prowjob = get_prowjob(old_prowjob_url)
+    old_upgrade_to = old_prowjob.metadata.annotations["release.openshift.io/from-tag"]
+    if old_prowjob.status.state != prowjob_fail:
+        raise ValueError(f'existing prowjob {old_prowjob_url} test has state={old_prowjob.status.state} and not {prowjob_fail}')
+
+    # make sure new test has passed
+    new_prowjob = get_prowjob(new_prowjob_url)
+    if new_prowjob.status.state != prowjob_success:
+        raise ValueError(f'new prowjob {new_prowjob_url} test has state={new_prowjob.status.state} and not {prowjob_success}')
+
+    # make sure new test release tag is same as the given release
+    new_release = new_prowjob.metadata.annotations["release.openshift.io/tag"]
+    if new_release != release_name:
+        raise ValueError(f'new prowjob {new_prowjob_url} test has release tag={new_release} and not {release_name}')
+
+    # make sure new test upgrade_to is same as old test upgrade_to
+    new_upgrade_to = new_prowjob.metadata.annotations["release.openshift.io/from-tag"]
+    if new_upgrade_to != old_upgrade_to:
+        if allow_upgrade_to_change:
+            print('new prowjob upgrade_to_version is different from old prowjob. --allow-upgrade-to-change is in effect so progressing..')
+        else:
+            raise ValueError(f'new prowjob {new_prowjob_url} has upgrade_to={new_upgrade_to} and not {old_upgrade_to}. To override pass --allow-upgrade-to-change')
 
 
 if __name__ == '__main__':

--- a/hacks/release_controller/accept.py
+++ b/hacks/release_controller/accept.py
@@ -3,18 +3,14 @@ import click
 import os
 import sys
 import openshift as oc
-import json
 import re
 import requests
 import subprocess
 
-WARNING = '\033[91m'
-ENDC = '\033[0m'
-
 
 @click.command()
 @click.option('-a', '--arch', default='amd64', help='Release architecture', type=click.Choice(['amd64',
-'arm64','s390x','ppc64le']))
+              'arm64','s390x','ppc64le']))
 @click.option('-r', '--release', required=True, help='Release name (e.g. 4.3.13)')
 @click.option('-u', '--upgrade-url', default=None, required=False, help='URL to successful upgrade job')
 @click.option('-m', '--upgrade-minor-url', default=None, required=False, help='URL to successful upgrade-minor job')
@@ -22,7 +18,8 @@ ENDC = '\033[0m'
 @click.option("--confirm", type=bool, is_flag=True, default=False,
               help="Must be specified to apply changes to server")
 @click.option("--why", default=None, required=False, help='Reason to perform this action. required with --reject')
-@click.option("--allow-upgrade-to-change", type=bool, is_flag=True, default=False, help='Allow when new upgrade-to version is different from old upgrade-to')
+@click.option("--allow-upgrade-to-change", type=bool, is_flag=True, default=False,
+              help='Allow when new upgrade-to version is different from old upgrade-to')
 def run(arch, release, upgrade_url, upgrade_minor_url, confirm, reject, why, allow_upgrade_to_change):
 
     """
@@ -45,17 +42,14 @@ def run(arch, release, upgrade_url, upgrade_minor_url, confirm, reject, why, all
     """
 
     if not upgrade_minor_url and not upgrade_url:
-        click.echo('One or both upgrade urls must be specified in order to accept the release')
-        sys.exit(1)
+        raise click.BadParameter('One or both upgrade urls must be specified in order to accept the release')
 
     if reject and not why:
-        click.echo('--why (a reason) is required when rejecting a release')
-        sys.exit(1)
+        raise click.BadParameter('--why (a reason) is required when rejecting a release')
 
     kubeconfig = os.getenv('KUBECONFIG')
     if not kubeconfig:
-        click.echo('cannot find KUBECONFIG env')
-        sys.exit(1)
+        raise ValueError('cannot find KUBECONFIG env')
 
     release_phase_rejected = 'Rejected'
     upgrade_state_failed = 'Failed'

--- a/jobs/build/accept-release/Jenkinsfile
+++ b/jobs/build/accept-release/Jenkinsfile
@@ -1,0 +1,83 @@
+#!/usr/bin/env groovy
+
+node {
+    checkout scm
+    def buildlib = load("pipeline-scripts/buildlib.groovy")
+    def commonlib = buildlib.commonlib
+    commonlib.describeJob("accept-release", """
+        <h2>Accept a release on Release Controller given passing upgrade test(s)</h2>
+    """)
+
+    // Expose properties for a parameterized build
+    properties(
+        [
+            buildDiscarder(
+                logRotator(
+                    artifactDaysToKeepStr: '7',
+                    daysToKeepStr: '7'
+                )
+            ),
+            [
+                $class: 'ParametersDefinitionProperty',
+                parameterDefinitions: [
+                    string(
+                        name: 'RELEASE_NAME',
+                        description: 'Release name (e.g 4.10.4). Arch is amd64 by default.',
+                        trim: true,
+                        defaultValue: ""
+                    ),
+                    string(
+                        name: 'UPGRADE_URL',
+                        description: 'URL to successful upgrade-minor job example: https://prow.ci.openshift.org/view/...origin-installer-e2e-gcp-upgrade/575',
+                        trim: true,
+                        defaultValue: ""
+                    ),
+                    string(
+                        name: 'UPGRADE_MINOR_URL',
+                        description: 'URL to successful upgrade-minor job example: https://prow.ci.openshift.org/view/...origin-installer-e2e-gcp-upgrade/575',
+                        trim: true,
+                        defaultValue: ""
+                    ),
+                    booleanParam(
+                        name: 'CONFIRM',
+                        description: 'Running without this would be a [dry-run]. Must be specified to apply changes to server',
+                        defaultValue: false
+                    ),
+                    booleanParam(
+                        name: 'ALLOW_UPGRADE_TO_CHANGE',
+                        description: 'For allowing upgrade_to version change with new test. Use with caution',
+                        defaultValue: false
+                    ),
+                    commonlib.mockParam(),
+                ]
+            ],
+        ]
+    )
+
+    commonlib.checkMock()
+
+    if (!params.RELEASE_NAME || !(params.UPGRADE_URL || params.UPGRADE_MINOR_URL)) {
+        error("You must provide a release name and atleast one upgrade test url")
+    }
+
+    def dry_run = params.CONFIRM ? '' : '[DRY_RUN]'
+    currentBuild.displayName = "${params.RELEASE_NAME} ${dry_run}"
+
+    def upgrade_param = params.UPGRADE_URL ? "--upgrade-url ${params.UPGRADE_URL}" : ''
+    def upgrade_minor_param = params.UPGRADE_MINOR_URL ? "--upgrade-minor-url ${params.UPGRADE_MINOR_URL}" : ''
+    def allow_upgrade_to_change_param = params.ALLOW_UPGRADE_TO_CHANGE ? "--allow-upgrade-to-change" : ''
+    def confirm_param = params.CONFIRM ? "--confirm" : ''
+    
+    withEnv(['KUBECONFIG=/home/jenkins/kubeconfigs/art-publish.app.ci.kubeconfig']) {
+        res = commonlib.shell(
+            returnAll: true,
+            script: """
+                hacks/release_controller/accept.py --release ${params.RELEASE_NAME} ${upgrade_param} ${upgrade_minor_param} ${allow_upgrade_to_change_param} ${confirm_param}
+            """,
+        )
+        if (res.returnStatus != 0) {
+            error("Script failed. See error above")
+        }
+    }
+    buildlib.cleanWorkspace()
+}

--- a/jobs/build/accept-release/Jenkinsfile
+++ b/jobs/build/accept-release/Jenkinsfile
@@ -5,7 +5,7 @@ node {
     def buildlib = load("pipeline-scripts/buildlib.groovy")
     def commonlib = buildlib.commonlib
     commonlib.describeJob("accept-release", """
-        <h2>Accept a release on Release Controller given passing upgrade test(s)</h2>
+        <h2>Accept a release on Release Controller</h2>
     """)
 
     // Expose properties for a parameterized build
@@ -26,26 +26,9 @@ node {
                         trim: true,
                         defaultValue: ""
                     ),
-                    string(
-                        name: 'UPGRADE_URL',
-                        description: 'URL to successful upgrade-minor job example: https://prow.ci.openshift.org/view/...origin-installer-e2e-gcp-upgrade/575',
-                        trim: true,
-                        defaultValue: ""
-                    ),
-                    string(
-                        name: 'UPGRADE_MINOR_URL',
-                        description: 'URL to successful upgrade-minor job example: https://prow.ci.openshift.org/view/...origin-installer-e2e-gcp-upgrade/575',
-                        trim: true,
-                        defaultValue: ""
-                    ),
                     booleanParam(
                         name: 'CONFIRM',
                         description: 'Running without this would be a [dry-run]. Must be specified to apply changes to server',
-                        defaultValue: false
-                    ),
-                    booleanParam(
-                        name: 'ALLOW_UPGRADE_TO_CHANGE',
-                        description: 'For allowing upgrade_to version change with new test. Use with caution',
                         defaultValue: false
                     ),
                     commonlib.mockParam(),
@@ -56,23 +39,20 @@ node {
 
     commonlib.checkMock()
 
-    if (!params.RELEASE_NAME || !(params.UPGRADE_URL || params.UPGRADE_MINOR_URL)) {
-        error("You must provide a release name and atleast one upgrade test url")
+    if (!params.RELEASE_NAME) {
+        error("You must provide a release name")
     }
 
     def dry_run = params.CONFIRM ? '' : '[DRY_RUN]'
     currentBuild.displayName = "${params.RELEASE_NAME} ${dry_run}"
 
-    def upgrade_param = params.UPGRADE_URL ? "--upgrade-url ${params.UPGRADE_URL}" : ''
-    def upgrade_minor_param = params.UPGRADE_MINOR_URL ? "--upgrade-minor-url ${params.UPGRADE_MINOR_URL}" : ''
-    def allow_upgrade_to_change_param = params.ALLOW_UPGRADE_TO_CHANGE ? "--allow-upgrade-to-change" : ''
     def confirm_param = params.CONFIRM ? "--confirm" : ''
     
     withEnv(['KUBECONFIG=/home/jenkins/kubeconfigs/art-publish.app.ci.kubeconfig']) {
         res = commonlib.shell(
             returnAll: true,
             script: """
-                hacks/release_controller/accept.py --release ${params.RELEASE_NAME} ${upgrade_param} ${upgrade_minor_param} ${allow_upgrade_to_change_param} ${confirm_param}
+                hacks/release_controller/accept.py --release ${params.RELEASE_NAME} ${confirm_param}
             """,
         )
         if (res.returnStatus != 0) {

--- a/jobs/build/accept-release/README.md
+++ b/jobs/build/accept-release/README.md
@@ -1,0 +1,37 @@
+# Accept a Named Release on Release controller
+
+## Purpose
+
+This job can be used to "Accept" a previously "Failed" release on [release controller](https://amd64.ocp.releases.ci.openshift.org/) given a passing upgrade test url. Only intended/available for x64 arch for now.
+
+## Timing
+
+After the [promote-assembly](https://github.com/openshift/aos-cd-jobs/tree/master/scheduled-jobs/build/promote-assembly) job creates a named release on Release controller, and either the upgrade or upgrade-minor tests fail to turn the Release to "Failed" state.
+
+## Parameters
+
+### RELEASE_NAME
+Release name (e.g 4.10.4). Arch (and release controller) is amd64 by default
+
+
+### UPGRADE_URL
+URL to successful upgrade job example: https://prow.ci.openshift.org/view/...origin-installer-e2e-gcp-upgrade/575
+
+
+### UPGRADE_MINOR_URL
+URL to successful upgrade-minor job example: https://prow.ci.openshift.org/view/...origin-installer-e2e-gcp-upgrade/575
+
+
+### CONFIRM
+
+Running without this would be a [dry-run]. Must be specified to apply changes to server
+It's default value is False.
+
+### ALLOW_UPGRADE_TO_CHANGE
+
+For allowing upgrade_to version change with new test. Use with caution
+It's default value is False.
+
+## Known issues
+
+None yet.

--- a/jobs/build/accept-release/README.md
+++ b/jobs/build/accept-release/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This job can be used to "Accept" a previously "Failed" release on [release controller](https://amd64.ocp.releases.ci.openshift.org/) given a passing upgrade test url. Only intended/available for x64 arch for now.
+This job can be used to "Accept" a release on [release controller](https://amd64.ocp.releases.ci.openshift.org/). Only intended/available for x64 arch for now.
 
 ## Timing
 
@@ -14,22 +14,9 @@ After the [promote-assembly](https://github.com/openshift/aos-cd-jobs/tree/maste
 Release name (e.g 4.10.4). Arch (and release controller) is amd64 by default
 
 
-### UPGRADE_URL
-URL to successful upgrade job example: https://prow.ci.openshift.org/view/...origin-installer-e2e-gcp-upgrade/575
-
-
-### UPGRADE_MINOR_URL
-URL to successful upgrade-minor job example: https://prow.ci.openshift.org/view/...origin-installer-e2e-gcp-upgrade/575
-
-
 ### CONFIRM
 
 Running without this would be a [dry-run]. Must be specified to apply changes to server
-It's default value is False.
-
-### ALLOW_UPGRADE_TO_CHANGE
-
-For allowing upgrade_to version change with new test. Use with caution
 It's default value is False.
 
 ## Known issues


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-3395

Use Brad's script https://github.com/openshift/release-controller/blob/master/hack/release-tool.py to accept a release.

Automatically verify passing upgrade and upgrade minor tests based on Release Controller info

```
hacks/release_controller/accept.py -r 4.9.46
Found passing upgrade test from 4.9.45: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws-modern/1557366737253437440
Found passing upgrade test from 4.8.47: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-gcp-modern/1557464175456817152
Would have run ['python3', 'release-tool.py', '--arch', 'amd64', '--message', 'Manually accepted by ART', '--reason', 'Accepting a release on the basis a successful upgrade test', '--context', 'app.ci', '--kubeconfig', None, '--imagestream', 'release', 'accept', '4.9.46']

```

Needs python 3.7 (dependency of brad's script) - buildvm right now has python3.6.8
Update: we have https://github.com/openshift/aos-cd-jobs/pull/3165