### PR TITLE
[ART-5644]: Various microshift pipeline` improvements

### DIFF
--- a/jobs/build/build-microshift/Jenkinsfile
+++ b/jobs/build/build-microshift/Jenkinsfile
@@ -30,6 +30,11 @@ node {
                             defaultValue: "test",
                             trim: true
                         ),
+                        booleanParam(
+                            name: "FORCE_REBUILD",
+                            description: "(For named assemblies) Rebuild even if a build already exists",
+                            defaultValue: false
+                        ),
                         string(
                             name: 'RELEASE_PAYLOADS',
                             description: '(Optional) List of release payloads to rebase against; can be nightly names or full pullspecs',
@@ -94,6 +99,9 @@ node {
                     for (nightly in commonlib.parseList(params.RELEASE_PAYLOADS)) {
                         cmd << "--payload" << nightly.trim()
                     }
+                }
+                if (params.FORCE_REBUILD) {
+                    cmd << "--force"
                 }
                 if (params.NO_REBASE) {
                     cmd << "--no-rebase"

--- a/jobs/build/promote-assembly/Jenkinsfile
+++ b/jobs/build/promote-assembly/Jenkinsfile
@@ -394,7 +394,7 @@ node {
         }
         build(
             job: "build%2Fbuild-microshift",
-            propagate: false,
+            propagate: true,
             parameters: [
                 string(name: 'BUILD_VERSION', value: params.VERSION),
                 string(name: 'ASSEMBLY', value: params.ASSEMBLY),


### PR DESCRIPTION
- If `build-microshift` build fails, makes `promote-assembly` fail as well.
- Unless `--force` is specified, only rebuild if the build doesn't exist.
- Update Slack message.