### PR TITLE
[review-cvp] Remove release-artists ping

### DIFF
--- a/pyartcd/pyartcd/pipelines/review_cvp.py
+++ b/pyartcd/pyartcd/pipelines/review_cvp.py
@@ -84,7 +84,7 @@ class ReviewCVPPipeline:
                     result = await self._create_or_update_pull_request(owner="openshift", repo="ocp-build-data", base=self.group, head=pr_head, title=title, body=body)
                     pr_html_url = result.html_url
                     messages.append("")
-                    messages.append(f"A PR has been created/updated to fix common CVP content_set_check failures: {pr_html_url}, @release-artists")
+                    messages.append(f"A PR has been created/updated to fix common CVP content_set_check failures: {pr_html_url}")
                     self._logger.info(messages[-1])
 
         if not failed and not failed_optional:


### PR DESCRIPTION
Would like to remove the release-artist ping from review-cvp message, 
since it's 1 ping per version. Instead would like to have 1 reminder/ping
to check cvp PR's since they run on a regular schedule
