### PR TITLE
Switch from blocks to text

### DIFF
--- a/scheduled-jobs/scanning/unresolved-art-threads/unresolved-thread-notification.py
+++ b/scheduled-jobs/scanning/unresolved-art-threads/unresolved-thread-notification.py
@@ -47,7 +47,7 @@ if __name__ == '__main__':
     header_text = "Currently unresolved ART threads"
     fallback_text = header_text
 
-    message_blocks = []
+    response_messages = []
     current_epoch_time = time.time()
     for match in all_matches:
         team_id = match.get('team', '')
@@ -86,28 +86,15 @@ if __name__ == '__main__':
         # Slack includes an arrow character in the text if should be replaced by rich text elements (e.g. a n@username).
         # We just remove them since we are just trying for a short summary.
         snippet = snippet.replace('\ue006', '...')
-        message_blocks.append(
-            {
-                "type": "section",
-                "fields": [
-                    {
-                        "type": "mrkdwn",
-                        "text": f"*Channel:* <https://jupierce.slack.com/archives/{channel_id}|#{channel_name}>\n*Date:* {str_date}Z\n*Age:* {age} {age_type}"
-                    },
-                    {
-                        "type": "mrkdwn",
-                        f"text": f"*Message:* <{permalink}|Link>\n*Snippet:* {snippet}..."
-                    }
-                ]
-            },
-        )
+        response_messages.append(
+            f"*Channel:* <https://redhat-internal.slack.com/archives/{channel_id}|#{channel_name}>\n*Date:* {str_date}Z\n*Age:* {age} {age_type}\n*Message:* <{permalink}|Link>\n*Snippet:* {snippet}...")
 
     header_block = [
         {
             "type": "header",
             "text": {
                 "type": "plain_text",
-                "text": f"{header_text} ({len(message_blocks)})",
+                "text": f"{header_text} ({len(response_messages)})",
                 "emoji": True
             }
         },
@@ -126,7 +113,7 @@ if __name__ == '__main__':
                                            blocks=header_block,
                                            unfurl_links=False)
 
-    app.client.chat_postMessage(channel=TEAM_ART_CHANNEL,
-                                text=f'@{RELEASE_ARTIST_HANDLE} - {fallback_text}',
-                                blocks=message_blocks,
-                                thread_ts=response['ts'])  # use the timestamp from the response
+    for response_message in response_messages:
+        app.client.chat_postMessage(channel=TEAM_ART_CHANNEL,
+                                    text=response_message,
+                                    thread_ts=response['ts'])  # use the timestamp from the response


### PR DESCRIPTION
Send response as multiple messages, instead of a single one thereby making it easier to identify different messages. Link previews will be shown below the message itself.