### PR TITLE
fix bug list naming

### DIFF
--- a/pyartcd/pyartcd/pipelines/check_bugs.py
+++ b/pyartcd/pyartcd/pipelines/check_bugs.py
@@ -170,7 +170,7 @@ class CheckBugsPipeline:
         out = out.decode().strip().splitlines()
         if len(out) < 2:
             return None
-        bugs = out[-1].split(':')[1].split(', ')
+        bugs = [b.strip() for b in out[-1].split(':')[1].split(', ')]
 
         # Verify bugs
         cmd = [


### PR DESCRIPTION
fix the issue with space in list item `2022-09-01 07:26:45,849 WARNING Cannot fetch bugs from a different project (current project: OCPBUGS): [' 1996013', '2096508', '2097724', '2101092', '2101794', '2104669', '2105584', '2105592']`