### PR TITLE
Microshift nightlies: Move to own assembly

### DIFF
--- a/scheduled-jobs/build/poll-payload/Jenkinsfile
+++ b/scheduled-jobs/build/poll-payload/Jenkinsfile
@@ -82,7 +82,7 @@ def startBuildMicroshiftJob(String releaseStream, Map latestRelease, Map previou
         propagate: false,
         parameters: [
             string(name: 'BUILD_VERSION', value: buildVersion),
-            string(name: 'ASSEMBLY', value: "test"),
+            string(name: 'ASSEMBLY', value: "microshift"),
             string(name: 'RELEASE_PAYLOADS', value: nightlies),
             booleanParam(name: 'UPDATE_POCKET', value: false),
         ]


### PR DESCRIPTION
When running a test build in assembly `test`, the microshift build will be found when creating the repository. If this is for a GA or RC release, the build will get signed. I think this should not be a side effect of running a test.

Not sure if anything depends on the tooling being in the test assembly.