### PR TITLE
Await is_build_permitted() as needed

### DIFF
--- a/pyartcd/pyartcd/pipelines/ocp4_scan.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan.py
@@ -25,7 +25,7 @@ class Ocp4ScanPipeline:
 
     async def run(self):
         # Check if automation is frozen for current group
-        if not util.is_build_permitted(self.version):
+        if not await util.is_build_permitted(self.version):
             return
 
         self.logger.info('Building: %s', self.version)


### PR DESCRIPTION
Fixing this error:
```
/mnt/workspace/jenkins/working/aos-cd-builds_build_ocp4_scan/pyartcd/pyartcd/pipelines/ocp4_scan.py:28: RuntimeWarning: coroutine 'is_build_permitted' was never awaited
```