### PR TITLE
Fix env requirement for pyartcd/tox.ini

### DIFF
--- a/pyartcd/tox.ini
+++ b/pyartcd/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36
+envlist = py38
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
To prevent this error while running tox against pyartcd:
```
ERROR:   py36: could not install deps [-rrequirements-dev.txt]; v = InvocationError('/home/dpaolell/develop/github.com/openshift/aos-cd-jobs/pyartcd/.tox/py36/bin/python -m pip install -rrequirements-dev.txt', 1)
```