### PR TITLE
WIP ART-4437 Update clients at latest-{major}.{minor} on mirror

### DIFF
--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -488,7 +488,9 @@ def stagePublishClient(quay_url, from_release_tag, release_name, arch, client_ty
     // From the newly built release, extract the client tools into the workspace following the directory structure
     // we expect to publish to mirror
     def CLIENT_MIRROR_DIR="${BASE_TO_MIRROR_DIR}/${arch}/clients/${client_type}/${release_name}"
+    def CLIENT_MIRROR_LATEST_DIR="${BASE_TO_MIRROR_DIR}/${arch}/clients/${client_type}/latest-${major}.${minor}"
     sh "mkdir -p ${CLIENT_MIRROR_DIR}"
+    sh "ln -s ${CLIENT_MIRROR_DIR} ${CLIENT_MIRROR_LATEST_DIR}"
 
     if ( arch == 'x86_64' ) {
         // oc image  extract requires an empty destination directory. So do this before extracting tools.
@@ -631,7 +633,7 @@ extract_opm "$OUTDIR"
     sh "tree $CLIENT_MIRROR_DIR"
     sh "cat $CLIENT_MIRROR_DIR/sha256sum.txt"
 
-    mirror_cmd = "aws s3 sync --no-progress --exact-timestamps ${BASE_TO_MIRROR_DIR}/ s3://art-srv-enterprise/pub/openshift-v4/"
+    mirror_cmd = "aws s3 sync --no-progress --exact-timestamps --follow-symlinks ${BASE_TO_MIRROR_DIR}/ s3://art-srv-enterprise/pub/openshift-v4/"
     if ( ! params.DRY_RUN ) {
         // Publish the clients to our S3 bucket.
         try {


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-4437

Right now we don't update latest-4.y dirs when uploading
clients, this automates that.

Initially tried to create latest symlink in the existing dir
structure (https://github.com/openshift/aos-cd-jobs/pull/3226/commits/0dc4cbebc5e851efba30842ab7532e9e9e4dc06b)

But having `aws s3 sync --delete` for latest meant that
we couldn't do it in the same command, so do it separately
(https://github.com/openshift/aos-cd-jobs/pull/3226/commits/a2d44532b5bf1880684cee133f6aa525113d4a12)