### PR TITLE
Skip ocp4 by timer if already locked

### DIFF
--- a/scheduled-jobs/build/ocp4_scan/Jenkinsfile
+++ b/scheduled-jobs/build/ocp4_scan/Jenkinsfile
@@ -19,6 +19,13 @@ node {
             continue
         }
 
+        // Skip the build if already locked
+        activityLockName = "github-activity-lock-${cv}"
+        if (!commonlib.canLock(activityLockName)) {
+            echo "Looks like there is another build ongoing for ${cv} -- skipping for this run"
+            continue
+        }
+
         // Trigger ocp4-scan build for ${version}
         versionJobs["scan-v${version}"] = {
             try {


### PR DESCRIPTION
Currently, `scheduled-builds/ocp4-scan` schedules builds for all non-frozen ocp4 versions. Then, `build/ocp4-scan` checks if the activity lock for that specific version is already acquired; if this is the case, it marks the build as `[SKIPPED]` and quits. This uselessly pollutes the ocp4-scan dashboard with skipped builds.

Instead of skipping `build/ocp4-scan`, we could just avoid scheduling it in the first place, if the activity lock is not available. This way, we'll make the ocp4-scan dashboard more meaningful.