### PR TITLE
Revert "build signed compose for 4.12"

### DIFF
--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -97,8 +97,8 @@ def goSuffixForArch(String arch) {
  */
 ocpReleaseState = [
         "4.12": [
-            'release': [ 'x86_64', 's390x', 'ppc64le', 'aarch64' ],
-            "pre-release": [],
+            'release': [],
+            "pre-release": [ 'x86_64', 's390x', 'ppc64le', 'aarch64' ],
         ],
         "4.11": [
             'release': ['x86_64', 's390x', 'ppc64le', 'aarch64'],


### PR DESCRIPTION
Reverts openshift/aos-cd-jobs#3288

We're missing product listings, which fails the build. Reverting for now.