### PR TITLE
Create placeholder bug before attach-cve-flaws

### DIFF
--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -232,10 +232,6 @@ class PrepareReleasePipeline:
         _LOGGER.info("Sweep bugs into the the advisories...")
         self.sweep_bugs(check_builds=True)
 
-        _LOGGER.info("Processing attached Security Trackers")
-        for _, advisory in advisories.items():
-            self.attach_cve_flaws(advisory)
-
         _LOGGER.info("Adding placeholder bugs...")
         for kind, advisory in advisories.items():
             bug_ids = get_bug_ids(advisory)
@@ -243,6 +239,10 @@ class PrepareReleasePipeline:
             if not bug_ids and not jira_ids:  # Only create placeholder bug if the advisory has no attached bugs
                 _LOGGER.info("Create placeholder bug for %s advisory %s...", kind, advisory)
                 self.create_and_attach_placeholder_bug(kind, advisory)
+
+        _LOGGER.info("Processing attached Security Trackers")
+        for _, advisory in advisories.items():
+            self.attach_cve_flaws(advisory)
 
         # Verify the swept builds match the nightlies
         if self.release_version[0] < 4:


### PR DESCRIPTION
attach-cve-flaws is a step that errors out often,
and those errors can block creating placeholder bugs.
creation of placeholder is not dependent on attach-cve-flaws
step, since it just processes attached-bugs and if no bugs
are attached, it will exit. So there should be no side effect of
doing this