### PR TITLE
Bring back "Migrate to new IDM service account keytab"

### DIFF
--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -75,8 +75,8 @@ def kinit() {
     // The '-f' ensures that the ticket is forwarded to remote hosts
     // when using SSH. This is required for when we build signed
     // puddles.
-    keytab = '/home/jenkins/ocp-build_buildvm.openshift.eng.bos.redhat.com_IPA.REDHAT.COM.keytab'
-    account = 'ocp-build/buildvm.openshift.eng.bos.redhat.com@IPA.REDHAT.COM'
+    keytab = '/home/jenkins/exd-ocp-buildvm-bot-prod.keytab'
+    account = 'exd-ocp-buildvm-bot-prod@IPA.REDHAT.COM'
     try {
         retry(3) {
             sh "if ! kinit -f -k -t ${keytab} ${account}; then sleep 3; false; fi"

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -104,7 +104,7 @@ async def kinit():
         '-f',
         '-k',
         '-t',
-        '/home/jenkins/ocp-build_buildvm.openshift.eng.bos.redhat.com_IPA.REDHAT.COM.keytab',
-        'ocp-build/buildvm.openshift.eng.bos.redhat.com@IPA.REDHAT.COM'
+        '/home/jenkins/exd-ocp-buildvm-bot-prod.keytab',
+        'exd-ocp-buildvm-bot-prod@IPA.REDHAT.COM'
     ]
     await exectools.cmd_assert_async(cmd)


### PR DESCRIPTION
Reverts openshift/aos-cd-jobs#3336