### PR TITLE
[wip] [ART-3874] gen-assembly: automate PR creation

### DIFF
--- a/jobs/build/gen-assembly/Jenkinsfile
+++ b/jobs/build/gen-assembly/Jenkinsfile
@@ -74,33 +74,24 @@ node {
         }
 
         stage("gen-assembly") {
+            sh "rm -rf ./artcd_working && mkdir -p ./artcd_working"
+            def cmd = [
+                            "artcd",
+                            "-v",
+                            "--working-dir=./artcd_working",
+                            "--config=./config/artcd.toml",
+                            "gen-assembly",
+                            "--nightlies='${params.NIGHTLIES}'",
+                            "--in-flight-prev=${params.IN_FLIGHT_PREV}",
+                            "--build-version=${BUILD_VERSION}",
+                            "--assembly-name=${params.ASSEMBLY_NAME}"
+                            ]
+
             withEnv(['KUBECONFIG=/home/jenkins/kubeconfigs/art-publish.app.ci.kubeconfig']) {
-                nightly_args = ""
-                for (nightly in commonlib.parseList(params.NIGHTLIES)) {
-                    nightly_args += " --nightly ${nightly.trim()}"
+                withCredentials([string(credentialsId: 'openshift-art-build-bot_github_api_token', variable: 'GITHUB_TOKEN'), string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN')]) {
+                            def out = sh(script: cmd.join(' '), returnStdout: true).trim()
+                            currentBuild.description = "${out}"
                 }
-                cmd = "--group openshift-${BUILD_VERSION} release:gen-assembly --name ${ASSEMBLY_NAME} from-releases ${nightly_args}"
-                if (params.CUSTOM) {
-                    cmd += ' --custom'
-                    if ((params.IN_FLIGHT_PREV && params.IN_FLIGHT_PREV != 'none') || params.PREVIOUS) {
-                        error("Specifying IN_FLIGHT_PREV or PREVIOUS for a custom release is not allowed.")
-                    }
-                }
-                else {
-                    if (params.IN_FLIGHT_PREV && params.IN_FLIGHT_PREV != 'none') {
-                        cmd += " --in-flight ${IN_FLIGHT_PREV}"
-                    }
-                    if (params.PREVIOUS) {
-                        if (params.PREVIOUS != 'none') {
-                            for (previous in params.PREVIOUS.split(',')) {
-                                cmd += " --previous ${previous.trim()}"
-                            }
-                        }
-                    } else {
-                        cmd += ' --auto-previous'
-                    }
-                }
-                buildlib.doozer(cmd)
             }
         }
 

--- a/pyartcd/pyartcd/__main__.py
+++ b/pyartcd/pyartcd/__main__.py
@@ -2,7 +2,7 @@ from typing import Optional, Sequence
 
 from pyartcd.cli import cli
 from pyartcd.pipelines import (prepare_release, promote, rebuild,
-                               tarball_sources, check_bugs, sweep, report_rhcos)
+                               tarball_sources, check_bugs, sweep, report_rhcos, gen_assembly)
 
 
 def main(args: Optional[Sequence[str]] = None):

--- a/pyartcd/pyartcd/exceptions.py
+++ b/pyartcd/pyartcd/exceptions.py
@@ -1,2 +1,11 @@
 class VerificationError(ValueError):
     pass
+
+
+class GithubApiException(Exception):
+    """GiHub API exceptions"""
+    pass
+
+
+class ReleaseConfigUpdateError(Exception):
+    """Exception raised when there's an error while updating releases.yml file"""

--- a/pyartcd/pyartcd/github.py
+++ b/pyartcd/pyartcd/github.py
@@ -1,0 +1,158 @@
+import requests
+from pyartcd.exceptions import GithubApiException
+from ghapi.all import GhApi
+
+
+# create_pr function is kept separate as the owner of the pull request URL has to be the upstream owner
+# but with the token of the current repository owner
+def create_pr(token: str, upstream_owner: str, repo: str, title: str, head: str, base: str, body: str,
+              maintainer_can_modify=True) -> str:
+    """
+    Function to create a PR against an upstream repo
+    :param token: Token of the current repo (where the head branch is)
+    :param upstream_owner: The owner of the upstream repo
+    :param repo: Name of the repo (same name)
+    :param title: The title of the PR
+    :param head: The head branch eg: ashwindasr/temp_branch
+    :param base: The base branch to which we are creating the PR to eg: openshift-4.10
+    :param body: The text body of the PR
+    :param maintainer_can_modify: A flag to set maintainer edit permissions
+    :return: The html link of the new PR generated
+    """
+    try:
+        client = GhApi(owner=upstream_owner, repo=repo, token=token)
+        response = client.pulls.create(
+            title=title,
+            head=head,
+            base=base,
+            body=body,
+            maintainer_can_modify=maintainer_can_modify  # default set to true
+        )
+        return response['html_url']
+    except Exception as e:
+        raise GithubApiException(f"Could not create PR. Error: {repr(e)}")
+
+
+class GithubAPI(GhApi):
+    """
+    This API extends ghapi: https://ghapi.fast.ai/
+    """
+
+    def __init__(self, owner, repo, token):
+        super().__init__(owner, repo, token)
+        self.owner = owner
+        self.repo = repo
+
+    def branch_exists(self, branch: str) -> bool:
+        """
+        Function to check if a branch exists in the current repo.
+        :param branch: Name of the branch
+        :return: bool
+        """
+        try:
+            _ = self.get_branch(branch=branch)
+            return True
+        except IndexError:  # ghapi will throw an Index error if the branch does not exist
+            return False
+
+    def sync_with_upstream(self, branch: str) -> None:
+        """
+        Function to sync a branch in your GitHub forked repo with the corresponding upstream repo branch.
+        This feature is not available in this version of ghapi, so defining new function
+        https://docs.github.com/rest/reference/repos#sync-a-fork-branch-with-the-upstream-repository
+        :param branch: The name of a branch on GitHub
+        """
+        json_data = {
+            "branch": branch
+        }
+        url = f"{self.gh_host}/repos/{self.owner}/{self.repo}/merge-upstream"
+        response = requests.post(url, headers=self.headers, json=json_data)
+
+        if response.status_code != 200:
+            raise GithubApiException(
+                f"Could not sync with upstream. Error {response.status_code}: {response.json().get('message')}")
+
+    def get_branch_sha(self, branch: str) -> str:
+        """
+        Returns the sha of the branch
+        :param branch: The branch that we need the sha of
+        :returns: The sha of that branch
+        """
+        try:
+            branches = self.list_branches()
+            for current_branch in branches:
+                if current_branch['ref'] == f"refs/heads/{branch}":  # If this is the branch we are looking for
+                    # Get the SHA of the base branch (needed for API to create a new branch)
+                    sha = current_branch['object']['sha']
+                    return sha
+        except Exception as e:
+            raise GithubApiException(f"Could not get the sha of the base branch. Error: {repr(e)}")
+
+    def create_branch(self, base: str, new_branch_name: str) -> None:
+        """
+        Function to create a new branch from the given base branch.
+        :param base: The base branch that we are creating the new branch off of
+        :param new_branch_name: The name of the new branch to be created. Format "automation_{build_version}_{build_number}"
+        :return: None
+        """
+        try:
+            sha = self.get_branch_sha(base)
+            _ = self.git.create_ref(ref=f"refs/heads/{new_branch_name}", sha=sha)
+        except Exception as e:
+            raise GithubApiException(
+                f"Could not create new branch {new_branch_name} of off base {base}. Error: {repr(e)}")
+
+    def get_file(self, file_name: str, branch="master") -> str:
+        """
+        To retrieve a file from the repository
+        :param file_name: The name of the file we need to retrive
+        :param branch: The branch that we need to get the file from. Default set to master
+        :return: The file as string
+        """
+        try:
+            url = f"https://raw.githubusercontent.com/{self.owner}/{self.repo}/{branch}/{file_name}"
+            response = requests.get(url)
+            return response.text
+        except Exception as e:
+            raise GithubApiException(
+                f"Could not download file {file_name} from {self.owner}/{self.repo}. Error: {repr(e)}")
+
+    def get_file_sha(self, file_name, branch="master") -> str:
+        """
+        Function to get the SHA of a file from a particular branch.
+        :param file_name: The name of the file we need to get the branch from
+        :param branch: The branch where the file is. Default set to master
+        :return: The SHA value of the file
+        """
+        try:
+            response = self.repos.get_content(path=file_name, ref=branch)
+            return response['sha']
+        except Exception as e:
+            raise GithubApiException(f"Could not retrieve SHA for file {file_name}. Error: {repr(e)}")
+
+    def push_change(self, branch: str, content: str, file_path, commit_message, git_author, git_email) -> None:
+        """
+        Push changes to repo
+        :param branch: Name of the branch which has the file
+        :param content: The updated content
+        :param file_path: The file path in the branch
+        :param commit_message: The commit message
+        :param git_author: The name of the author to keep in the commit message
+        :param git_email: The email ID of the git author
+        :return: None
+        """
+        try:
+            sha = self.get_file_sha(file_path, branch)
+            _ = self.update_contents(
+                path=file_path,
+                message=commit_message,
+                content=content,
+                sha=sha,
+                branch=branch,
+                committer={
+                    "name": git_author,
+                    "email": git_email
+                }
+            )
+        except Exception as e:
+            raise GithubApiException(f"Could not push changes to branch {branch}. Error: {repr(e)}")

--- a/pyartcd/pyartcd/pipelines/gen_assembly.py
+++ b/pyartcd/pyartcd/pipelines/gen_assembly.py
@@ -1,0 +1,166 @@
+import sys
+import os
+import click
+import re
+from pyartcd import exceptions, exectools
+from pyartcd.github import GithubAPI, create_pr
+from pyartcd.runtime import Runtime
+from pyartcd.cli import cli, click_coroutine, pass_runtime
+from ruamel.yaml import YAML
+from io import StringIO
+
+TOKEN = os.environ.get("GITHUB_TOKEN")
+UPSTREAM_OWNER = "openshift"
+OWNER = "openshift-art-build-bot"
+REPO = "ocp-build-data"
+GIT_AUTHOR = "AOS Automation Release Team"
+GIT_EMAIL = "noreply@redhat.com"
+RELEASE_CONFIG_FILE = "releases.yml"
+DOOZER_OUTPUT_PATH = "doozer_output.txt"
+
+
+def update_release_config(release_yml: str, data: str) -> str:
+    """
+    Function to update the release config with the new output from doozer
+    :param release_yml: The yml file for the particular release currently in ocp-build-data
+    :param data: The new data that we need to add to the releases.yml file of the specific release
+    :return: The updated releases.yml file contents in string format
+    """
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    releases_config = yaml.load(release_yml)
+    new_release_data = yaml.load(data)['releases']
+
+    key = list(new_release_data.keys())[0]  # there is only one value in the list (key of the new release config)
+    releases_config['releases'].update(new_release_data)
+    releases_config['releases'].move_to_end(key, last=False)
+
+    out = StringIO()
+    yaml.dump(releases_config, out)
+    return out.getvalue()
+
+
+class GenPipeline:
+    def __init__(self, runtime: Runtime, nightlies: str, custom: str, in_flight_prev: str, previous: str,
+                 build_version: str, assembly_name: str):
+        self.runtime = runtime
+        self.nightlies = nightlies
+        self.custom = custom
+        self.in_flight_prev = in_flight_prev
+        self.previous = previous
+        self.build_version = build_version
+        self.assembly_name = assembly_name
+        self.build_number = self.runtime.get_job_run_name()
+
+    async def run(self):
+        # Create doozer cmd arguments
+        nightly_args = ""
+        for nightly in re.findall(r"([\w\-.]+)", self.nightlies):
+            nightly_args += f" --nightly {nightly.strip()}"
+
+        cmd = f"--group openshift-{self.build_version} release:gen-assembly --name {self.assembly_name} from-releases {nightly_args}"
+        if self.custom:
+            cmd += ' --custom'
+            if (self.in_flight_prev and self.in_flight_prev != 'none') or self.previous:
+                print("ERROR: Specifying IN_FLIGHT_PREV or PREVIOUS for a custom release is not allowed.")
+                sys.exit(1)
+
+        else:
+            if self.in_flight_prev and self.in_flight_prev.lower() != 'none':
+                cmd += f" --in-flight {self.in_flight_prev}"
+
+            if self.previous and self.previous.lower() != 'none':
+                for previous_data in re.findall(r"([\w\-.]+)", self.previous):
+                    cmd += f" --previous {previous_data.strip()}"
+            else:
+                cmd += ' --auto-previous'
+
+        # Run doozer command
+        output_all = await exectools.cmd_gather_async(f"doozer --assembly=stream {cmd}")
+        if output_all[0]:
+            self.runtime.logger.error(f"Error: {output_all[2]}")
+            self.runtime.logger.info(output_all[2])
+            sys.exit(1)
+
+        output = output_all[1]
+        release_data = output[output.find("releases:"):].strip()
+
+        self.runtime.logger.info(release_data)
+
+        base = f"openshift-{self.build_version}"  # The base that we have to branch off of
+        temp_branch = f"automation_{self.build_version}_{self.build_number}"  # format of the temporary branch
+
+        # Create GitHub PR
+        client = GithubAPI(
+            owner=OWNER,
+            repo=REPO,
+            token=TOKEN
+        )
+
+        if client.branch_exists(branch=temp_branch):  # If a branch exists with the same name as temp_branch
+            exceptions.GithubApiException(
+                "Temporary branch already exists. Cannot push changes. Delete the temp branch and try again")
+
+        # WARNING!!! This function will automatically sync your branch with upstream. Please take care if you are
+        # trying to test! Please comment out the below function if you are testing.
+        client.sync_with_upstream(branch=base)  # Sync the base branch with its upstream
+        self.runtime.logger.info(f"Branch {base} synced with upstream")
+
+        client.create_branch(base=base, new_branch_name=temp_branch)
+        self.runtime.logger.info(f"Temporary branch {temp_branch} created")
+
+        release_yml = client.get_file(branch=temp_branch, file_name=RELEASE_CONFIG_FILE)
+        self.runtime.logger.info(f"Retrieved releases.yml from branch {temp_branch}")
+
+        updated_config = update_release_config(release_yml, release_data)
+        self.runtime.logger.info(f"Updated {RELEASE_CONFIG_FILE}")
+
+        client.push_change(branch=temp_branch,
+                           content=updated_config,
+                           file_path=RELEASE_CONFIG_FILE,
+                           commit_message=f"updated {RELEASE_CONFIG_FILE}",
+                           git_author=GIT_AUTHOR,
+                           git_email=GIT_EMAIL
+                           )
+        self.runtime.logger.info(f"Pushed changes from branch {temp_branch} to remote {base}")
+
+        pr_url = create_pr(
+            token=TOKEN,
+            upstream_owner=UPSTREAM_OWNER,
+            repo=REPO,
+            title=f"Automated: Prepare release for {self.assembly_name}",
+            body=f"Automated PR for gen-assembly {self.assembly_name}",
+            head=f"{OWNER}:{temp_branch}",
+            base=f"{base}"
+        )
+        self.runtime.logger.info(f"PR created successfully: {pr_url}")
+
+        # Send back the doozer output and newly created URL so that it can be set in the build description
+        temp_data = release_data.replace("\n", "<br>").replace(" ", "&nbsp;")
+        temp_url = f"<a href={pr_url}> {pr_url} </a>"
+
+        # It needs to be print here and not return as Jenkins will read from STDOUT
+        print(
+            "<u>Doozer output:</u><br>" + f"{temp_data}" + "<br><br>PR: " + f"{temp_url}"
+        )
+
+        # Send message to the corresponding release channel
+        slack_client = self.runtime.new_slack_client()
+        slack_client.bind_channel(f"{self.build_version}")
+        await slack_client.say(
+            f"Gen-assembly job for *{self.build_version}* successful. PR created: {pr_url}")
+
+
+@cli.command("gen-assembly")
+@click.option('--nightlies', required=True)
+@click.option('--custom', required=False)
+@click.option('--in-flight-prev', required=False)
+@click.option('--previous', required=False)
+@click.option('--build-version', required=True)
+@click.option('--assembly-name', required=True)
+@pass_runtime
+@click_coroutine
+async def gen_assembly_main(runtime, nightlies, custom, in_flight_prev, previous, build_version, assembly_name):
+    pipeline = GenPipeline(runtime, nightlies=nightlies, custom=custom, in_flight_prev=in_flight_prev,
+                           previous=previous, build_version=build_version, assembly_name=assembly_name)
+    await pipeline.run()


### PR DESCRIPTION
This [feature](https://issues.redhat.com/browse/ART-3874) allows us to automatically create a PR at the end of the gen-assembly job to ocp-build-data. Reviewers can review and merge if everything looks fine.

Sample build run: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/ashwin-aos-cd-jobs/job/build%252Fgen-assembly/121/
Sample PR created: https://github.com/openshift/ocp-build-data/pull/1825

Workflow:
- The corresponding release branch in [openshift-art-build-bot](https://github.com/openshift-art-build-bot/ocp-build-data) is synced with upstream `openshift/ocp-build-data`
- A new temporary branch is created off of the corresponding release branch.
- The releases.yml file is updated with the output from doozer.
- The updated file is committed and a PR is raised from  [openshift-art-build-bot](https://github.com/openshift-art-build-bot/ocp-build-data) to openshift/ocp-build-data.
- The corresponding Slack release channel is notified.
- The build description is updated with the doozer output and the new PR link.

Please take care if you are trying to test it. The `sync_with_upstream` function will automatically merge all changes from upstream to your branch, without warnings or prompts. Please comment out the function before running tests.