### PR TITLE
Fix set-client-latest fix

### DIFF
--- a/jobs/build/set_client_latest/S3-set-v4-client-latest.sh
+++ b/jobs/build/set_client_latest/S3-set-v4-client-latest.sh
@@ -84,7 +84,7 @@ for arch in ${ARCHES}; do
         CHANNEL_RELEASES=$(
             curl -sH "Accept:application/json" "https://api.openshift.com/api/upgrades_info/v1/graph?channel=${USE_CHANNEL}&arch=${qarch}" |
               jq '.nodes[].version' -r |
-              grep -vFx 4.11.2
+              { grep -vFx 4.11.2 || true; }
         )
         if [[ -z "$CHANNEL_RELEASES" ]]; then
             echo "No versions currently detected in ${USE_CHANNEL} for arch ${qarch} ; No ${LINK_NAME} will be set"


### PR DESCRIPTION
`grep -v`'s exit code is always 0, except when stdin does not have a
newline at all:

```console
$ printf "" | grep -v abc; echo $?
1
```

This deals with grep's behavior in the degenerate case.