### PR TITLE
[build-sync] Alert less as errors stack up

### DIFF
--- a/jobs/build/build-sync/Jenkinsfile
+++ b/jobs/build/build-sync/Jenkinsfile
@@ -219,10 +219,19 @@ node {
 
             if (failCount > 1) {
                 msg = "Pipeline has failed to assemble release payload for ${BUILD_VERSION} (assembly ${ASSEMBLY}) ${failCount} times."
-                if (failCount % 2 == 0) {  // spam ourselves a little more often than forum-release
+                artNotifyFrequency = 2
+                forumReleaseNotifyFrequency = 5
+                if (failCount > 10) {
+                    artNotifyFrequency = 5
+                    forumReleaseNotifyFrequency = 10
+                } else if (failCount > 50) {
+                    artNotifyFrequency = 10
+                    forumReleaseNotifyFrequency = 20
+                }
+                if (failCount % artNotifyFrequency == 0) {  // spam ourselves a little more often than forum-release
                     slacklib.to(params.BUILD_VERSION).failure(msg)
                 }
-                if (assembly == "stream" && (failCount % 5 == 0) && (failCount < 50)) {
+                if (assembly == "stream" && (failCount % forumReleaseNotifyFrequency == 0)) {
                     if (commonlib.ocpReleaseState[BUILD_VERSION]['release'].isEmpty()) {
                         // For development releases, notify TRT and release artists
                         slacklib.to("#forum-release-oversight").failure("@release-artists ${msg}")

--- a/jobs/build/build-sync/Jenkinsfile
+++ b/jobs/build/build-sync/Jenkinsfile
@@ -219,6 +219,7 @@ node {
 
             if (failCount > 1) {
                 msg = "Pipeline has failed to assemble release payload for ${BUILD_VERSION} (assembly ${ASSEMBLY}) ${failCount} times."
+                // TODO: https://issues.redhat.com/browse/ART-5657
                 artNotifyFrequency = 2
                 forumReleaseNotifyFrequency = 5
                 if (failCount > 10) {


### PR DESCRIPTION
Keeping it simple so we can get spammed less.
Until we can get something smarter - something that takes into account when the last alert went out and adjust
, that should be something that resides in doozer DB.
Future follow up https://issues.redhat.com/browse/ART-5657