### PR TITLE
[ART-5150] poll-payload: Fix publish-rpms not being triggered

### DIFF
--- a/scheduled-jobs/build/poll-payload/Jenkinsfile
+++ b/scheduled-jobs/build/poll-payload/Jenkinsfile
@@ -12,20 +12,20 @@ import groovy.json.JsonOutput
 // A map of release stream names to be polled and and actions to be taken
 @Field final ACTIONS = [
     // as part of 4.next we will manually publish only sprintly dev-previews
-    "4-dev-preview": this.&setDevPreviewLatest,
-    "4-dev-preview-s390x": this.&setDevPreviewLatest,
-    "4-dev-preview-ppc64le": this.&setDevPreviewLatest,
-    "4-dev-preview-arm64": this.&setDevPreviewLatest,
+    "4-dev-preview": [this.&setDevPreviewLatest],
+    "4-dev-preview-s390x": [this.&setDevPreviewLatest],
+    "4-dev-preview-ppc64le": [this.&setDevPreviewLatest],
+    "4-dev-preview-arm64": [this.&setDevPreviewLatest],
 
-    // "4.12.0-0.nightly": this.&startPreReleaseJob,
+    "4.12.0-0.nightly":  [this.&publishRPMs],
     // "4.12.0-0.nightly-s390x": this.&startPreReleaseJob,
     // "4.12.0-0.nightly-ppc64le": this.&startPreReleaseJob,
     // "4.12.0-0.nightly-arm64": this.&startPreReleaseJob,
-    "4.12.0-0.nightly-multi": this.&startPreReleaseJob,
+    "4.12.0-0.nightly-multi": [this.&startPreReleaseJob],
     // 4.11 is not going to be released as a fc/rc named release, so
     // continue to publish as dev-preview until all 4.11 heterogeneous
     // users are using named releases.
-    "4.11.0-0.nightly-multi": this.&startPreReleaseJob,
+    "4.11.0-0.nightly-multi": [this.&startPreReleaseJob],
 ]
 
 def setDevPreviewLatest(String releaseStream, Map latestRelease, Map previousRelease) {
@@ -49,15 +49,13 @@ def startPreReleaseJob(String releaseStream, Map latestRelease, Map previousRele
     )
 }
 
-def publishRPMs(String releaseStream, Map latestRelease) {
-    if (commonlib.extractArchFromReleaseName(latestRelease.name) == "x86_64") {
-        build(
-            job: '/aos-cd-builds/build%2Fpublish-rpms',
-            parameters: [
-                string(name: 'BUILD_VERSION', value: commonlib.extractMajorMinorVersion(releaseStream)),
-            ],
-        )
-    }
+def publishRPMs(String releaseStream, Map latestRelease, Map previousRelease) {
+    build(
+        job: '/aos-cd-builds/build%2Fpublish-rpms',
+        parameters: [
+            string(name: 'BUILD_VERSION', value: commonlib.extractMajorMinorVersion(releaseStream)),
+        ],
+    )
 }
 
 /**
@@ -120,7 +118,6 @@ node() {
                 description += " [no change]\n"
                 continue
             }
-            publishRPMs(releaseStream, latestRelease)
             actionArguments[releaseStream] = [releaseStream, latestRelease, previousRelease]
             saveToReleaseCache(latestRelease, "${releaseStream}.json")
         } catch (Exception ex) {
@@ -138,7 +135,15 @@ node() {
             stage(releaseStream) {
                 try {
                     echo "Invoking action for $releaseStream"
-                    ACTIONS[releaseStream](args[0], args[1], args[2])
+                    def action = ACTIONS[releaseStream]
+                    if (action instanceof List) {
+                        // If action is a list, invoke all functions one by one
+                        for (fn in action) {
+                            fn(args[0], args[1], args[2])
+                        }
+                    } else {
+                        action(args[0], args[1], args[2])
+                    }
                 } catch (Exception ex) {
                     echo "Error invoking action for $releaseStream: $ex"
                     currentBuild.result = "UNSTABLE"


### PR DESCRIPTION
`publish-rpms` is a job to publish RHEL 8 worker RPMs to the mirror.

We expect to run publish-rpms whenever there is a new x86_64 nightly is created and accepted by the Release Controller.

However this is broken because commit https://github.com/openshift/aos-cd-jobs/commit/f75f7c75e0d0c038af096c2fab84f7d2c3fe3c91 removes the handlers of triggering pre-release job. As a side effect, `publish-rpms` will not be invoked as well.

Currently, starting publish-rpms is invoked in the logic of checking for release stream changes. It is not obvious enough and breaks the design of poll-payload job. It should be refactored to become a callback function like other event handlers.

This PR:
- Changes `publishRpms` to an event handler like `setDevPreviewLatest` and `startPreReleaseJob`.
- Enhances the event loop to call multiple event handlers defined in `ACTIONS`.
- Removes the arch check in `publishRPMs`. It will be hooked into the x86_64 release stream change event, so the arch check will not be needed.