### PR TITLE
use jenkins version if latest dir not exist

### DIFF
--- a/hacks/update-jenkins-plugins/collect-jenkins-plugins.sh
+++ b/hacks/update-jenkins-plugins/collect-jenkins-plugins.sh
@@ -197,7 +197,7 @@ for plugin_entry in ${DEP_LIST}; do
     plugin_line=${plugin_line%\;*}
 
     stripped_entry=$(echo "${plugin_entry}:" | cut -d : -f 1)  # Strip off the version since Jenkins doesn't really honor dependency versions
-    get_plugin "${stripped_entry}" || exit 1
+    get_plugin "${stripped_entry}" || get_plugin "${plugin_entry}" || exit 1
 done
 
 echo


### PR DESCRIPTION
some jenkins plugin repo may not have latest dir, like
https://ftp.belnet.be/pub/jenkins/plugins/ionicons-api/