### PR TITLE
Adding support for manually accepting/rejecting ReleasePayloads

### DIFF
--- a/hacks/release_controller/accept.py
+++ b/hacks/release_controller/accept.py
@@ -3,7 +3,6 @@ import click
 import openshift as oc
 import json
 import time
-import pprint
 
 WARNING = '\033[91m'
 ENDC = '\033[0m'
@@ -46,47 +45,92 @@ def run(arch, release, upgrade_url, upgrade_minor_url, confirm, reject):
     if arch != 'amd64' and arch != 'x86_64':
         arch_suffix = f'-{arch}'
 
-    with oc.api_server(api_url='https://api.ci.l2s4.p1.openshiftapps.com:6443'), \
-         oc.project(f'ocp{arch_suffix}'):
+    with oc.api_server(api_url='https://api.ci.l2s4.p1.openshiftapps.com:6443'), oc.project(f'ocp{arch_suffix}'):
+        update_imagestreamtag(arch_suffix, release, upgrade_url, upgrade_minor_url, confirm, reject)
+        update_releasepayload(release, confirm, reject)
 
-        istag_qname = f'istag/release{arch_suffix}:{release}'
-        istag = oc.selector(istag_qname).object(ignore_not_found=True)
-        if not istag:
-            raise IOError(f'Could not find {istag_qname}')
+    exit(0)
 
-        ts = int(round(time.time() * 1000))
-        backup_filename = f'release{arch_suffix}_{release}.{ts}.json'
+
+def update_imagestreamtag(arch_suffix, release, upgrade_url, upgrade_minor_url, confirm, reject):
+    istag_qname = f'istag/release{arch_suffix}:{release}'
+    istag = oc.selector(istag_qname).object(ignore_not_found=True)
+    if not istag:
+        raise IOError(f'Could not find {istag_qname}')
+
+    ts = int(round(time.time() * 1000))
+    backup_filename = f'release{arch_suffix}_{release}.{ts}.json'
+    if confirm:
+        with open(backup_filename, mode='w+', encoding='utf-8') as backup:
+            print(f'Creating backup file: {backup_filename}')
+            backup.write(json.dumps(istag.model._primitive(), indent=4))
+
+    def make_release_accepted(obj):
+        for annotations in (obj.model.image.metadata.annotations, obj.model.metadata.annotations, obj.model.tag.annotations):
+            annotations.pop('release.openshift.io/message', None)
+            annotations.pop('release.openshift.io/reason', None)
+            annotations['release.openshift.io/phase'] = 'Accepted' if not reject else 'Rejected'
+
+            verify_str = annotations['release.openshift.io/verify']
+            verify = oc.Model(json.loads(verify_str))
+            verify.upgrade.state = 'Succeeded' if not reject else 'Failed'
+            if upgrade_url:
+                verify.upgrade.url = upgrade_url
+            verify['upgrade-minor'].state = 'Succeeded' if not reject else 'Failed'
+            if upgrade_minor_url:
+                verify['upgrade-minor'].url = upgrade_minor_url
+            annotations['release.openshift.io/verify'] = json.dumps(verify._primitive(), indent=None)
+
+        print(json.dumps(obj.model._primitive(), indent=4))
         if confirm:
-            with open(backup_filename, mode='w+', encoding='utf-8') as backup:
-                print(f'Creating backup file: {backup_filename}')
-                backup.write(json.dumps(istag.model._primitive(), indent=4))
+            print('Attempting to apply this object.')
+            return True
+        else:
+            print(WARNING + '--confirm was not specified. Run again to apply these changes.' + ENDC)
+            return False
 
-        def make_release_accepted(obj):
-            for annotations in (obj.model.image.metadata.annotations, obj.model.metadata.annotations, obj.model.tag.annotations):
-                annotations.pop('release.openshift.io/message', None)
-                annotations.pop('release.openshift.io/reason', None)
-                annotations['release.openshift.io/phase'] = 'Accepted' if not reject else 'Rejected'
-
-                verify_str = annotations['release.openshift.io/verify']
-                verify = oc.Model(json.loads(verify_str))
-                verify.upgrade.state = 'Succeeded' if not reject else 'Failed'
-                if upgrade_url:
-                    verify.upgrade.url = upgrade_url
-                verify['upgrade-minor'].state = 'Succeeded' if not reject else 'Failed'
-                if upgrade_minor_url:
-                    verify['upgrade-minor'].url = upgrade_minor_url
-                annotations['release.openshift.io/verify'] = json.dumps(verify._primitive(), indent=None)
-
-            print(json.dumps(obj.model._primitive(), indent=4))
-            if confirm:
-                print('Attempting to apply this object.')
-                return True
-            else:
-                print(WARNING + '--confirm was not specified. Run again to apply these changes.' + ENDC)
-                exit(0)
-
-        make_release_accepted(istag)
+    if make_release_accepted(istag):
         istag.replace()
+        print('Success!')
+        print(f'Backup written to: {backup_filename}')
+
+
+def update_releasepayload(release, confirm, reject):
+    rp_qname = f'releasepayload/{release}'
+    payload = oc.selector(rp_qname).object(ignore_not_found=True)
+    if not payload:
+        # TODO: Eventually, when ReleasePayloads are the source of truth, this should raise an exception...
+        # raise IOError(f'Could not find {rp_qname}')
+        print(WARNING + f'Warning: unable to find releasepayload "{release}"' + ENDC)
+        return
+
+    ts = int(round(time.time() * 1000))
+    backup_filename = f'releasepayload_{release}.{ts}.json'
+    if confirm:
+        with open(backup_filename, mode='w+', encoding='utf-8') as backup:
+            print(f'Creating backup file: {backup_filename}')
+            backup.write(json.dumps(payload.model._primitive(), indent=4))
+
+    def update_payload_override(obj):
+        override = "Accepted"
+        if reject:
+            override = "Rejected"
+
+        obj.model.spec.payloadOverride = {
+            "override": override,
+            "reason": f'Manually {override.lower()} by ART',
+        }
+
+        print(json.dumps(obj.model._primitive(), indent=4))
+        if confirm:
+            print('Attempting to apply this object.')
+            return True
+        else:
+            print(WARNING + '--confirm was not specified. Run again to apply these changes.' + ENDC)
+            return False
+
+    if update_payload_override(payload):
+        payload.replace()
         print('Success!')
         print(f'Backup written to: {backup_filename}')
 


### PR DESCRIPTION
The release-controller is migrating away from the annotation based tracking of its release verification jobs, to the `ReleasePayload` API.  Currently, whenever ART manually accepts a release via the `accept.py` script, it creates a discrepancy between the two methods of tracking the verification results.  
This PR adds support to instruct the `release-payload-controller` to manually accept or reject the specified release.  Unfortunately, there isn't any way to override the `upgrade` and/or `upgrade-minor` results of a releasepayload.  That being said, at a minimum, this will more closely reflect the actual reality of any manually accepted/rejected releases.  