### PR TITLE
Install elliott, doozer, and pyartcd with a single command

### DIFF
--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -151,10 +151,7 @@ def setup_venv(use_python38=false) {
         where = DOOZER_COMMIT.split('@')
         commonlib.shell(script: "rm -rf art-tools/doozer ; cd art-tools; git clone https://github.com/${where[0]}/doozer.git; cd doozer; git checkout ${where[1]}")
     }
-    commonlib.shell(script: "pip install -q -e art-tools/doozer/")
-    commonlib.shell(script: "pip install -q -e art-tools/elliott/")
-    commonlib.shell(script: "pip install -e pyartcd/")
-
+    commonlib.shell(script: "pip install -e art-tools/elliott/ -e art-tools/doozer/ -e pyartcd/")
     out = sh(
         script: 'pip list | grep "doozer\\|elliott"',
         returnStdout: true

--- a/pyartcd/requirements.txt
+++ b/pyartcd/requirements.txt
@@ -5,7 +5,7 @@ contextvars
 ghapi
 jenkinsapi
 Jinja2
-jira ~= 3.2.0  # Pin 3.2.0 until https://github.com/pycontribs/jira/issues/1486 is resolved.toml
+jira >= 3.4.1  # https://github.com/pycontribs/jira/issues/1486
 rh-elliott
 rh-doozer
 ruamel.yaml


### PR DESCRIPTION
This will ensure that dependencies are consistent and will not override each other.