### PR TITLE
rhcos_sync: allow alternative meta.json

### DIFF
--- a/jobs/build/rhcos_sync/Jenkinsfile
+++ b/jobs/build/rhcos_sync/Jenkinsfile
@@ -68,7 +68,7 @@ node {
                     ),
                     string(
                         name: 'SYNC_LIST',
-                        description: 'Instead of figuring out items to sync from meta.json, use this input file.<br>Must be a URL reachable from buildvm',
+                        description: 'Instead of figuring out items to sync from meta.json, use this input file.<br>Must be a URL reachable from buildvm.<br>If name ends in ".json" then read it like meta.json, otherwise content should be line-separated filenames.',
                         defaultValue: "",
                         trim: true,
                     ),
@@ -168,10 +168,11 @@ node {
     rhcoslib.initialize(ocpVersion, rhcosBuild, arch, name, mirrorPrefix)
 
     try {
-        if ( params.SYNC_LIST == "" ) {
-            stage("Get/Generate sync list") { rhcoslib.rhcosSyncPrintArtifacts() }
-        } else {
-            stage("Get/Generate sync list") { rhcoslib.rhcosSyncManualInput() }
+        stage("Get/Generate sync list") {
+            if ( params.SYNC_LIST == "" || params.SYNC_LIST.endsWith(".json") )
+                rhcoslib.rhcosSyncPrintArtifacts()
+            else
+                rhcoslib.rhcosSyncManualInput()
         }
         stage("Mirror artifacts") {
             rhcoslib.rhcosSyncMirrorArtifacts(mirrorPrefix, arch, rhcosBuild, name)

--- a/jobs/build/rhcos_sync/Jenkinsfile
+++ b/jobs/build/rhcos_sync/Jenkinsfile
@@ -217,6 +217,7 @@ node {
                     wait: true,
                     parameters: [
                         string(name: 'VERSION', value: ocpVersion),
+                        booleanParam(name: 'DRY_RUN', value: params.DRY_RUN),
                     ]
                 )
             } else {

--- a/jobs/build/rhcos_sync/rhcoslib.groovy
+++ b/jobs/build/rhcos_sync/rhcoslib.groovy
@@ -51,8 +51,8 @@ def initialize(ocpVersion, rhcosBuild, arch, name, mirrorPrefix) {
     }
 
     dir ( rhcosWorking ) {
-        if ( params.SYNC_LIST == "" ) {
-            sh("wget ${metaUrl}")
+        if ( params.SYNC_LIST == "" || params.SYNC_LIST.endsWith(".json") ) {
+            sh("wget ${params.SYNC_LIST ?: metaUrl} -O meta.json")
             artifacts.add("${rhcosWorking}/meta.json")
         }
 


### PR DESCRIPTION
I expected it to work like this already, turns out SYNC_LIST was expected to be a list of files, so this makes it act like meta.json if it ends with .json