### PR TITLE
plashet: Don't include previous for rust-afterburn, buildah, skopeo

### DIFF
--- a/hacks/plashet/build-plashet.py
+++ b/hacks/plashet/build-plashet.py
@@ -56,7 +56,6 @@ async def main():
     signing_advisory: bool = args.signing_advisory
     dry_run = args.dry_run
     previous_packages = [
-        "buildah",
         "conmon",
         "cri-o",
         "cri-tools",
@@ -68,8 +67,6 @@ async def main():
         "ovn",
         "podman",
         "python3-openvswitch",
-        "rust-afterburn",
-        "skopeo"
     ]
 
     # PLASHET_CONFIG should be moved to ocp-build-data in the future


### PR DESCRIPTION
With the change to include previous builds for rpms that rhcos consumes, errata tool takes issue. It refuses to sign builds that are older than builds already signed.

This PR removes the offenders. These builds do not tend to change very frequently, so this tactical retreat seems fine.