### PR TITLE
Add retry logic to check-bugs http requests

### DIFF
--- a/pyartcd/requirements.txt
+++ b/pyartcd/requirements.txt
@@ -13,3 +13,4 @@ ruamel.yaml
 semver ~= 2.13.0
 slack_sdk ~= 3.13.0
 tenacity
+aiohttp_retry


### PR DESCRIPTION
HTTP requests to api.openshift.com started failing, causing our job to break and stop notifying about blockers and regressions. Using `aiohttp_retry`, we can ensure that data is re-requested from the server in case of failures.

Tested in a hack space: https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/dpaolell/job/check-bugs/267/console