### PR TITLE
Log command invocations in promote-assembly

### DIFF
--- a/pyartcd/pyartcd/exectools.py
+++ b/pyartcd/pyartcd/exectools.py
@@ -57,7 +57,7 @@ async def cmd_gather_async(cmd: Union[List[str], str], check: bool = True, **kwa
         cmd_list = shlex.split(cmd)
     else:
         cmd_list = cmd
-    logger.debug("Executing:cmd_gather_async %s", cmd_list)
+    logger.info("Executing:cmd_gather_async %s", cmd_list)
     # capture stdout and stderr if they are not set in kwargs
     if "stdout" not in kwargs:
         kwargs["stdout"] = asyncio.subprocess.PIPE
@@ -87,7 +87,7 @@ async def cmd_assert_async(cmd: Union[List[str], str], check: bool = True, **kwa
         cmd_list = shlex.split(cmd)
     else:
         cmd_list = cmd
-    logger.debug("Executing:cmd_assert_async %s", cmd_list)
+    logger.info("Executing:cmd_assert_async %s", cmd_list)
     proc = await asyncio.subprocess.create_subprocess_exec(cmd_list[0], *cmd_list[1:], **kwargs)
     returncode = await proc.wait()
     if returncode != 0:


### PR DESCRIPTION
I noticed that we weren't logging commands that were being run
as we do in prepare-release.
This helps in debugging when such commands fail.