### PR TITLE
Expand match for rhcos tags based on new naming convention

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -129,14 +129,14 @@ class BuildSyncPipeline:
 
     async def _tags_to_transfer(self) -> list:
         """
-        Gather a list of tags to mirror to the CI imagestream. This will include rhel-coreos-*
-        to pick up any future RHCOS RHEL versions (e.g. rhel-coreos-9).
+        Gather a list of tags to mirror to the CI imagestream. This will include rhel-coreos*
+        to pick up any future RHCOS RHEL versions (e.g. rhel-coreos-8 and rhel-coreos[-extensions] starting with RHEL9).
         """
 
         cmd = f'oc --kubeconfig {os.environ["KUBECONFIG"]} get -n ocp is/{self.version}-art-latest -o=json'
         _, out, _ = await exectools.cmd_gather_async(cmd)
         tags = json.loads(out)['spec']['tags']
-        tags_to_transfer = [tag['name'] for tag in tags if 'machine-os-content' in tag['name'] or 'rhel-coreos-' in tag['name']]
+        tags_to_transfer = [tag['name'] for tag in tags if 'machine-os-content' in tag['name'] or 'rhel-coreos' in tag['name']]
         return tags_to_transfer
 
     @exectools.limit_concurrency(500)


### PR DESCRIPTION
With the transition to RHEL9, the version number is being dropped from the releae payload tag names.