### PR TITLE
Allow mirror binaries stage to be skipped

### DIFF
--- a/jobs/build/promote-assembly/Jenkinsfile
+++ b/jobs/build/promote-assembly/Jenkinsfile
@@ -53,6 +53,11 @@ node {
                         defaultValue: false,
                     ),
                     booleanParam(
+                        name: 'SKIP_MIRROR_BINARIES',
+                        description: 'Do not mirror binaries. Useful in case of reruns on subsequent failure',
+                        defaultValue: false,
+                    ),
+                    booleanParam(
                         name: 'SKIP_CINCINNATI_PR_CREATION',
                         description: 'DO NOT USE without team lead approval. This is an unusual option.',
                         defaultValue: false,


### PR DESCRIPTION
This uses the [existing param on line 191](https://github.com/openshift/aos-cd-jobs/pull/3160/files#diff-5bedc224ad0bb6116c7bbccd6debee89795c42d1931f02c75b94c5e8b91b6558R191)
Useful when signing job fails and we don't
want to run the binary mirror stage, since
it can take a long time.