### PR TITLE
Don't update microshift pocket by default

### DIFF
--- a/scheduled-jobs/build/poll-payload/Jenkinsfile
+++ b/scheduled-jobs/build/poll-payload/Jenkinsfile
@@ -84,7 +84,7 @@ def startBuildMicroshiftJob(String releaseStream, Map latestRelease, Map previou
             string(name: 'BUILD_VERSION', value: buildVersion),
             string(name: 'ASSEMBLY', value: "test"),
             string(name: 'RELEASE_PAYLOADS', value: nightlies),
-            booleanParam(name: 'UPDATE_POCKET', value: true),
+            booleanParam(name: 'UPDATE_POCKET', value: false),
         ]
     )
 }


### PR DESCRIPTION
As requested by QE, don't update microshift pocket for automated builds.