### PR TITLE
Port ocp4-scan to Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__/
 
 # editor backup files
 *.yml~
+*.orig
 
 # Distribution / packaging
 .Python

--- a/pyartcd/pyartcd/__main__.py
+++ b/pyartcd/pyartcd/__main__.py
@@ -3,7 +3,7 @@ from typing import Optional, Sequence
 from pyartcd.cli import cli
 from pyartcd.pipelines import (
     build_microshift, check_bugs, gen_assembly, prepare_release, promote, rebuild, report_rhcos,
-    review_cvp, sweep, tarball_sources, build_sync, build_rhcos
+    review_cvp, sweep, tarball_sources, build_sync, build_rhcos, ocp4_scan
 )
 
 

--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -1,0 +1,60 @@
+import base64
+import logging
+import os
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+
+async def trigger_jenkins_job(job_path: str, params=None):
+    """
+    Trigger a job using remote API calls.
+    :param job_path: relative path to the job, starting from <buildvm hostname>:<jenkins port>
+    :param params: optional dict containing job parameters
+    """
+
+    service_account = os.environ['JENKINS_SERVICE_ACCOUNT']
+    token = os.environ['JENKINS_SERVICE_ACCOUNT_TOKEN']
+
+    # Build authorization header
+    auth = base64.b64encode(f'{service_account}:{token}'.encode()).decode()
+    auth_header = f'Basic {auth}'
+    headers = {'Authorization': auth_header}
+
+    # Build url
+    # If the job to be triggered is parametrized, use 'buildWithParameters' and send HTTP data
+    # Otherwise, just call the 'build' endpoint with empty data
+    url = f'https://buildvm.hosts.prod.psi.bos.redhat.com:8443/{job_path}'
+    if params:
+        url += f'/buildWithParameters'
+    else:
+        url += f'/build'
+
+    # Call API endpoint
+    logger.info('Triggering remote job %s', job_path)
+    async with aiohttp.ClientSession(headers=headers) as session:
+        async with session.post(url, data=params) as response:
+            response.raise_for_status()
+            await response.text()
+
+
+async def trigger_ocp4(build_version: str):
+    await trigger_jenkins_job(
+        job_path='job/triggered-builds/job/ocp4',
+        params={'BUILD_VERSION': build_version}
+    )
+
+
+async def trigger_rhcos(build_version: str, new_build: bool):
+    await trigger_jenkins_job(
+        job_path='job/triggered-builds/job/rhcos',
+        params={'BUILD_VERSION': build_version, 'NEW_BUILD': new_build}
+    )
+
+
+async def trigger_build_sync(build_version: str):
+    await trigger_jenkins_job(
+        job_path='job/triggered-builds/job/build-sync',
+        params={'BUILD_VERSION': build_version}
+    )

--- a/pyartcd/pyartcd/pipelines/ocp4_scan.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan.py
@@ -1,0 +1,117 @@
+import asyncio
+import os
+import yaml
+
+import click
+
+from pyartcd import exectools, util
+from pyartcd.cli import cli, click_coroutine, pass_runtime
+from pyartcd.runtime import Runtime
+from pyartcd.jenkins import trigger_ocp4, trigger_rhcos, trigger_build_sync
+
+DOOZER_WORKING = f'{os.environ["WORKSPACE"]}/doozer_working'
+
+
+class Ocp4ScanPipeline:
+
+    def __init__(self, runtime: Runtime, version: str):
+        self.runtime = runtime
+        self.version = version
+        self.logger = runtime.logger
+        self.rhcos_changed = False
+        self.rhcos_inconsistent = False
+        self.changes = {}
+
+    async def run(self):
+        self.logger.info('Building: %s', self.version)
+
+        # KUBECONFIG env var must be defined in order to scan sources
+        if not os.getenv('KUBECONFIG'):
+            raise RuntimeError('Environment variable KUBECONFIG must be defined')
+
+        # Jenkins service account and token must be defined to trigger jobs remotely
+        if not os.getenv('JENKINS_SERVICE_ACCOUNT') or not os.getenv('JENKINS_SERVICE_ACCOUNT_TOKEN'):
+            raise RuntimeError('JENKINS_SERVICE_ACCOUNT and JENKINS_SERVICE_ACCOUNT_TOKEN env vars must be defined')
+
+        # Check for RHCOS changes and inconsistencies
+        # Running these two commands sequentially (instead of using asyncio.gather) to avoid file system conflicts
+        await self._get_changes()
+        await self._rhcos_inconsistent()
+
+        # Handle source changes, if any
+        if self.changes.get('rpms', None) or self.changes.get('images', None):
+            self.logger.info('Detected source changes:\n%s', yaml.safe_dump(self.changes))
+
+            if self.runtime.dry_run:
+                self.logger.info('Would have triggered a %s ocp4 build', self.version)
+                return
+
+            # Trigger ocp4
+            self.logger.info('Triggering a %s ocp4 build', self.version)
+            await trigger_ocp4(self.version)
+
+        elif self.rhcos_inconsistent:
+            if self.runtime.dry_run:
+                self.logger.info('Would have triggered a %s RHCOS build', self.version)
+                return
+
+            # Inconsistency probably means partial failure and we would like to retry.
+            #  but don't kick off more if already in progress.
+            self.logger.info('Triggering a %s RHCOS build for consistency', self.version)
+            await trigger_rhcos(self.version, True)
+
+        elif self.rhcos_changed:
+            if self.runtime.dry_run:
+                self.logger.info('Would have triggered a %s build-sync build', self.version)
+                return
+
+            self.logger.info('Triggering a %s build-sync', self.version)
+            await trigger_build_sync(self.version)
+
+    async def _get_changes(self):
+        """
+        Check for changes by calling doozer config:scan-sources
+        Changed rpms, images or rhcos are recorded in self.changes
+        self.rhcos_changed is also updated accordingly
+        """
+
+        # Run doozer scan-sources
+        cmd = f'doozer --assembly stream --working-dir={DOOZER_WORKING} --group=openshift-{self.version} ' \
+              f'config:scan-sources --yaml --ci-kubeconfig {os.environ["KUBECONFIG"]}'
+        _, out, err = await exectools.cmd_gather_async(cmd)
+        self.logger.info('scan-sources output for openshift-%s:\n%s', self.version, out)
+        yaml_data = yaml.safe_load(out)
+        changes = util.get_changes(yaml_data)
+
+        # Check for RHCOS changes
+        if changes.get('rhcos', None):
+            self.rhcos_changed = True
+            self.logger.info('Detected at least one updated RHCOS')
+        else:
+            self.logger.info('No RHCOS changes detected')
+            self.rhcos_changed = False
+
+        self.changes = changes
+
+    async def _rhcos_inconsistent(self):
+        """
+        Check for RHCOS inconsistencies by calling doozer inspect:stream INCONSISTENT_RHCOS_RPMS
+        """
+
+        cmd = f'doozer --assembly stream --working-dir {DOOZER_WORKING} --group openshift-{self.version} ' \
+              f'inspect:stream INCONSISTENT_RHCOS_RPMS --strict'
+        try:
+            _, out, _ = await exectools.cmd_gather_async(cmd)
+            self.logger.info(out)
+            self.rhcos_inconsistent = False
+        except ChildProcessError as e:
+            self.logger.info('INCONSISTENT_RHCOS_RPMS:\n%s', e)
+            self.rhcos_inconsistent = True
+
+
+@cli.command('ocp4-scan')
+@click.option('--version', required=True, help='OCP version to scan')
+@pass_runtime
+@click_coroutine
+async def ocp4_scan(runtime: Runtime, version: str):
+    await Ocp4ScanPipeline(runtime, version).run()

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -135,3 +135,28 @@ async def branch_arches(group: str, assembly: str, ga_only: bool = False) -> lis
 
     # Otherwise, read supported arches from group config
     return group_config['arches']
+
+
+def get_changes(yaml_data: dict) -> dict:
+    """
+    Scans data outputted by config:scan-sources yaml and records changed
+    elements in the object it returns.
+    The return dict has optional .rpms, .images and .rhcos fields,
+    that are omitted if no change was detected.
+    """
+
+    changes = {}
+
+    rpms = [rpm['name'] for rpm in yaml_data['rpms'] if rpm['changed']]
+    if rpms:
+        changes['rpms'] = rpms
+
+    images = [image['name'] for image in yaml_data['images'] if image['changed']]
+    if images:
+        changes['images'] = images
+
+    rhcos = [rhcos['name'] for rhcos in yaml_data['rhcos'] if rhcos['changed']]
+    if rhcos:
+        changes['rhcos'] = rhcos
+
+    return changes

--- a/test.py
+++ b/test.py
@@ -1,0 +1,14 @@
+import asyncio
+import yaml
+
+from pyartcd.util import branch_arches
+
+
+async def get_arches_2():
+    return await branch_arches('openshift-4.12', 'stream')
+
+
+if __name__ == '__main__':
+    arches = asyncio.get_event_loop().run_until_complete(get_arches_2())
+    print(yaml.safe_dump(arches))
+    print(type(arches))

--- a/triggered-jobs/build-sync/Jenkinsfile
+++ b/triggered-jobs/build-sync/Jenkinsfile
@@ -1,0 +1,39 @@
+#!/usr/bin/env groovy
+
+node() {
+    checkout scm
+    commonlib = load("pipeline-scripts/commonlib.groovy")
+
+    commonlib.describeJob("build-sync", """
+This job is meant to be triggered by remote API calls (namely from ocp4_scan). It will forward the call to 
+<a href="https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fbuild-sync">build-sync</a>,
+that being part of a multibranch pipeline could not be configured to receive remote triggers directly.<br>
+In this context, the only <strong>BUILD_VERSION</strong> param is required.
+    """)
+
+    // Expose properties for a parameterized build
+    properties(
+        [
+            disableResume(),
+            buildDiscarder(
+                logRotator(
+                    artifactDaysToKeepStr: '365',
+                    daysToKeepStr: '365')),
+            [
+                $class: 'ParametersDefinitionProperty',
+                parameterDefinitions: [
+                    commonlib.mockParam(),
+                    commonlib.ocpVersionParam('BUILD_VERSION', '4'),
+                ]
+            ],
+        ]
+    )
+
+    commonlib.checkMock()
+
+    build job: '../aos-cd-builds/build%252Fbuild-sync/', parameters: [
+            string(name: 'BUILD_VERSION', value: params.BUILD_VERSION)
+        ],
+        propagate: false,
+        wait: false
+}

--- a/triggered-jobs/ocp4/Jenkinsfile
+++ b/triggered-jobs/ocp4/Jenkinsfile
@@ -1,0 +1,40 @@
+#!/usr/bin/env groovy
+
+node() {
+    checkout scm
+    commonlib = load("pipeline-scripts/commonlib.groovy")
+
+    commonlib.describeJob("ocp4", """
+This job is meant to be triggered by remote API calls (namely from ocp4_scan).
+It will forward the call to <a href="https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp4">ocp4</a>,
+that being part of a multibranch pipeline could not be configured to receive remote triggers directly.<br>
+In this context, the only <strong>BUILD_VERSION</strong> param is required.
+    """)
+
+    // Expose properties for a parameterized build
+    properties(
+        [
+            disableResume(),
+            buildDiscarder(
+                logRotator(
+                    artifactDaysToKeepStr: '365',
+                    daysToKeepStr: '365')),
+            [
+                $class: 'ParametersDefinitionProperty',
+                parameterDefinitions: [
+                    commonlib.mockParam(),
+                    commonlib.ocpVersionParam('BUILD_VERSION', '4'),
+                ]
+            ],
+        ]
+    )
+
+    commonlib.checkMock()
+
+    build job: '../aos-cd-builds/build%252Focp4/', parameters: [
+            string(name: 'BUILD_VERSION', value: params.BUILD_VERSION),
+            booleanParam(name: 'FORCE_BUILD', value: false)
+        ],
+        propagate: false,
+        wait: false
+}

--- a/triggered-jobs/rhcos/Jenkinsfile
+++ b/triggered-jobs/rhcos/Jenkinsfile
@@ -1,0 +1,45 @@
+#!/usr/bin/env groovy
+
+node() {
+    checkout scm
+    commonlib = load("pipeline-scripts/commonlib.groovy")
+
+    commonlib.describeJob("rhcos", """
+This job is meant to be triggered by remote API calls (namely from ocp4_scan). It will forward the call to 
+<a href="https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Frhcos">rhcos</a>,
+that being part of a multibranch pipeline could not be configured to receive remote triggers directly.<br>
+In this context, the only <strong>BUILD_VERSION</strong> and <strong>NEW_BUILD</strong> params are required.
+    """)
+
+    // Expose properties for a parameterized build
+    properties(
+        [
+            disableResume(),
+            buildDiscarder(
+                logRotator(
+                    artifactDaysToKeepStr: '365',
+                    daysToKeepStr: '365')),
+            [
+                $class: 'ParametersDefinitionProperty',
+                parameterDefinitions: [
+                    commonlib.mockParam(),
+                    commonlib.ocpVersionParam('BUILD_VERSION', '4'),
+                    booleanParam(
+                        name: "NEW_BUILD",
+                        description: "(Multi pipeline only) Request a new build from the RHCOS pipeline even when it finds no changes from the last.",
+                        defaultValue: false
+                    ),
+                ]
+            ],
+        ]
+    )
+
+    commonlib.checkMock()
+
+    build job: '../aos-cd-builds/build%252Frhcos/', parameters: [
+            string(name: 'BUILD_VERSION', value: params.BUILD_VERSION),
+            booleanParam(name: 'NEW_BUILD', value: params.NEW_BUILD)
+        ],
+        propagate: false,
+        wait: false
+}


### PR DESCRIPTION
Ref. https://issues.redhat.com/browse/ART-3673

Test run: https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/dpaolell/job/ocp4-scan/31/console

With this PR, `ocp4-scan` takes a single OCP version param (cannot scan multiple versions). This should be acceptable as automation only scans one version at the time. Scanning multiple versions can be done manually for testing purposes, but is discouraged and should not be done for frozen releases.

If changes/inconsistencies are found, `ocp4-scan` can trigger these builds:
- rhcos
- ocp4
- build-sync

The adopted pattern here is to trigger these jobs remotely using Jenkins API. A service account has been created for this purpose, along with the relevant token, and both are stored inside Jenkins credentials store.

Since the aforementioned jobs are part of a multibranch pipeline, they cannot be configured to receive remote triggers. As a workaround, a new folder named `triggered-jobs` has been created in Jenkins; these jobs are acting like proxies between the caller `ocp4-scan` Python job, and the called jobs.

This PR also moves `ocp4-scan` to `buildvm`. This makes triggering jobs via remote API easier. To compensate resource consumption, `build-sync` has been moved to `buildvm2`