### PR TITLE
[ART-5142]  Use patch_version defined or implied in assembly definition

### DIFF
--- a/jobs/build/promote-assembly/Jenkinsfile
+++ b/jobs/build/promote-assembly/Jenkinsfile
@@ -37,11 +37,6 @@ node {
                         defaultValue: "stream",
                         trim: true,
                     ),
-                    string(
-                        name: 'RELEASE_OFFSET',
-                        description: 'Integer. Required for a custom release. Do not specify for a standard or candidate release. If offset is X for 4.9, the release name will be 4.9.X-assembly.ASSEMBLY_NAME',
-                        trim: true,
-                    ),
                     booleanParam(
                         name: 'NO_MULTI',
                         description: 'Do not promote a multi-arch/heterogeneous payload.',
@@ -121,7 +116,6 @@ node {
 
     commonlib.checkMock()
     def (major, minor) = commonlib.extractMajorMinorVersionNumbers(params.VERSION)
-    def release_offset = params.RELEASE_OFFSET? Integer.parseInt(params.RELEASE_OFFSET) : null
     def skipAttachedBugCheck = params.SKIP_ATTACHED_BUG_CHECK
     def next_minor = "${major}.${minor + 1}"
     if (params.DRY_RUN) {
@@ -158,9 +152,6 @@ node {
             "--group=openshift-${params.VERSION}",
             "--assembly=${params.ASSEMBLY}",
         ]
-        if (release_offset != null) {
-            cmd << "--release-offset=${release_offset}"
-        }
         if (skipAttachedBugCheck) {
             cmd << "--skip-attached-bug-check"
         }

--- a/jobs/build/promote-assembly/README.md
+++ b/jobs/build/promote-assembly/README.md
@@ -67,11 +67,6 @@ This specifies the name of the assembly. The assembly must be explicitly defined
 Leave this to empty to promote all supported architectures.
 Otherwise, specify a list of architectures (separated by comma) to promote (e.g. x86_64,aarch64).
 
-### RELEASE\_OFFSET
-
-This parameter is required to promote a custom release. If offset is X for 4.9, the release name will be 4.9.X-assembly.ASSEMBLY_NAME.
-
-
 ### PERMIT\_PAYLOAD\_OVERWRITE
 
 **DO NOT USE** without discussing with your team or pillar lead for approval.

--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -19,7 +19,7 @@ from pyartcd import constants
 from pyartcd.record import parse_record_log
 from pyartcd.runtime import Runtime
 from pyartcd.util import (get_assembly_basis, get_assembly_type,
-                          get_release_name, isolate_el_version_in_release,
+                          isolate_el_version_in_release,
                           load_group_config, load_releases_config)
 from ruamel.yaml import YAML
 from semver import VersionInfo
@@ -90,7 +90,7 @@ class BuildMicroShiftPipeline:
                 # rebase against named releases
                 if self.payloads:
                     raise ValueError(f"Specifying payloads for assembly type {assembly_type.value} is not allowed.")
-                release_name = get_release_name(assembly_type, self.group, self.assembly, None)
+                release_name = util.get_release_name_for_assembly(self.group, releases_config, self.assembly)
 
             # Rebases and builds microshift
             if assembly_type is not assembly_type.STREAM:

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -26,7 +26,7 @@ from pyartcd.mail import MailService
 from pyartcd.record import parse_record_log
 from pyartcd.runtime import Runtime
 from pyartcd.util import (get_assembly_basis, get_assembly_type,
-                          get_release_name)
+                          get_release_name_for_assembly)
 from ruamel.yaml import YAML
 from tenacity import retry, stop_after_attempt, wait_fixed
 
@@ -116,7 +116,7 @@ class PrepareReleasePipeline:
                 raise ValueError("Preparing a release from a stream assembly for OCP4+ is no longer supported.")
         else:
             release_config = releases_config.get("releases", {}).get(self.assembly, {})
-            self.release_name = get_release_name(assembly_type, self.group_name, self.assembly, 0 if assembly_type == AssemblyTypes.CUSTOM else None)
+            self.release_name = get_release_name_for_assembly(self.group_name, releases_config, self.assembly)
             self.release_version = semver.VersionInfo.parse(self.release_name).to_tuple()
             if not release_config:
                 raise ValueError(f"Assembly {self.assembly} is not explicitly defined in releases.yml for group {self.group_name}.")

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -35,7 +35,7 @@ yaml.default_flow_style = False
 class PromotePipeline:
     DEST_RELEASE_IMAGE_REPO = constants.RELEASE_IMAGE_REPO
 
-    def __init__(self, runtime: Runtime, group: str, assembly: str, release_offset: Optional[int],
+    def __init__(self, runtime: Runtime, group: str, assembly: str,
                  skip_blocker_bug_check: bool = False,
                  skip_attached_bug_check: bool = False, skip_attach_cve_flaws: bool = False,
                  skip_image_list: bool = False, permit_overwrite: bool = False,
@@ -43,7 +43,6 @@ class PromotePipeline:
         self.runtime = runtime
         self.group = group
         self.assembly = assembly
-        self.release_offset = release_offset
         self.skip_blocker_bug_check = skip_blocker_bug_check
         self.skip_attached_bug_check = skip_attached_bug_check
         self.skip_attach_cve_flaws = skip_attach_cve_flaws
@@ -89,7 +88,7 @@ class PromotePipeline:
 
         # Get release name
         assembly_type = util.get_assembly_type(releases_config, self.assembly)
-        release_name = util.get_release_name(assembly_type, self.group, self.assembly, self.release_offset)
+        release_name = util.get_release_name_for_assembly(self.group, releases_config, self.assembly)
         # Ensure release name is valid
         if not VersionInfo.isvalid(release_name):
             raise ValueError(f"Release name `{release_name}` is not a valid semver.")
@@ -979,8 +978,6 @@ class PromotePipeline:
               help="The group of components on which to operate. e.g. openshift-4.9")
 @click.option("--assembly", metavar="ASSEMBLY_NAME", required=True,
               help="The name of an assembly. e.g. 4.9.1")
-@click.option("--release-offset", "-r", metavar="OFFSET", type=int,
-              help="Use this option if assembly type is custom. If offset is X for 4.9, release name will become 4.9.X-assembly.ASSEMBLY_NAME.")
 @click.option("--skip-blocker-bug-check", is_flag=True,
               help="Skip blocker bug check. Note block bugs are never checked for CUSTOM and CANDIDATE releases.")
 @click.option("--skip-attached-bug-check", is_flag=True,
@@ -996,11 +993,11 @@ class PromotePipeline:
 @click.option("--use-multi-hack", is_flag=True, help="Add '-multi' to heterogeneous payload name to workaround a Cincinnati issue")
 @pass_runtime
 @click_coroutine
-async def promote(runtime: Runtime, group: str, assembly: str, release_offset: Optional[int],
+async def promote(runtime: Runtime, group: str, assembly: str,
                   skip_blocker_bug_check: bool, skip_attached_bug_check: bool,
                   skip_attach_cve_flaws: bool, skip_image_list: bool,
                   permit_overwrite: bool, no_multi: bool, multi_only: bool, use_multi_hack: bool):
-    pipeline = PromotePipeline(runtime, group, assembly, release_offset,
+    pipeline = PromotePipeline(runtime, group, assembly,
                                skip_blocker_bug_check, skip_attached_bug_check, skip_attach_cve_flaws,
                                skip_image_list, permit_overwrite, no_multi, multi_only, use_multi_hack)
     await pipeline.run()

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -7,7 +7,7 @@ import logging
 import aiofiles
 import yaml
 
-from doozerlib import assembly, model
+from doozerlib import assembly, model, util as doozerutil
 from pyartcd import exectools
 
 logger = logging.getLogger(__name__)
@@ -89,25 +89,8 @@ def get_assembly_promotion_permits(releases_config: Dict, assembly_name: str):
     return assembly._assembly_config_struct(model.Model(releases_config), assembly_name, 'promotion_permits', [])
 
 
-def get_release_name(assembly_type: str, group_name: str, assembly_name: str, release_offset: Optional[int]):
-    major, minor = isolate_major_minor_in_group(group_name)
-    if major is None or minor is None:
-        raise ValueError(f"Invalid group name: {group_name}")
-    if assembly_type == assembly.AssemblyTypes.CUSTOM:
-        if release_offset is None:
-            raise ValueError("release_offset is required for a CUSTOM release.")
-        release_name = f"{major}.{minor}.{release_offset}-assembly.{assembly_name}"
-    elif assembly_type in [assembly.AssemblyTypes.CANDIDATE, assembly.AssemblyTypes.PREVIEW]:
-        if release_offset is not None:
-            raise ValueError(f"release_offset can't be set for a {assembly_type.value} release.")
-        release_name = f"{major}.{minor}.0-{assembly_name}"
-    elif assembly_type == assembly.AssemblyTypes.STANDARD:
-        if release_offset is not None:
-            raise ValueError("release_offset can't be set for a STANDARD release.")
-        release_name = f"{assembly_name}"
-    else:
-        raise ValueError(f"Assembly type {assembly_type} is not supported.")
-    return release_name
+def get_release_name_for_assembly(group_name: str, releases_config: Dict, assembly_name: str):
+    return doozerutil.get_release_name_for_assembly(group_name, model.Model(releases_config), assembly_name)
 
 
 async def kinit():

--- a/pyartcd/tests/pipelines/test_check_bugs.py
+++ b/pyartcd/tests/pipelines/test_check_bugs.py
@@ -51,13 +51,13 @@ class TestCheckBugsPipeline(unittest.TestCase):
 
         # All OCP versions defined above are applicable
         pipeline = CheckBugsPipeline(runtime, '#test', versions, [])
-        asyncio.get_event_loop().run_until_complete(pipeline._check_applicable_versions())
+        asyncio.run(pipeline._check_applicable_versions())
         pipeline.applicable_versions.sort()
         self.assertEqual(versions, pipeline.applicable_versions)
 
         # Add 4.11, currently (Mar 30, 2022) not in GA
         pipeline.versions.append('4.11')
-        asyncio.get_event_loop().run_until_complete(pipeline._check_applicable_versions())
+        asyncio.run(pipeline._check_applicable_versions())
         self.assertNotIn('4.11', pipeline.applicable_versions)
 
 


### PR DESCRIPTION
Use patch_version defined or implied in assembly definition

This will also allow to build microshift for a custom release.

Requires https://github.com/openshift/doozer/pull/683
Also fix unit tests.