### PR TITLE
Fix public notifications

### DIFF
--- a/scheduled-jobs/build/poll-for-failed-nightlies/Jenkinsfile
+++ b/scheduled-jobs/build/poll-for-failed-nightlies/Jenkinsfile
@@ -119,10 +119,16 @@ node() {
                         writeFile(file: notificationFile, text: "${System.currentTimeMillis()}" )
                         currentBuild.description += "\nNotifying for ${stream_name}"
 
-                        // Send out notifications
+                        // Notify ART internal channels
                         msg = "ART automation has detected that the latest ${rejects} nightlies have been rejected in ${stream_name}"
                         commonlib.slacklib.to(stream_name).failure(msg)
-                        if (commonlib.ocpReleaseState[BUILD_VERSION]['release'].isEmpty()) {
+
+                        // Get build version from stream name
+                        // stream_name has format 4.y.z-0.nightly
+                        build_version = stream_name.split('.0-0.nightly')[0]
+
+                        // Send public notifications
+                        if (commonlib.ocpReleaseState[build_version]['release'].isEmpty()) {
                             // For development releases, notify TRT and release artists
                             commonlib.slacklib.to('#forum-release-oversight').say("@release-artists ${msg}")
                         } else {


### PR DESCRIPTION
`BUILD_VERSION` is not defined. This PR infers the OCP version from the stream name, e.g.

```
4.10.0-0.nightly -> 4.10
4.9.0-0.nightly -> 4.9
```

Ref. https://issues.redhat.com/browse/ART-5643