### PR TITLE
Revert "Stop producing 4.6 and 4.7"

### DIFF
--- a/hacks/triage/install
+++ b/hacks/triage/install
@@ -3,6 +3,8 @@
 set -euo pipefail
 
 versions=(
+  "4.6"
+  "4.7"
   "4.8"
   "4.9"
   "4.10"

--- a/jobs/devex/jenkins-bump-version/Jenkinsfile
+++ b/jobs/devex/jenkins-bump-version/Jenkinsfile
@@ -16,6 +16,8 @@ properties(
                             'rhaos-4.10-rhel-8',
                             'rhaos-4.9-rhel-8',
                             'rhaos-4.8-rhel-8',
+                            'rhaos-4.7-rhel-8',
+                            'rhaos-4.6-rhel-8',
                         ].join('\n'),
                     defaultValue: 'rhaos-4.10-rhel-8'
                 ],

--- a/jobs/devex/jenkins-plugins/Jenkinsfile
+++ b/jobs/devex/jenkins-plugins/Jenkinsfile
@@ -17,6 +17,8 @@ properties(
                             'rhaos-4.10-rhel-8',
                             'rhaos-4.9-rhel-8',
                             'rhaos-4.8-rhel-8',
+                            'rhaos-4.7-rhel-8',
+                            'rhaos-4.6-rhel-8',
                         ].join('\n'),
                     defaultValue: 'rhaos-4.10-rhel-8'
                 ],

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -12,6 +12,8 @@ ocp4Versions = [
     "4.10",
     "4.9",
     "4.8",
+    "4.7",
+    "4.6",
 ]
 
 ocpVersions = ocp4Versions + ocp3Versions

--- a/pyartcd/pyartcd/pipelines/report_rhcos.py
+++ b/pyartcd/pyartcd/pipelines/report_rhcos.py
@@ -9,6 +9,8 @@ from subprocess import run
 
 
 VERSIONS = [
+    "4.6",
+    "4.7",
     "4.8",
     "4.9",
     "4.10",


### PR DESCRIPTION
Reverts openshift/aos-cd-jobs#3276

There is a special request to produce one more 4.6 + 4.7 to get a RHEL fix in. Reenabling the builds to make that happen.