### PR TITLE
drop-advisory: use improved version of `elliott drop-advisory`

### DIFF
--- a/jobs/build/drop_advisories/Jenkinsfile
+++ b/jobs/build/drop_advisories/Jenkinsfile
@@ -52,9 +52,6 @@ node {
             commonlib.shell(
                 script: """
                 ${elliott} repair-bugs --advisory ${adv} --auto --comment "${comment}" --close-placeholder --from RELEASE_PENDING --to VERIFIED
-                ${elliott} change-state --state NEW_FILES --advisory ${adv}
-                ${elliott} remove-bugs --advisory ${adv} --all
-                ${elliott} find-builds --advisory ${adv} --clean
                 ${elliott} advisory-drop ${adv}
                 """,
             )


### PR DESCRIPTION
With https://github.com/openshift/elliott/pull/470/, `elliott drop-advisory` will drop bugs and builds before dropping an advisory.