### PR TITLE
Add --working-dir to Doozer invocation in ocp4-scan

### DIFF
--- a/pyartcd/pyartcd/pipelines/ocp4_scan.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan.py
@@ -25,7 +25,7 @@ class Ocp4ScanPipeline:
 
     async def run(self):
         # Check if automation is frozen for current group
-        if not await util.is_build_permitted(self.version):
+        if not await util.is_build_permitted(self.version, doozer_working=DOOZER_WORKING):
             return
 
         self.logger.info('Building: %s', self.version)

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -163,13 +163,15 @@ def get_changes(yaml_data: dict) -> dict:
     return changes
 
 
-async def get_freeze_automation(version: str, data_path: str = constants.OCP_BUILD_DATA_URL) -> str:
+async def get_freeze_automation(version: str, data_path: str = constants.OCP_BUILD_DATA_URL,
+                                doozer_working: str = '') -> str:
     """
     Returns freeze_automation flag for a specific group
     """
 
     cmd = [
         'doozer',
+        f'--working-dir={doozer_working}' if doozer_working else '',
         '--assembly=stream',
         f'--data-path={data_path}',
         f'--group=openshift-{version}',
@@ -192,7 +194,8 @@ def is_manual_build() -> bool:
     return os.getenv('BUILD_USER_EMAIL') is not None
 
 
-async def is_build_permitted(version: str, data_path: str = constants.OCP_BUILD_DATA_URL) -> bool:
+async def is_build_permitted(version: str, data_path: str = constants.OCP_BUILD_DATA_URL,
+                             doozer_working: str = '') -> bool:
     """
     Check whether the group should be built right now.
     This depends on:
@@ -202,7 +205,7 @@ async def is_build_permitted(version: str, data_path: str = constants.OCP_BUILD_
     """
 
     # Get 'freeze_automation' flag
-    freeze_automation = await get_freeze_automation(version, data_path)
+    freeze_automation = await get_freeze_automation(version, data_path, doozer_working)
 
     # Check for frozen automation
     # yaml parses unquoted "yes" as a boolean... accept either


### PR DESCRIPTION
This should fix
```
mv: cannot stat ‘/mnt/workspace/jenkins/working/aos-cd-builds_build_ocp4_scan@2/doozer_working/debug.log’: No such file or directory
```