### PR TITLE
rhcos: point at new cluster for legacy pipeline

### DIFF
--- a/jobs/build/rhcos/Jenkinsfile
+++ b/jobs/build/rhcos/Jenkinsfile
@@ -45,7 +45,7 @@ node {
         kubeconfigs = [
             'x86_64': 'jenkins_serviceaccount_ocp-virt.prod.psi.redhat.com.kubeconfig',
             'ppc64le': 'jenkins_serviceaccount_ocp-ppc.stage.psi.redhat.com',
-            's390x': 'jenkins_serviceaccount_osbs-s390x-3.prod.engineering.redhat.com.kubeconfig',
+            's390x': 'jenkins_serviceaccount_legacy_rhcos_s390x.psi.redhat.com',
             'aarch64': 'jenkins_serviceaccount_osbs-aarch64-1.engineering.redhat.com',
             'multi': 'multi_jenkins_serviceaccount_ocp-virt.prod.psi.redhat.com.kubeconfig',
         ]


### PR DESCRIPTION
[ref](https://issues.redhat.com/browse/COS-1825?focusedCommentId=21333298&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-21333298)

p8 and x86 migrated previously, just this one left for 4.8 support