### PR TITLE
Do not fail on kinit

### DIFF
--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -75,7 +75,16 @@ def kinit() {
     // The '-f' ensures that the ticket is forwarded to remote hosts
     // when using SSH. This is required for when we build signed
     // puddles.
-    sh "kinit -f -k -t /home/jenkins/ocp-build_buildvm.openshift.eng.bos.redhat.com_IPA.REDHAT.COM.keytab ocp-build/buildvm.openshift.eng.bos.redhat.com@IPA.REDHAT.COM"
+    keytab = '/home/jenkins/ocp-build_buildvm.openshift.eng.bos.redhat.com_IPA.REDHAT.COM.keytab'
+    account = 'ocp-build/buildvm.openshift.eng.bos.redhat.com@IPA.REDHAT.COM'
+    try {
+        retry(3) {
+            sh "if ! kinit -f -k -t ${keytab} ${account}; then sleep 3; false; fi"
+        }
+    catch (e) {
+        echo "Failed to renew kerberos ticket. Assuming the ticket has been renewed recently enough"
+        echo "${e}"
+    }
 }
 
 def registry_login() {


### PR DESCRIPTION
Generally, the ticket cache is fresh enough to work. With this commit, the kerberos credentials are refreshed on virtually every job run. If it fails, it is retried three times. If there is a failure after three times, it is assumed all is still good.

For reference, this is how the ticket cache for the jenkins user currently looks like:

```
[jenkins@buildvm ~]$ klist
Ticket cache: KEYRING:persistent:1000:1000
Default principal: ocp-build/buildvm.openshift.eng.bos.redhat.com@IPA.REDHAT.COM

Valid starting       Expires              Service principal
10/05/2022 08:19:27  10/05/2022 18:19:27  krbtgt/IPA.REDHAT.COM@IPA.REDHAT.COM
	renew until 10/12/2022 08:19:26
```

Meaning, ticket is valid for 8 more hours