### PR TITLE
Add DOOZER_DATA_GITREF param to olm_bundle

### DIFF
--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -128,7 +128,8 @@ node {
     def doozer_data_path = params.DOOZER_DATA_PATH
     def (majorVersion, minorVersion) = commonlib.extractMajorMinorVersionNumbers(params.BUILD_VERSION)
     def groupParam = "openshift-${params.BUILD_VERSION}"
-    if (params.DOOZER_DATA_GITREF) {
+    def doozer_data_gitref = params.DOOZER_DATA_GITREF
+    if (doozer_data_gitref) {
         groupParam += "@${params.DOOZER_DATA_GITREF}"
     }
     def doozerOpts = "--working-dir ${doozer_working} --data-path ${doozer_data_path} --group '${groupParam}' "
@@ -258,7 +259,8 @@ node {
                         "aos-team-art@redhat.com", // "reply to"
                         params.ASSEMBLY,
                         operator_nvrs,
-                        doozer_data_path
+                        doozer_data_path,
+                        doozer_data_gitref
                     )
                 }
             }

--- a/jobs/build/olm_bundle/Jenkinsfile
+++ b/jobs/build/olm_bundle/Jenkinsfile
@@ -47,6 +47,12 @@ pipeline {
             trim: true,
         )
         string(
+            name: 'DOOZER_DATA_GITREF',
+            description: '(Optional) Doozer data path git [branch / tag / sha] to use',
+            defaultValue: "",
+            trim: true,
+        )
+        string(
             name: 'OPERATOR_NVRS',
             description: '(Optional) List **only** the operator NVRs you want to build bundles for, everything else gets ignored. The operators should not be mode:disabled/wip in ocp-build-data',
             defaultValue: "",
@@ -130,7 +136,11 @@ pipeline {
                         cmd += operator_nvrs.join(' ')
 
                         def doozer_working = "${WORKSPACE}/doozer_working"
-                        def doozer_opts = "--working-dir ${doozer_working} -g openshift-${params.BUILD_VERSION}"
+                        def groupParam = "openshift-${params.BUILD_VERSION}"
+                        if (doozer_data_gitref) {
+                            groupParam += "@${params.DOOZER_DATA_GITREF}"
+                        }
+                        def doozer_opts = "--working-dir ${doozer_working} -g '${groupParam}'"
 
                         buildlib.doozer("${doozer_opts} ${cmd}")
                         def record_log = buildlib.parse_record_log(doozer_working)

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -698,7 +698,7 @@ def sweep(String buildVersion, Boolean sweepBuilds = false, Boolean attachBugs =
     }
 }
 
-def sync_images(major, minor, mail_list, assembly, operator_nvrs = null, doozer_data_path) {
+def sync_images(major, minor, mail_list, assembly, operator_nvrs = null, doozer_data_path, doozer_data_gitref = "") {
     // Run an image sync after a build. This will mirror content from
     // internal registries to quay. After a successful sync an image
     // stream is updated with the new tags and pullspecs.
@@ -725,6 +725,7 @@ def sync_images(major, minor, mail_list, assembly, operator_nvrs = null, doozer_
                 param('String', 'BUILD_VERSION', fullVersion),  // https://stackoverflow.com/a/53735041
                 param('String', 'ASSEMBLY', assembly),
                 param('String', 'DOOZER_DATA_PATH', doozer_data_path),
+                param('String', 'DOOZER_DATA_GITREF', doozer_data_gitref),
                 param('String', 'OPERATOR_NVRS', operator_nvrs != null ? operator_nvrs.join(",") : ""),
                 param('Boolean', 'DRY_RUN', params.DRY_RUN),
             ])


### PR DESCRIPTION
DOOZER_DATA_GITREF has been added to build-sync and custom jobs. Let's finish the job by letting olm_bundle job (in particular, when called from custom jobs) accept this param to avoid inconsistencies with the previous stages.