### PR TITLE
Increase promote job wait_for_stable time to 12 hours with 10m intervals

### DIFF
--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -616,8 +616,8 @@ Please open a chat with @cluster_bot and issue each of these lines individually:
                     arch, retry_state.outcome.result(), retry_state.next_action.sleep
                 )
         return await retry(
-            stop=(stop_after_attempt(36)),  # wait for 5m * 36 = 180m = 3 hours
-            wait=wait_fixed(300),  # wait for 5 minutes between retries
+            stop=(stop_after_attempt(72)),  # wait for 10m * 72 = 720m = 12 hours
+            wait=wait_fixed(300),  # wait for 10 minutes between retries
             retry=(retry_if_result(lambda phase: phase != "Accepted") | retry_if_exception_type()),
             before_sleep=_my_before_sleep,
         )(self.get_release_phase)(release_controller_url, release_stream, release_name)

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -617,7 +617,7 @@ Please open a chat with @cluster_bot and issue each of these lines individually:
                 )
         return await retry(
             stop=(stop_after_attempt(72)),  # wait for 10m * 72 = 720m = 12 hours
-            wait=wait_fixed(300),  # wait for 10 minutes between retries
+            wait=wait_fixed(600),  # wait for 10 minutes between retries
             retry=(retry_if_result(lambda phase: phase != "Accepted") | retry_if_exception_type()),
             before_sleep=_my_before_sleep,
         )(self.get_release_phase)(release_controller_url, release_stream, release_name)


### PR DESCRIPTION
Right now wait_for_stable is not effective since rarely 
a release is accepted on RC in 3 hours. 3 hours is too 
short of a window to be useful. Extending the time to 
12 hours, with 10 min intervals (instead of 5), 
would be more useful.