### PR TITLE
Swap art-insights credentials with art-bot

### DIFF
--- a/scheduled-jobs/scanning/unresolved-art-threads/Jenkinsfile
+++ b/scheduled-jobs/scanning/unresolved-art-threads/Jenkinsfile
@@ -11,7 +11,7 @@ node() {
 
     try {
         withCredentials([
-                            string(credentialsId: "art-bot-slack-api-token", variable: "SLACK_API_TOKEN"),
+                            string(credentialsId: "art-bot-slack-token", variable: "SLACK_API_TOKEN"),
                             string(credentialsId: "art-bot-slack-user-token", variable: "SLACK_USER_TOKEN"),
                             string(credentialsId: "art-bot-slack-signing-secret", variable: "SLACK_SIGNING_SECRET")
                         ]) {

--- a/scheduled-jobs/scanning/unresolved-art-threads/Jenkinsfile
+++ b/scheduled-jobs/scanning/unresolved-art-threads/Jenkinsfile
@@ -11,9 +11,9 @@ node() {
 
     try {
         withCredentials([
-                            string(credentialsId: "art-insights-bot-slack-api-token", variable: "SLACK_API_TOKEN"),
-                            string(credentialsId: "art-insights-bot-slack-user-token", variable: "SLACK_USER_TOKEN"),
-                            string(credentialsId: "art-insights-bot-slack-signing-secret", variable: "SLACK_SIGNING_SECRET")
+                            string(credentialsId: "art-bot-slack-api-token", variable: "SLACK_API_TOKEN"),
+                            string(credentialsId: "art-bot-slack-user-token", variable: "SLACK_USER_TOKEN"),
+                            string(credentialsId: "art-bot-slack-signing-secret", variable: "SLACK_SIGNING_SECRET")
                         ]) {
             commonlib.shell(script: "scl enable rh-python38 -- scheduled-jobs/scanning/unresolved-art-threads/unresolved-thread-notification.py")
         }


### PR DESCRIPTION
Since art-bot can implement the functionality by art-insights, after discussion with the team, we decided to use art-bot to post art-insights messages. The functionality will not change, only that the messages will be posted as art-bot from now on, instead of art-insights.