### PR TITLE
Build sync accepts doozer data path gitref

### DIFF
--- a/jobs/README.md
+++ b/jobs/README.md
@@ -79,6 +79,11 @@ This is so standard that when provided, `buildlib.doozer` and
 Fork of `ocp-build-data` to use instead of the [default](https://github.com/openshift/ocp-build-data)
 (e.g. when you have an assembly definition in your own fork).
 
+### DOOZER\_DATA\_GITREF
+
+Doozer data path Git [branch / tag / sha] to use instead of the default group branch ("openshift-4.Y") 
+(e.g. when you have an assembly definition in a different branch).
+
 #### DRY\_RUN
 
 A common parameter, used when testing (but not standardized anywhere).

--- a/jobs/build/build-sync/Jenkinsfile
+++ b/jobs/build/build-sync/Jenkinsfile
@@ -56,6 +56,12 @@ node {
                                         defaultValue: "https://github.com/openshift/ocp-build-data",
                                         trim: true,
                                     ),
+                                    string(
+                                        name: 'DOOZER_DATA_GITREF',
+                                        description: '(Optional) Doozer data path git [branch / tag / sha] to use',
+                                        defaultValue: "",
+                                        trim: true,
+                                    ),
                                     booleanParam(
                                             name        : 'DEBUG',
                                             description : 'Run "oc" commands with greater logging',

--- a/jobs/build/build-sync/build.groovy
+++ b/jobs/build/build-sync/build.groovy
@@ -69,13 +69,18 @@ def buildSyncGenInputs() {
 
     def dryRunParams = params.DRY_RUN ? '--skip-gc-tagging --moist-run' : ''
 
+    def groupParam = 'openshift-${params.BUILD_VERSION}'
+    if (params.DOOZER_DATA_GITREF) {
+        groupParam += '@${params.DOOZER_DATA_GITREF}'
+    }
+
     withEnv(["KUBECONFIG=${buildlib.ciKubeconfig}", "https_proxy=", "http_proxy="]) {
         sh "rm -rf ${env.WORKSPACE}/${output_dir}"
         buildlib.doozer """
 ${images}
 --working-dir "${mirrorWorking}"
 --data-path "${params.DOOZER_DATA_PATH}"
---group 'openshift-${params.BUILD_VERSION}'
+--group ${groupParam}
 release:gen-payload
 --output-dir "${env.WORKSPACE}/${output_dir}"
 --apply

--- a/jobs/build/build-sync/build.groovy
+++ b/jobs/build/build-sync/build.groovy
@@ -69,9 +69,9 @@ def buildSyncGenInputs() {
 
     def dryRunParams = params.DRY_RUN ? '--skip-gc-tagging --moist-run' : ''
 
-    def groupParam = 'openshift-${params.BUILD_VERSION}'
+    def groupParam = "openshift-${params.BUILD_VERSION}"
     if (params.DOOZER_DATA_GITREF) {
-        groupParam += '@${params.DOOZER_DATA_GITREF}'
+        groupParam += "@${params.DOOZER_DATA_GITREF}"
     }
 
     withEnv(["KUBECONFIG=${buildlib.ciKubeconfig}", "https_proxy=", "http_proxy="]) {


### PR DESCRIPTION
This will help us run build-sync with an automated PR like this https://github.com/openshift/ocp-build-data/pull/1885
https://github.com/openshift/aos-cd-jobs/pull/3182

[Test run](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Fbuild-sync/8/console)