### PR TITLE
Do not make jobs UNSTABLE on build-sync failures

### DIFF
--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -758,7 +758,6 @@ def sync_images(major, minor, mail_list, assembly, operator_nvrs = null, doozer_
                 body: "Jenkins console: ${commonlib.buildURL('console')}",
             )
         }
-        currentBuild.result = 'UNSTABLE'
     }
 }
 


### PR DESCRIPTION
Context: https://coreos.slack.com/archives/GDBRP5YJH/p1669370404510709

TL;DR: this PR is proposing to decouple `build-sync` failures from the status of the jobs that trigger it. For example, we do not want to have an UNSTABLE `ocp4` job if all builds passed, but build-sync eventually failed. Same applies to `olm-bundle` job.

Failing build-sync is already resulting in pings and release-artists' attention, so we might want to avoid polluting other builds.