### PR TITLE
Move build-sync to buildvm2

### DIFF
--- a/jobs/build/build-sync/Jenkinsfile
+++ b/jobs/build/build-sync/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-node {
+node('covscan') {
 
     checkout scm
     def buildlib = load("pipeline-scripts/buildlib.groovy")


### PR DESCRIPTION
`ocp4-scan` is going to be moved to buildvm after the porting to Python is complete. We can move `build-sync` to buildvm2 to balance resources usage.