### PR TITLE
[ART-4863] Support building microshift against nightlies

### DIFF
--- a/pyartcd/pyartcd/constants.py
+++ b/pyartcd/pyartcd/constants.py
@@ -8,3 +8,10 @@ TARBALL_SOURCES_REMOTE_BASE_DIR = "/mnt/rcm-guest/ocp-client-handoff"
 RELEASE_IMAGE_REPO = "quay.io/openshift-release-dev/ocp-release"
 
 GIT_AUTHOR = "AOS Automation Release Team <noreply@redhat.com>"
+
+NIGHTLY_PAYLOAD_REPOS = {
+    "x86_64": "registry.ci.openshift.org/ocp/release",
+    "s390x": "registry.ci.openshift.org/ocp-s390x/release-s390x",
+    "ppc64le": "registry.ci.openshift.org/ocp-ppc64le/release-ppc64le",
+    "aarch64": "registry.ci.openshift.org/ocp-arm64/release-arm64",
+}

--- a/pyartcd/pyartcd/oc.py
+++ b/pyartcd/pyartcd/oc.py
@@ -1,0 +1,22 @@
+import json
+import os
+
+from pyartcd import exectools
+
+
+async def get_release_image_info(pullspec: str, raise_if_not_found: bool = False):
+    cmd = ["oc", "adm", "release", "info", "-o", "json", "--", pullspec]
+    env = os.environ.copy()
+    env["GOTRACEBACK"] = "all"
+    rc, stdout, stderr = await exectools.cmd_gather_async(cmd, check=False, env=env)
+    if rc != 0:
+        if "not found: manifest unknown" in stderr or "was deleted or has expired" in stderr:
+            # release image doesn't exist
+            if raise_if_not_found:
+                raise IOError(f"Image {pullspec} is not found.")
+            return None
+        raise ChildProcessError(f"Error running {cmd}: exit_code={rc}, stdout={stdout}, stderr={stderr}")
+    info = json.loads(stdout)
+    if not isinstance(info, dict):
+        raise ValueError(f"Invalid release info: {info}")
+    return info

--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 import re
@@ -5,39 +6,41 @@ import traceback
 from collections import namedtuple
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, Iterable, List, Optional, Tuple
 
 import click
-import yaml
 from doozerlib.assembly import AssemblyTypes
+from doozerlib.util import brew_arch_for_go_arch, isolate_nightly_name_components
 from ghapi.all import GhApi
-from pyartcd import exectools
+from pyartcd import exectools, oc, util
 from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.git import GitRepository
+from pyartcd import constants
 from pyartcd.record import parse_record_log
 from pyartcd.runtime import Runtime
-from pyartcd.util import (get_assembly_type, get_release_name,
-                          isolate_el_version_in_release, load_group_config,
-                          load_releases_config)
-from semver import VersionInfo
+from pyartcd.util import (get_assembly_basis, get_assembly_type,
+                          get_release_name, isolate_el_version_in_release,
+                          load_group_config, load_releases_config)
 from ruamel.yaml import YAML
-
+from semver import VersionInfo
 
 yaml = YAML(typ="rt")
+yaml.preserve_quotes = True
 
 
 class BuildMicroShiftPipeline:
     """ Rebase and build MicroShift for an assembly """
 
-    SUPPORTED_ASSEMBLY_TYPES = {AssemblyTypes.STANDARD, AssemblyTypes.CANDIDATE, AssemblyTypes.PREVIEW}
+    SUPPORTED_ASSEMBLY_TYPES = {AssemblyTypes.STANDARD, AssemblyTypes.CANDIDATE, AssemblyTypes.PREVIEW, AssemblyTypes.STREAM}
 
-    def __init__(self, runtime: Runtime, group: str, assembly: str,
+    def __init__(self, runtime: Runtime, group: str, assembly: str, payloads: Tuple[str, ...], no_rebase: bool,
                  ocp_build_data_url: str, logger: Optional[logging.Logger] = None):
         self.runtime = runtime
         self.group = group
         self.assembly = assembly
+        self.payloads = payloads
+        self.no_rebase = no_rebase
         self._logger = logger or runtime.logger
-        self._slack_client = self.runtime.new_slack_client()
         self._working_dir = self.runtime.working_dir.absolute()
 
         # determines OCP version
@@ -56,36 +59,93 @@ class BuildMicroShiftPipeline:
             self._doozer_env_vars["DOOZER_DATA_PATH"] = ocp_build_data_url
 
     async def run(self):
-        self._slack_client.bind_channel(self.group)
-        slack_response = await self._slack_client.say(f":construction: Build microshift for assembly {self.assembly} :construction:")
-        slack_thread = slack_response["message"]["ts"]
-
+        slack_client = None
         try:
             await load_group_config(self.group, self.assembly, env=self._doozer_env_vars)
             releases_config = await load_releases_config(Path(self._doozer_env_vars["DOOZER_WORKING_DIR"], "ocp-build-data"))
             assembly_type = get_assembly_type(releases_config, self.assembly)
             if assembly_type not in self.SUPPORTED_ASSEMBLY_TYPES:
                 raise ValueError(f"Building MicroShift for assembly type {assembly_type.value} is not currently supported.")
-            release_name = get_release_name(assembly_type, self.group, self.assembly, None)
+
+            custom_payloads = None
+            if assembly_type is AssemblyTypes.STREAM:
+                # rebase against nightlies
+                # rpm version-release will be like `4.12.0~test-202201010000.p?`
+                if self.no_rebase:
+                    # Without knowning the nightly name, it is hard to determine rpm version-release.
+                    raise ValueError("--no-rebase is not supported to build against assembly stream.")
+                if not self.payloads:
+                    raise ValueError("Release payloads must be specified to rebase against assembly stream.")
+                payload_infos = await self.parse_release_payloads(self.payloads)
+                if "x86_64" not in payload_infos or "aarch64" not in payload_infos:
+                    raise ValueError("x86_64 payload and aarch64 payload are required for rebasing microshift.")
+                major, minor = util.isolate_major_minor_in_group(self.group)
+                for info in payload_infos.values():
+                    payload_version = VersionInfo.parse(info["version"])
+                    if (payload_version.major, payload_version.minor) != (major, minor):
+                        raise ValueError(f"Specified payload {info['pullspec']} does not match group major.minor {major}.{minor}: {payload_version}")
+                release_name = payload_infos["x86_64"]["version"]  # use the version of the x86_64 payload to generate the rpm version-release.
+                custom_payloads = payload_infos
+            else:
+                # rebase against named releases
+                if self.payloads:
+                    raise ValueError(f"Specifying payloads for assembly type {assembly_type.value} is not allowed.")
+                release_name = get_release_name(assembly_type, self.group, self.assembly, None)
 
             # Rebases and builds microshift
+            if assembly_type is not assembly_type.STREAM:
+                slack_client = self.runtime.new_slack_client()
+                slack_client.bind_channel(self.group)
+                slack_response = await slack_client.say(f":construction: Build microshift for assembly {self.assembly} :construction:")
+                slack_thread = slack_response["message"]["ts"]
             version, release = self.generate_microshift_version_release(release_name)
-            nvrs = await self._rebase_and_build_rpm(version, release)
+            nvrs = await self._rebase_and_build_rpm(version, release, custom_payloads)
 
             # Create a PR to pin microshift build
-            pr = await self._create_or_update_pull_request(nvrs)
+            pr = None
+            assembly_basis = get_assembly_basis(releases_config, self.assembly)
+            if assembly_basis.brew_event:
+                pr = await self._create_or_update_pull_request(nvrs)
 
             # Sends a slack message
             message = f"Hi @release-artists , microshift for assembly {self.assembly} has been successfully built."
             if pr:
                 message += f"\nA PR to update the assembly definition has been created/updated: {pr.html_url}"
                 message += "\nTo publish the build to the pocket, run update-microshift-pocket job after the PR is merged."
-            await self._slack_client.say(message, slack_thread)
+            if slack_client:
+                await slack_client.say(message, slack_thread)
         except Exception as err:
             error_message = f"Error building microshift: {err}\n {traceback.format_exc()}"
             self._logger.error(error_message)
-            await self._slack_client.say(error_message, slack_thread)
+            if slack_client:
+                await slack_client.say(error_message, slack_thread)
             raise
+
+    @staticmethod
+    async def parse_release_payloads(payloads: Iterable[str]):
+        result = {}
+        pullspecs = []
+        for payload in payloads:
+            if "/" not in payload:
+                # Convert nightly name to pullspec
+                # 4.12.0-0.nightly-2022-10-25-210451 ==> registry.ci.openshift.org/ocp/release:4.12.0-0.nightly-2022-10-25-210451
+                _, brew_cpu_arch, _ = isolate_nightly_name_components(payload)
+                pullspecs.append(constants.NIGHTLY_PAYLOAD_REPOS[brew_cpu_arch] + ":" + payload)
+            else:
+                # payload is a pullspec
+                pullspecs.append(payload)
+        payload_infos = await asyncio.gather(*(oc.get_release_image_info(pullspec) for pullspec in pullspecs))
+        for info in payload_infos:
+            arch = info["config"]["architecture"]
+            brew_arch = brew_arch_for_go_arch(arch)
+            version = info["metadata"]["version"]
+            result[brew_arch] = {
+                "version": version,
+                "arch": arch,
+                "pullspec": info["image"],
+                "digest": info["digest"],
+            }
+        return result
 
     @staticmethod
     def generate_microshift_version_release(ocp_version: str, timestamp: Optional[str] = None):
@@ -99,11 +159,11 @@ class BuildMicroShiftPipeline:
         release_version = VersionInfo.parse(ocp_version)
         version = f"{release_version.major}.{release_version.minor}.{release_version.patch}"
         if release_version.prerelease is not None:
-            version += f"~{release_version.prerelease}"
+            version += f"~{release_version.prerelease.replace('-', '_')}"
         release = f"{timestamp}.p?"
         return version, release
 
-    async def _rebase_and_build_rpm(self, version, release: str) -> List[str]:
+    async def _rebase_and_build_rpm(self, version, release: str, custom_payloads: Optional[Dict[str, str]]) -> List[str]:
         """ Rebase and build RPM
         :param release: release field for rebase
         :return: NVRs
@@ -119,7 +179,13 @@ class BuildMicroShiftPipeline:
         ]
         if self.runtime.dry_run:
             cmd.append("--dry-run")
-        await exectools.cmd_assert_async(cmd, env=self._doozer_env_vars)
+        set_env = self._doozer_env_vars.copy()
+        if custom_payloads:
+            set_env["MICROSHIFT_PAYLOAD_X86_64"] = custom_payloads["x86_64"]["pullspec"]
+            set_env["MICROSHIFT_PAYLOAD_AARCH64"] = custom_payloads["aarch64"]["pullspec"]
+        if self.no_rebase:
+            set_env["MICROSHIFT_NO_REBASE"] = "1"
+        await exectools.cmd_assert_async(cmd, env=set_env)
 
         if self.runtime.dry_run:
             return [f"microshift-{version}-{release.replace('.p?', '.p0')}.el8"]
@@ -211,8 +277,13 @@ class BuildMicroShiftPipeline:
               help="The group of components on which to operate. e.g. openshift-4.9")
 @click.option("--assembly", metavar="ASSEMBLY_NAME", required=True,
               help="The name of an assembly to rebase & build for. e.g. 4.9.1")
+@click.option("--payload", "payloads", metavar="PULLSPEC", multiple=True,
+              help="[Multiple] Release payload to rebase against; Can be a nightly name or full pullspec")
+@click.option("--no-rebase", is_flag=True,
+              help="Don't rebase microshift code; build the current source we have in the upstream repo for testing purpose")
 @pass_runtime
 @click_coroutine
-async def rebuild(runtime: Runtime, ocp_build_data_url: str, group: str, assembly: str):
-    pipeline = BuildMicroShiftPipeline(runtime=runtime, group=group, assembly=assembly, ocp_build_data_url=ocp_build_data_url)
+async def build_microshift(runtime: Runtime, ocp_build_data_url: str, group: str, assembly: str, payloads: Tuple[str, ...], no_rebase: bool):
+    pipeline = BuildMicroShiftPipeline(runtime=runtime, group=group, assembly=assembly,
+                                       payloads=payloads, no_rebase=no_rebase, ocp_build_data_url=ocp_build_data_url)
     await pipeline.run()

--- a/pyartcd/tests/pipelines/test_promote.py
+++ b/pyartcd/tests/pipelines/test_promote.py
@@ -77,7 +77,7 @@ class TestPromotePipeline(TestCase):
         load_releases_config.assert_awaited_once_with(Path("/path/to/working/doozer-working/ocp-build-data"))
 
     @patch("pyartcd.pipelines.promote.PromotePipeline.build_release_image", return_value=None)
-    @patch("pyartcd.pipelines.promote.PromotePipeline.get_release_image_info", side_effect=lambda pullspec, raise_if_not_found=False: {
+    @patch("pyartcd.pipelines.promote.get_release_image_info", side_effect=lambda pullspec, raise_if_not_found=False: {
         "image": pullspec,
         "digest": f"fake:deadbeef-{pullspec}",
         "metadata": {
@@ -149,7 +149,7 @@ class TestPromotePipeline(TestCase):
         load_releases_config.assert_awaited_once_with(Path("/path/to/working/doozer-working/ocp-build-data"))
 
     @patch("pyartcd.pipelines.promote.PromotePipeline.build_release_image", return_value=None)
-    @patch("pyartcd.pipelines.promote.PromotePipeline.get_release_image_info", side_effect=lambda pullspec, raise_if_not_found=False: {
+    @patch("pyartcd.pipelines.promote.get_release_image_info", side_effect=lambda pullspec, raise_if_not_found=False: {
         "image": pullspec,
         "digest": f"fake:deadbeef-{pullspec}",
         "metadata": {
@@ -242,7 +242,7 @@ class TestPromotePipeline(TestCase):
     @patch("pyartcd.pipelines.promote.PromotePipeline.tag_release", return_value=None)
     @patch("pyartcd.pipelines.promote.PromotePipeline.get_image_stream_tag", return_value=None)
     @patch("pyartcd.pipelines.promote.PromotePipeline.build_release_image", return_value=None)
-    @patch("pyartcd.pipelines.promote.PromotePipeline.get_release_image_info", side_effect=lambda pullspec, raise_if_not_found=False: {
+    @patch("pyartcd.pipelines.promote.get_release_image_info", side_effect=lambda pullspec, raise_if_not_found=False: {
         "image": pullspec,
         "digest": "fake:deadbeef",
         "metadata": {


### PR DESCRIPTION
Adds the following parameters to `build-microshift` job:
- RELEASE_PAYLOADS: Specify a list of nightlies to rebase against.
- UPDATE_POCKET: If checked, call `update-microshift-pocket` job after build completes.
- NO_REBASE: If checked, build without rebase.

Parameter `RELEASE_PAYLOADS` and `NO_REBASE` are implemented by setting environment variables for `microshift-rebase` modification script.

Requires https://github.com/openshift/ocp-build-data/pull/2121/.

Test build: https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/yuxzhu/job/aos-cd-builds/job/build%252Fbuild-microshift/40/console