### PR TITLE
Fix Jenkins WAR file location

### DIFF
--- a/jobs/maintenance/buildvm_backup/build.groovy
+++ b/jobs/maintenance/buildvm_backup/build.groovy
@@ -33,7 +33,7 @@ backupPlan = [
         '/home/jenkins/go',
 
         // Jenkins war
-        '/usr/lib/jenkins',
+        '/usr/share/java',
 
         // Jenkins configuration, plugins, etc
         '/mnt/nfs/jenkins_home/*.xml',


### PR DESCRIPTION
Fix [this error](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/maintenance/job/maintenance%252Fbuildvm_backup/1205/artifact/shell.1205/sh.5.mkdir_-p_d_mnt_workspace_backups_bui...home_jobs_config.xml_root_network/sh.5.err.txt):

```
tar: /usr/lib/jenkins: Cannot stat: No such file or directory
tar: Exiting with failure status due to previous errors
```