### PR TITLE
Moving 4.13 to 'release'

### DIFF
--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -102,8 +102,8 @@ ocpReleaseState = [
             "pre-release": [ 'x86_64', 's390x', 'ppc64le', 'aarch64' ],
         ],
         "4.13": [
-            'release': [],
-            "pre-release": [ 'x86_64', 's390x', 'ppc64le', 'aarch64' ],
+            'release': [ 'x86_64', 's390x', 'ppc64le', 'aarch64' ],
+            "pre-release": [],
         ],
         "4.12": [
             'release': [ 'x86_64', 's390x', 'ppc64le', 'aarch64' ],


### PR DESCRIPTION
We reached branch cut and started building 4.14 on a daily basis. Let's start signing 4.13 artifacts as well