### PR TITLE
Differentiate between nightly and ECs

### DIFF
--- a/jobs/signing/sign-artifacts/Jenkinsfile
+++ b/jobs/signing/sign-artifacts/Jenkinsfile
@@ -184,7 +184,7 @@ node {
                             // again for each manifest within it.
 
                             quay_repo = 'ocp-release'
-                            if (params.CLIENT_TYPE == 'ocp-dev-preview') {
+                            if (params.CLIENT_TYPE == 'ocp-dev-preview' && params.RELEASE_NAME.contains('nightly')) {
                                 quay_repo = 'ocp-release-nightly'
                             }
 


### PR DESCRIPTION
Fix failure where ECs are wrongly identified with nightly repo https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/signing-jobs/job/signing%252Fsign-artifacts/18854/
