### PR TITLE
check-bugs: Set run to unstable when commands crash

### DIFF
--- a/jobs/build/check-bugs/Jenkinsfile
+++ b/jobs/build/check-bugs/Jenkinsfile
@@ -63,7 +63,7 @@ node {
                 def out = sh(script: cmd.join(' '), returnStdout: true).trim()
                 echo out
 
-                if (out.contains('failed with')) {
+                if (out.contains('Command failed:')) {
                     currentBuild.result = "UNSTABLE"
                 }
             }

--- a/jobs/build/check-bugs/Jenkinsfile
+++ b/jobs/build/check-bugs/Jenkinsfile
@@ -60,10 +60,8 @@ node {
 
         buildlib.withAppCiAsArtPublish() {
             withCredentials([string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'), string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN')]) {
-                def out = sh(script: cmd.join(' '), returnStdout: true).trim()
-                echo out
-
-                if (out.contains('Command failed:')) {
+                def returnStatus = sh(script: cmd.join(' '), returnStatus: true)
+                if (returnStatus != 0) {
                     currentBuild.result = "UNSTABLE"
                 }
             }

--- a/jobs/build/check-bugs/Jenkinsfile
+++ b/jobs/build/check-bugs/Jenkinsfile
@@ -64,7 +64,7 @@ node {
                 echo out
 
                 if (out.contains('failed with')) {
-                    currentBuild.result = "FAILURE"
+                    currentBuild.result = "UNSTABLE"
                 }
             }
         }

--- a/pyartcd/Makefile
+++ b/pyartcd/Makefile
@@ -1,7 +1,7 @@
 .PHONY: venv tox lint test
 
 venv:
-	python3 -m venv venv
+	python3.8 -m venv venv
 	./venv/bin/pip install -r requirements-dev.txt -r requirements.txt
 	# source venv/bin/activate
 

--- a/pyartcd/pyartcd/pipelines/check_bugs.py
+++ b/pyartcd/pyartcd/pipelines/check_bugs.py
@@ -122,7 +122,7 @@ class CheckBugsPipeline:
             self.logger.info(out.decode())
         errcode = process.returncode
         if errcode:
-            self.logger.error(f'Command {cmd} failed with {errcode}: see output below')
+            self.logger.error(f'Command failed: cmd={cmd} errcode={errcode}. See output below')
             self.logger.info(err)
             return None
 
@@ -176,7 +176,7 @@ class CheckBugsPipeline:
         if out:
             res = {version: out}
         else:
-            self.logger.error(f'Command {cmd} failed with {err}: see output below')
+            self.logger.error(f'Command failed: cmd={cmd} errcode={errcode}. See output below')
             self.logger.info(err)
         return res
 


### PR DESCRIPTION
Right now there are times when [we silently fail](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fcheck-bugs/684/console) - fix those cases 
Set the Jenkins run to Unstable if any of the commands fail

Test run
https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Fcheck-bugs/11/console