### PR TITLE
ART-3761 Use release_date from assembly definition if present

### DIFF
--- a/jobs/build/gen-assembly/Jenkinsfile
+++ b/jobs/build/gen-assembly/Jenkinsfile
@@ -46,6 +46,12 @@ node {
                             trim: true,
                         ),
                         string(
+                            name: "DATE",
+                            description: "Intended release date. Format: YYYY-Mon-dd (example: 2050-Jan-01)",
+                            defaultValue: "${dateFormat.format(date)}",
+                            trim: true
+                        ),
+                        string(
                             name: 'PREVIOUS',
                             description: '[Optional] Leave empty to use suggested previous. Otherwise, follow item #6 "PREVIOUS" of the following doc for instructions on how to fill this field:\nhttps://mojo.redhat.com/docs/DOC-1201843#jive_content_id_Completing_a_4yz_release',
                             defaultValue: "",
@@ -90,6 +96,9 @@ node {
                         }
                     } else {
                         cmd += ' --auto-previous'
+                    }
+                    if (params.DATE) {
+                        cmd += " --date ${DATE}"
                     }
                 }
                 buildlib.doozer(cmd)

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -744,7 +744,7 @@ update JIRA accordingly, then notify QE and multi-arch QE for testing.""")
               help="don't create advisories/jira; pick them up from ocp-build-data")
 @pass_runtime
 @click_coroutine
-async def rebuild(runtime: Runtime, group: str, assembly: str, name: Optional[str], date: Optional[str],
+async def prepare_release(runtime: Runtime, group: str, assembly: str, name: Optional[str], date: Optional[str],
                   package_owner: Optional[str], nightlies: Tuple[str, ...], default_advisories: bool):
     # parse environment variables for credentials
     jira_token = os.environ.get("JIRA_TOKEN")

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -198,8 +198,8 @@ class PrepareReleasePipeline:
             parent_jira = self._jira_client.get_issue(jira_issue_key)
             subtask = self._jira_client.get_issue(parent_jira.fields.subtasks[1].key)
             self._jira_client.add_comment(
-                    subtask,
-                    "prepare release job : {}".format(os.environ.get("BUILD_URL"))
+                subtask,
+                f"prepare release job: {os.environ.get('BUILD_URL')}"
             )
             self._jira_client.close_task(subtask)
         else:
@@ -216,7 +216,6 @@ class PrepareReleasePipeline:
                     "prepare release job : {}".format(os.environ.get("BUILD_URL"))
                 )
                 self._jira_client.close_task(subtask)
-
 
         _LOGGER.info("Updating ocp-build-data...")
         build_data_changed = await self.update_build_data(advisories, jira_issue_key)
@@ -745,7 +744,7 @@ update JIRA accordingly, then notify QE and multi-arch QE for testing.""")
 @pass_runtime
 @click_coroutine
 async def prepare_release(runtime: Runtime, group: str, assembly: str, name: Optional[str], date: Optional[str],
-                  package_owner: Optional[str], nightlies: Tuple[str, ...], default_advisories: bool):
+                          package_owner: Optional[str], nightlies: Tuple[str, ...], default_advisories: bool):
     # parse environment variables for credentials
     jira_token = os.environ.get("JIRA_TOKEN")
     if not jira_token:

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -130,18 +130,20 @@ class PrepareReleasePipeline:
             _LOGGER.info("Checking Blocker Bugs for release %s...", self.release_name)
             self.check_blockers()
 
-        release_date = group_config.get("release_date")
-        if not (release_date or self.release_date):
+        assembly_rel_date = group_config.get("release_date")
+        valid_assembly_date = (assembly_rel_date and assembly_rel_date != "YYYY-Mon-DD")
+        if not (valid_assembly_date or self.release_date):
             raise ValueError(
                 "release_date missing in assembly definition"
             )
-        if release_date:
-            if self.release_date and self.release_date != release_date:
+        if valid_assembly_date:
+            if self.release_date and self.release_date != assembly_rel_date:
                 raise ValueError(
-                    f"Given release_date {self.release_date} is different from the one in assembly definition {release_date}. If you want to update the release_date, update it in the assembly definition"
+                    f"Given release_date {self.release_date} is different from the one in assembly definition "
+                    f"{assembly_rel_date}. If you want to update the release_date, update it in the assembly definition"
                 )
-            _LOGGER.info("Using release date from assembly definition %s", release_date)
-            self.release_date = release_date
+            _LOGGER.info("Using release date from assembly definition %s", assembly_rel_date)
+            self.release_date = assembly_rel_date
 
         advisories = {}
 

--- a/pyartcd/pyartcd/pipelines/report_rhcos.py
+++ b/pyartcd/pyartcd/pipelines/report_rhcos.py
@@ -48,7 +48,6 @@ class CheckRhcosPipeline:
         for arch, answer in zip(ARCHES, answers):
             self.result[arch] = answer
 
-
     async def get_data_for_arch(self, arch):
         jenkins = Jenkins(RHCOS_URLS[arch])
         print(f"Checking {arch}")


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-3761
Summary
- Update gen-assembly job to accept a date (required=False). Needs https://github.com/openshift/doozer/pull/626 to work
- Update prepare-release job to read release_date from assembly if present
    - It will raise an error if given date and assembly date don't match
    - If date is given through the job itself, record it in assembly definition
    - Try and update advisories with release date (using elliott advisory-commons). This will let us change assembly definition and run prepare-release to update dates in advisories.