### PR TITLE
[ART-4931] Define GITLAB_TOKEN env var when calling doozer images:rebase

### DIFF
--- a/jobs/build/golang-builder/Jenkinsfile
+++ b/jobs/build/golang-builder/Jenkinsfile
@@ -88,23 +88,25 @@ pipeline {
         }
         stage('build') {
             steps {
-                script {
-                    lock("golang-builder-lock-${env._GOLANG_MAJOR_MINOR}-el${params.RHEL_VERSION}") {
-                        echo "Rebasing..."
-                        def opts = "${env._DOOZER_OPTS} images:rebase --version v${params.GOLANG_VERSION}"
-                        release = params.RELEASE ?: "${new Date().format("yyyyMMddHHmm")}.el${params.RHEL_VERSION}"
-                        currentBuild.displayName += "-${release}"
-                        opts += " --release ${release}  -m 'bumping to ${params.GOLANG_VERSION}-${release}'"
-                        if (!params.DRY_RUN)
-                            opts += " --push"
-                        buildlib.doozer(opts)
-                        echo "Building..."
-                        opts = "${env._DOOZER_OPTS} images:build --repo-type unsigned --push-to-defaults"
-                        if (params.DRY_RUN)
-                            opts += " --dry-run"
-                        if (params.SCRATCH)
-                            opts += " --scratch"
-                        buildlib.doozer(opts)
+                withCredentials([string(credentialsId: 'gitlab-ocp-release-schedule-schedule', variable: 'GITLAB_TOKEN')]) {
+                    script {
+                        lock("golang-builder-lock-${env._GOLANG_MAJOR_MINOR}-el${params.RHEL_VERSION}") {
+                            echo "Rebasing..."
+                            def opts = "${env._DOOZER_OPTS} images:rebase --version v${params.GOLANG_VERSION}"
+                            release = params.RELEASE ?: "${new Date().format("yyyyMMddHHmm")}.el${params.RHEL_VERSION}"
+                            currentBuild.displayName += "-${release}"
+                            opts += " --release ${release}  -m 'bumping to ${params.GOLANG_VERSION}-${release}'"
+                            if (!params.DRY_RUN)
+                                opts += " --push"
+                            buildlib.doozer(opts)
+                            echo "Building..."
+                            opts = "${env._DOOZER_OPTS} images:build --repo-type unsigned --push-to-defaults"
+                            if (params.DRY_RUN)
+                                opts += " --dry-run"
+                            if (params.SCRATCH)
+                                opts += " --scratch"
+                            buildlib.doozer(opts)
+                        }
                     }
                 }
             }

--- a/jobs/build/ocp3/Jenkinsfile
+++ b/jobs/build/ocp3/Jenkinsfile
@@ -658,15 +658,17 @@ node {
             }
 
             stage("update dist-git") {
-                buildlib.doozer """
-                    ${doozerOpts}
-                    --source ose ${OSE_DIR}
-                    ${ODCS_FLAG}
-                    images:rebase --version v${NEW_VERSION}
-                    --release ${NEW_DOCKERFILE_RELEASE}
-                    --message 'Updating Dockerfile version and release v${NEW_VERSION}-${NEW_DOCKERFILE_RELEASE}' --push
-                """
-                buildlib.notify_dockerfile_reconciliations(DOOZER_WORKING, params.BUILD_VERSION)
+                withCredentials([string(credentialsId: 'gitlab-ocp-release-schedule-schedule', variable: 'GITLAB_TOKEN')]) {
+                    buildlib.doozer """
+                        ${doozerOpts}
+                        --source ose ${OSE_DIR}
+                        ${ODCS_FLAG}
+                        images:rebase --version v${NEW_VERSION}
+                        --release ${NEW_DOCKERFILE_RELEASE}
+                        --message 'Updating Dockerfile version and release v${NEW_VERSION}-${NEW_DOCKERFILE_RELEASE}' --push
+                    """
+                    buildlib.notify_dockerfile_reconciliations(DOOZER_WORKING, params.BUILD_VERSION)
+                }
             }
 
             stage("build images") {

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -175,7 +175,11 @@ node {
                     build wait: false, propagate: false, job: 'build%2Frhcos', parameters: [string(name: 'BUILD_VERSION', value: params.BUILD_VERSION)]
                 }
 
-                stage("update dist-git") { joblib.stageUpdateDistgit() }
+                stage("update dist-git") {
+                    withCredentials([string(credentialsId: 'gitlab-ocp-release-schedule-schedule', variable: 'GITLAB_TOKEN')]) {
+                        joblib.stageUpdateDistgit()
+                    }
+                }
                 stage("build images") { joblib.stageBuildImages() }
             }
             stage("sync images") {

--- a/jobs/build/rebuild/Jenkinsfile
+++ b/jobs/build/rebuild/Jenkinsfile
@@ -106,11 +106,13 @@ node {
                 cmd << params.DISTGIT_KEY
             }
             sshagent(["openshift-bot"]) {
-                echo "Will run ${cmd}"
-                if (params.IGNORE_LOCKS) {
-                     commonlib.shell(script: cmd.join(' '))
-                } else {
-                    lock("github-activity-lock-${params.BUILD_VERSION}") { commonlib.shell(script: cmd.join(' ')) }
+                withCredentials([string(credentialsId: 'gitlab-ocp-release-schedule-schedule', variable: 'GITLAB_TOKEN')]) {
+                    echo "Will run ${cmd}"
+                    if (params.IGNORE_LOCKS) {
+                        commonlib.shell(script: cmd.join(' '))
+                    } else {
+                        lock("github-activity-lock-${params.BUILD_VERSION}") { commonlib.shell(script: cmd.join(' ')) }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Ref. https://issues.redhat.com/browse/ART-4931

With https://github.com/openshift/doozer/pull/659, if `canonical_builders_from_upstream` is `auto` Doozer will need to clone https://gitlab.cee.redhat.com/ocp-release-schedule/schedule to verify whether we are before or after feature freeze for a given release. In order to do so, it will need to use an access token which is stored in Jenkins with the name `gitlab-ocp-release-schedule-schedule`. This PR makes sure we always provide this token when calling `doozer images:rebase`