### PR TITLE
[ART-5903] publish-rpms: enable openvswitch-selinux-extra-policy.el9

### DIFF
--- a/jobs/build/publish-rpms/collect_deps.py
+++ b/jobs/build/publish-rpms/collect_deps.py
@@ -49,7 +49,7 @@ PACKAGES = {
         "openshift-clients-redistributable",
         "slirp4netns",
         "conmon-rs",
-        # "openvswitch-selinux-extra-policy",  # Not present in repos at this time. Not sure if this is expected or not.
+        "openvswitch-selinux-extra-policy",
         "openvswitch2.17"
     ],
 }


### PR DESCRIPTION
[tested](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/lmeyer/job/lmeyer-dev/job/dev-build%252Fpublish-rpms/32/parameters/)